### PR TITLE
Add validation mode for disallowing unrecognized fields.

### DIFF
--- a/data/src/main/java/com/linkedin/data/schema/validation/UnrecognizedFieldMode.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/UnrecognizedFieldMode.java
@@ -1,0 +1,17 @@
+package com.linkedin.data.schema.validation;
+
+/**
+ * Enum for how unrecognized fields should be handled during validation.
+ */
+public enum UnrecognizedFieldMode {
+
+  /**
+   * Ignore unrecognized fields during validation.
+   */
+  IGNORE,
+
+  /**
+   * If an unrecognized is present, then validation fails.
+   */
+  DISALLOW
+}

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -163,6 +163,10 @@ public final class ValidateDataAgainstSchema
         {
           validate(nextElement, nextElementSchema, nextElement.getValue());
         }
+        else if (_options.getUnrecognizedFieldMode() == UnrecognizedFieldMode.DISALLOW)
+        {
+          addMessage(element, "unrecognized field found but not allowed");
+        }
       }
     }
 
@@ -682,7 +686,7 @@ public final class ValidateDataAgainstSchema
         return object;
       }
     }
-    
+
     protected void addMessage(DataElement element, String format, Object... args)
     {
       _messages.add(new Message(element.path(), format, args));

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
@@ -61,6 +61,7 @@ public final class ValidationOptions
   {
     _coercionMode = CoercionMode.NORMAL;
     _requiredMode = RequiredMode.CAN_BE_ABSENT_IF_HAS_DEFAULT;
+    _unrecognizedFieldMode = UnrecognizedFieldMode.IGNORE;
   }
 
   /**
@@ -74,6 +75,7 @@ public final class ValidationOptions
   {
     _coercionMode = CoercionMode.NORMAL;
     _requiredMode = requiredMode;
+    _unrecognizedFieldMode = UnrecognizedFieldMode.IGNORE;
   }
 
   /**
@@ -86,6 +88,21 @@ public final class ValidationOptions
   {
     _coercionMode = coercionMode;
     _requiredMode = requiredMode;
+    _unrecognizedFieldMode = UnrecognizedFieldMode.IGNORE;
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param requiredMode specifies the required mode.
+   * @param coercionMode specifies the coercion mode.
+   * @param unrecognizedFieldMode specifies the unrecognized field mode.
+   */
+  public ValidationOptions(RequiredMode requiredMode, CoercionMode coercionMode, UnrecognizedFieldMode unrecognizedFieldMode)
+  {
+    _coercionMode = coercionMode;
+    _requiredMode = requiredMode;
+    _unrecognizedFieldMode = unrecognizedFieldMode;
   }
 
   /**
@@ -128,6 +145,26 @@ public final class ValidationOptions
   {
     ArgumentUtil.notNull(requiredMode, "RequiredMode");
     _requiredMode = requiredMode;
+  }
+
+  /**
+   * Returns how unrecognized fields are handled during validation.
+   *
+   * @return the unrecognized field mode.
+   */
+  public UnrecognizedFieldMode getUnrecognizedFieldMode()
+  {
+    return _unrecognizedFieldMode;
+  }
+
+  /**
+   * Set how unrecognized fields are handled during validation.
+   *
+   * @param unrecognizedFieldMode provides unrecognized field mode.
+   */
+  public void setUnrecognizedFieldMode(UnrecognizedFieldMode unrecognizedFieldMode)
+  {
+    _unrecognizedFieldMode = unrecognizedFieldMode;
   }
 
   /**
@@ -249,6 +286,7 @@ public final class ValidationOptions
 
   private CoercionMode _coercionMode;
   private RequiredMode _requiredMode;
+  private UnrecognizedFieldMode _unrecognizedFieldMode;
   private boolean      _avroUnionMode = false;
   private Map<String,Object> _validatorParameters = NO_VALIDATOR_PARAMETERS;
   private Set<String> _optionalFields = Collections.emptySet();

--- a/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
+++ b/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
@@ -85,6 +85,14 @@ public class TestValidation
     return options;
   }
 
+  public static ValidationOptions disallowUnrecognizedFieldOption()
+  {
+    ValidationOptions options = new ValidationOptions();
+    assertSame(options.getUnrecognizedFieldMode(), UnrecognizedFieldMode.IGNORE);
+    options.setUnrecognizedFieldMode(UnrecognizedFieldMode.DISALLOW);
+    return options;
+  }
+
   // For CoercionMode.STRING_TO_PRIMITIVE we want to coerce Strings into the correct datatype
   // also
   private static void assertAllowedClass(CoercionMode coercionMode, Class<?> clazz)
@@ -517,7 +525,7 @@ public class TestValidation
             { new Double(1), new Long(1) }
         };
 
-    
+
     Object badObjects[] =
         {
             new Boolean(true),
@@ -2080,5 +2088,45 @@ public class TestValidation
         assertFalse(message.contains(notExpected), message + " contains " + notExpected);
       }
     }
+  }
+
+  @Test
+  public void testDisallowUnrecognizedFieldValidation() throws IOException
+  {
+    String schemaText =
+        "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : " +
+            "[ { \"name\" : \"bar\", \"type\" : \"string\" } ] }";
+
+    Object goodObjects[] =
+        {
+            "a valid string"
+        };
+
+    Object badObjects[] =
+        {
+        };
+
+    // There is no coercion for this type.
+    // Test with all coercion modes, result should be the same for all cases.
+    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, disallowUnrecognizedFieldOption());
+
+    Object goodObjectsForUnrecognizedField[] =
+        {
+        };
+
+    Object badObjectsForUnrecognizedField[] =
+        {
+            "a string",
+            new Boolean(false),
+            new Integer(1),
+            new Long(1),
+            new Float(1),
+            new Double(1),
+            ByteString.copyAvroString("bytes", false),
+            new DataMap(),
+            new DataList()
+        };
+
+    testCoercionValidation(schemaText, "unrecognized", goodObjectsForUnrecognizedField, goodObjectsForUnrecognizedField, disallowUnrecognizedFieldOption());
   }
 }


### PR DESCRIPTION
This gives developers the option run the validator in a mode that disallows unrecognized fields.  For most use cases, ignoring unrecognized fields is the best approach for backward compatibility reasons.  But there are a couple use cases at system boundaries where a validation mode that disallows unrecognized fields might be generally useful:

- When accepting API requests from the public web of via 3rd party API endpoints.
- Before persisting data at the storage layer.

We're hoping to get this into rest.li because we need to perform this type of validation and would like to leverage the existing validator to do so.