### PR TITLE
Remove extra double quote from error message

### DIFF
--- a/data/src/main/java/com/linkedin/data/codec/JacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/JacksonDataCodec.java
@@ -651,7 +651,7 @@ public class JacksonDataCodec implements TextDataCodec
       {
         if (!JsonToken.START_OBJECT.equals(token))
         {
-          throw new DataDecodingException("JSON text for object must start with \"{\".\"");
+          throw new DataDecodingException("JSON text for object must start with \"{\".");
         }
 
         final DataMap map = new DataMap();
@@ -666,7 +666,7 @@ public class JacksonDataCodec implements TextDataCodec
       {
         if (!JsonToken.START_ARRAY.equals(token))
         {
-          throw new DataDecodingException("JSON text for array must start with \"[\".\"");
+          throw new DataDecodingException("JSON text for array must start with \"[\".");
         }
 
         final DataList list = new DataList();


### PR DESCRIPTION
Remove extraneous double quotes. Changes error message from:
`JSON text for object must start with "{"."` to `JSON text for object must start with "{".`
and
`JSON text for object must start with "["."` to `JSON text for object must start with "[".`