### PR TITLE
AsyncPool Improvements and Fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.1.22
+version=28.1.23
 sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
 sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 org.gradle.configureondemand=true

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolStats.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolStats.java
@@ -36,6 +36,8 @@ public class AsyncPoolStats implements PoolStats
   private final int _totalDestroyErrors;
   private final int _totalBadDestroyed;
   private final int _totalTimedOut;
+  private final int _totalWaiterTimedOut;
+  private final int _totalCreationIgnored;
 
   private final int _checkedOut;
   private final int _maxPoolSize;
@@ -64,6 +66,8 @@ public class AsyncPoolStats implements PoolStats
       int totalDestroyErrors,
       int totalBadDestroyed,
       int totalTimedOut,
+      int totalWaiterTimedOut,
+      int totalCreationsIgnored,
 
       int checkedOut,
       int maxPoolSize,
@@ -88,6 +92,8 @@ public class AsyncPoolStats implements PoolStats
     _totalDestroyErrors = totalDestroyErrors;
     _totalBadDestroyed = totalBadDestroyed;
     _totalTimedOut = totalTimedOut;
+    _totalCreationIgnored = totalCreationsIgnored;
+    _totalWaiterTimedOut = totalWaiterTimedOut;
 
     _checkedOut = checkedOut;
     _maxPoolSize = maxPoolSize;
@@ -175,6 +181,27 @@ public class AsyncPoolStats implements PoolStats
   public int getTotalTimedOut()
   {
     return _totalTimedOut;
+  }
+
+  /**
+   * Get the total number of timed out pool waiters between the
+   * starting of the Pool and the call to getStats().
+   * @return The total number of timed out objects
+   */
+  @Override
+  public int getTotalWaiterTimedOut()
+  {
+    return _totalWaiterTimedOut;
+  }
+  /**
+   * Get the total number of times the object creation ignored between the
+   * starting of the AsyncPool and the call to getStats().
+   * @return The total number of times the object creation ignored
+   */
+  @Override
+  public int getTotalCreationIgnored()
+  {
+    return _totalCreationIgnored;
   }
 
   /**
@@ -316,6 +343,7 @@ public class AsyncPoolStats implements PoolStats
         "\ntotalDestroyErrors: " + _totalDestroyErrors +
         "\ntotalBadDestroyed: " + _totalBadDestroyed +
         "\ntotalTimeOut: " + _totalTimedOut +
+        "\ntotalWaiterTimedOut: " + _totalWaiterTimedOut +
         "\ncheckedOut: " + _totalTimedOut +
         "\nmaxPoolSize: " + _maxPoolSize +
         "\npoolSize: " + _poolSize +

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolStatsTracker.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolStatsTracker.java
@@ -52,6 +52,9 @@ public class AsyncPoolStatsTracker
   private int _totalDestroyErrors = 0;
   private int _totalBadDestroyed = 0;
   private int _totalTimedOut = 0;
+  private int _totalWaiterTimedOut = 0;
+  private int _totalCreationIgnored = 0;
+
 
   /**
    * These counters are sampled and reset based on sampling rules
@@ -118,6 +121,11 @@ public class AsyncPoolStatsTracker
     _totalCreated++;
   }
 
+  public void incrementIgnoredCreation()
+  {
+    _totalCreationIgnored++;
+  }
+
   public void incrementDestroyed()
   {
     _totalDestroyed++;
@@ -141,6 +149,11 @@ public class AsyncPoolStatsTracker
   public void incrementTimedOut()
   {
     _totalTimedOut++;
+  }
+
+  public void incrementWaiterTimedOut()
+  {
+    _totalWaiterTimedOut++;
   }
 
   public void sampleMaxPoolSize()
@@ -187,6 +200,8 @@ public class AsyncPoolStatsTracker
         _totalDestroyErrors,
         _totalBadDestroyed,
         _totalTimedOut,
+        _totalWaiterTimedOut,
+        _totalCreationIgnored,
         _checkedOutSupplier.get(),
         _maxSizeSupplier.get(),
         _minSizeSupplier.get(),

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ExponentialBackOffRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ExponentialBackOffRateLimiter.java
@@ -173,24 +173,10 @@ public class ExponentialBackOffRateLimiter implements RateLimiter
   @Override
   public void submit(Task t)
   {
-    boolean runNow = false;
     synchronized (this)
     {
-      if (_period == 0 && _pending.isEmpty() && _runningTasks < _maxRunningTasks)
-      {
-        _runningTasks ++;
-        runNow = true;
-      }
-      else
-      {
-        _pending.add(t);
-        schedule();
-      }
-    }
-
-    if (runNow)
-    {
-      t.run(_doneCallback);
+      _pending.add(t);
+      schedule();
     }
   }
 
@@ -206,6 +192,11 @@ public class ExponentialBackOffRateLimiter implements RateLimiter
       }
       return cancelled;
     }
+  }
+
+  public int numberOfPendingTasks()
+  {
+    return _pending.size();
   }
 
   /**

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/PoolStats.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/PoolStats.java
@@ -74,6 +74,20 @@ public interface PoolStats
   int getTotalTimedOut();
 
   /**
+   * Get the total number of timed out pool waiters between the
+   * starting of the Pool and the call to getStats().
+   * @return The total number of timed out objects
+   */
+  int getTotalWaiterTimedOut();
+
+  /**
+   * Get the total number of times the creation of objects ignored between the
+   * starting of the Pool and the call to getStats().
+   * @return The total number of times the object creation ignored
+   */
+  int getTotalCreationIgnored();
+
+  /**
    * Get the number of pool objects checked out at the time of
    * the call to getStats().
    * @return The number of checked out pool objects

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/WaiterTimeoutException.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/WaiterTimeoutException.java
@@ -1,0 +1,68 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.r2.transport.http.client;
+
+import com.linkedin.r2.RetriableRequestException;
+
+
+/**
+ * Represents a wait time out error while waiting for object from the pool.
+ *
+ * @author Nizar Mankulangara
+ */
+public class WaiterTimeoutException extends RetriableRequestException
+{
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Construct a new instance.
+   */
+  public WaiterTimeoutException()
+  {
+  }
+
+  /**
+   * Construct a new instance with specified message.
+   *
+   * @param message the message to be used for this exception.
+   */
+  public WaiterTimeoutException(String message)
+  {
+    super(message);
+  }
+
+  /**
+   * Construct a new instance with specified message and cause.
+   *
+   * @param message the message to be used for this exception.
+   * @param cause the cause to be used for this exception.
+   */
+  public WaiterTimeoutException(String message, Throwable cause)
+  {
+    super(message, cause);
+  }
+
+  /**
+   * Construct a new instance with specified cause.
+   *
+   * @param cause the cause to be used for this exception.
+   */
+  public WaiterTimeoutException(Throwable cause)
+  {
+    super(cause);
+  }
+}

--- a/r2-core/src/test/java/test/r2/transport/http/client/TestAsyncPool.java
+++ b/r2-core/src/test/java/test/r2/transport/http/client/TestAsyncPool.java
@@ -26,13 +26,22 @@ import com.linkedin.common.stats.LongTracking;
 import com.linkedin.r2.transport.http.client.AsyncPool;
 import com.linkedin.r2.transport.http.client.AsyncPoolImpl;
 import com.linkedin.common.util.None;
+import com.linkedin.r2.transport.http.client.ExponentialBackOffRateLimiter;
 import com.linkedin.r2.transport.http.client.NoopRateLimiter;
 import com.linkedin.r2.transport.http.client.PoolStats;
 import com.linkedin.r2.util.Cancellable;
+import com.linkedin.test.util.AssertionMethods;
+import com.linkedin.test.util.ClockedExecutor;
 import com.linkedin.util.clock.SettableClock;
 import com.linkedin.util.clock.Time;
+import java.util.LinkedList;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -338,11 +347,12 @@ public class TestAsyncPool
     final int PUT_BAD = 3;
     final int DISPOSE = 4;
     final int TIMEOUT = 100;
+    final int WAITER_TIMEOUT = 200;
     final int DELAY = 1200;
 
     final UnreliableLifecycle lifecycle = new UnreliableLifecycle();
     final AsyncPool<AtomicBoolean> pool = new AsyncPoolImpl<AtomicBoolean>(
-        "object pool", lifecycle, POOL_SIZE, TIMEOUT, _executor, MAX_WAITER_SIZE, AsyncPoolImpl.Strategy.MRU,
+        "object pool", lifecycle, POOL_SIZE, TIMEOUT, WAITER_TIMEOUT, _executor, MAX_WAITER_SIZE, AsyncPoolImpl.Strategy.MRU,
         MIN_SIZE, new NoopRateLimiter(), clock, waitTimeTracker);
     PoolStats stats;
     final List<AtomicBoolean> objects = new ArrayList<AtomicBoolean>();
@@ -357,6 +367,7 @@ public class TestAsyncPool
     Assert.assertEquals(stats.getTotalDestroyErrors(), 0);
     Assert.assertEquals(stats.getCheckedOut(), 0);
     Assert.assertEquals(stats.getTotalTimedOut(), 0);
+    Assert.assertEquals(stats.getTotalWaiterTimedOut(), 0);
     Assert.assertEquals(stats.getTotalBadDestroyed(), 0);
     Assert.assertEquals(stats.getMaxPoolSize(), POOL_SIZE);
     Assert.assertEquals(stats.getMinPoolSize(), 0);
@@ -532,9 +543,7 @@ public class TestAsyncPool
     }
     stats = pool.getStats();
     Assert.assertEquals(stats.getCheckedOut(), GET - PUT_BAD - DISPOSE);
-    // When the each create fails, it will retry and cancel the waiter,
-    // resulting in a second create error.
-    Assert.assertEquals(stats.getTotalCreateErrors(), 2*CREATE_BAD);
+    Assert.assertEquals(stats.getTotalCreateErrors(), CREATE_BAD);
   }
 
   /**
@@ -568,6 +577,368 @@ public class TestAsyncPool
 
     stats = pool.getStats();
     Assert.assertEquals(stats.getWaitTimeAvg(), DELAY, DELTA * DELAY);
+  }
+
+  /***
+   * This test case verifies that if more request object creation requests are submitted to the rate limiter, it only
+   * creates the absolute required maximum (see below example)
+   *
+   *  Assumption: the channel pool max size is always bigger than the requested checkout size
+   *
+   *|----------A------------|---------------B---------------|---------------C--------------|-------------D--------------
+   *  A = In Phase A , N number of object checkout request to the pool when there are no tasks pending in the
+   *      rate limiter. A's Expected result = channel pool will create N number of new objects and check them out
+   *  B = In Phase B, N number of object checkout request again sent to the channel pool when the pool has already
+   *      checkout N number of objects, In this phase, the object creation inside the pool is blocked and the
+   *      rate limiter will Queue the creation requests once it reached its maximum concurrency configured.
+   *  C = Ih Phase C, N number of objects are returned to the pool which are created in Phase A, this will make
+   *      the number of idle objects in the pool as N.
+   *  D = In Phase D, All the object creation blocked in Phase B will get un blocked and create number of new objects
+   *      that are equal to the rate limiter concurrency. When rate limiter executes the queued creation requests - it
+   *      should ignore the creation requests as there are no object waiters in the pool and thus effectively only
+   *      creating the absolute minimum required count (N+Concurrency)
+   *
+   * @param numberOfCheckouts the N number of checkout operations that will be performed in phase A & B
+   * @param poolSize the maximum Object Pool Size
+   * @param concurrency the maximum allowed concurrent object creation
+   */
+  @Test(dataProvider = "channelStateRandomDataProvider")
+  public void testObjectsAreNotCreatedWhenThereAreNoWaiters(int numberOfCheckouts, int poolSize, int concurrency)
+      throws Exception
+  {
+    CreationBlockableSynchronousLifecycle blockableObjectCreator =
+        new CreationBlockableSynchronousLifecycle(numberOfCheckouts, concurrency);
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(500);
+    ExponentialBackOffRateLimiter rateLimiter = new ExponentialBackOffRateLimiter(0, 5000,
+        10, executor, concurrency);
+
+    final AsyncPool<Object> pool = new AsyncPoolImpl<Object>("object pool",
+        blockableObjectCreator,
+        poolSize,
+        Integer.MAX_VALUE,
+        _executor,
+        Integer.MAX_VALUE,
+        AsyncPoolImpl.Strategy.MRU,
+        0, rateLimiter
+    );
+
+    pool.start();
+
+    // Phase A:Checking out object 'numberOfCheckout' times!
+    List<Object> checkedOutObjects = performCheckout(numberOfCheckouts, pool);
+
+    // Phase B:Blocking object creation and performing the checkout 'numberOfCheckout' times again
+    blockableObjectCreator.blockCreation();
+    Future<None> future = performUnblockingCheckout(numberOfCheckouts, numberOfCheckouts, pool);
+    blockableObjectCreator.waitUntilAllBlocked();
+
+    // Phase C:Returning the checkedOut objects from Phase A back to the object pool
+    for (Object checkedOutObject : checkedOutObjects)
+    {
+      pool.put(checkedOutObject);
+    }
+
+    // Phase D:All the object creation in phase B gets unblocked now
+    blockableObjectCreator.unblockCreation();
+    try
+    {
+      // Wait for all object creation to be unblocked
+      future.get(5, TimeUnit.SECONDS);
+    }
+    catch (Exception e)
+    {
+      Assert.fail("Did not complete unblocked object creations on time, Unexpected interruption", e);
+    }
+
+    // Making sure the rate limiter pending tasks are submitted to the executor
+    AssertionMethods.assertWithTimeout(5000, ()->
+        Assert.assertEquals(rateLimiter.numberOfPendingTasks(),0,"Number of tasks has to drop to 0"));
+
+    // Wait for all the tasks in the rate limiter executor to finish
+    executor.shutdown();
+    try
+    {
+      if (!executor.awaitTermination(10, TimeUnit.SECONDS))
+      {
+        Assert.fail("Executor took too long to shutdown");
+      }
+    }
+    catch (Exception ex)
+    {
+      Assert.fail("Unexpected interruption while shutting down executor", ex);
+    }
+
+    // Verify all the expectations
+    PoolStats stats = pool.getStats();
+    Assert.assertEquals(stats.getTotalCreationIgnored(), numberOfCheckouts-concurrency);
+    Assert.assertEquals(stats.getCheckedOut(), numberOfCheckouts);
+    Assert.assertEquals(stats.getIdleCount(), concurrency);
+    Assert.assertEquals(stats.getTotalCreated(), numberOfCheckouts+concurrency);
+    Assert.assertEquals(stats.getPoolSize(), numberOfCheckouts+concurrency);
+    Assert.assertEquals(stats.getTotalDestroyed(), 0);
+    Assert.assertEquals(stats.getTotalBadDestroyed(), 0);
+    Assert.assertEquals(stats.getTotalTimedOut(), 0);
+  }
+
+  /***
+   * This test case verifies that the correct number of waiters are timed out while waiting for object from the pool
+   *
+   *     Assumption: the channel pool max size is always bigger than the requested checkout size
+   *
+   *|----------A------------|---------------B---------------|---------------C--------------|-------------D--------------
+   *   A = In Phase A , N number of object checkout request to the pool when there are no tasks pending in the rate
+   *       limiter. A's Expected result = channel pool will create N number of new objects and check them out
+   *   B = In Phase B, O number of object checkout request again sent to the channel pool when the pool has already
+   *       checkout N number of objects, In this phase, the object creation inside the pool is blocked
+   *       and the rate limiter will Queue the creation requests once it reached its maximum concurrency configured.
+   *   C = Ih Phase C, P number of objects are returned to the pool which are created in Phase A, this will make
+   *       the number of waiter queue size to be O-P
+   *   D = In Phase D, A delay will be introduced to timeout the waiters and all the O-P waiters should be timed out.
+   *       After the delay the object creation will be unblocked and it should create aleast the concurrency number of
+   *       objects even though the waiters are timedout.
+   *
+   * @param numberOfCheckoutsInPhaseA the N number of checkout operations that will be performed in phase A
+   * @param numberOfCheckoutsInPhaseB the O number of checkout operations that will be performed in Phase B
+   * @param numbOfObjectsToBeReturnedInPhaseC the numeber of objects returned in Phase C
+   * @param poolSize size of the pool,
+   * @param concurrency concurrency of the rate limiter
+   */
+  @Test(dataProvider = "waiterTimeoutDataProvider")
+  public void testWaiterTimeout(int numberOfCheckoutsInPhaseA, int numberOfCheckoutsInPhaseB,
+      int numbOfObjectsToBeReturnedInPhaseC,
+      int poolSize, int concurrency, int waiterTimeout) throws Exception
+  {
+    CreationBlockableSynchronousLifecycle blockableObjectCreator =
+        new CreationBlockableSynchronousLifecycle(numberOfCheckoutsInPhaseB, concurrency);
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(500);
+    ExponentialBackOffRateLimiter rateLimiter = new ExponentialBackOffRateLimiter(0, 5000,
+        10, executor, concurrency);
+
+    ClockedExecutor clockedExecutor = new ClockedExecutor();
+
+    final AsyncPool<Object> pool = new AsyncPoolImpl<Object>("object pool",
+        blockableObjectCreator,
+        poolSize,
+        Integer.MAX_VALUE,
+        waiterTimeout,
+        clockedExecutor,
+        Integer.MAX_VALUE,
+        AsyncPoolImpl.Strategy.MRU,
+        0, rateLimiter, clockedExecutor, new LongTracking()
+    );
+
+    pool.start();
+
+    // Phase A : Checking out object 'numberOfCheckoutsInPhaseA' times !
+    List<Object> checkedOutObjects = performCheckout(numberOfCheckoutsInPhaseA, pool);
+
+    // Phase B : Blocking object creation and performing the checkout 'numberOfCheckoutsInPhaseB' times again
+    blockableObjectCreator.blockCreation();
+    Future<None> future = performUnblockingCheckout(numberOfCheckoutsInPhaseB,
+        0, pool);
+
+    blockableObjectCreator.waitUntilAllBlocked();
+
+    // Phase C : Returning the checkedOut objects from Phase A back to the object pool
+    for (int i = 0; i < numbOfObjectsToBeReturnedInPhaseC; i++)
+    {
+      pool.put(checkedOutObjects.remove(0));
+    }
+
+    clockedExecutor.runFor(waiterTimeout);
+
+    // Phase D : All the object creation in phase B gets unblocked now
+    blockableObjectCreator.unblockCreation();
+    try
+    {
+      future.get(5, TimeUnit.SECONDS);
+    }
+    catch (Exception e)
+    {
+      Assert.fail("Did not complete unblocked object creations on time, Unexpected interruption", e);
+    }
+
+    // Making sure the rate limiter pending tasks are submitted to the executor
+    AssertionMethods.assertWithTimeout(5000, () ->
+        Assert.assertEquals(rateLimiter.numberOfPendingTasks(),0,"Number of tasks has to drop to 0"));
+
+    executor.shutdown();
+
+    try
+    {
+      if (!executor.awaitTermination(10, TimeUnit.SECONDS))
+      {
+        Assert.fail("Executor took too long to shutdown");
+      }
+    }
+    catch (Exception ex)
+    {
+      Assert.fail("Unexpected interruption while shutting down executor", ex);
+    }
+
+    PoolStats stats = pool.getStats();
+    Assert.assertEquals(stats.getTotalCreationIgnored(), numberOfCheckoutsInPhaseB - concurrency);
+    Assert.assertEquals(stats.getCheckedOut(), numberOfCheckoutsInPhaseA);
+    Assert.assertEquals(stats.getIdleCount(), concurrency);
+    Assert.assertEquals(stats.getTotalCreated(), numberOfCheckoutsInPhaseA + concurrency);
+    Assert.assertEquals(stats.getPoolSize(), numberOfCheckoutsInPhaseA + concurrency);
+    Assert.assertEquals(stats.getTotalWaiterTimedOut(), numberOfCheckoutsInPhaseB - numbOfObjectsToBeReturnedInPhaseC);
+  }
+
+  @DataProvider
+  public Object[][] channelStateRandomDataProvider()
+  {
+    // 500 represent a good sample for the randomized data.
+    // This has been verified against 100K test cases in local
+    int numberOfTestCases = 500;
+    Random randomNumberGenerator = ThreadLocalRandom.current();
+
+    Object[][] data = new Object[numberOfTestCases][3];
+    for (int i = 0; i < numberOfTestCases; i++)
+    {
+      int checkout = randomNumberGenerator.nextInt(200)+1;
+      int poolSize = randomNumberGenerator.nextInt(checkout)+checkout*2;
+      int concurrency = randomNumberGenerator.nextInt(Math.min(checkout,499))+1;
+      data[i][0] = checkout;
+      data[i][1] = poolSize;
+      data[i][2] = concurrency;
+    }
+
+    return data;
+  }
+
+  @DataProvider
+  public Object[][] waiterTimeoutDataProvider()
+  {
+    // 500 represent a good sample for the randomized data.
+    // This has been verified against 100K test cases in local
+    int numberOfTestCases = 500;
+    Random randomNumberGenerator = new Random();
+
+    Object[][] data = new Object[numberOfTestCases][6];
+    for (int i = 0; i < numberOfTestCases; i++)
+    {
+      int numberOfCheckoutsInPhaseA = randomNumberGenerator.nextInt(100)+1;
+      int numberOfCheckoutsInPhaseB = randomNumberGenerator.nextInt(numberOfCheckoutsInPhaseA)+1;
+      numberOfCheckoutsInPhaseB = Math.min(numberOfCheckoutsInPhaseA, numberOfCheckoutsInPhaseB);
+      int numbOfObjectsToBeReturnedInPhaseC = randomNumberGenerator.nextInt(numberOfCheckoutsInPhaseB);
+      int poolSize = randomNumberGenerator.nextInt(numberOfCheckoutsInPhaseA)+numberOfCheckoutsInPhaseA*2;
+      int concurrency = randomNumberGenerator.nextInt(Math.min(numberOfCheckoutsInPhaseB,499))+1;
+      concurrency = Math.min(concurrency, numberOfCheckoutsInPhaseB);
+
+      data[i][0] = numberOfCheckoutsInPhaseA;
+      data[i][1] = numberOfCheckoutsInPhaseB;
+      data[i][2] = numbOfObjectsToBeReturnedInPhaseC;
+      data[i][3] = poolSize;
+      data[i][4] = concurrency;
+      data[i][5] = randomNumberGenerator.nextInt(500)+100;
+    }
+
+    return data;
+  }
+
+  private List<Object> performCheckout(int numberOfCheckouts, AsyncPool<Object> pool)
+  {
+    List<Object> checkedOutObjects = new ArrayList<>(numberOfCheckouts);
+
+    ScheduledExecutorService checkoutExecutor = Executors.newScheduledThreadPool(50);
+    CountDownLatch checkoutLatch = new CountDownLatch(numberOfCheckouts);
+    Runnable checkoutTask = getCheckoutTask(pool, checkedOutObjects, new Object(), checkoutLatch, new CountDownLatch(numberOfCheckouts));
+
+    for (int i = 0; i < numberOfCheckouts; i++)
+    {
+      checkoutExecutor.execute(checkoutTask);
+    }
+
+    try
+    {
+      checkoutLatch.await(5, TimeUnit.SECONDS);
+      checkoutExecutor.shutdownNow();
+    }
+    catch (Exception ex)
+    {
+      Assert.fail("Too long to perform checkout operation");
+    }
+
+    return checkedOutObjects;
+  }
+
+  private Future<None> performUnblockingCheckout(int numberOfCheckoutRequests, int numberOfCheckouts, AsyncPool<Object> pool)
+  {
+    ScheduledExecutorService checkoutExecutor = Executors.newScheduledThreadPool(500);
+
+    CountDownLatch checkoutLatch = new CountDownLatch(numberOfCheckouts);
+    CountDownLatch requestLatch = new CountDownLatch(numberOfCheckoutRequests);
+    Runnable checkoutTask = getCheckoutTask(pool, new LinkedList<>(), new Object(), checkoutLatch,
+        requestLatch);
+
+    for (int i = 0; i < numberOfCheckoutRequests; i++)
+    {
+      checkoutExecutor.execute(checkoutTask);
+    }
+
+    try
+    {
+      requestLatch.await(5, TimeUnit.SECONDS);
+    }
+    catch (Exception ex)
+    {
+      Assert.fail("Too long to perform checkout operation");
+    }
+
+    return new DelayedFutureCallback<>(checkoutLatch, checkoutExecutor);
+  }
+
+  private class DelayedFutureCallback<T> extends FutureCallback<T>
+  {
+    private CountDownLatch _checkoutLatch;
+    private ScheduledExecutorService _checkoutExecutor;
+
+    public DelayedFutureCallback(CountDownLatch checkoutLatch, ScheduledExecutorService checkoutExecutor)
+    {
+      _checkoutLatch = checkoutLatch;
+      _checkoutExecutor = checkoutExecutor;
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+      _checkoutLatch.await(timeout, unit);
+      _checkoutExecutor.shutdownNow();
+      return null;
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+      throw new ExecutionException(new Exception("Not Implemented"));
+    }
+  }
+
+  private Runnable getCheckoutTask(AsyncPool<Object> pool, List<Object> checkedOutObjects, Object sync, CountDownLatch latch,
+      CountDownLatch requestLatch)
+  {
+    return new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        FutureCallback<Object> cb = new FutureCallback<>();
+        pool.get(cb);
+        requestLatch.countDown();
+        try
+        {
+          Object checkedOutObject = cb.get();
+          synchronized (sync)
+          {
+            checkedOutObjects.add(checkedOutObject);
+          }
+          latch.countDown();
+        }
+        catch (Exception e)
+        {
+          Assert.fail("Unexpected failure", e);
+        }
+      }
+    };
   }
 
   public static class SynchronousLifecycle implements AsyncPool.Lifecycle<Object>
@@ -619,6 +990,53 @@ public class TestAsyncPool
     public int getLive()
     {
       return _live;
+    }
+  }
+
+  public static class CreationBlockableSynchronousLifecycle extends SynchronousLifecycle
+  {
+    private CountDownLatch _blockersDoneLatch;
+    private int _totalBlockers;
+
+    public CreationBlockableSynchronousLifecycle(int checkout, int concurrency) {
+      _blockersDoneLatch = new CountDownLatch(checkout);
+      _totalBlockers = concurrency;
+    }
+
+    private CountDownLatch _doneLatch = new CountDownLatch(0);
+
+    public void unblockCreation()
+    {
+      _doneLatch.countDown();
+    }
+
+    public void blockCreation()
+    {
+      _doneLatch = new CountDownLatch(1);
+      _blockersDoneLatch = new CountDownLatch(_totalBlockers);
+    }
+
+    public void waitUntilAllBlocked() throws InterruptedException
+    {
+      _blockersDoneLatch.await();
+    }
+
+    @Override
+    public void create(Callback<Object> callback)
+    {
+      long latch;
+      try
+      {
+        latch = _blockersDoneLatch.getCount();
+        _blockersDoneLatch.countDown();
+        _doneLatch.await();
+      }
+      catch (Exception ex)
+      {
+        latch = -1;
+      }
+
+      callback.onSuccess(latch);
     }
   }
 

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestHttpsEarlyHandshake.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestHttpsEarlyHandshake.java
@@ -20,6 +20,7 @@ import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
 import com.linkedin.r2.netty.common.SslHandlerUtil;
 import com.linkedin.r2.transport.http.client.AsyncPool;
+import com.linkedin.r2.transport.http.client.HttpClientFactory;
 import com.linkedin.r2.transport.http.client.common.ChannelPoolManager;
 import com.linkedin.r2.transport.http.client.common.ChannelPoolManagerFactoryImpl;
 import com.linkedin.r2.transport.http.client.common.ChannelPoolManagerKey;
@@ -65,7 +66,9 @@ public class TestHttpsEarlyHandshake extends AbstractEchoServiceTest
     ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     ChannelPoolManagerFactoryImpl channelPoolManagerFactory =
-        new ChannelPoolManagerFactoryImpl(eventLoopGroup, scheduler, SSL_SESSION_RESUMPTION_ENABLED, _clientProvider.getUsePipelineV2());
+        new ChannelPoolManagerFactoryImpl(eventLoopGroup, scheduler, SSL_SESSION_RESUMPTION_ENABLED,
+            _clientProvider.getUsePipelineV2(), HttpClientFactory.DEFAULT_CHANNELPOOL_WAITER_TIMEOUT,
+            HttpClientFactory.DEFAULT_CONNECT_TIMEOUT, HttpClientFactory.DEFAULT_SSL_HANDSHAKE_TIMEOUT);
     SSLContext context = SslContextUtil.getContext();
 
     ChannelPoolManagerKey key = new ChannelPoolManagerKeyBuilder()

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelInitializer.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelInitializer.java
@@ -73,11 +73,13 @@ class HttpChannelInitializer extends ChannelInitializer<NioSocketChannel>
   private final int _maxHeaderSize;
   private final int _maxChunkSize;
   private final int _maxContentLength;
+  private final int _sslHandShakeTimeout;
   private final boolean _ssl;
   private final boolean _enableSSLSessionResumption;
 
   HttpChannelInitializer(SSLContext sslContext, SSLParameters sslParameters, int maxInitialLineLength,
-      int maxHeaderSize, int maxChunkSize, long maxContentLength, boolean enableSSLSessionResumption)
+      int maxHeaderSize, int maxChunkSize, long maxContentLength, boolean enableSSLSessionResumption,
+      int sslHandShakeTimeout)
   {
     _sslContext = sslContext;
     _sslParameters = sslParameters;
@@ -85,6 +87,7 @@ class HttpChannelInitializer extends ChannelInitializer<NioSocketChannel>
     _maxHeaderSize = maxHeaderSize;
     _maxChunkSize = maxChunkSize;
     _maxContentLength = maxContentLength > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) maxContentLength;
+    _sslHandShakeTimeout = sslHandShakeTimeout;
     _ssl = _sslContext != null && _sslParameters != null;
     _enableSSLSessionResumption = enableSSLSessionResumption;
   }
@@ -95,7 +98,7 @@ class HttpChannelInitializer extends ChannelInitializer<NioSocketChannel>
     if (_ssl)
     {
       channel.pipeline().addLast(SessionResumptionSslHandler.PIPELINE_SESSION_RESUMPTION_HANDLER,
-          new SessionResumptionSslHandler(_sslContext, _sslParameters, _enableSSLSessionResumption));
+          new SessionResumptionSslHandler(_sslContext, _sslParameters, _enableSSLSessionResumption, _sslHandShakeTimeout));
     }
 
     channel.pipeline().addLast("codec", new HttpClientCodec(_maxInitialLineLength, _maxHeaderSize, _maxChunkSize));

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelInitializer.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelInitializer.java
@@ -122,11 +122,13 @@ class Http2ChannelInitializer extends ChannelInitializer<NioSocketChannel>
   private final int _maxHeaderSize;
   private final int _maxChunkSize;
   private final int _maxContentLength;
+  private final int _sslHandShakeTimeout;
   private final boolean _ssl;
   private final boolean _enableSSLSessionResumption;
 
   Http2ChannelInitializer(SSLContext sslContext, SSLParameters sslParameters, int maxInitialLineLength,
-      int maxHeaderSize, int maxChunkSize, long maxContentLength, boolean enableSSLSessionResumption)
+      int maxHeaderSize, int maxChunkSize, long maxContentLength, boolean enableSSLSessionResumption,
+      int sslHandShakeTimeout)
   {
     _sslContext = sslContext;
     _sslParameters = sslParameters;
@@ -134,6 +136,7 @@ class Http2ChannelInitializer extends ChannelInitializer<NioSocketChannel>
     _maxHeaderSize = maxHeaderSize;
     _maxChunkSize = maxChunkSize;
     _maxContentLength = maxContentLength > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) maxContentLength;
+    _sslHandShakeTimeout = sslHandShakeTimeout;
     _ssl = _sslContext != null && _sslParameters != null;
     _enableSSLSessionResumption = enableSSLSessionResumption;
   }
@@ -163,7 +166,7 @@ class Http2ChannelInitializer extends ChannelInitializer<NioSocketChannel>
 
     channel.pipeline().addLast(
         SessionResumptionSslHandler.PIPELINE_SESSION_RESUMPTION_HANDLER,
-        new SessionResumptionSslHandler(sslCtx, _enableSSLSessionResumption));
+        new SessionResumptionSslHandler(sslCtx, _enableSSLSessionResumption, _sslHandShakeTimeout));
     channel.pipeline().addLast(new Http2AlpnHandler(alpnPromise, createHttp2Settings()));
   }
 

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
@@ -26,6 +26,7 @@ import com.linkedin.util.clock.SystemClock;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -69,10 +70,13 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
       long idleTimeout,
       long maxContentLength,
       boolean tcpNoDelay,
-      boolean enableSSLSessionResumption)
+      boolean enableSSLSessionResumption,
+      int connectTimeout,
+      int sslHandShakeTimeout)
   {
     final ChannelInitializer<NioSocketChannel> initializer = new Http2ChannelInitializer(
-        sslContext, sslParameters, maxInitialLineLength, maxHeaderSize, maxChunkSize, maxContentLength, enableSSLSessionResumption);
+        sslContext, sslParameters, maxInitialLineLength, maxHeaderSize, maxChunkSize, maxContentLength,
+        enableSSLSessionResumption, sslHandShakeTimeout);
 
     _scheduler = scheduler;
     _allChannels = channelGroup;
@@ -84,7 +88,11 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
     _maxContentLength = maxContentLength;
     _tcpNoDelay = tcpNoDelay;
 
-    _bootstrap = new Bootstrap().group(eventLoopGroup).channel(NioSocketChannel.class).handler(initializer);
+    _bootstrap = new Bootstrap().
+        group(eventLoopGroup).
+        channel(NioSocketChannel.class).
+        option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout).
+        handler(initializer);
     _ssl = sslContext != null && sslParameters != null;
   }
 

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolManagerFactoryImpl.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolManagerFactoryImpl.java
@@ -53,6 +53,9 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
   private final ScheduledExecutorService _scheduler;
   private final boolean _enableSSLSessionResumption;
   private final boolean _usePipelineV2;
+  private final int _channelPoolWaiterTimeout;
+  private final int _connectTimeout;
+  private final int _sslHandShakeTimeout;
 
   /**
    * @param eventLoopGroup The NioEventLoopGroup; it is the caller's responsibility to
@@ -63,12 +66,16 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
    * @param usePipelineV2 Use unified new code.
    */
   public ChannelPoolManagerFactoryImpl(NioEventLoopGroup eventLoopGroup, ScheduledExecutorService scheduler,
-      boolean enableSSLSessionResumption, boolean usePipelineV2)
+      boolean enableSSLSessionResumption, boolean usePipelineV2, int channelPoolWaiterTimeout,
+      int connectTimeout, int sslHandShakeTimeout)
   {
     _eventLoopGroup = eventLoopGroup;
     _scheduler = scheduler;
     _enableSSLSessionResumption = enableSSLSessionResumption;
     _usePipelineV2 = usePipelineV2;
+    _channelPoolWaiterTimeout = channelPoolWaiterTimeout;
+    _connectTimeout = connectTimeout;
+    _sslHandShakeTimeout = sslHandShakeTimeout;
   }
 
   @Override
@@ -101,7 +108,10 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
         _scheduler,
         channelPoolManagerKey.getMaxConcurrentConnectionInitializations(),
         _enableSSLSessionResumption,
-        channelGroup),
+        channelGroup,
+        _channelPoolWaiterTimeout,
+        _connectTimeout,
+        _sslHandShakeTimeout),
       channelPoolManagerKey.getName(),
       channelGroup,
       _scheduler);
@@ -131,7 +141,10 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
           channelPoolManagerKey.getIdleTimeout(),
           channelPoolManagerKey.getMaxResponseSize(),
           channelPoolManagerKey.isTcpNoDelay(),
-          _enableSSLSessionResumption);
+          _enableSSLSessionResumption,
+          _channelPoolWaiterTimeout,
+          _connectTimeout,
+          _sslHandShakeTimeout);
     }
     else
     {
@@ -151,7 +164,10 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
           channelPoolManagerKey.getMaxResponseSize(),
           _enableSSLSessionResumption,
           _eventLoopGroup,
-          channelGroup);
+          channelGroup,
+          _channelPoolWaiterTimeout,
+          _connectTimeout,
+          _sslHandShakeTimeout);
     }
     return new ChannelPoolManagerImpl(
         channelPoolFactory,
@@ -184,7 +200,9 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
           channelPoolManagerKey.getIdleTimeout(),
           channelPoolManagerKey.getMaxResponseSize(),
           channelPoolManagerKey.isTcpNoDelay(),
-          _enableSSLSessionResumption);
+          _enableSSLSessionResumption,
+          _connectTimeout,
+          _sslHandShakeTimeout);
     }
     else
     {
@@ -202,7 +220,9 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
           channelPoolManagerKey.getMaxResponseSize(),
           _enableSSLSessionResumption,
           _eventLoopGroup,
-          channelGroup);
+          channelGroup,
+          _connectTimeout,
+          _sslHandShakeTimeout);
     }
 
     return new ChannelPoolManagerImpl(

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/stream/http/RAPStreamClientPipelineInitializer.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/stream/http/RAPStreamClientPipelineInitializer.java
@@ -42,6 +42,7 @@ public class RAPStreamClientPipelineInitializer extends ChannelInitializer<NioSo
   private final int _maxChunkSize;
   private final long _maxResponseSize;
   private final boolean _enableSSLSessionResumption;
+  private final int _sslHandShakeTimeout;
 
   /**
    * Creates new instance.
@@ -53,7 +54,8 @@ public class RAPStreamClientPipelineInitializer extends ChannelInitializer<NioSo
    *          configuration in sslContext.
    */
   RAPStreamClientPipelineInitializer(SSLContext sslContext, SSLParameters sslParameters, int maxHeaderSize,
-                                     int maxChunkSize, long maxResponseSize, boolean enableSSLSessionResumption)
+                                     int maxChunkSize, long maxResponseSize, boolean enableSSLSessionResumption,
+                                     int sslHandShakeTimeout)
   {
     // Check if requested parameters are present in the supported params of the context.
     // Log warning for those not present. Throw an exception if none present.
@@ -86,6 +88,7 @@ public class RAPStreamClientPipelineInitializer extends ChannelInitializer<NioSo
     _maxChunkSize = maxChunkSize;
     _maxResponseSize = maxResponseSize;
     _enableSSLSessionResumption = enableSSLSessionResumption;
+    _sslHandShakeTimeout = sslHandShakeTimeout;
   }
 
   /**
@@ -127,7 +130,7 @@ public class RAPStreamClientPipelineInitializer extends ChannelInitializer<NioSo
     if (_sslContext != null)
     {
       ch.pipeline().addLast(SessionResumptionSslHandler.PIPELINE_SESSION_RESUMPTION_HANDLER,
-        new SessionResumptionSslHandler(_sslContext, _sslParameters, _enableSSLSessionResumption));
+          new SessionResumptionSslHandler(_sslContext, _sslParameters, _enableSSLSessionResumption, _sslHandShakeTimeout));
     }
     ch.pipeline().addLast("codec", new HttpClientCodec(4096, _maxHeaderSize, _maxChunkSize));
     ch.pipeline().addLast("rapFullRequestEncoder", new RAPStreamFullRequestEncoder());

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/stream/http2/Http2AlpnHandler.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/stream/http2/Http2AlpnHandler.java
@@ -57,8 +57,10 @@ class Http2AlpnHandler extends ChannelDuplexHandler
 
   private ChannelPromise _alpnPromise;
   private final boolean _enableSSLSessionResumption;
+  private final int _sslHandShakeTimeout;
 
-  public Http2AlpnHandler(SslContext sslContext, Http2StreamCodec http2Handler, boolean enableSSLSessionResumption)
+  public Http2AlpnHandler(SslContext sslContext, Http2StreamCodec http2Handler, boolean enableSSLSessionResumption,
+      int sslHandShakeTimeout)
   {
     ObjectUtil.checkNotNull(sslContext, "sslContext");
     ObjectUtil.checkNotNull(http2Handler, "http2Handler");
@@ -66,6 +68,7 @@ class Http2AlpnHandler extends ChannelDuplexHandler
     _sslContext = sslContext;
     _http2Handler = http2Handler;
     _enableSSLSessionResumption = enableSSLSessionResumption;
+    _sslHandShakeTimeout = sslHandShakeTimeout;
   }
 
   @Override
@@ -75,7 +78,7 @@ class Http2AlpnHandler extends ChannelDuplexHandler
 
     // the class will take care of establishing the SSL connection
     ctx.pipeline().addFirst(SessionResumptionSslHandler.PIPELINE_SESSION_RESUMPTION_HANDLER,
-      new SessionResumptionSslHandler(_sslContext, _enableSSLSessionResumption));
+      new SessionResumptionSslHandler(_sslContext, _enableSSLSessionResumption, _sslHandShakeTimeout));
 
     // Fail the ALPN promise when channel is closed
     ctx.channel().closeFuture().addListener(future -> {

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/stream/http2/Http2ClientPipelineInitializer.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/stream/http2/Http2ClientPipelineInitializer.java
@@ -65,10 +65,12 @@ class Http2ClientPipelineInitializer extends ChannelInitializer<NioSocketChannel
   public static final AttributeKey<Http2Connection.PropertyKey> CHANNEL_POOL_HANDLE_ATTR_KEY
       = AttributeKey.valueOf("Handle");
   private final boolean _enableSSLSessionResumption;
+  private final int _sslHandShakeTimeout;
 
   public Http2ClientPipelineInitializer(SSLContext sslContext, SSLParameters sslParameters,
                                         int maxHeaderSize, int maxChunkSize, long maxResponseSize,
-                                        long gracefulShutdownTimeout, boolean enableSSLSessionResumption)
+                                        long gracefulShutdownTimeout, boolean enableSSLSessionResumption,
+                                        int sslHandShakeTimeout)
   {
     // Check if requested parameters are present in the supported params of the context.
     // Log warning for those not present. Throw an exception if none present.
@@ -102,6 +104,7 @@ class Http2ClientPipelineInitializer extends ChannelInitializer<NioSocketChannel
     _maxResponseSize = maxResponseSize;
     _gracefulShutdownTimeout = gracefulShutdownTimeout;
     _enableSSLSessionResumption = enableSSLSessionResumption;
+    _sslHandShakeTimeout = sslHandShakeTimeout;
   }
 
   @Override
@@ -179,7 +182,7 @@ class Http2ClientPipelineInitializer extends ChannelInitializer<NioSocketChannel
       .gracefulShutdownTimeoutMillis(_gracefulShutdownTimeout)
       .build();
 
-    Http2AlpnHandler alpnHandler = new Http2AlpnHandler(context, http2Codec, _enableSSLSessionResumption);
+    Http2AlpnHandler alpnHandler = new Http2AlpnHandler(context, http2Codec, _enableSSLSessionResumption, _sslHandShakeTimeout);
     Http2SchemeHandler schemeHandler = new Http2SchemeHandler(HttpScheme.HTTPS.toString());
     Http2StreamResponseHandler responseHandler = new Http2StreamResponseHandler();
 

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/stream/http2/Http2NettyStreamChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/stream/http2/Http2NettyStreamChannelPoolFactory.java
@@ -27,6 +27,7 @@ import com.linkedin.util.clock.SystemClock;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -63,12 +64,14 @@ public class Http2NettyStreamChannelPoolFactory implements ChannelPoolFactory
     long maxResponseSize,
     boolean enableSSLSessionResumption,
     EventLoopGroup eventLoopGroup,
-    ChannelGroup channelGroup)
+    ChannelGroup channelGroup, int connectTimeout, int sslHandShakeTimeout)
   {
     ChannelInitializer<NioSocketChannel> initializer = new Http2ClientPipelineInitializer(
-      sslContext, sslParameters, maxHeaderSize, maxChunkSize, maxResponseSize, gracefulShutdownTimeout, enableSSLSessionResumption);
+      sslContext, sslParameters, maxHeaderSize, maxChunkSize, maxResponseSize, gracefulShutdownTimeout,
+        enableSSLSessionResumption, sslHandShakeTimeout);
 
-    _bootstrap = new Bootstrap().group(eventLoopGroup).channel(NioSocketChannel.class).handler(initializer);
+    _bootstrap = new Bootstrap().group(eventLoopGroup).channel(NioSocketChannel.class).
+        option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout).handler(initializer);
     _idleTimeout = idleTimeout;
     _maxPoolWaiterSize = maxPoolWaiterSize;
 

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/HttpClientBuilder.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/HttpClientBuilder.java
@@ -59,7 +59,8 @@ public class HttpClientBuilder
     _channelPoolManagerKeyBuilder = new ChannelPoolManagerKeyBuilder();
     _sslChannelPoolManagerKeyBuilder = new ChannelPoolManagerKeyBuilder();
     _channelPoolManagerFactory = new ChannelPoolManagerFactoryImpl(_eventLoopGroup, _scheduler,
-        SSL_SESSION_RESUMPTION_ENABLED, NEW_PIPELINE_ENABLED);
+        SSL_SESSION_RESUMPTION_ENABLED, NEW_PIPELINE_ENABLED, HttpClientFactory.DEFAULT_CHANNELPOOL_WAITER_TIMEOUT,
+        HttpClientFactory.DEFAULT_CONNECT_TIMEOUT, HttpClientFactory.DEFAULT_SSL_HANDSHAKE_TIMEOUT);
   }
 
   public HttpClientBuilder setCallbackExecutors(ExecutorService callbackExecutors)

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/stream/http2/TestEarlyUpgrade.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/stream/http2/TestEarlyUpgrade.java
@@ -19,6 +19,7 @@ package com.linkedin.r2.transport.http.client.stream.http2;
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
 import com.linkedin.r2.testutils.server.HttpServerBuilder;
+import com.linkedin.r2.transport.http.client.HttpClientFactory;
 import com.linkedin.r2.transport.http.client.common.ChannelPoolManager;
 import com.linkedin.r2.transport.http.client.common.ChannelPoolManagerFactoryImpl;
 import com.linkedin.r2.transport.http.client.common.ChannelPoolManagerKey;
@@ -51,7 +52,6 @@ public class TestEarlyUpgrade
   private ScheduledExecutorService _scheduler;
   private final boolean _newPipelineEnabled;
 
-
   @Factory(dataProvider = "pipelines")
   public TestEarlyUpgrade(boolean newPipelineEnabled)
   {
@@ -81,7 +81,8 @@ public class TestEarlyUpgrade
   {
     ChannelPoolManagerFactoryImpl channelPoolManagerFactory =
         new ChannelPoolManagerFactoryImpl(_eventLoopGroup, _scheduler,
-            SSL_SESSION_RESUMPTION_ENABLED, _newPipelineEnabled);
+            SSL_SESSION_RESUMPTION_ENABLED, _newPipelineEnabled, HttpClientFactory.DEFAULT_CHANNELPOOL_WAITER_TIMEOUT,
+            HttpClientFactory.DEFAULT_CONNECT_TIMEOUT, HttpClientFactory.DEFAULT_SSL_HANDSHAKE_TIMEOUT);
 
     ChannelPoolManagerKey key = new ChannelPoolManagerKeyBuilder()
       // min pool set to one in such a way a connection is opened before the request

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/stream/http2/TestHttp2AlpnHandler.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/stream/http2/TestHttp2AlpnHandler.java
@@ -39,7 +39,7 @@ public class TestHttp2AlpnHandler
     SslContext sslContext = Mockito.mock(SslContext.class);
     Http2StreamCodec http2StreamCodec = Mockito.mock(Http2StreamCodec.class);
 
-    Http2AlpnHandler handler = new Http2AlpnHandler(sslContext, http2StreamCodec, true);
+    Http2AlpnHandler handler = new Http2AlpnHandler(sslContext, http2StreamCodec, true, Integer.MAX_VALUE);
     EmbeddedChannel channel = new EmbeddedChannel(handler);
 
     // Write should not succeed before negotiation completes
@@ -54,7 +54,7 @@ public class TestHttp2AlpnHandler
     SslContext sslContext = Mockito.mock(SslContext.class);
     Http2StreamCodec http2StreamCodec = Mockito.mock(Http2StreamCodec.class);
 
-    Http2AlpnHandler handler = new Http2AlpnHandler(sslContext, http2StreamCodec, true);
+    Http2AlpnHandler handler = new Http2AlpnHandler(sslContext, http2StreamCodec, true, Integer.MAX_VALUE);
     EmbeddedChannel channel = new EmbeddedChannel(handler);
 
     RequestWithCallback request = Mockito.mock(RequestWithCallback.class);


### PR DESCRIPTION
When a object creation request to the pool is faster than the actual creation itself - the rate limiter queues all the incoming requests and creates the object without considering the fact that the checked out objects would come back to the pool.

This change is to make sure that the rate limiter task always check if there is a waiter in the queue or the pool is under the minimum level.