### PR TITLE
Add documentation for namespace override in Avro translation

### DIFF
--- a/Rest_li_Avro_conversions.md
+++ b/Rest_li_Avro_conversions.md
@@ -33,7 +33,11 @@ com.linkedin.data.avro.SchemaTranslator.dataToAvroSchema(dataSchema);
 com.linkedin.data.avro.SchemaTranslator.dataToAvroSchema(dataSchema, translationOptions);
 ```
 
-`DataToAvroSchemaTranslationOptions` has three parts: the translation mode `OptionalDefaultMode`, the JSON style `JsonBuilder.Pretty`, and the schema embedding mode `EmbedSchemaMode`.
+`DataToAvroSchemaTranslationOptions` has four parts:
+* The translation mode `OptionalDefaultMode`
+* The JSON style `JsonBuilder.Pretty`
+* The schema embedding mode `EmbedSchemaMode`
+* The namespace override flag `overrideNamespace`
 
 `OptionalDefaultMode` determines how defaults are translated into Rest.li format.  Since Avro requires that a union's default value always be of the same type as the first member type of the union, if a type is not consistently initialized with a single default type, translations may encounter problems.  By default this value is set to `TRANSLATE_DEFAULT`, but if your translations are encountering issues around default values, you may wish to set this to `TRANSLATE_TO_NULL`, which will cause all optional fields with a default value to have their default value set to null in the Avro translation.
 
@@ -41,6 +45,8 @@ com.linkedin.data.avro.SchemaTranslator.dataToAvroSchema(dataSchema, translation
 
 `EmbedSchemaMode` determines whether or not to embed the original Rest.li schema into the resulting Avro schema.  This can speed translation back (or make a translation back more accurate) to Rest.li format with the correct settings passed to the `avroToDataSchema` method. By default, this is set to `NONE`.
 
+`overrideNamespace` is a boolean flag indicating whether the namespaces of the translated Avro schemas should be overridden. If this flag is set to `true`, then the namespace of each translated Avro schema will be prepended with a special prefix,
+`"avro."` (e.g. `com.x.y` becomes `avro.com.x.y`). This is helpful in cases where PDSC schemas and their Avro counterparts are included in the same project, potentially causing namespace/package conflicts.
 
 ## Converting Data
 The key class for converting data is the `DataTranslator` class.

--- a/gradle.md
+++ b/gradle.md
@@ -392,13 +392,17 @@ This is provided for reference only.  A understanding of these classes is not re
 Generate Avro avsc files from Pegasus Data Model schemas (.pdsc files):
 
     java [-Dgenerator.resolver.path=<dataSchemaRelativePath>] \
+      [-Dgenerator.avro.optional.default=<optionalDefault>] \
+      [-Dgenerator.avro.namespace.override=<overrideNamespace>] \
       -cp <CLASSPATH> com.linkedin.data.avro.generator.AvroSchemaGenerator \
       <outputDir> [<inputFileOrDir> ...]
 
-* dataSchemaRelativePath - Path to .pdsc files. (e.g.,  /src/main/pegasus).
+* dataSchemaRelativePath - Path to `.pdsc` files. (e.g., `/src/main/pegasus`).
+* optionalDefault - Specifies how an optional field with a default value should be translated (see [Converting Rest.li to Avro](/rest.li/Rest_li_Avro_conversions#converting-restli-to-avro)).
+* overrideNamespace - If `true`, each translated `.avsc` file will have its namespace prepended with `"avro."` (see [Converting Rest.li to Avro](/rest.li/Rest_li_Avro_conversions#converting-restli-to-avro)).
 * CLASSPATH - `com.linkedin.pegasus:data:[CURRENT_VERSION]` AND `com.linkedin.pegasus:data-avro:[CURRENT_VERSION]` artifacts and all their dependencies.
-* outputDir - output directory for generated avsc files
-* inputFileOrDir - file name of a Pegasus data schema file, a directory containing Pegasus data schema files, or a fully qualified schema name
+* outputDir - output directory for generated `.avsc` files.
+* inputFileOrDir - file name of a Pegasus data schema file, a directory containing Pegasus data schema files, or a fully qualified schema name.
 
 Build integration: for builds requiring avro schemas, assembly (creation of jar) should depend on this task
 


### PR DESCRIPTION
Adding documentation for how to use the namespace override option in Avro translation, since apparently there's no documentation at all about this. Also updated the part that describes the command-line arguments to use in order to add the system properties for this as well as for the optional default option.