### PR TITLE
Update build.gradle to use siging.signPom instead of just signPom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ subprojects {
     uploadArchives {
       repositories {
         mavenDeployer {
-          beforeDeployment { MavenDeployment deployment -> signPom(deployment) }
+          beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
           repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
             authentication(userName: sonatypeUsername, password: sonatypePassword)


### PR DESCRIPTION
Seems to be required to publish. This may have changed in a recent version of Gradle.