### PR TITLE
Fix formatting on the "How to Use Projections" page

### DIFF
--- a/How-to-use-projections-in-Java_converted.md
+++ b/How-to-use-projections-in-Java_converted.md
@@ -42,14 +42,15 @@ which represent specific fields of an object. To get a `PathSpec` of a
 field *bar* of a RecordTemplate object *Foo*, you would write the
 following:
 
-```java  
-PathSpec pathSpec = Foo.fields().bar();  
+```java
+PathSpec pathSpec = Foo.fields().bar();
 ```
 
 For Paging projection, here is an example on how to get the `PathSpec`
-of the *total* field:  
-```java  
-PathSpec pathSpec = CollectionMetadata.fields().total();  
+of the *total* field:
+
+```java
+PathSpec pathSpec = CollectionMetadata.fields().total();
 ```
 
 It is not possible to set projections for non-RecordTemplate objects.
@@ -60,17 +61,17 @@ Projections are set by the request builder. To set a request projection
 for entity objects in the response, create your builder as you normally
 would and then add your projection to it:
 
-```java  
-builder.fields(pathSpec);  
+```java
+builder.fields(pathSpec);
 ```
 
 the `fields()` method can take as arguments any number of PathSpecs, or
 an array of them.
 
-```java  
+```java
 builder.fields(pathSpec1, pathSpec2, pathSpec3);
 
-builder.fields(pathSpecArray);  
+builder.fields(pathSpecArray);
 ```
 
 This will create a positive projection for your given fields. The
@@ -81,9 +82,9 @@ Similarly, you can do the same for custom Metadata projection and Paging
 projection for resource methods that return `CollectionResult`, for
 example:
 
-```java  
-builder.metadataFields(pathSpec1, pathSpec2);  
-builder.pagingFields(CollectionMetadata.fields().total());  
+```java
+builder.metadataFields(pathSpec1, pathSpec2);
+builder.pagingFields(CollectionMetadata.fields().total());
 ```
 
 ## Turning Off the Rest.li Framework’s `AUTOMATIC` Projection
@@ -95,111 +96,103 @@ turn off the framework’s `AUTOMATIC` projection processing.
 This can be done by setting the “projection mode” to `MANUAL` on the
 ResourceContext:
 
-```java  
-//For entity objects in the response  
+```java
+//For entity objects in the response
 getContext().setProjectionMode(ProjectionMode.MANUAL);
 
-//For custom Metadata projection (CollectionResult only)  
-getContext().setMetadataProjectionMode(ProjectionMode.MANUAL);  
+//For custom Metadata projection (CollectionResult only)
+getContext().setMetadataProjectionMode(ProjectionMode.MANUAL);
 ```
 
 For example:
 
-```java  
-public Greeting get(Long key)  
-{  
-MaskTree mask = context.getProjectionMask();  
-if (mask != null)  
-{  
-// client has requested a projection of the entity  
-getContext().setProjectionMode(ProjectionMode.MANUAL); // since we’re
-manually applying the projection  
-// manually examine the projection and apply it entity before
-returning  
-// here we can take advantage of the information the projection provides
-to only load the data the  
-// client requested  
-}  
-else  
-{  
-// client is requesting the full entity  
-// construct and return the full entity  
-}  
-}  
+```java
+public Greeting get(Long key)
+{
+  MaskTree mask = context.getProjectionMask();
+  if (mask != null)
+  {
+    // client has requested a projection of the entity
+    getContext().setProjectionMode(ProjectionMode.MANUAL); // since we’re manually applying the projection
+    // manually examine the projection and apply it entity before returning
+    // here we can take advantage of the information the projection provides to only load the data the
+    // client requested
+  }
+  else
+  {
+    // client is requesting the full entity
+    // construct and return the full entity
+  }
+}
 ```
 
 and in the case of CollectionResult, you could do the following as well:
 
-```java  
+```java
 @Finder("myFinder")
-public CollectionResult<SomeEntity, SomeCustomEntity>
-myFinderResourceMethod(
-final @PagingContextParam PagingContext ctx,  
-final @ProjectionParam MaskTree entityObjectProjection,
-final @MetadataProjectionParam MaskTree metadataProjection,  
-final @PagingProjectionParam MaskTree pagingProjection)  
+public CollectionResult<SomeEntity, SomeCustomEntity> myFinderResourceMethod(
+  final @PagingContextParam PagingContext ctx,
+  final @ProjectionParam MaskTree entityObjectProjection,
+  final @MetadataProjectionParam MaskTree metadataProjection,
+  final @PagingProjectionParam MaskTree pagingProjection)
 {
 
-final List<SomeEntity> responseList = new ArrayList<>();  
-if (entityObjectProjection != null)  
-{  
-  // client has requested a projection of the entity  
-  getContext().setProjectionMode(ProjectionMode.MANUAL); // since we’re
-  manually applying the projection  
-  // manually examine the projection and apply it entity before
-  returning  
-  // here we can take advantage of the information the projection provides
-  to only load the data the  
-  // client requested  
-  responseList.addAll(fetchFiltereredEntities());  
-}  
-else  
-{  
-  // client is requesting the full entities  
-  // construct the full entities  
-  responseList.addAll(fetchEntities());  
+  final List<SomeEntity> responseList = new ArrayList<>();
+  if (entityObjectProjection != null)
+  {
+    // client has requested a projection of the entity
+    getContext().setProjectionMode(ProjectionMode.MANUAL); // since we’re manually applying the projection
+
+    // manually examine the projection and apply it entity before returning
+    // here we can take advantage of the information the projection provides to only load the data the
+    // client requested
+    responseList.addAll(fetchFiltereredEntities());
+  }
+  else
+  {
+    // client is requesting the full entities
+    // construct the full entities
+    responseList.addAll(fetchEntities());
+  }
+
+  final SomeCustomEntity customEntity;
+  if (metadataProjection != null)
+  {
+    // client has requested a projection of the custom metadata
+    getContext().setMetadataProjectionMode(ProjectionMode.MANUAL); // since we’re manually applying the meta data projection
+
+    // manually examine the projection and apply it entity before returning
+    // here we can take advantage of the information the projection provides to only load the data the
+    // client requested
+    customEntity = fetchSomeFilteredCustomEntity();
+  }
+  else
+  {
+    // client is requesting the full metadata entity
+    // construct and return the full metadata
+    customEntity = fetchSomeCustomEntity();
+  }
+
+  final Integer total;
+  if (pagingProjection != null)
+  {
+    // client has requested a projection of the paging information
+    // since the rest.li framework will always automatically project paging,
+    // we can still selectively calculate the total based on the path spec
+    if(pagingProjections.getOperations.get(CollectionMetadata.fields().total()) == MaskOperation.POSITIVE_MASK_OP)
+    {
+      total = calculateTimeConsumingTotal();
+    }
+  }
+  else
+  {
+    total = null;
+  }
+
+  return new CollectionResult(responseList, total, customEntity);
 }
 
-final SomeCustomEntity customEntity;  
-if (metadataProjection != null)  
-{  
-  // client has requested a projection of the custom metadata  
-  getContext().setMetadataProjectionMode(ProjectionMode.MANUAL); // since
-  we’re manually applying the meta data projection  
-  // manually examine the projection and apply it entity before
-  returning  
-  // here we can take advantage of the information the projection provides
-  to only load the data the  
-  // client requested  
-  customEntity = fetchSomeFilteredCustomEntity();  
-}  
-else  
-{  
-  // client is requesting the full metadata entity  
-  // construct and return the full metadata  
-  customEntity = fetchSomeCustomEntity();  
-}
-
-final Integer total;  
-if (pagingProjection != null)  
-{  
-  // client has requested a projection of the paging information  
-  // since the rest.li framework will always automatically project paging,
-  we can still selectively calculate the total based on the path spec  
-  if(pagingProjections.getOperations.get(CollectionMetadata.fields().total())
-  == MaskOperation.POSITIVE_MASK_OP)  
-  {  
-    total = calculateTimeConsumingTotal();  
-  }  
-}  
-else  
-{  
-  total = null;  
-}
-
-return new CollectionResult(responseList, total, customEntity);  
-}  
-```  
+```
 Note that Paging projection is always automatically applied by the
 Rest.li framework if there is a request by the client to do so. This is
 because it is the Rest.li framework who is responsible for constructing
@@ -221,10 +214,13 @@ call.
 
 Yes, the simplest way to is to use the `RecordTemplate.fields()` method
 to help construct the appropriate pathspec to pass to the builder’s
-`.fields(...)` method call. E.g.
+`.fields(...)` method call. For example:
 
-```java  
-new ExampleBuilders(options).get().id(id).fields(RootRecord.fields().message().id()).build()  
+```java
+new ExampleBuilders(options).get()
+  .id(id)
+  .fields(RootRecord.fields().message().id())
+  .build()
 ```
 
 Applies projection on a GET request to a resource where the “message”
@@ -244,22 +240,21 @@ itself.
 However, it is possible for the server to examine a request’s
 projection.
 
-```java  
-MaskTree entityProjection = getContext().getProjectionMask();  
-MaskTree metadataProjection =
-getContext().getMetadataProjectionMask();  
+```java
+MaskTree entityProjection = getContext().getProjectionMask();
+MaskTree metadataProjection = getContext().getMetadataProjectionMask();
 MaskTree pagingProjection = getContext().getPagingProjectionMask();
-
 ```
 
 Or, if you are using free-form resources, you can get the same
 `MaskTree` by having it injected in, for example:
 
-```java  
+```java
 @RestMethod.Get
-public Greeting get(Long key, @ProjectionParam MaskTree projection) {  
-// …  
-}  
+public Greeting get(Long key, @ProjectionParam MaskTree projection)
+{
+  // …
+}
 ```
 
 This will get you all possible projections of a request. If there were
@@ -272,26 +267,25 @@ If there were projections, you can check the status of each field.
 ```java
 MaskOperation mask = projections.getOperations.get(pathSpec);
 
-if (mask == MaskOperation.POSITIVE_MASK_OP)  
-{  
-  // field is requested.  
-}  
-else  
-{  
-  // field is not requested  
+if (mask == MaskOperation.POSITIVE_MASK_OP)
+{
+  // field is requested.
+}
+else
+{
+  // field is not requested
 }
 
-MaskOperation totalMask =
-pagingProjections.getOperations.get(CollectionMetadata.fields().total());
+MaskOperation totalMask = pagingProjections.getOperations.get(CollectionMetadata.fields().total());
 
-if (totalMask == MaskOperation.POSITIVE_MASK_OP)  
-{  
-  // the total field in pagination is requested.  
-}  
-else  
-{  
-  // total is not requested  
-}  
+if (totalMask == MaskOperation.POSITIVE_MASK_OP)
+{
+  // the total field in pagination is requested.
+}
+else
+{
+  // total is not requested
+}
 ```
 
 You can use this information in whatever way you wish to. For example,


### PR DESCRIPTION
Junchuan pointed out that there were formatting issues on [this page](https://linkedin.github.io/rest.li/How-to-use-projections-in-Java). I went in and fixed the formatting. I also removed the empty whitespace at the end of some lines.