### PR TITLE
Properly escape union member aliases in PDL

### DIFF
--- a/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
@@ -411,7 +411,7 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
       }
       writeDocAndProperties(docString, symbolProperties);
       _builder.indent()
-          .write(symbol)
+          .writeIdentifier(symbol)
           .newline();
     }
     _builder.decreaseIndent()
@@ -510,7 +510,7 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
       }
       writeDocAndProperties(member.getDoc(), member.getProperties());
       _builder.indent()
-          .write(member.getAlias())
+          .writeIdentifier(member.getAlias())
           .write(":")
           .writeSpace();
     }

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/PdlEncoderTest.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/PdlEncoderTest.java
@@ -58,6 +58,7 @@ public class PdlEncoderTest extends GeneratorTest
             { "deprecated.DeprecatedRecord" },
             { "enums.Fruits" },
             { "enums.EnumProperties" },
+            { "enums.EscapedSymbols" },
             { "enums.DeprecatedSymbols" },
             { "enums.WithAliases" },
             { "escaping.record.NamespacePackageEscaping" },

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/enums/EscapedSymbols.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/enums/EscapedSymbols.pdl
@@ -1,0 +1,15 @@
+namespace com.linkedin.pegasus.generator.test.idl.enums
+
+/**
+ * Reserved keywords should be escaped when used as enum symbols.
+ */
+enum EscapedSymbols {
+  ENUM,
+  `enum`,
+  RECORD,
+  `record`,
+  NAMESPACE,
+  `namespace`,
+  FOO,
+  foo
+}

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/unions/WithAliases.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/unions/WithAliases.pdl
@@ -40,5 +40,10 @@ record WithAliases {
       record Foo {}
 
     F: array[Message]
+
+    /**
+     * Reserved keywords used as aliases must be escaped.
+     */
+    `record`: long
   ]
 }


### PR DESCRIPTION
Previously, the PDL encoder wasn't escaping reserved keywords
when used as union member aliases.

e.g.

``union[`record`: int, `namespace`: string]``
``enum{`record`, `namespace`}``

rather than

`union[record: int, namespace: string]`
`enum{record, namespace}`