### PR TITLE
Make getServiceName public

### DIFF
--- a/restli-client/src/main/java/com/linkedin/restli/client/Request.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/Request.java
@@ -491,7 +491,7 @@ public class Request<T>
    * Get the name of the service for this request
    * @return the service name for this request
    */
-  String getServiceName()
+  public String getServiceName()
   {
     if (_baseUriTemplate != null)
     {


### PR DESCRIPTION
I used to get service name from getResourcePath but now it's deprecated and this method is by some reason not public.
