### PR TITLE
Enhance MockCollectionResponseFactory to mock custom metadata

### DIFF
--- a/restli-client-testutils/src/main/java/com/linkedin/restli/client/testutils/MockCollectionResponseFactory.java
+++ b/restli-client-testutils/src/main/java/com/linkedin/restli/client/testutils/MockCollectionResponseFactory.java
@@ -75,4 +75,24 @@ public class MockCollectionResponseFactory
     response.setPaging(metadata);
     return response;
   }
+
+  /**
+   * Creates a {@link CollectionResponse}
+   *
+   * @param entryClass the class of the objects being stored in the {@link CollectionResponse}
+   * @param recordTemplates the objects that will be stored in the {@link CollectionResponse}
+   * @param metadata the {@link CollectionMetadata} for this {@link CollectionResponse}
+   * @param customMetadata raw custom metadata for this {@link CollectionResponse}
+   * @param <T> the class of the objects being stored in the {@link CollectionResponse}
+   * @return a {@link CollectionResponse} with the above properties
+   */
+  public static <T extends RecordTemplate> CollectionResponse<T> create(Class<T> entryClass,
+      Collection<T> recordTemplates,
+      CollectionMetadata metadata,
+      DataMap customMetadata)
+  {
+    CollectionResponse<T> response = create(entryClass, recordTemplates, metadata);
+    response.setMetadataRaw(customMetadata);
+    return response;
+  }
 }

--- a/restli-client-testutils/src/test/java/com/linkedin/restli/client/testutils/test/TestMockCollectionResponseFactory.java
+++ b/restli-client-testutils/src/test/java/com/linkedin/restli/client/testutils/test/TestMockCollectionResponseFactory.java
@@ -17,6 +17,7 @@
 package com.linkedin.restli.client.testutils.test;
 
 
+import com.linkedin.data.DataMap;
 import com.linkedin.restli.client.testutils.MockCollectionResponseFactory;
 import com.linkedin.restli.common.CollectionMetadata;
 import com.linkedin.restli.common.CollectionResponse;
@@ -40,13 +41,16 @@ public class TestMockCollectionResponseFactory
 
     List<Greeting> greetings = Arrays.asList(g1, g2);
 
-    CollectionMetadata metadata = new CollectionMetadata().setCount(2).setStart(0).setTotal(2);
+    CollectionMetadata pagingMetadata = new CollectionMetadata().setCount(2).setStart(0).setTotal(2);
 
-    CollectionResponse<Greeting> collectionResponse = MockCollectionResponseFactory.create(Greeting.class,
-                                                                                           greetings,
-                                                                                           metadata);
+    DataMap customMetadata = new DataMap();
+    customMetadata.put("foo", "bar");
+
+    CollectionResponse<Greeting> collectionResponse =
+        MockCollectionResponseFactory.create(Greeting.class, greetings, pagingMetadata, customMetadata);
 
     Assert.assertEquals(collectionResponse.getElements(), greetings);
-    Assert.assertEquals(collectionResponse.getPaging(), metadata);
+    Assert.assertEquals(collectionResponse.getPaging(), pagingMetadata);
+    Assert.assertEquals(collectionResponse.getMetadataRaw(), customMetadata);
   }
 }


### PR DESCRIPTION
The current version of `MockCollectionResponseFactory` only allows mocking `elements` and `paging` data. The PR adds a small enhancement for mocking custom metadata.