### PR TITLE
Fix syntax highlighter configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,4 +11,5 @@ toc:
 
 # Enables syntax highlighting
 highlighter:
-  rogue
+  rouge
+


### PR DESCRIPTION
Fixes bug from PR #137 

Misspelled "rouge" as "rogue"