### PR TITLE
WIP: Add documentation for service errors

### DIFF
--- a/_data/api_reference_navigation.yml
+++ b/_data/api_reference_navigation.yml
@@ -17,6 +17,8 @@ toc:
         url: /rest.li/Rest_li-2_0-response-API
   - title: Rest.li Server
     subfolderitems:
+      - page: Service Errors
+        url: /rest.li/spec/service_errors
       - page: Return Entity
         url: /rest.li/spec/return_entity
   - title: Rest.li Resource Method

--- a/_data/urls.yml
+++ b/_data/urls.yml
@@ -1,0 +1,1 @@
+repo: https://github.com/linkedin/rest.li/blob/master

--- a/_data/user_guide_navigation.yml
+++ b/_data/user_guide_navigation.yml
@@ -61,6 +61,8 @@ toc:
         url: /rest.li/testsuite_how_to
       - page: Test Suite - Add New Language
         url: /rest.li/howto_add_new_language
+      - page: Configure Service Errors in Java
+        url: /rest.li/user_guide/service_errors_java
   - title: FAQ
     subfolderitems:    
       - page: Rest.li - FAQ

--- a/guide_restli_server.md
+++ b/guide_restli_server.md
@@ -2046,8 +2046,8 @@ By default, Rest.li returns an extensive HTTP error response that
 includes:
 
 -   HTTP Status Code (manditory)
--   X-LinkedIn-Error-Response header (this will be renamed to
-    X-RestLi-Error-Response shortly)
+-   `X-LinkedIn-Error-Response` header (this will be renamed to
+    `X-RestLi-Error-Response` shortly)
 -   A response body containing:
     -   A full stack trace
     -   A service error code (optional)
@@ -2067,10 +2067,13 @@ the HTTP response. However if any other Java exception is thrown,
 Rest.li automatically provides a default error message of "Error in
 application code" in the error response. This default error message may
 be customized via RestLiConfig as well, as shown in this example:
-java
-```
+
+```java
 restLiConfig.setInternalErrorMessage("Internal error, please try again later.");
 ```
+
+See [this page](/rest.li/spec/service_errors#error-responses) for more information on
+error responses in Rest.li.
 
 <a id="wiki-Projections"></a>
 

--- a/guide_service_errors_java.md
+++ b/guide_service_errors_java.md
@@ -1,0 +1,254 @@
+---
+layout: guide
+title: Configuring Service Errors in Java
+permalink: /user_guide/service_errors_java
+index: 2
+excerpt: This page describes how to configure service errors for a resource in Java.
+---
+
+# Configuring Service Errors in Java
+
+{{ page.excerpt }}
+
+See [Service Errors](/rest.li/spec/service_errors) for an in-depth reference of service errors in Rest.li.
+
+## Contents
+
+-   [Background](#background)
+-   [Step 1: Define your Service Errors](#step-1-define-your-service-errors)
+-   [Step 2: Write Your Service Error Definition](#step-2-write-your-service-error-definition)
+-   [Step 3: Apply the Service Errors to your Resource](#step-3-apply-the-service-errors-to-your-resource)
+-   [Step 4: Returning Service Errors](#step-4-returning-service-errors)
+-   [Step 5: Enabling Service Error Validation](#step-5-enabling-service-error-validation)
+
+## Background
+
+It's important to communicate to the consumers of a service what types of errors may be returned by a particular API.
+Fortunately, Rest.li allows application developers to configure service errors for their resources. This makes APIs
+clearer by documenting in the IDL what sorts of errors should be expected, allowing clients to effectively handle and
+process returned errors. Also, enabling service error validation allows services to guarantee which errors a client
+should expect to encounter.
+
+## Step 1: Define your Service Errors
+
+First, you need to determine which service error codes your service may return, and what information will be contained
+in error responses corresponding with these codes. You'll need to define four things:
+
+- The application-specific string code associated with some service error (e.g. `QUOTA_EXCEEDED`)
+- The HTTP status code it'll return (e.g. `429`)
+- The string message it'll return
+- The schema defining the format of the error details
+
+For example, say we want to standardize the way errors are returned as a result of violating the service's rate-limiting
+constraint. We would need to pick a string error code such as `QUOTA_EXCEEDED`, an HTTP status such as `429`, a string
+message describing the failure, and some schema describing the custom error details sent back to the client.
+
+If you need help determining which HTTP status code is right for your service error, please
+see [this table of codes](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
+
+## Step 2: Write Your Service Error Definition
+
+Write a Java enum implementing the `ServiceError` interface, which will contain a set of service error definitions for
+your service. The enum implementation may expose methods for obtaining the HTTP status, the error code, the error
+message, and the error detail type. Here is an example implementation which defines one service error and exposes all
+four accessor methods:
+
+```java
+public enum SampleServiceError implements ServiceError
+{
+  QUOTA_EXCEEDED(HttpStatus.S_429_TOO_MANY_REQUESTS, "You've exceeded your daily request quota.", QuotaDetails.class),
+  INVALID_PERMISSIONS(HttpStatus.S_403_FORBIDDEN, "User does not have valid permissions", null),
+  ILLEGAL_PARAM(HttpStatus.S_400_BAD_REQUEST, "Request parameter cannot be used", null);
+  // Add more service errors here...
+
+  SampleServiceError(HttpStatus status, String message, Class<? extends RecordTemplate> errorDetailType)
+  {
+    _httpStatus = status;
+    _message = message;
+    _errorDetailType = errorDetailType;
+  }
+
+  private final HttpStatus _status;
+  private final String _message;
+  private final Class<? extends RecordTemplate> _errorDetailType;
+
+  /*
+   * Suggested: Define string constants for each of the error codes for easy access.
+   * These codes should match the enum value names.
+   */
+  public class Codes
+  {
+    QUOTA_EXCEEDED = "QUOTA_EXCEEDED";
+    INVALID_PERMISSIONS = "INVALID_PERMISSIONS";
+    ILLEGAL_PARAM = "ILLEGAL_PARAM";
+  }
+
+  @Override
+  public HttpStatus httpStatus()
+  {
+    return _status;
+  }
+
+  @Override
+  public String code()
+  {
+    // Note how the application-specific code defers to the enum value name
+    return name();
+  }
+
+  @Override
+  public String message()
+  {
+    return _message;
+  }
+
+  @Override
+  public Class<? extends RecordTemplate> errorDetailType()
+  {
+    return _errorDetailType;
+  }
+}
+```
+
+## Step 3: Apply the Service Errors to your Resource
+
+Now that you have defined your service errors, you can use them to specify which resources
+or particular resource methods may return such errors. You can do this by using a few
+Java annotations described below.
+
+Keep in mind that adding or removing service error codes impacts the backward compatibility of a resource.
+See [here](/rest.li/spec/service_errors#backward-compatibility) for more information.
+
+### `@ServiceErrorDef`
+
+In order to apply your service error definitions to a particular resource, you first need to use the `@ServiceErrorDef`
+annotation at the resource level to reference your enum. This class-level annotation is used to reference your service
+error enum definition. This is used by Rest.li during build-time when generating IDLs and also during runtime when
+validating service errors returned by your resource. Without this annotation, Rest.li will have no way of referencing
+the information in your service error definition.
+
+```java
+@ServiceErrorDef(SampleServiceError.class)
+class MyResource extends CollectionResourceTemplate<Long, MyRecord>
+{
+  // Resource methods here...
+}
+```
+
+### `@ServiceErrors`
+
+Next, you can use the `@ServiceErrors` annotation to indicate which service error codes may be returned by a particular
+resource or method. It can be used as a class-level annotation (to refer to a resource) or as a method-level annotation
+(to refer to a resource method). This is used during build-time when generating IDLs and also during runtime when
+validating service errors returned by your resource. In the following example, all methods in the resource may return a
+`QUOTA_EXCEEDED` error, but only `getAll` can return an `INVALID_PERMISSIONS` error:
+
+```java
+@ServiceErrorDef(SampleServiceError.class)
+@ServiceErrors(SampleServiceError.Codes.QUOTA_EXCEEDED)
+class MyResource extends CollectionResourceTemplate<Long, MyRecord>
+{
+  @Override
+  public MyRecord get(Long id)
+  {
+    // Logic here...
+  }
+
+  @Override
+  @ServiceErrors(SampleServiceError.Codes.INVALID_PERMISSIONS)
+  public List<MyRecord> getAll()
+  {
+    // Logic here...
+  }
+}
+```
+
+### `@ParamError`
+
+Additionally, you can use the `@ParamError` annotation to indicate that a service error may be returned by a particular
+method, but also that it references a specific parameter of such method. This is used solely as a means of documentation
+in the IDL; no validation at all is done at runtime using this information. In this example, the `search` method may
+return an `ILLEGAL_PARAM` error related to either the `foo` parameter or the `bar` parameter:
+
+```java
+@ServiceErrorDef(SampleServiceError.class)
+class MyResource extends CollectionResourceTemplate<Long, MyRecord>
+{
+  @Finder("search")
+  @ParamError(code = SampleServiceError.Codes.ILLEGAL_PARAM, parameterNames = { "foo", "bar" })
+  public List<MyRecord> search(@QueryParam("foo") String foo, @QueryParam("bar") String bar)
+  {
+    // Logic here...
+  }
+}
+```
+
+### `@SuccessResponse`
+
+In addition to service errors, success response codes can also be specified for a resource method. Note that success
+codes (unlike service errors) are not validated by the Rest.li framework, meaning that the framework will allow
+unrecognized success codes to be returned. This feature is meant only for enhancing IDL documentation, please see
+[this page](/rest.li/spec/service_errors#success-codes) for how this are documented. In this example, the `action`
+method may return an HTTP `200` or `204` response:
+
+```java
+@ServiceErrorDef(SampleServiceError.class)
+class MyResource extends CollectionResourceTemplate<Long, MyRecord>
+{
+  @Action(name = "action")
+  @SuccessResponse(statuses = { HttpStatus.S_200_OK, HttpStatus.S_204_NO_CONTENT })
+  public void action()
+  {
+    // Logic here...
+  }
+}
+```
+
+## Step 4: Returning Service Errors
+
+To return one of your defined service errors, you can simply do the following in your
+resource implementation:
+
+```java
+throw new RestLiServiceException(SampleServiceError.QUOTA_EXCEEDED);
+```
+
+This automatically constructs an `ErrorResponse` using information from your service error definition:
+
+```json
+{
+  "code": "QUOTA_EXCEEDED",
+  "httpStatus": 429,
+  "message": "You've exceeded your daily request quota."
+}
+```
+
+This looks good, except it's missing some extra information such as error details and
+a request ID. Fortunately, you can use builder syntax to easily add this data:
+
+```java
+RestLiServiceException exception = new RestLiServiceException(SampleServiceError.QUOTA_EXCEEDED);
+
+throw exception.setRequestId(requestId).setErrorDetails(quotaInfo);
+```
+
+You can also use purely builder syntax to construct your exception:
+
+```java
+throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST).setCode(code);
+```
+
+## Step 5: Enabling Service Error Validation
+
+Returned service errors can be validated in order to ensure that only specified
+service errors are returned. In other words, if a method returns an error that
+isn't specified via an annotation, a `500` exception will be thrown.
+
+This validation can be enabled by adding an `ErrorResponseValidationFilter` to
+the server filter chain:
+
+```java
+restLiConfig.addFilter(new ErrorResponseValidationFilter());
+```
+
+Note that only exceptions containing a `code` property will be validated.

--- a/reference_service_errors.md
+++ b/reference_service_errors.md
@@ -1,0 +1,207 @@
+---
+layout: api_reference
+title: Service Errors
+permalink: /spec/service_errors
+index: 2
+excerpt: This page describes how service errors are returned by Rest.li and how they are documented in a resource's IDL.
+---
+
+# Service Errors
+
+{{ page.excerpt }}
+
+See [Configuring Service Errors in Java](/rest.li/user_guide/service_errors_java) for a step-by-step guide showing how
+to configure service errors in Rest.li Java.
+
+## Contents
+
+-   [Error Responses](#error-responses)
+    - [Fields](#fields)
+    - [Example](#example)
+    - [Returning a Subset of Fields](#returning-a-subset-of-fields)
+-   [Documenting Service Errors in the IDL](#documenting-service-errors-in-the-idl)
+    - [Resource-Level Errors](#resource-level-errors)
+    - [Method-Level Errors](#method-level-errors)
+    - [Success Codes](#success-codes)
+    - [Backward Compatibility](#backward-compatibility)
+
+## Error Responses
+
+All error responses are returned by Rest.li in a format conforming to the
+[ErrorResponse schema]({{site.data.urls.repo}}/restli-common/src/main/pegasus/com/linkedin/restli/common/ErrorResponse.pdsc),
+which contains various fields describing the service failure.
+
+### Fields
+
+| Field             | Description |
+|-------------------|-------------|
+| `status`          | The HTTP status code. |
+| `code`            | The canonical error code, e.g. for '400 Bad Request' it can be 'INPUT_VALIDATION_FAILED'. Only predefined codes should be used. |
+| `message`         | A human-readable explanation of the error. |
+| `docUrl`          | URL to a page that describes this particular error in more detail. |
+| `requestId`       | The unique identifier that would identify this error. For example, it can be used to identify requests in the service's logs. |
+| `exceptionClass`  | The FQCN of the exception thrown by the server. |
+| `stackTrace`      | The full stack trace of the exception thrown by the server. |
+| `errorDetailType` | The type of the error detail model, e.g. com.example.api.BadRequest. Clients can use this field to identify the actual error detail schema. |
+| `errorDetails`    | This field should be used for communicating extra error details to clients. |
+
+### Example
+
+Here is an example error response serialized to JSON as it would be sent over the wire and received by the client.
+This scenario involves a client which has used up its daily quota for a particular service, triggering the resource
+method to throw a fictitious `QuotaExceededException`. The error details object conforms to the fictitious `QuotaDetails`
+schema, which we can see contains relevant information about the quota usage.
+
+Please note that the stack trace has been truncated for the sake of space.
+
+```json
+{
+    "status": 429,
+    "code": "QUOTA_EXCEEDED",
+    "message": "You've exceeded your daily request quota.",
+    "docUrl": "https://example.com/docs/errors/QUOTA_EXCEEDED",
+    "requestId": "cgA4qNoE48AJabrC",
+    "exceptionClass": "com.example.QuotaExceededException",
+    "stackTrace": "Exception in thread \"main\" com.example.QuotaExceededException: ...",
+    "errorDetailType": "com.example.api.QuotaDetails",
+    "errorDetails": {
+        "interval": "DAILY",
+        "quota": 10000,
+        "usage": 10034
+    }
+}
+```
+
+### Returning a Subset of Fields
+
+By default, Rest.li returns the error response containing all the fields described above, in addition to
+an `X-RestLi-Error-Response` HTTP header. However, Rest.li supports returning only a subset of these fields.
+
+#### Java
+
+In Java, the `RestLiConfig` class is used to configure which `ErrorResponse` fields should be included
+in the response.
+
+Using a predefined error response format to only return the status, code, and message:
+
+```java
+restLiConfig.setErrorResponseFormat(ErrorResponseFormat.MESSAGE_AND_SERVICECODE);
+```
+
+```json
+{
+    "status": 429,
+    "code": "QUOTA_EXCEEDED",
+    "message": "You've exceeded your daily request quota."
+}
+```
+
+Creating a custom subset of fields to return:
+
+```java
+EnumSet<ErrorResponseFormat.ErrorResponsePart> parts = EnumSet.of(HEADERS,
+                                                                  STATUS_CODE_IN_BODY,
+                                                                  DOC_URL,
+                                                                  STACKTRACE);
+restLiConfig.setErrorResponseFormat(new ErrorResponseFormat(parts));
+```
+
+```json
+{
+    "status": 429,
+    "docUrl": "https://example.com/docs/errors/QUOTA_EXCEEDED",
+    "stackTrace": "Exception in thread \"main\" com.example.QuotaExceededException: ..."
+}
+```
+
+## Documenting Service Errors in the IDL
+
+Although it's important for developers to be aware of the expected, successful inputs and outputs of an API, it's also
+just as important for them to be aware of the unexpected failures that the API may return. Having well-documented
+service errors as part of an API enables clients to handle failures resiliently, and allows developers to intelligently
+prepare their clients for failures.
+
+For a full, in-depth example of what an IDL looks like documented with service errors and success codes, see
+[AlbumEntryResource]({{site.data.urls.repo}}/restli-example-server/src/main/java/com/linkedin/restli/example/impl/AlbumEntryResource.java)
+and its [generated IDL]({{site.data.urls.repo}}/restli-example-api/src/main/idl/com.linkedin.restli.example.photos.albumEntry.restspec.json).
+
+### Resource-Level Errors
+
+If a resource has been given a set of service errors (done in Java using `@ServiceErrors`, see
+[here](/rest.li/user_guide/service_errors_java)), those service errors will be documented in the IDL as a list of
+objects, each containing the HTTP status code, the application-specific string error code, the message, and the
+error detail type (for each that is present). For example, a resource `someResource` that may fail due to some
+rate-limiting restrictions will be documented in the IDL as:
+
+```js
+{
+  "name" : "someResource",
+  ...
+  "collection" : {
+    "serviceErrors" : [ {
+      "status" : 429,
+      "code" : "QUOTA_EXCEEDED",
+      "message" : "You've exceeded your daily request quota.",
+      "errorDetailType" : "com.example.api.QuotaDetails"
+    } ],
+    ...
+  }
+  ...
+}
+```
+
+### Method-Level Errors
+
+If a resource has been given a set of service errors (done in Java using `@ServiceErrors` or `@ParamErrors`, see
+[here](/rest.li/user_guide/service_errors_java)), those service errors will be documented in the IDL as a list of
+objects similar to what is shown above. The difference here is that these will be documented per-method, and also
+support indicating specific parameter names. For example, a `finder` method that may fail on some parameter `albumId`
+will documented in the IDL as:
+
+```js
+{
+  "serviceErrors" : [ {
+    "status" : 422,
+    "code" : "INVALID_ID",
+    "message" : "Id cannot be less than 0",
+    "errorDetailType" : "com.example.api.IdError",
+    "parameters" : [ "albumId" ]
+  } ],
+  "name" : "search",
+  "parameters" : [ {
+    "name" : "albumId",
+    "type" : "long",
+  }
+}
+```
+
+### Success Codes
+
+If a resource method has been given a set of success codes (done in Java using `@SuccessResponse`), those success codes
+will be documented in the IDL as a list of integers. For example, a `get` method that returns an HTTP `200` response on
+success will be documented in the IDL as:
+
+```json
+{
+  "success" : [ 200 ],
+  "method" : "get",
+  "doc" : "Gets a thing."
+}
+```
+
+### Backward Compatibility
+
+Making changes to the service error information in a resource's IDL has an impact on the
+[compatibility checker](/rest.li/modeling/compatibility_check).
+
+The following changes are considered **backward compatible**:
+
+- Removing a service error code from a resource or a method.
+- Removing a service error code from a resource then adding it to a subset of its methods.
+
+The following changes are considered **backward incompatible**:
+
+- Adding a new service error code to a resource or a method.
+- Changing the `errorDetailType` for an existing service error code.
+- Changing the HTTP `status` code for an existing service error code.
+- Changing the `message` for an existing service error code.


### PR DESCRIPTION
Not done yet, would just like some preliminary review.

Added:

- Page for detailing service errors in detail. So far just has ErrorResponse info.
- Page for describing how to set up service errors step-by-step.
- Added information for success responses.
- Added examples of IDLs with service error and success response info.
- Added data file containing base URL for GitHub repo for easy usage when making links.