### PR TITLE
Add validation mode for trimming and disallowing unrecognized fields

### DIFF
--- a/data/src/main/java/com/linkedin/data/schema/validation/UnrecognizedFieldMode.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/UnrecognizedFieldMode.java
@@ -1,0 +1,22 @@
+package com.linkedin.data.schema.validation;
+
+/**
+ * Enum for how unrecognized fields should be handled during validation.
+ */
+public enum UnrecognizedFieldMode {
+
+  /**
+   * Ignore unrecognized fields during validation.
+   */
+  IGNORE,
+
+  /**
+   * Remove unrecognized fields from data during validation.
+   */
+  TRIM,
+
+  /**
+   * If an unrecognized is present, then validation fails.
+   */
+  DISALLOW
+}

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -153,24 +153,23 @@ public final class ValidateDataAgainstSchema
      * This is a specialized version of {@link com.linkedin.data.it.Remover.ToRemove} which is and
      * should remain private, so could not be used here.
      */
-    private class FieldToTrim
+    private static class FieldToTrim
     {
       private FieldToTrim(DataMap parent, String fieldName)
       {
+        assert(!parent.isReadOnly());
         _parent = parent;
         _fieldName = fieldName;
       }
 
       private void trim()
       {
-        if (_parent != null) {
-          if (_parent.isReadOnly())
-          {
-            throw new ConcurrentModificationException("Map marked as read-only during validation.");
-          }
-          else {
-            _parent.remove(_fieldName);
-          }
+        if (_parent.isReadOnly())
+        {
+          throw new ConcurrentModificationException("Map marked as read-only during validation.");
+        }
+        else {
+          _parent.remove(_fieldName);
         }
       }
 

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -190,7 +190,7 @@ public final class ValidateDataAgainstSchema
 
           if (map.isReadOnly()) {
             _hasFixupReadOnlyError = true;
-            addMessage(element.path(), "unrecognized field cannot be trimmed because DataMap backing it is read-only");
+            addMessage(element, "unrecognized field cannot be trimmed because DataMap backing it is read-only");
           } else {
             _toTrim.add(new FieldToTrim(map, fieldName));
           }
@@ -759,12 +759,6 @@ public final class ValidateDataAgainstSchema
     protected void addMessage(DataElement element, String format, Object... args)
     {
       _messages.add(new Message(element.path(), format, args));
-      _valid = false;
-    }
-
-    protected void addMessage(Object[] path, String format, Object... args)
-    {
-      _messages.add(new Message(path, format, args));
       _valid = false;
     }
 

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -462,6 +462,21 @@ public final class ValidateDataAgainstSchema
           addMessage(element, "null is not a member type of union %1$s", schema);
         }
       }
+      else if (_options.isAvroUnionMode())
+      {
+        // Avro union default value does not include member type discriminator
+        List<DataSchema> memberTypes = schema.getTypes();
+        if (memberTypes.isEmpty())
+        {
+          addMessage(element, "value %1$s is not valid for empty union", object.toString());
+        }
+        else
+        {
+          DataSchema memberSchema = memberTypes.get(0);
+          assert(_recursive);
+          validate(element, memberSchema, object);
+        }
+      }
       else if (object instanceof DataMap)
       {
         // Pegasus mode
@@ -474,17 +489,7 @@ public final class ValidateDataAgainstSchema
         {
           Map.Entry<String, Object> entry = map.entrySet().iterator().next();
           String key = entry.getKey();
-
-          DataSchema memberSchema;
-          if (_options.isAvroUnionMode())
-          {
-            memberSchema = schema.getTypeByName(key);
-          }
-          else
-          {
-            memberSchema = schema.getType(key);
-          }
-
+          DataSchema memberSchema = schema.getType(key);
           if (memberSchema == null)
           {
             addMessage(element, "\"%1$s\" is not a member type of union %2$s", key, schema);

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -462,21 +462,6 @@ public final class ValidateDataAgainstSchema
           addMessage(element, "null is not a member type of union %1$s", schema);
         }
       }
-      else if (_options.isAvroUnionMode())
-      {
-        // Avro union default value does not include member type discriminator
-        List<DataSchema> memberTypes = schema.getTypes();
-        if (memberTypes.isEmpty())
-        {
-          addMessage(element, "value %1$s is not valid for empty union", object.toString());
-        }
-        else
-        {
-          DataSchema memberSchema = memberTypes.get(0);
-          assert(_recursive);
-          validate(element, memberSchema, object);
-        }
-      }
       else if (object instanceof DataMap)
       {
         // Pegasus mode
@@ -489,7 +474,17 @@ public final class ValidateDataAgainstSchema
         {
           Map.Entry<String, Object> entry = map.entrySet().iterator().next();
           String key = entry.getKey();
-          DataSchema memberSchema = schema.getType(key);
+
+          DataSchema memberSchema;
+          if (_options.isAvroUnionMode())
+          {
+            memberSchema = schema.getTypeByName(key);
+          }
+          else
+          {
+            memberSchema = schema.getType(key);
+          }
+
           if (memberSchema == null)
           {
             addMessage(element, "\"%1$s\" is not a member type of union %2$s", key, schema);

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
@@ -218,25 +218,22 @@ public final class ValidationOptions
   /**
    * Set Avro union mode.
    *
-   * If Avro union mode is enabled, validate union default values according to Avro's rules.
+   * When set, data is validated as a Avro schema default value, which has a different data format
+   * than other data.
    *
-   * For default values  of unions in Avro, the discriminator is not present to prevent verbose
-   * syntax like:
+   * This mode should be used exclusively to validate Avro default values.
    *
-   * <pre>
-   * { "type" : [ "int", null ], "default" : { "int" : 5 } }
-   * </pre>
-   *
-   *
-   * Avro default value of union is always the 1st type.
+   * For default values of unions in Avro, the discriminator is not present and the default
+   * value always applies to the first member type of the union. E.g.:
    *
    * <pre>
    * { "type" : [ "int", null ], "default" : 5 }
    * </pre>
    *
-   * This is why it always uses the 1st type of the union and because they is no key in the data.
-   *
    * This applies transitively even to default values of embedded unions.
+   *
+   * For additional details, see the comments about union default values here:
+   * https://avro.apache.org/docs/1.7.7/spec.html#Unions
    *
    * @param value set to true to enable Avro union mode.
    */

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
@@ -61,6 +61,7 @@ public final class ValidationOptions
   {
     _coercionMode = CoercionMode.NORMAL;
     _requiredMode = RequiredMode.CAN_BE_ABSENT_IF_HAS_DEFAULT;
+    _unrecognizedFieldMode = UnrecognizedFieldMode.IGNORE;
   }
 
   /**
@@ -74,6 +75,7 @@ public final class ValidationOptions
   {
     _coercionMode = CoercionMode.NORMAL;
     _requiredMode = requiredMode;
+    _unrecognizedFieldMode = UnrecognizedFieldMode.IGNORE;
   }
 
   /**
@@ -86,6 +88,21 @@ public final class ValidationOptions
   {
     _coercionMode = coercionMode;
     _requiredMode = requiredMode;
+    _unrecognizedFieldMode = UnrecognizedFieldMode.IGNORE;
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param requiredMode specifies the required mode.
+   * @param coercionMode specifies the coercion mode.
+   * @param unrecognizedFieldMode specifies the unrecognized field mode.
+   */
+  public ValidationOptions(RequiredMode requiredMode, CoercionMode coercionMode, UnrecognizedFieldMode unrecognizedFieldMode)
+  {
+    _coercionMode = coercionMode;
+    _requiredMode = requiredMode;
+    _unrecognizedFieldMode = unrecognizedFieldMode;
   }
 
   /**
@@ -128,6 +145,26 @@ public final class ValidationOptions
   {
     ArgumentUtil.notNull(requiredMode, "RequiredMode");
     _requiredMode = requiredMode;
+  }
+
+  /**
+   * Returns how unrecognized fields are handled during validation.
+   *
+   * @return the unrecognized field mode.
+   */
+  public UnrecognizedFieldMode getUnrecognizedFieldMode()
+  {
+    return _unrecognizedFieldMode;
+  }
+
+  /**
+   * Set how unrecognized fields are handled during validation.
+   *
+   * @param unrecognizedFieldMode provides unrecognized field mode.
+   */
+  public void setUnrecognizedFieldMode(UnrecognizedFieldMode unrecognizedFieldMode)
+  {
+    _unrecognizedFieldMode = unrecognizedFieldMode;
   }
 
   /**
@@ -249,6 +286,7 @@ public final class ValidationOptions
 
   private CoercionMode _coercionMode;
   private RequiredMode _requiredMode;
+  private UnrecognizedFieldMode _unrecognizedFieldMode;
   private boolean      _avroUnionMode = false;
   private Map<String,Object> _validatorParameters = NO_VALIDATOR_PARAMETERS;
   private Set<String> _optionalFields = Collections.emptySet();

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
@@ -168,19 +168,6 @@ public final class ValidationOptions
   }
 
   /**
-   * Set Avro union mode.
-   *
-   * If Avro union mode is enabled, a union uses the name (instead of full name) of the
-   * member type as the key to specify the type of the value in the union.
-   *
-   * @param value set to true to enable Avro union mode.
-   */
-  public void setAvroUnionMode(boolean value)
-  {
-    _avroUnionMode = value;
-  }
-
-  /**
    * Set a parameter intended to be passed to a {@link com.linkedin.data.schema.validator.Validator}.
    *
    * @param key to identify option.
@@ -229,12 +216,42 @@ public final class ValidationOptions
   }
 
   /**
+   * Set Avro union mode.
+   *
+   * If Avro union mode is enabled, validate union default values according to Avro's rules.
+   *
+   * For default values  of unions in Avro, the discriminator is not present to prevent verbose
+   * syntax like:
+   *
+   * <pre>
+   * { "type" : [ "int", null ], "default" : { "int" : 5 } }
+   * </pre>
+   *
+   *
+   * Avro default value of union is always the 1st type.
+   *
+   * <pre>
+   * { "type" : [ "int", null ], "default" : 5 }
+   * </pre>
+   *
+   * This is why it always uses the 1st type of the union and because they is no key in the data.
+   *
+   * This applies transitively even to default values of embedded unions.
+   *
+   * @param value set to true to enable Avro union mode.
+   */
+  public void setAvroUnionMode(boolean value)
+  {
+    _avroUnionMode = value;
+  }
+
+  /**
    * Return whether Avro union mode is enabled.
    *
-   * If Avro union mode is enabled, a union uses the name (instead of full name) of the
-   * member type as the key to specify the type of the value in the union.
+   * If Avro union mode is enabled, validate union default values according to Avro's rules.
    *
    * @return true if Avro union mode is enabled.
+   * @see {@link #setAvroUnionMode(boolean)}
    */
   public boolean isAvroUnionMode()
   {

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidationOptions.java
@@ -265,6 +265,7 @@ public final class ValidationOptions
     ValidationOptions otherOptions = (ValidationOptions) other;
     return (otherOptions._coercionMode == _coercionMode
         && otherOptions._requiredMode == _requiredMode
+        && otherOptions._unrecognizedFieldMode == _unrecognizedFieldMode
         && otherOptions._avroUnionMode == _avroUnionMode
         && otherOptions._validatorParameters.equals(_validatorParameters));
   }
@@ -275,6 +276,7 @@ public final class ValidationOptions
     int code = 17;
     code = code * 31 + (_requiredMode == null ? 0 : _requiredMode.hashCode());
     code = code * 31 + (_coercionMode == null ? 0 : _coercionMode.hashCode());
+    code = code * 31 + (_unrecognizedFieldMode == null ? 0 : _unrecognizedFieldMode.hashCode());
     code = code * 31 + (_avroUnionMode ? 0 : 53);
     code = code * 31 + (_validatorParameters.hashCode());
     return code;
@@ -288,6 +290,8 @@ public final class ValidationOptions
       .append(_requiredMode)
       .append(", FixupMode=")
       .append(_coercionMode)
+      .append(", UnrecognizedFieldMode=")
+      .append(_unrecognizedFieldMode)
       .append(", AvroUnionMode=")
       .append(_avroUnionMode);
     if (_validatorParameters != NO_VALIDATOR_PARAMETERS)

--- a/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
+++ b/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
@@ -2201,9 +2201,8 @@ public class TestValidation
     ValidationResult readOnlyResult = validate(readOnlyToValidate, schema, options);
     assertTrue(readOnlyResult.hasFixupReadOnlyError());
     String message = readOnlyResult.getMessages().toString();
-    assertTrue(readOnlyResult.getMessages().size() == 8);
+    assertTrue(readOnlyResult.getMessages().size() == 7);
     String[] expectedStrings = new String[] {
-        "/unrecognizedMap/key",
         "/unrecognizedMap",
         "/unrecognizedArray",
         "/recordField/unrecognizedPrimitive",

--- a/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
+++ b/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
@@ -22,6 +22,7 @@ import java.io.PrintStream;
 import java.util.Collection;
 import java.util.Collections;
 
+import com.linkedin.data.message.MessageUtil;
 import org.testng.annotations.Test;
 
 import com.linkedin.data.ByteString;
@@ -2191,7 +2192,7 @@ public class TestValidation
     // mutable
     DataMap toValidate = dataMapFromString(dataString);
     ValidationResult result = validate(toValidate, schema, options);
-    assertTrue(result.isValid());
+    assertTrue(result.isValid(), MessageUtil.messagesToString(result.getMessages()));
     assertEquals(result.getFixed(), dataMapFromString(trimmedDataString));
     assertSame(toValidate, result.getFixed());
 

--- a/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
+++ b/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
@@ -2117,8 +2117,15 @@ public class TestValidation
 
     // There is no coercion for this type.
     // Test with all coercion modes, result should be the same for all cases.
-    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, disallowUnrecognizedFieldOption());
-    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, trimUnrecognizedFieldOption());
+    ValidationOptions disallowOptions = disallowUnrecognizedFieldOption();
+    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, disallowOptions);
+    disallowOptions.setAvroUnionMode(true);
+    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, disallowOptions);
+
+    ValidationOptions trimOptions = trimUnrecognizedFieldOption();
+    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, trimOptions);
+    trimOptions.setAvroUnionMode(true);
+    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, trimOptions);
 
     Object allowedForUnrecognizedField[] =
         {
@@ -2147,6 +2154,16 @@ public class TestValidation
         RequiredMode.CAN_BE_ABSENT_IF_HAS_DEFAULT,
         CoercionMode.NORMAL,
         UnrecognizedFieldMode.TRIM);
+    testUnrecognizedFieldTrimming(options);
+
+    options.setAvroUnionMode(true);
+
+    testUnrecognizedFieldTrimming(options);
+  }
+
+  public void testUnrecognizedFieldTrimming(ValidationOptions options) throws IOException
+  {
+
 
     String schemaText =
         "{\n" +

--- a/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
+++ b/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
@@ -85,6 +85,22 @@ public class TestValidation
     return options;
   }
 
+  public static ValidationOptions disallowUnrecognizedFieldOption()
+  {
+    ValidationOptions options = new ValidationOptions();
+    assertSame(options.getUnrecognizedFieldMode(), UnrecognizedFieldMode.IGNORE);
+    options.setUnrecognizedFieldMode(UnrecognizedFieldMode.DISALLOW);
+    return options;
+  }
+
+  public static ValidationOptions trimUnrecognizedFieldOption()
+  {
+    ValidationOptions options = new ValidationOptions();
+    assertSame(options.getUnrecognizedFieldMode(), UnrecognizedFieldMode.IGNORE);
+    options.setUnrecognizedFieldMode(UnrecognizedFieldMode.TRIM);
+    return options;
+  }
+
   // For CoercionMode.STRING_TO_PRIMITIVE we want to coerce Strings into the correct datatype
   // also
   private static void assertAllowedClass(CoercionMode coercionMode, Class<?> clazz)
@@ -517,7 +533,7 @@ public class TestValidation
             { new Double(1), new Long(1) }
         };
 
-    
+
     Object badObjects[] =
         {
             new Boolean(true),
@@ -2079,6 +2095,126 @@ public class TestValidation
       {
         assertFalse(message.contains(notExpected), message + " contains " + notExpected);
       }
+    }
+  }
+
+  @Test
+  public void testUnrecognizedFieldValidation() throws IOException
+  {
+    String schemaText =
+        "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : " +
+            "[ { \"name\" : \"bar\", \"type\" : \"string\" } ] }";
+
+    Object goodObjects[] =
+        {
+            "a valid string"
+        };
+
+    Object badObjects[] =
+        {
+        };
+
+    // There is no coercion for this type.
+    // Test with all coercion modes, result should be the same for all cases.
+    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, disallowUnrecognizedFieldOption());
+    testCoercionValidation(schemaText, "bar", goodObjects, badObjects, trimUnrecognizedFieldOption());
+
+    Object allowedForUnrecognizedField[] =
+        {
+        };
+
+    Object disallowedForUnrecognizedField[] =
+        {
+            "a string",
+            new Boolean(false),
+            new Integer(1),
+            new Long(1),
+            new Float(1),
+            new Double(1),
+            ByteString.copyAvroString("bytes", false),
+            new DataMap(),
+            new DataList()
+        };
+
+    testCoercionValidation(schemaText, "unrecognized", allowedForUnrecognizedField, disallowedForUnrecognizedField, disallowUnrecognizedFieldOption());
+  }
+
+  @Test
+  public void testUnrecognizedFieldTrimming() throws IOException
+  {
+    ValidationOptions options = new ValidationOptions(
+        RequiredMode.CAN_BE_ABSENT_IF_HAS_DEFAULT,
+        CoercionMode.NORMAL,
+        UnrecognizedFieldMode.TRIM);
+
+    String schemaText =
+        "{\n" +
+            "  \"name\" : \"Foo\",\n" +
+            "  \"type\" : \"record\",\n" +
+            "  \"fields\" : [\n" +
+            "    { \"name\" : \"primitive\", \"type\" : \"int\", \"optional\" : true },\n" +
+            "    { \"name\" : \"arrayField\", \"type\" : { \"type\" : \"array\", \"items\" : \"Foo\" }, \"optional\" : true },\n" +
+            "    { \"name\" : \"mapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"Foo\" }, \"optional\" : true },\n" +
+            "    { \"name\" : \"unionField\", \"type\" : [ \"int\", \"string\", \"Foo\" ], \"optional\" : true },\n" +
+            "    { \"name\" : \"recordField\", \"type\" : \"Foo\", \"optional\" : true }\n" +
+            "  ]\n" +
+            "}\n";
+
+    DataSchema schema = dataSchemaFromString(schemaText);
+
+    String dataString =
+        "{\n" +
+        "  \"primitive\" : 1,\n" +
+        "  \"unrecognizedPrimitive\": -1,\n" +
+        "  \"arrayField\" : [ { \"primitive\": 2, \"unrecognizedInArray\": -2 } ],\n" +
+        "  \"mapField\" : { \"key\": { \"primitive\": 3, \"unrecognizedInMap\": -3 } },\n" +
+        "  \"unionField\" : { \"Foo\": { \"primitive\": 4, \"unrecognizedInMap\": -4 } },\n" +
+        "  \"recordField\" : {\n" +
+        "    \"primitive\" : 5,\n" +
+        "    \"unrecognizedPrimitive\": -5\n" +
+        "  },\n" +
+        "  \"unrecognizedMap\": { \"key\": -100},\n" +
+        "  \"unrecognizedArray\": [ -101 ]\n" +
+        "}";
+
+    String trimmedDataString =
+        "{\n" +
+        "  \"primitive\" : 1,\n" +
+        "  \"arrayField\" : [ { \"primitive\": 2 } ],\n" +
+        "  \"mapField\" : { \"key\": { \"primitive\": 3 } },\n" +
+        "  \"unionField\" : { \"Foo\": { \"primitive\": 4 } },\n" +
+        "  \"recordField\" : {\n" +
+        "    \"primitive\" : 5\n" +
+        "  }\n" +
+        "}";
+
+    // mutable
+    DataMap toValidate = dataMapFromString(dataString);
+    ValidationResult result = validate(toValidate, schema, options);
+    assertTrue(result.isValid());
+    assertEquals(result.getFixed(), dataMapFromString(trimmedDataString));
+    assertSame(toValidate, result.getFixed());
+
+    // read-only
+    DataMap readOnlyToValidate = dataMapFromString(dataString);
+    readOnlyToValidate.makeReadOnly();
+    ValidationResult readOnlyResult = validate(readOnlyToValidate, schema, options);
+    assertTrue(readOnlyResult.hasFixupReadOnlyError());
+    String message = readOnlyResult.getMessages().toString();
+    assertTrue(readOnlyResult.getMessages().size() == 8);
+    String[] expectedStrings = new String[] {
+        "/unrecognizedMap/key",
+        "/unrecognizedMap",
+        "/unrecognizedArray",
+        "/recordField/unrecognizedPrimitive",
+        "/unionField/Foo/unrecognizedInMap",
+        "/unrecognizedPrimitive",
+        "/arrayField/0/unrecognizedInArray",
+        "/mapField/key/unrecognizedInMap"
+    };
+    for (String expected : expectedStrings)
+    {
+      assertTrue(message.contains(expected), message + " does not contain " + expected);
     }
   }
 }


### PR DESCRIPTION
This gives developers the option run the validator in a mode that disallows or filters out unrecognized fields when needed.  For most use cases ignoring unrecognized fields for backward compatibility reasons.  But there are a couple system boundaries where these approaches have been found useful.

Note that I've included a specialized version of `com.linkedin.data.it.Remover.ToRemove` called `ToTrim`.  Alternatively, could modified and then exposed some of the currently private functionality from `Remover`, but that would have resulted in a public API where developers could directly accumulate `Remover.ToRemove` objects, which is risky because if the order of those objects is not correct, the wrong elements can be removed from arrays. Also, `ToTrim` needs to track the paths of the elements it visits for validation message purposes.

Questions for reviewers:
* Does the naming look reasonable for the new Enum values? "TRIM" could alternatively have been named "FILTER".
* Did I handle fixup correctly here?