### PR TITLE
Upgrade to apache commons IO 2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ project.ext.externalDependency = [
   'commonsCodec': 'commons-codec:commons-codec:1.3',
   'commonsCompress': 'org.apache.commons:commons-compress:1.2',
   'commonsHttpClient': 'commons-httpclient:commons-httpclient:3.1',
-  'commonsIo': 'commons-io:commons-io:1.4',
+  'commonsIo': 'commons-io:commons-io:2.4',
   'commonsLang': 'commons-lang:commons-lang:2.4',
   'disruptor': 'com.lmax:disruptor:3.2.0',
   'easymock': 'org.easymock:easymock:3.1',


### PR DESCRIPTION
The current 1.4 version is very old.

When using 2.4 in source code and depending on rest.li which depends on 1.4, build system conflict resolution gets unhappy, mainly because of how build systems handle version conflict resolution for major versions.