### PR TITLE
Fix #106: Add missing testCompile dependencies on guava

### DIFF
--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -18,6 +18,8 @@ dependencies {
   compile externalDependency.jacksonDataBind
   compile externalDependency.jdkTools
   compile externalDependency.zero_allocation_hashing
+
+  testCompile externalDependency.guava
   testCompile externalDependency.testng
   testCompile externalDependency.commonsIo
   testCompile externalDependency.easymock

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compile externalDependency.jacksonSmile
 
   testCompile project(':data-testutils')
+  testCompile externalDependency.guava
   testCompile externalDependency.commonsIo
   testCompile externalDependency.testng
 

--- a/generator/build.gradle
+++ b/generator/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   compile externalDependency.codemodel
   compile externalDependency.jsr305
 
+  testCompile externalDependency.guava
   testCompile externalDependency.testng
   testCompile externalDependency.mockito
 }


### PR DESCRIPTION
Everything now compiles and most tests pass, but the fixture `test.r2.integ.clientserver.TestHttpsCheckCertificate#setUp` fails with the following:
```
java.io.IOException: Failed to start Jetty on port 6943
	at com.linkedin.r2.transport.http.server.HttpJettyServer.start(HttpJettyServer.java:133)
	at test.r2.integ.clientserver.providers.AbstractEchoServiceTest.setUp(AbstractEchoServiceTest.java:83)
...
Caused by: java.net.BindException: Address already in use
```
