### PR TITLE
Add typed map key support to DataSchemas and TemplateSpecs.

### DIFF
--- a/data/src/main/java/com/linkedin/data/schema/DataSchemaConstants.java
+++ b/data/src/main/java/com/linkedin/data/schema/DataSchemaConstants.java
@@ -40,6 +40,7 @@ public class DataSchemaConstants
   public static final String SYMBOLS_KEY = "symbols";
   public static final String SYMBOL_DOCS_KEY = "symbolDocs";
   public static final String TYPE_KEY = "type";
+  public static final String KEYS_KEY = "keys";
   public static final String VALUES_KEY = "values";
 
   public static final String NULL_TYPE = "null";
@@ -89,7 +90,7 @@ public class DataSchemaConstants
 
     Set<String> schemaKeys = new HashSet<String>(Arrays.asList(ALIASES_KEY, DOC_KEY, FIELDS_KEY, INCLUDE_KEY, ITEMS_KEY, NAME_KEY,
                                                                NAMESPACE_KEY, REF_KEY,
-                                                               SIZE_KEY, SYMBOLS_KEY, SYMBOL_DOCS_KEY, TYPE_KEY, VALUES_KEY));
+                                                               SIZE_KEY, SYMBOLS_KEY, SYMBOL_DOCS_KEY, TYPE_KEY, KEYS_KEY, VALUES_KEY));
     SCHEMA_KEYS = Collections.unmodifiableSet(schemaKeys);
 
     Set<String> fieldKeys = new HashSet<String>(Arrays.asList(ALIASES_KEY, DEFAULT_KEY, DOC_KEY, NAME_KEY, OPTIONAL_KEY, ORDER_KEY, TYPE_KEY));

--- a/data/src/main/java/com/linkedin/data/schema/DataSchemaTraverse.java
+++ b/data/src/main/java/com/linkedin/data/schema/DataSchemaTraverse.java
@@ -90,6 +90,7 @@ public class DataSchemaTraverse
         break;
       case MAP:
         MapDataSchema mapDataSchema = (MapDataSchema) schema;
+        traverseChild(DataSchemaConstants.KEYS_KEY, mapDataSchema.getKeys());
         traverseChild(DataSchemaConstants.VALUES_KEY, mapDataSchema.getValues());
         break;
       case ARRAY:

--- a/data/src/main/java/com/linkedin/data/schema/MapDataSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/MapDataSchema.java
@@ -16,6 +16,8 @@
 
 package com.linkedin.data.schema;
 
+import java.util.Objects;
+
 /**
  * {@link DataSchema} for map.
  *
@@ -25,8 +27,34 @@ public final class MapDataSchema extends ComplexDataSchema
 {
   public MapDataSchema(DataSchema values)
   {
+    this(null, values);
+  }
+
+  public MapDataSchema(DataSchema keys, DataSchema values)
+  {
     super(Type.MAP);
+    setKeys(keys);
     setValues(values);
+  }
+
+  /**
+   * Set the {@link DataSchema} of keys in the map.
+   *
+   * @param keys is the {@link DataSchema} of keys in the map.
+   */
+  void setKeys(DataSchema keys)
+  {
+    _keys = keys;
+  }
+
+  /**
+   * Return the {@link DataSchema} for the map's keys.
+   *
+   * @return the {@link DataSchema} for the map's keys.
+   */
+  public DataSchema getKeys()
+  {
+    return _keys;
   }
 
   /**
@@ -73,7 +101,7 @@ public final class MapDataSchema extends ComplexDataSchema
     if (object != null && object.getClass() == MapDataSchema.class)
     {
       MapDataSchema other = (MapDataSchema) object;
-      return super.equals(other) && _values.equals(other._values);
+      return super.equals(other) && _values.equals(other._values) && Objects.equals(_keys, other._keys);
     }
     return false;
   }
@@ -84,5 +112,6 @@ public final class MapDataSchema extends ComplexDataSchema
     return super.hashCode() ^ _values.hashCode();
   }
 
+  private DataSchema _keys = null;
   private DataSchema _values = DataSchemaConstants.NULL_DATA_SCHEMA;
 }

--- a/data/src/main/java/com/linkedin/data/schema/SchemaParser.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaParser.java
@@ -491,8 +491,9 @@ public class SchemaParser extends AbstractDataParser
         appendCalleeMessage(size);
         break;
       case MAP:
+        DataSchema keysSchema = getOptionalSchemaData(map, KEYS_KEY);
         DataSchema valuesSchema = getSchemaData(map, VALUES_KEY);
-        MapDataSchema mapSchema = new MapDataSchema(valuesSchema);
+        MapDataSchema mapSchema = new MapDataSchema(keysSchema, valuesSchema);
         schema = mapSchema;
         break;
       case RECORD:
@@ -1047,6 +1048,19 @@ public class SchemaParser extends AbstractDataParser
       startErrorMessage(map).append(key).append(" is required but it is not present.\n");
     }
     return schema;
+  }
+
+  protected DataSchema getOptionalSchemaData(DataMap map, String key)
+  {
+    Object obj = map.get(key);
+    if (obj != null)
+    {
+      return parseObject(obj);
+    }
+    else
+    {
+      return null;
+    }
   }
 
   /**

--- a/data/src/main/java/com/linkedin/data/schema/SchemaParser.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaParser.java
@@ -851,6 +851,10 @@ public class SchemaParser extends AbstractDataParser
           parseObject(items);
           break;
         case MAP:
+          Object keys = map.get(KEYS_KEY);
+          if (keys != null) {
+            parseObject(keys);
+          }
           Object values = map.get(VALUES_KEY);
           parseObject(values);
           break;

--- a/data/src/main/java/com/linkedin/data/schema/SchemaToJsonEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToJsonEncoder.java
@@ -169,6 +169,13 @@ public class SchemaToJsonEncoder
       case MAP:
         _builder.writeStartObject();
         _builder.writeStringField(TYPE_KEY, MAP_TYPE, true);
+
+        DataSchema keysSchema = ((MapDataSchema) schema).getKeys();
+        if (keysSchema != null) {
+          _builder.writeFieldName(KEYS_KEY);
+          encode(keysSchema);
+        }
+
         _builder.writeFieldName(VALUES_KEY);
         encode(((MapDataSchema) schema).getValues());
         encodeProperties(schema);

--- a/generator/src/main/java/com/linkedin/pegasus/generator/spec/MapTemplateSpec.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/spec/MapTemplateSpec.java
@@ -27,7 +27,11 @@ public class MapTemplateSpec extends ClassTemplateSpec
 {
   private ClassTemplateSpec _valueClass;
   private ClassTemplateSpec _valueDataClass;
-  private CustomInfoSpec _customInfo;
+  private CustomInfoSpec _valueCustomInfo;
+
+  private ClassTemplateSpec _keyClass;
+  private ClassTemplateSpec _keyDataClass;
+  private CustomInfoSpec _keyCustomInfo;
 
   public MapTemplateSpec(MapDataSchema schema)
   {
@@ -60,13 +64,59 @@ public class MapTemplateSpec extends ClassTemplateSpec
     _valueDataClass = valueDataClass;
   }
 
-  public CustomInfoSpec getCustomInfo()
+  public CustomInfoSpec getValueCustomInfo()
   {
-    return _customInfo;
+    return _valueCustomInfo;
   }
 
-  public void setCustomInfo(CustomInfoSpec customInfo)
+  public void setValueCustomInfo(CustomInfoSpec customInfo)
   {
-    _customInfo = customInfo;
+    _valueCustomInfo = customInfo;
+  }
+
+  /**
+   * Same as {#link getValueCustomInfo}. Provided for backward compatibility.
+   */
+  public CustomInfoSpec getCustomInfo()
+  {
+    return getValueCustomInfo();
+  }
+
+  /**
+   * Same as {#link setValueCustomInfo}. Provided for backward compatibility.
+   */
+  public void setCustomInfo(CustomInfoSpec valueCustomInfo)
+  {
+    setValueCustomInfo(valueCustomInfo);
+  }
+
+  public ClassTemplateSpec getKeyClass()
+  {
+    return _keyClass;
+  }
+
+  public void setKeyClass(ClassTemplateSpec keyClass)
+  {
+    _keyClass = keyClass;
+  }
+
+  public ClassTemplateSpec getKeyDataClass()
+  {
+    return _keyDataClass;
+  }
+
+  public void setKeyDataClass(ClassTemplateSpec keyDataClass)
+  {
+    _keyDataClass = keyDataClass;
+  }
+
+  public CustomInfoSpec getKeyCustomInfo()
+  {
+    return _keyCustomInfo;
+  }
+
+  public void setKeyCustomInfo(CustomInfoSpec keyCustomInfo)
+  {
+    _keyCustomInfo = keyCustomInfo;
   }
 }


### PR DESCRIPTION
This adds the ability to indicate the type of a map key in pegasus schemas. E.g.:

```
{ "type": "map", "keys": "int", "values": "org.example.Fortune" }
```

The wire protocol stays exactly as-is. Keys are still encoded as strings in JSON objects.

The benefit of this change is that data binding generators may provide improved type-safety.  For example, a data binding generator might bind to `Map<Int, Fortune>` for the above schema example, and could also validate that the map keys are all valid integers.

This is only the groundwork for typed map keys.

If this is accepted there are two potential follow up changes:
- Improve the existing pegasus data schema generator for Java to generate typesafe bindings for typed map keys.
- Introduce a string representation for complex types OR deliberately limit keys to primitive types and typerefs to primitive types.  In Courier at Courser we use [InlineStringCodec](https://github.com/coursera/courier/blob/master/runtime/src/main/scala/org/coursera/courier/codecs/InlineStringCodec.scala), so we could potentially add a Java implementation of such a codec to Pegasus to be the standard way complex types are encoded as map keys.  Or we could just add the primitive key type support, which would enable developers to clearly indicate things like that a key must be an integer or must be a URN (which is a typeref to string).

We have been using typed map keys in Courier in production for quite some time and are really happy with them.

I realize that there should be unit tests,  if this approach looks reasonable, let me know and I'll add the unit tests to this pull-request.
