### PR TITLE
expose pool waiter count

### DIFF
--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolImpl.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolImpl.java
@@ -119,7 +119,7 @@ public class AsyncPoolImpl<T> implements AsyncPool<T>
                        int maxWaiters)
   {
     this(name, lifecycle, maxSize, idleTimeout, timeoutExecutor,
-         callbackExecutor, maxWaiters, Strategy.MRU, 0);
+        callbackExecutor, maxWaiters, Strategy.MRU, 0);
   }
 
   /**

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolImpl.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolImpl.java
@@ -119,7 +119,7 @@ public class AsyncPoolImpl<T> implements AsyncPool<T>
                        int maxWaiters)
   {
     this(name, lifecycle, maxSize, idleTimeout, timeoutExecutor,
-        callbackExecutor, maxWaiters, Strategy.MRU, 0);
+         callbackExecutor, maxWaiters, Strategy.MRU, 0);
   }
 
   /**
@@ -211,6 +211,12 @@ public class AsyncPoolImpl<T> implements AsyncPool<T>
           synchronized (_lock)
           {
             return _idle.size();
+          }
+        },
+        () -> {
+          synchronized (_lock)
+          {
+            return _waiters.size();
           }
         });
   }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolStats.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolStats.java
@@ -46,6 +46,7 @@ public class AsyncPoolStats implements PoolStats
   private final int _sampleMaxPoolSize;
 
   private final int _idleCount;
+  private final int _waitersCount;
   private final double _waitTimeAvg;
   private final long _waitTime50Pct;
   private final long _waitTime95Pct;
@@ -73,6 +74,7 @@ public class AsyncPoolStats implements PoolStats
       int sampleMaxPoolSize,
 
       int idleCount,
+      int waitersCount,
       double waitTimeAvg,
       long waitTime50Pct,
       long waitTime95Pct,
@@ -96,6 +98,7 @@ public class AsyncPoolStats implements PoolStats
     _sampleMaxPoolSize = sampleMaxPoolSize;
 
     _idleCount = idleCount;
+    _waitersCount = waitersCount;
     _waitTimeAvg = waitTimeAvg;
     _waitTime50Pct = waitTime50Pct;
     _waitTime95Pct = waitTime95Pct;
@@ -249,6 +252,17 @@ public class AsyncPoolStats implements PoolStats
   }
 
   /**
+   * Get the number of objects that are waiting
+   * in the pool.
+   * @return The number of waiting objects
+   */
+  @Override
+  public int getWaitersCount()
+  {
+    return _waitersCount;
+  }
+
+  /**
    * Get the average wait time to get a pooled object.
    * @return The average wait time.
    */
@@ -313,6 +327,7 @@ public class AsyncPoolStats implements PoolStats
         "\nsampleMaxCheckedOut: " + _sampleMaxCheckedOut +
         "\nsampleMaxPoolSize: " + _sampleMaxPoolSize +
         "\nidleCount: " + _idleCount +
+        "\nwaitersCount: " + _waitersCount +
         "\nwaitTimeAvg: " + _waitTimeAvg +
         "\nwaitTime50Pct: " + _waitTime50Pct +
         "\nwaitTime95Pct: " + _waitTime95Pct +

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolStatsTracker.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolStatsTracker.java
@@ -49,6 +49,7 @@ public class AsyncPoolStatsTracker
   private final Supplier<Integer> _poolSizeSupplier;
   private final Supplier<Integer> _checkedOutSupplier;
   private final Supplier<Integer> _idleSizeSupplier;
+  private final Supplier<Integer> _waitersSizeSupplier;
   private final LongTracking _waitTimeTracker;
 
   public AsyncPoolStatsTracker(
@@ -57,7 +58,8 @@ public class AsyncPoolStatsTracker
       Supplier<Integer> minSizeSupplier,
       Supplier<Integer> poolSizeSupplier,
       Supplier<Integer> checkedOutSupplier,
-      Supplier<Integer> idleSizeSupplier)
+      Supplier<Integer> idleSizeSupplier,
+      Supplier<Integer> waitersSizeSupplier)
   {
     _lifecycleStatsSupplier = lifecycleStatsSupplier;
     _maxSizeSupplier = maxSizeSupplier;
@@ -65,6 +67,7 @@ public class AsyncPoolStatsTracker
     _poolSizeSupplier = poolSizeSupplier;
     _checkedOutSupplier = checkedOutSupplier;
     _idleSizeSupplier = idleSizeSupplier;
+    _waitersSizeSupplier = waitersSizeSupplier;
     _waitTimeTracker = new LongTracking();
   }
 
@@ -130,6 +133,7 @@ public class AsyncPoolStatsTracker
         _sampleMaxCheckedOut,
         _sampleMaxPoolSize,
         _idleSizeSupplier.get(),
+        _waitersSizeSupplier.get(),
         waitTimeStats.getAverage(),
         waitTimeStats.get50Pct(),
         waitTimeStats.get95Pct(),

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncSharedPoolImpl.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncSharedPoolImpl.java
@@ -111,6 +111,7 @@ public class AsyncSharedPoolImpl<T> implements AsyncPool<T>
     _maxWaiters = maxWaiters;
 
     _item = new TimedObject<>();
+    _waiters = new LinkedDeque<>();
     _statsTracker = new AsyncPoolStatsTracker(
         () -> _lifecycle.getStats(),
         () -> 1,
@@ -136,8 +137,13 @@ public class AsyncSharedPoolImpl<T> implements AsyncPool<T>
             }
             return _item.get() == null ? 0 : 1;
           }
+        },
+        () -> {
+          synchronized (_lock)
+          {
+            return _waiters.size();
+          }
         });
-    _waiters = new LinkedDeque<>();
   }
 
   @Override

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/PoolStats.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/PoolStats.java
@@ -120,6 +120,13 @@ public interface PoolStats
   int getIdleCount();
 
   /**
+   * Get the number of objects that are waiting
+   * in the pool.
+   * @return The number of waiting objects
+   */
+  int getWaitersCount();
+
+  /**
    * Get the average wait time to get a pooled object.
    * @return The average wait time.
    */

--- a/r2-core/src/test/java/test/r2/transport/http/client/TestAsyncPoolStatsTracker.java
+++ b/r2-core/src/test/java/test/r2/transport/http/client/TestAsyncPoolStatsTracker.java
@@ -39,6 +39,7 @@ public class TestAsyncPoolStatsTracker
   private static final int MAX_SIZE = Integer.MAX_VALUE;
   private static final int MIN_SIZE = 0;
   private static final int IDLE_SIZE = 100;
+  private static final int WAITERS_SIZE = 150;
   private static final int POOL_SIZE = 200;
   private static final int CHECKED_OUT = 300;
 
@@ -61,13 +62,15 @@ public class TestAsyncPoolStatsTracker
         () -> MIN_SIZE,
         () -> POOL_SIZE,
         () -> CHECKED_OUT,
-        () -> IDLE_SIZE);
+        () -> IDLE_SIZE,
+        () -> WAITERS_SIZE);
 
     AsyncPoolStats stats = tracker.getStats();
     Assert.assertSame(stats.getLifecycleStats(), LIFECYCLE_STATS);
     Assert.assertEquals(stats.getMaxPoolSize(), MAX_SIZE);
     Assert.assertEquals(stats.getMinPoolSize(), MIN_SIZE);
     Assert.assertEquals(stats.getIdleCount(), IDLE_SIZE);
+    Assert.assertEquals(stats.getWaitersCount(), WAITERS_SIZE);
     Assert.assertEquals(stats.getCheckedOut(), CHECKED_OUT);
     Assert.assertEquals(stats.getPoolSize(), POOL_SIZE);
 
@@ -93,7 +96,8 @@ public class TestAsyncPoolStatsTracker
         () -> MIN_SIZE,
         () -> POOL_SIZE,
         () -> CHECKED_OUT,
-        () -> IDLE_SIZE);
+        () -> IDLE_SIZE,
+        () -> WAITERS_SIZE);
 
     IntStream.range(0, DESTROY_ERROR_INCREMENTS).forEach(i -> tracker.incrementDestroyErrors());
     IntStream.range(0, DESTROY_INCREMENTS).forEach(i -> tracker.incrementDestroyed());
@@ -122,7 +126,8 @@ public class TestAsyncPoolStatsTracker
         () -> MIN_SIZE,
         () -> _poolSize,
         () -> _checkedOut,
-        () -> IDLE_SIZE);
+        () -> IDLE_SIZE,
+        () -> WAITERS_SIZE);
 
     // Samples the max pool size at POOL_SIZE
     tracker.sampleMaxPoolSize();
@@ -158,7 +163,8 @@ public class TestAsyncPoolStatsTracker
         () -> MIN_SIZE,
         () -> _poolSize,
         () -> _checkedOut,
-        () -> IDLE_SIZE);
+        () -> IDLE_SIZE,
+        () -> WAITERS_SIZE);
 
     for (int i = 0; i < 10; i++)
     {


### PR DESCRIPTION
In order to monitor R2 waiters and prevent "reached maximum waiter size" exceptions, I have exposed a pool waitersCount stat.