### PR TITLE
Fix all known broken links

### DIFF
--- a/Asynchronous-Servers-and-Clients-in-Rest_li.md
+++ b/Asynchronous-Servers-and-Clients-in-Rest_li.md
@@ -308,7 +308,7 @@ We want to make our Rest.li requests in parallel. To do this we use the `Tasks.p
 
 #### Using Promises
 
-`ParSeqRestClient` also has a `Promise` based API. It is very similar to the `Callback` based approach of sending a request. The main difference is that instead of passing in a `Callback` to the `sendRequest` call we attach a `PromiseListener` that is invoked asynchronously when we get a result from the server. Here is the [Callback example](Asynchronous-Servers-and-Clients-in-Rest.li#using-callbacks-1) implemented using the `Promise` API - 
+`ParSeqRestClient` also has a `Promise` based API. It is very similar to the `Callback` based approach of sending a request. The main difference is that instead of passing in a `Callback` to the `sendRequest` call we attach a `PromiseListener` that is invoked asynchronously when we get a result from the server. Here is the [Callback example](#using-callbacks-1) implemented using the `Promise` API:
 
 ```java
 Request<Greeting> getRequest = BUILDERS.get().id(1L).build();

--- a/Dynamic-Discovery.md
+++ b/Dynamic-Discovery.md
@@ -9,12 +9,12 @@ excerpt: Dynamic Discovery (D2) is a layer of indirection similar to DNS for the
 
 ## Contents
 
-* [What is D2](Dynamic-Discovery#what-is-d2)
-* [Terminology](Dynamic-Discovery#terminology)
-* [D2 and Zookeeper](Dynamic-Discovery#d2-and-zookeeper)
-* [D2 Load Balancer](Dynamic-Discovery#d2-load-balancer)
-* [Stores](Dynamic-Discovery#stores)
-* [Operations](Dynamic-Discovery#operations)
+* [What is D2](#what-is-d2)
+* [Terminology](#terminology)
+* [D2 and Zookeeper](#d2-and-zookeeper)
+* [D2 Load Balancer](#d2-load-balancer)
+* [Stores](#stores)
+* [Operations](#operations)
 
 ## What is D2
 

--- a/Rest_li-2.x-upgrade-instructions.md
+++ b/Rest_li-2.x-upgrade-instructions.md
@@ -6,14 +6,14 @@ permalink: /Rest_li-2_x-upgrade-instructions
 
 ## Contents
 
-* [Introduction](Rest.li-2.x-upgrade-instructions#introduction)
-* [Source Code Changes](Rest.li-2.x-upgrade-instructions#source-code-changes)
-* [Protocol Changes](Rest.li-2.x-upgrade-instructions#protocol-changes)
-* [Upgrade and Deployment Ordering](Rest.li-2.x-upgrade-instructions#upgrade-and-deployment-ordering)
+* [Introduction](#introduction)
+* [Source Code Changes](#source-code-changes)
+* [Protocol Changes](#protocol-changes)
+* [Upgrade and Deployment Ordering](#upgrade-and-deployment-ordering)
 
 ## Introduction
 
-Rest.li 2.0 introduces a new backwards incompatible URI format, as well as removes several APIs that have been marked as deprecated for quite some time. You can find details about these changes on our [user guide](Rest.li-User-Guide) as well as our [protocol documentation](Rest.li-Protocol). This page documents the steps needed to upgrade from a 1.x release to a 2.x release.
+Rest.li 2.0 introduces a new backwards incompatible URI format, as well as removes several APIs that have been marked as deprecated for quite some time. You can find details about these changes on our [user guide](user_guide/server_architecture) as well as our [protocol documentation](spec/protocol). This page documents the steps needed to upgrade from a 1.x release to a 2.x release.
 
 Having issues with any of the steps listed below? Please [create an issue](https://github.com/linkedin/rest.li/issues) and someone from the Rest.li team will help you.
 
@@ -32,7 +32,7 @@ Take these steps to make your source code compatible with Rest.li 2.x:
 
 For the most part the protocol changes are taken care off under the hood by Rest.li. As an application developer, you don't have to worry about the Rest.li 2.0 protocol changes.
 
-However, if you are hard coding URLs, HTTP request/response bodies, or HTTP request/response headers in your code you will have to update these to the Rest.li 2.0 protocol format. Details of the protocol can be found on [this page](Rest.li-Protocol).
+However, if you are hard coding URLs, HTTP request/response bodies, or HTTP request/response headers in your code you will have to update these to the Rest.li 2.0 protocol format. Details of the protocol can be found on [this page](spec/protocol).
 
 ## Upgrade and Deployment Ordering
 

--- a/Rest_li_Avro_conversions.md
+++ b/Rest_li_Avro_conversions.md
@@ -62,7 +62,7 @@ com.linkedin.data.avro.DataTranslator(dataMap, dataSchema, avroSchema);
 
 Rest.li will generate avro schemas for all your pegasus schemas (.pdsc files) automatically if the build is configured to enable this.
 
-See [Gradle generateAvroSchema Task](Gradle-build-integration#wiki-generateavroschema) for details on how to enable.
+See [Gradle generateAvroSchema Task](setup/gradle#generateavroschema) for details on how to enable.
 
 ## FAQ
 ### How do I get the RecordDataSchema of a particular Record type?

--- a/Send-Rest_li-Request-Query-In-Request-Body_converted.md
+++ b/Send-Rest_li-Request-Query-In-Request-Body_converted.md
@@ -17,7 +17,7 @@ excerpt: Rest.li protocol specifies what HTTP method will be used for each type 
 
 ## Introduction
 
-[Rest.li protocol](Rest.li-Protocol) specifies what HTTP method will be used for each type of Rest.li request. However, sometimes due to security constraint  (i.e. not wanting to send some sensitive information in URI) or jetty buffer limitation (i.e. there may pose a threshold on the longest query that can go through), it may be required to customize the HTTP method used to send a particular Rest.li request to a Rest.li server.
+The [Rest.li protocol](spec/protocol) specifies what HTTP method will be used for each type of Rest.li request. However, sometimes due to security constraint  (i.e. not wanting to send some sensitive information in URI) or jetty buffer limitation (i.e. there may pose a threshold on the longest query that can go through), it may be required to customize the HTTP method used to send a particular Rest.li request to a Rest.li server.
 
 ## ClientQueryTunnelFilter and ServerQueryTunnelFilter
 

--- a/Validation-in-Rest_li_converted.md
+++ b/Validation-in-Rest_li_converted.md
@@ -256,7 +256,7 @@ ERROR :: /stringA :: length of “Lorem ipsum dolor sit amet” is out of range 
 ERROR :: /stringB :: field is required but not found and has no default value
 ```
 
-[Rest.li Filters - Configuration](Rest.li-Filters#configuring-filters) explains how to install the filter.
+[Rest.li Filters](Rest_li-Filters) explains how to install the filter.
 
 ### Request validation during resource handling
 
@@ -374,9 +374,8 @@ Otherwise the data and the schema information is enough. [Data to Schema
 Validation](DATA-Data-Schema-and-Templates#data-to-schema-validation)
 explains how to validate data using the `ValidateDataAgainstSchema`
 class. If it is used with `DataSchemaAnnotationValidator`, it will
-consider the first two types of rules out of three listed in [Specifying
-Validation
-Rules](Validation-in-Rest.li#specifying-validation-rules).
+consider the first two types of rules out of three listed in
+[Specifying Validation Rules](#specifying-validation-rules).
 
 For example:  
 ```java

--- a/Writing-unit-tests-for-Rest_li-clients-and-servers.md
+++ b/Writing-unit-tests-for-Rest_li-clients-and-servers.md
@@ -88,7 +88,7 @@ MockSuccessfulResponseFutureBuilder<CollectionResponse<Greeting>> responseFuture
 
 #### MockHttpServerFactory
 
-The `MockHttpServerFactory` class is used to create a stand-alone Rest.li server easily that you can then write tests against. The primary use case for this class would be to bring up a Rest.li server at the start of the test, and then each test can test a different endpoint that this server supports. This factory also allows us to pass in beans that would have been injected into your Rest.li server by the Rest.li framework. For more information on bean injection in a Rest.li server, see the [documentation on Dependency Injection](Rest.li-User-Guide#dependency-injection). 
+The `MockHttpServerFactory` class is used to create a stand-alone Rest.li server easily that you can then write tests against. The primary use case for this class would be to bring up a Rest.li server at the start of the test, and then each test can test a different endpoint that this server supports. This factory also allows us to pass in beans that would have been injected into your Rest.li server by the Rest.li framework. For more information on bean injection in a Rest.li server, see the [documentation on Dependency Injection](user_guide/restli_server#dependency-injection).
 
 Suppose we want to test that we have implemented the GET method correctly for our resource `GreetingsResource`. Let's assume that `GreetingsResource` needs one bean named "db" of type `DataBase` to be injected. Here is what our test might look like (assuming we are using TestNG):
 

--- a/_data/user_guide_navigation.yml
+++ b/_data/user_guide_navigation.yml
@@ -20,7 +20,7 @@ toc:
       - page: Modeling Resources
         url: /rest.li/modeling/modeling
       - page: Snapshots and Resource Compatibility Checking
-        url: /rest.li/modeling/compatibiltiy_check
+        url: /rest.li/modeling/compatibility_check
   - title: Main concepts
     subfolderitems:
       - page: Filters

--- a/compatibility_check.md
+++ b/compatibility_check.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Rest.li Snapshots and Resource Compatibility Checking
-permalink: /modeling/compatibiltiy_check
+permalink: /modeling/compatibility_check
 index: 2
 excerpt: Due to the fact that resources and clients can be upgraded separately, it is very important to developers that they be notified of any changes they make that could cause backwards or forwards compatibility issues. To that end, Rest.li uses a form of expanded IDLs, called Snapshots, to keep track of the state of resources and check compatibility between resource iterations.
 ---
@@ -59,7 +59,7 @@ It's true that there may be well controlled use case were an enum is used only b
 Given all these potential issues with adding a enum symbol, it's important to think of adding enum symbols as backward incompatible.  If a new symbols is to be added, a migration strategy for adding the enum symbol(s) must be performed just as for any other backward incompatible change.  Note that this is only possible when all clients are known and it is possible to coordinate changes with them.  If this is not the case,  one should consider making a backward compatible change (such as adding a new optional field containing a new enum field with more symbols) and supporting the existing clients, with the existing enum symbols, indefinitely.
 
 One possible backwards incompatible migration strategy for adding a enum symbol might be:
-* Add the symbol as a backward incompatible change to the data schema,  use the rest.li [gradle rest.model.compatibility flag](Gradle-build-integration#compatibility) to "ignore" the backward incompatible change.  If you are using [semantic versioning](http://semver.org/), you should also increment your MAJOR version number.  Do NOT start writing data that contains the new enum value yet.
+* Add the symbol as a backward incompatible change to the data schema,  use the rest.li [gradle `rest.model.compatibility` flag](/rest.li/setup/gradle#compatibility) to "ignore" the backward incompatible change.  If you are using [semantic versioning](http://semver.org/), you should also increment your MAJOR version number.  Do NOT start writing data that contains the new enum value yet.
 * Once the backward incompatible change has been published, REST API clients must be notified to the change. They should be provided with details on the enum symbol that has been added and how to migrate their applications.   Clients should NOT write using the new symbol yet (the resource implementation may choose to reject requests to POST or PUT data with the new symbol).
 * Only once all clients have migrated to the new (backward incompatible version) of the API, clients and the resource implementation may start writing data using the new symbol.
 

--- a/d2_quick_start.md
+++ b/d2_quick_start.md
@@ -447,8 +447,7 @@ ones.
     parameter and that’s beyond the scope of this example. 
 
 The rest of the config values should be pretty obvious. For the list of
-all configuration please see [D2 Zookeeper
-Properties](D2-Zookeeper-Properties)
+all configuration please see [D2 Zookeeper Properties](/rest.li/D2-Zookeeper-Properties).
 
 Then we modify the config’s build.gradle to add our java dependencies.
 

--- a/gradle.md
+++ b/gradle.md
@@ -161,7 +161,7 @@ To acknowledge a backwards compatible interface change use:
 
     gradle build -Prest.model.compatibility=backwards
 
-For additional details on compatibility checking, see [Resource Compatibility Checking](https://maximelamure.github.io/rest.li/modeling/compatibiltiy_check).
+For additional details on compatibility checking, see [Resource Compatibility Checking](/rest.li/modeling/compatibility_check).
 
 ## Publishing Maven Artifacts
 

--- a/guide_restli_client.md
+++ b/guide_restli_client.md
@@ -689,8 +689,7 @@ At a high level, the restspec contains the following information:
 -   a description of each subresource, containing the information
     described above
 
-Additional details on the Restspec format may be found in the [design
-documents](Rest.li-.restspec.json-Format).
+Additional details on the Restspec format may be found in the [design documents](/rest.li/spec/restspec_format).
 The Restspec format is formally described by the .pdsc schema files in
 "com.linkedin.restli.restspec.* " distributed in the restli-common
 module.

--- a/guide_restli_server.md
+++ b/guide_restli_server.md
@@ -197,7 +197,7 @@ the resource is intended to implement. Briefly, here are the options:
 The @`RestLiCollection` annotation is applied to classes to mark them as
 providing a Rest.li collection resource. Collection resources model a
 collection of entities, where each entity is referenced by a key. See
-[Collection Resource Pattern](/rest.li/modeling/modeling/#collection) for more details.
+[Collection Resource Pattern](/rest.li/modeling/modeling#collection) for more details.
 
 
 
@@ -440,8 +440,8 @@ The @`RestLiAssociation` annotation is applied to classes to mark them
 as providing a Rest.li association resource. Association resources model
 a collection of relationships between entities. Each relationship is
 referenced by the keys of the entities it relates and may define
-attributes on the relation itself. See [Association Resource
-Pattern](Modeling-Resources-with-Rest.li#wiki-Association)
+attributes on the relation itself. See
+[Association Resource Pattern](/rest.li/modeling/modeling#association)
 for more details.
 
 For Example:

--- a/modeling.md
+++ b/modeling.md
@@ -13,11 +13,9 @@ index: 2
   - [Rest.li’s Uniform Interface](#restlis-uniform-interface)
   - [Rest.li Modeling Tips](#restli-modeling-tips)
   - [Common Modeling Challenges](#common-modeling-challenges)
-  - [Options for Modeling Entity
-    Relationships](#options-for-modeling-entity-relationships)
+  - [Options for Modeling Entity Relationships](#options-for-modeling-entity-relationships)
   - [General Tips](#general-tips)
-  - [When All Else Fails: Non-Uniform
-    Interfaces](#when-all-else-fails-non-uniform-interfaces)
+  - [When All Else Fails: Non-Uniform Interfaces](#when-all-else-fails-non-uniform-interfaces)
 
 This document will describe how to model a resource using Rest.li. Before reading this page, you may want to get a feel for how to write and build code with Rest.li by reading the [Tutorial to Create a Server and Client](/rest.li/start/step_by_step).
 

--- a/protocol.md
+++ b/protocol.md
@@ -13,10 +13,8 @@ excerpt: Rest.li Protocol
   - [URI Syntax](#uri-syntax)
   - [Online Documentation](#online-documentation)
   - [Content Types](#content-types)
-  - [Rest.li Protocol 2.0 Object and List/Array
-    Representation](#restli-protocol-20-object-and-listarray-representation)
-  - [Complex types, complex keys, and compound keys in the Rest.li 2.0
-    Protocol](#complex-types-complex-keys-and-compound-keys-in-the-restli-20-protocol)
+  - [Rest.li Protocol 2.0 Object and List/Array Representation](#restli-protocol-20-object-and-listarray-representation)
+  - [Complex types, complex keys, and compound keys in the Rest.li 2.0 Protocol](#complex-types-complex-keys-and-compound-keys-in-the-restli-20-protocol)
   - [Collection Resources](#collection-resources)
   - [Simple Resources](#simple-resources)
   - [Association Resources](#association-resources)
@@ -69,10 +67,10 @@ Consider the following functions:
     `v`
   - if `v` is a map then `encoded(v)` = the URL encoding for a map as
     described in the [Rest.li 2.0 protocol object URL
-    representation](Rest.li-Protocol#url-representation)
+    representation](#url-representation)
   - if `v` is an array then `encoded(v)` = the URL encoding for an array
     as described in the [Rest.li 2.0 protocol array URL
-    representation](Rest.li-Protocol#url-representation-1)
+    representation](#url-representation-1)
 
 `reducedEncoded(v)` is defined as follows -
 
@@ -81,11 +79,11 @@ Consider the following functions:
   - if `v` is a map then `reducedEncoded(v)` = the HTTP body/header
     encoding for a map as described in the [Rest.li 2.0 protocol object
     HTTP body and headers
-    representation](Rest.li-Protocol#http-body-and-headers-representation)
+    representation](#http-body-and-headers-representation)
   - if `v` is an array then `reducedEncoded(v)` = the HTTP body/header
     encoding for an array as described in the [Rest.li 2.0 protocol
     array HTTP body and headers
-    representation](Rest.li-Protocol#http-body-and-headers-representation-1)
+    representation](#http-body-and-headers-representation-1)
 
 `encoded` and `reducedEncoded` will be used in the sections below.
 
@@ -94,7 +92,7 @@ Consider the following functions:
 Rest.li objects defined using Pegasus Data Schema (PDSC) is serialized
 as JSON representation for transportation over the wire. For detailed
 transport serialization, please see [How Data is Serialized for
-Transport](DATA-Data-Schema-and-Templates#how-data-is-serialized-for-transport).
+Transport](/rest.li/DATA-Data-Schema-and-Templates#how-data-is-serialized-for-transport).
 
 ### Rest.li Protocol 2.0 Object Representation
 
@@ -115,10 +113,10 @@ An object can be present as values for the following headers -
 
   - <code>Location</code> - if present here we simply use the
     [Rest.li 2.0 protocol object URL
-    representation](Rest.li-Protocol#url-representation)
+    representation](#url-representation)
   - <code>X-RestLi-Id</code> or <code>X-LinkedIn-Id</code> - we use the
     [Rest.li 2.0 protocol object HTTP body and headers
-    representation](Rest.li-Protocol#http-body-and-headers-representation)
+    representation](#http-body-and-headers-representation)
 
 ##### Body representation
 
@@ -143,10 +141,10 @@ An array can be present as values for the following headers -
 
   - <code>Location</code> - if present here we simply use the
     [Rest.li 2.0 protocol array URL
-    representation](Rest.li-Protocol#url-representation-1)
+    representation](#url-representation-1)
   - <code>X-RestLi-Id</code> or <code>X-LinkedIn-Id</code> - we use the
     [Rest.li 2.0 protocol array HTTP body and headers
-    representation](Rest.li-Protocol#http-body-and-headers-representation-1)
+    representation](#http-body-and-headers-representation-1)
 
 ##### Body representation
 
@@ -209,9 +207,9 @@ a collection of key-value pairs. Because of this similarity in structure
 we decided to represent both using the Rest.li 2.0 object notation. Any
 list present as a value in the complex key uses the Rest.li 2.0 list
 notation. Details can be found in the [Association
-keys](Rest.li-Protocol#association-keys)
+keys](#association-keys)
 and [complex
-keys](Rest.li-Protocol#complex-types-as-keys-in-protocol-20)
+keys](#complex-types-as-keys-in-protocol-20)
 sections.
 
 ## Collection Resources
@@ -1016,7 +1014,7 @@ The `Params` of a `ComplexResourceKey` are always prefixed with
 
 The serialized form of a complex key uses the [Rest.li 2.0 protocol
 object
-notation](Rest.li-Protocol#restli-protocol-20-object-representation)
+notation](#restli-protocol-20-object-representation)
 . For example, given the complex data:
 
 
@@ -1113,7 +1111,7 @@ position, but the paths for the keys in the JSON body are not.
 
 If used in batch requests, each key in the batch is represented as an
 element in the <code>ids</code> array using the [protocol 2.0 array
-notation](Rest.li-Protocol#restli-20-protocol-array-notation)
+notation](#restli-20-protocol-array-notation)
 .
 
 For example,
@@ -1156,7 +1154,7 @@ the “entities” part of the body:
     
 
 As long as the [protocol 2.0 array
-notation](Rest.li-Protocol#restli-20-protocol-array-notation)
+notation](#restli-20-protocol-array-notation)
 is being adhered to no addional escaping is required for complex keys in
 a batch request.
 

--- a/step_by_step.md
+++ b/step_by_step.md
@@ -184,8 +184,7 @@ responds to GET requests.
 The basic steps you will follow to create a Rest.li server are:
 
 1.  Define data schema. Rest.li uses an Avro-like format known as
-    [Pegasus Data
-    Schema](DATA-Data-Schema-and-Templates) to
+    [Pegasus Data Schema](/rest.li/DATA-Data-Schema-and-Templates) to
     define the resource data.
 
 2. Generate language bindings. Rest.li will generate java class
@@ -238,8 +237,8 @@ it in a path corresponding to your namespace, under
 `Fortune.pdsc` defines a record named Fortune, with an associated
 namespace. The record has one field, a string whose name is `fortune`.
 Fields as well as the record itself can have optional documentation
-strings. This is, of course, a very simple schema. See [Data Schema and
-Templates](DATA-Data-Schema-and-Templates) for
+strings. This is, of course, a very simple schema. See
+[Data Schema and Templates](/rest.li/DATA-Data-Schema-and-Templates) for
 details on the syntax and more complex examples.
 
 ### Step 2. Generate Java Bindings
@@ -394,9 +393,8 @@ that can respond to a GET request by returning data according to the
 model. The only thing remaining is to configure a HTTP framework to call
 our application logic. We will use Netty, an excellent framework that
 works great with Rest.li to build fully async services. For details on
-how to configure Rest.li with other servlet containers see [Rest.li with
-Servlet
-Containers](Rest.li-with-Servlet-Containers).
+how to configure Rest.li with other servlet containers see
+[Rest.li with Servlet Containers](/rest.li/Rest_li-with-Servlet-Containers).
 
 Rest.li also includes a Request Response layer (R2) that provides a
 transport abstraction and other services.


### PR DESCRIPTION
Closes #131 

Fixes all broken links picked up by a site crawler script.
Also fixes some line-ending issues which resulted in whole
files being altered. Also fixed a misspelled file name.