### PR TITLE
ClusterInfoProvider API and implementation

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/Facilities.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/Facilities.java
@@ -20,6 +20,7 @@
 
 package com.linkedin.d2.balancer;
 
+import com.linkedin.d2.balancer.util.ClusterInfoProvider;
 import com.linkedin.d2.balancer.util.hashing.HashRingProvider;
 import com.linkedin.d2.balancer.util.partitions.PartitionInfoProvider;
 import com.linkedin.r2.transport.common.TransportClientFactory;
@@ -62,4 +63,13 @@ public interface Facilities
    * @return TransportClientFactory for given scheme, or null if no factory is configured in d2
    */
   TransportClientFactory getClientFactory(String scheme);
+
+  /**
+   * Obtain a ClusterInfoProvider
+   * @return ClusterInfoProvider
+   */
+  default ClusterInfoProvider getClusterInfoProvider()
+  {
+    return (clusterName, scheme, partitionId) -> 0;
+  };
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesDelegator.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesDelegator.java
@@ -3,6 +3,7 @@ package com.linkedin.d2.balancer;
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.util.None;
 import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.util.ClusterInfoProvider;
 import com.linkedin.d2.balancer.util.hashing.HashRingProvider;
 import com.linkedin.d2.balancer.util.partitions.PartitionInfoProvider;
 import com.linkedin.d2.discovery.event.PropertyEventThread;
@@ -53,6 +54,11 @@ public abstract class LoadBalancerWithFacilitiesDelegator implements LoadBalance
   public TransportClientFactory getClientFactory(String scheme)
   {
     return _loadBalancer.getClientFactory(scheme);
+  }
+
+  @Override
+  public ClusterInfoProvider getClusterInfoProvider() {
+    return _loadBalancer.getClusterInfoProvider();
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -180,5 +180,6 @@ public class PropertyKeys
   public static final String DARK_CLUSTER_OUTBOUND_MAX_RATE = "dispatcherOutboundMaxRate";
 
   // used by ClusterInfoProvider
+  public static final String HTTP_SCHEME = "http";
   public static final String HTTPS_SCHEME = "https";
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -178,4 +178,7 @@ public class PropertyKeys
   public static final String DARK_CLUSTER_MULTIPLIER = "multiplier";
   public static final String DARK_CLUSTER_OUTBOUND_TARGET_RATE = "dispatcherOutboundTargetRate";
   public static final String DARK_CLUSTER_OUTBOUND_MAX_RATE = "dispatcherOutboundMaxRate";
+
+  // used by ClusterInfoProvider
+  public static final String HTTPS_SCHEME = "https";
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.balancer.util;
 
 import com.linkedin.d2.balancer.ServiceUnavailableException;
+import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
 
 
 /**
@@ -28,7 +29,6 @@ import com.linkedin.d2.balancer.ServiceUnavailableException;
 public interface ClusterInfoProvider
 {
   String HTTPS_SCHEME = "https";
-  int DEFAULT_PARTITION = 0;
 
   /**
    * Obtain d2 cluster count
@@ -41,6 +41,6 @@ public interface ClusterInfoProvider
    */
   default int getHttpsClusterCount(String clusterName) throws ServiceUnavailableException
   {
-    return getClusterCount(clusterName, HTTPS_SCHEME, DEFAULT_PARTITION);
+    return getClusterCount(clusterName, HTTPS_SCHEME, DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.balancer.util;
 
 import com.linkedin.d2.balancer.ServiceUnavailableException;
+import com.linkedin.d2.balancer.properties.PropertyKeys;
 import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
 
 
@@ -28,7 +29,6 @@ import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
  */
 public interface ClusterInfoProvider
 {
-  String HTTPS_SCHEME = "https";
 
   /**
    * Obtain d2 cluster count
@@ -41,6 +41,6 @@ public interface ClusterInfoProvider
    */
   default int getHttpsClusterCount(String clusterName) throws ServiceUnavailableException
   {
-    return getClusterCount(clusterName, HTTPS_SCHEME, DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
+    return getClusterCount(clusterName, PropertyKeys.HTTPS_SCHEME, DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
@@ -1,0 +1,46 @@
+/*
+   Copyright (c) 2019 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.util;
+
+import com.linkedin.d2.balancer.ServiceUnavailableException;
+
+
+/**
+ * ClusterInfoProvider provides a mechanism to access detailed cluster information from the D2 infrastructure.
+ *
+ * @author David Hoa
+ * @version $Revision: $
+ */
+public interface ClusterInfoProvider
+{
+  String HTTPS_SCHEME = "https";
+  int DEFAULT_PARTITION = 0;
+
+  /**
+   * Obtain d2 cluster count
+   * @return int
+   */
+  int getClusterCount(String clusterName, String scheme, int partitionId) throws ServiceUnavailableException;
+
+  /**
+   * Helpful utility method for default behavior
+   */
+  default int getHttpsClusterCount(String clusterName) throws ServiceUnavailableException
+  {
+    return getClusterCount(clusterName, HTTPS_SCHEME, DEFAULT_PARTITION);
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/DelegatingFacilities.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/DelegatingFacilities.java
@@ -49,6 +49,7 @@ public class DelegatingFacilities implements Facilities
   private final ClientFactoryProvider _clientFactoryProvider;
   private final PartitionInfoProvider _partitionInfoProvider;
   private final HashRingProvider _hashRingProvider;
+  private final ClusterInfoProvider _clusterInfoProvider;
 
   @Deprecated
   public DelegatingFacilities(DirectoryProvider directoryProvider,
@@ -92,17 +93,29 @@ public class DelegatingFacilities implements Facilities
     });
   }
 
+  @Deprecated
   public DelegatingFacilities(DirectoryProvider directoryProvider,
                               KeyMapperProvider keyMapperProvider,
                               ClientFactoryProvider clientFactoryProvider,
                               PartitionInfoProvider partitionInfoProvider,
                               HashRingProvider hashRingProvider)
   {
+    this(directoryProvider, keyMapperProvider, clientFactoryProvider, partitionInfoProvider, hashRingProvider,
+        (clusterName, scheme, partitionId) -> 0);
+  }
+  public DelegatingFacilities(DirectoryProvider directoryProvider,
+      KeyMapperProvider keyMapperProvider,
+      ClientFactoryProvider clientFactoryProvider,
+      PartitionInfoProvider partitionInfoProvider,
+      HashRingProvider hashRingProvider,
+      ClusterInfoProvider clusterInfoProvider)
+  {
     _directoryProvider = directoryProvider;
     _keyMapperProvider = keyMapperProvider;
     _clientFactoryProvider = clientFactoryProvider;
     _partitionInfoProvider = partitionInfoProvider;
     _hashRingProvider = hashRingProvider;
+    _clusterInfoProvider = clusterInfoProvider;
   }
 
   @Override
@@ -133,5 +146,10 @@ public class DelegatingFacilities implements Facilities
   public TransportClientFactory getClientFactory(String scheme)
   {
     return _clientFactoryProvider.getClientFactory(scheme);
+  }
+
+  @Override
+  public ClusterInfoProvider getClusterInfoProvider() {
+    return _clusterInfoProvider;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/TogglingLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/TogglingLoadBalancer.java
@@ -50,7 +50,7 @@ import java.util.Map;
  * @version $Revision: $
  */
 
-public class TogglingLoadBalancer implements LoadBalancer, HashRingProvider, ClientFactoryProvider, PartitionInfoProvider, WarmUpService
+public class TogglingLoadBalancer implements LoadBalancer, HashRingProvider, ClientFactoryProvider, PartitionInfoProvider, WarmUpService, ClusterInfoProvider
 {
   private final LoadBalancer _balancer;
   private final WarmUpService _warmUpService;
@@ -58,6 +58,7 @@ public class TogglingLoadBalancer implements LoadBalancer, HashRingProvider, Cli
   private final PartitionInfoProvider _partitionInfoProvider;
   private final ClientFactoryProvider _clientFactoryProvider;
   private final TogglingPublisher<?>[] _toggles;
+  private final ClusterInfoProvider _clusterInfoProvider;
 
   public TogglingLoadBalancer(SimpleLoadBalancer balancer, TogglingPublisher<?>... toggles)
   {
@@ -67,6 +68,7 @@ public class TogglingLoadBalancer implements LoadBalancer, HashRingProvider, Cli
     _partitionInfoProvider = balancer;
     _clientFactoryProvider = balancer;
     _toggles = toggles;
+    _clusterInfoProvider = balancer;
   }
 
   public TogglingLoadBalancer(LoadBalancer balancer, TogglingPublisher<?>... toggles)
@@ -189,5 +191,10 @@ public class TogglingLoadBalancer implements LoadBalancer, HashRingProvider, Cli
   public void warmUpService(String serviceName, Callback<None> callback)
   {
     _warmUpService.warmUpService(serviceName, callback);
+  }
+
+  @Override
+  public int getClusterCount(String clusterName, String scheme, int partitionId) throws ServiceUnavailableException {
+    return _clusterInfoProvider.getClusterCount(clusterName, scheme, partitionId);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
@@ -169,6 +169,11 @@ public class WarmUpLoadBalancer extends LoadBalancerWithFacilitiesDelegator
     });
   }
 
+  @Override
+  public ClusterInfoProvider getClusterInfoProvider() {
+    return _loadBalancer.getClusterInfoProvider();
+  }
+
   private class WarmUpTask
   {
     private final AtomicInteger _requestCompletedCount;

--- a/d2/src/main/java/com/linkedin/d2/balancer/zkfs/LastSeenLoadBalancerWithFacilities.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/zkfs/LastSeenLoadBalancerWithFacilities.java
@@ -26,6 +26,7 @@ import com.linkedin.d2.balancer.properties.ClusterProperties;
 import com.linkedin.d2.balancer.properties.ServiceProperties;
 import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancer;
+import com.linkedin.d2.balancer.util.ClusterInfoProvider;
 import com.linkedin.d2.balancer.util.hashing.ConsistentHashKeyMapper;
 import com.linkedin.d2.balancer.util.hashing.HashRingProvider;
 import com.linkedin.d2.balancer.util.partitions.PartitionInfoProvider;
@@ -175,5 +176,10 @@ public class LastSeenLoadBalancerWithFacilities implements LoadBalancerWithFacil
   @Override
   public TransportClientFactory getClientFactory(String scheme) {
     return _loadBalancer.getClientFactory(scheme);
+  }
+
+  @Override
+  public ClusterInfoProvider getClusterInfoProvider() {
+    return _loadBalancer;
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -56,7 +56,6 @@ import com.linkedin.d2.balancer.util.hashing.HashFunction;
 import com.linkedin.d2.balancer.util.hashing.MD5Hash;
 import com.linkedin.d2.balancer.util.hashing.RandomHash;
 import com.linkedin.d2.balancer.util.hashing.Ring;
-import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessException;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
 import com.linkedin.d2.discovery.PropertySerializer;
@@ -110,7 +109,7 @@ import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor.*;
+import static com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor.DEFAULT_PARTITION_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -167,20 +166,20 @@ public class SimpleLoadBalancerTest
   {
     return new Object[][] {
         // numHttp, numHttps, expectedNumHttp, expectedNumHttps, partitionIdForAdd, partitionIdForCheck
-        new Object[] {0, 3, 0, 3, 0, 0},
-        new Object[] {3, 0, 3, 0, 0, 0},
-        new Object[] {1, 1, 1, 1, 0, 0},
-        new Object[] {0, 0, 0, 0, 0, 0},
+        {0, 3, 0, 3, 0, 0},
+        {3, 0, 3, 0, 0, 0},
+        {1, 1, 1, 1, 0, 0},
+        {0, 0, 0, 0, 0, 0},
         // alter the partitions to check
-        new Object[] {0, 3, 0, 0, 0, 1},
-        new Object[] {3, 0, 0, 0, 0, 1},
-        new Object[] {1, 1, 0, 0, 0, 2},
-        new Object[] {0, 0, 0, 0, 0, 1},
+        {0, 3, 0, 0, 0, 1},
+        {3, 0, 0, 0, 0, 1},
+        {1, 1, 0, 0, 0, 2},
+        {0, 0, 0, 0, 0, 1},
         // alter the partitions to add and check to match
-        new Object[] {0, 3, 0, 3, 1, 1},
-        new Object[] {3, 0, 3, 0, 1, 1},
-        new Object[] {1, 1, 1, 1, 2, 2},
-        new Object[] {0, 0, 0, 0, 1, 1}
+        {0, 3, 0, 3, 1, 1},
+        {3, 0, 3, 0, 1, 1},
+        {1, 1, 1, 1, 2, 2},
+        {0, 0, 0, 0, 1, 1}
     };
   }
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
@@ -510,5 +510,11 @@ public class WarmUpLoadBalancerTest
     {
       return null;
     }
+
+    @Override
+    public ClusterInfoProvider getClusterInfoProvider()
+    {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Add API to provide basic cluster information. Initially this will just give a way to find the number of instances in a D2 cluster, based on scheme (http/https) and partitionid.  This new API will be part of Facilities. I provided a default implementation in Facilities, so this change is backwards compatible. This feature will allow dark cluster dispatchers to shape traffic to a dark canary cluster.

I'm not able to consolidate the tests because several of those variables are modified in many of the tests in different ways.