### PR TITLE
Fix prepare-release script so that tag is deleted on failed push

### DIFF
--- a/prepare-release
+++ b/prepare-release
@@ -44,3 +44,10 @@ fi
 # Push release tag
 echo "Pushing tag $TAG_NAME..."
 git push $REMOTE $TAG_NAME
+
+if [ $? -ne 0 ]
+then
+  echo 'Push failed, clearing tag from local repo...'
+  git tag -d $TAG_NAME
+  exit 1
+fi


### PR DESCRIPTION
When the `prepare-release` script fails to push the locally created
release tag, it should delete the tag locally so as not to confuse
the developer.