### PR TITLE
Fix issues when encoding/parsing custom properties in PDL.

### DIFF
--- a/data/src/main/antlr/com/linkedin/data/grammar/Pdl.g4
+++ b/data/src/main/antlr/com/linkedin/data/grammar/Pdl.g4
@@ -145,12 +145,13 @@ propName returns [List<String> path]
   : propSegment {$path.add($propSegment.value);} (DOT propSegment {$path.add($propSegment.value);})*
   ;
 
-// A property segment. Can be escaped with back-tick() to include dots (.) in the segment.
+// A property segment. Can be escaped with back-tick() to include dots (.) or other special characters in the segment.
 // Eg,
 // validate
 // `com.linkedin.validate.CustomValidator`
 // deprecated
-propSegment returns [String value]: (ID | ESCAPED_PROP_ID) {
+// `/*`
+propSegment returns [String value]: (ID | PROPERTY_ID | ESCAPED_PROP_ID) {
   $value = PdlParseUtils.unescapeIdentifier($text);
 };
 
@@ -236,5 +237,7 @@ ID: UNESCAPED_ID | ESCAPED_ID;
 // in source files, but they are treated as whitespace.
 WS: [ \t\n\r\f,]+ -> skip;
 
+// Property segments can be any group of regular chars without escaping.
+PROPERTY_ID: [A-Za-z0-9_\-]+;
 // Property segment id escaped with ` to include special characters in them.
 ESCAPED_PROP_ID: '`' (~[`])+ '`';

--- a/data/src/main/antlr/com/linkedin/data/grammar/Pdl.g4
+++ b/data/src/main/antlr/com/linkedin/data/grammar/Pdl.g4
@@ -236,5 +236,5 @@ ID: UNESCAPED_ID | ESCAPED_ID;
 // in source files, but they are treated as whitespace.
 WS: [ \t\n\r\f,]+ -> skip;
 
-// Property segment id escaped with ` to include dots in them.
-ESCAPED_PROP_ID: '`' UNESCAPED_ID (DOT UNESCAPED_ID)* '`';
+// Property segment id escaped with ` to include special characters in them.
+ESCAPED_PROP_ID: '`' (~[`])+ '`';

--- a/data/src/main/java/com/linkedin/data/schema/PdlBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/PdlBuilder.java
@@ -52,7 +52,7 @@ abstract class PdlBuilder
       "record", "typeref", "union", "null", "true", "false"
   ));
   private static final char ESCAPE_CHAR = '`';
-  private static final Pattern NON_IDENTIFIER_CHARS = Pattern.compile(".*[^0-9a-zA-Z_-].*");
+  private static final Pattern IDENTIFIER_CHARS = Pattern.compile("[0-9a-zA-Z_-]*");
 
   /**
    * Each subclass must define a provider for creating new instances.
@@ -136,10 +136,10 @@ abstract class PdlBuilder
    */
   PdlBuilder writeProperties(List<String> prefix, Map<String, Object> properties) throws IOException
   {
-    for (Map.Entry<String, Object> entry :
-        properties.entrySet().stream()
-            .sorted(Map.Entry.comparingByKey())
-            .collect(Collectors.toList()))
+    List<Map.Entry<String, Object>> orderedProperties =  properties.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .collect(Collectors.toList());
+    for (Map.Entry<String, Object> entry : orderedProperties)
     {
       String key = entry.getKey();
       Object value = entry.getValue();
@@ -211,7 +211,7 @@ abstract class PdlBuilder
   private static String escapePropertyKey(String propertyKey)
   {
     propertyKey = propertyKey.trim();
-    if (KEYWORDS.contains(propertyKey) || NON_IDENTIFIER_CHARS.matcher(propertyKey).matches())
+    if (KEYWORDS.contains(propertyKey) || !IDENTIFIER_CHARS.matcher(propertyKey).matches())
     {
       return ESCAPE_CHAR + propertyKey + ESCAPE_CHAR;
     }

--- a/data/src/test/java/com/linkedin/data/schema/grammar/TestPdlSchemaParser.java
+++ b/data/src/test/java/com/linkedin/data/schema/grammar/TestPdlSchemaParser.java
@@ -55,6 +55,8 @@ public class TestPdlSchemaParser
         + "@validate.`com.linkedin.namespace.CustomValidator`.low = 15\n"
         + "@validate.`com.linkedin.namespace.CustomValidator`.`union`.low.`record` = \"Date\"\n"
         + "@`com.linkedin.CustomValidator` = \"abc\"\n"
+        + "@pathProp.`/*`.`*/.$` = false\n"
+        + "@`/*.*/.$`\n"
         + "record RecordDataSchema {}";
 
     // construct expected data map
@@ -84,6 +86,14 @@ public class TestPdlSchemaParser
 
     expected.put("validate", validate);
     expected.put("com.linkedin.CustomValidator", "abc");
+
+    DataMap propertyWithPath = new DataMap();
+    DataMap propertyWithSpecialChars = new DataMap();
+    propertyWithPath.put("/*", propertyWithSpecialChars);
+    propertyWithSpecialChars.put("*/.$", false);
+    expected.put("pathProp", propertyWithPath);
+
+    expected.put("/*.*/.$", true);
 
     DataSchema encoded = TestUtil.dataSchemaFromPdlString(sourcePdl);
     Assert.assertNotNull(encoded);

--- a/data/src/test/java/com/linkedin/data/schema/grammar/TestPdlSchemaParser.java
+++ b/data/src/test/java/com/linkedin/data/schema/grammar/TestPdlSchemaParser.java
@@ -57,11 +57,14 @@ public class TestPdlSchemaParser
         + "@`com.linkedin.CustomValidator` = \"abc\"\n"
         + "@pathProp.`/*`.`*/.$` = false\n"
         + "@`/*.*/.$`\n"
+        + "@grammarChars.`foo[type=a.b.c].bar` = \"grammarChars\"\n"
         + "record RecordDataSchema {}";
 
     // construct expected data map
     Map<String, Object> expected = new HashMap<>();
     DataMap validate = new DataMap();
+    // @validate.one.two.arrayOne = ["a", "b"]"
+    // @validate.one.two.arrayTwo = [1,2,3,4]"
     DataMap one = new DataMap();
     DataMap two = new DataMap();
     two.put("arrayOne", new DataList(Arrays.asList("a", "b")));
@@ -69,31 +72,40 @@ public class TestPdlSchemaParser
     one.put("two", two);
     validate.put("one", one);
 
+    // @validate.`com.linkedin.CustomValidator`.low = 5"
     DataMap customValidator = new DataMap();
     customValidator.put("low", 5);
     validate.put("com.linkedin.CustomValidator", customValidator);
 
+    // @validate.`com.linkedin.namespace.CustomValidator`.low = 15"
+    // @validate.`com.linkedin.namespace.CustomValidator`.`union`.low.`record` = "Date"
     DataMap customValidator2 = new DataMap();
     customValidator2.put("low", 15);
-
     DataMap unionMap = new DataMap();
     customValidator2.put("union", unionMap);
-
     DataMap lowMap = new DataMap();
     unionMap.put("low", lowMap);
     lowMap.put("record", "Date");
     validate.put("com.linkedin.namespace.CustomValidator", customValidator2);
-
     expected.put("validate", validate);
+
+    // @`com.linkedin.CustomValidator` = "abc"
     expected.put("com.linkedin.CustomValidator", "abc");
 
+    // @pathProp.`/*`.`*/.$` = false
     DataMap propertyWithPath = new DataMap();
     DataMap propertyWithSpecialChars = new DataMap();
     propertyWithPath.put("/*", propertyWithSpecialChars);
     propertyWithSpecialChars.put("*/.$", false);
     expected.put("pathProp", propertyWithPath);
 
+    // @`/*.*/.$`
     expected.put("/*.*/.$", true);
+
+    // "@grammarChars.`foo[type=a.b.c].bar` = "grammarChars"
+    DataMap grammarChars = new DataMap();
+    grammarChars.put("foo[type=a.b.c].bar", "grammarChars");
+    expected.put("grammarChars", grammarChars);
 
     DataSchema encoded = TestUtil.dataSchemaFromPdlString(sourcePdl);
     Assert.assertNotNull(encoded);

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/escaping/PropertyKeyEscaping.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/escaping/PropertyKeyEscaping.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.pegasus.generator.test.idl.escaping
 
 record PropertyKeyEscaping {
   @`namespace` = "foo.bar"
+  @path.`/*.*/`
   @`test.path` = 1
   @validate.`com.linkedin.CustomValidator` = "foo"
   aField: string

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/escaping/PropertyKeyEscaping.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/escaping/PropertyKeyEscaping.pdl
@@ -2,7 +2,9 @@ namespace com.linkedin.pegasus.generator.test.idl.escaping
 
 record PropertyKeyEscaping {
   @`namespace` = "foo.bar"
-  @path.`/*.*/`
+  @path.`//`.`/*.*/`.`/** foo */`
+  @path2.`/**`.`*/`
+  @shouldNotBeEscaped.ABC.1-2.a_b.ab124.000.ABC-123
   @`test.path` = 1
   @validate.`com.linkedin.CustomValidator` = "foo"
   aField: string

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/escaping/PropertyKeyEscaping.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/escaping/PropertyKeyEscaping.pdl
@@ -1,6 +1,7 @@
 namespace com.linkedin.pegasus.generator.test.idl.escaping
 
 record PropertyKeyEscaping {
+  @grammarChars.`foo[type=a.b.c].bar`.`{:=}` = "grammarChars"
   @`namespace` = "foo.bar"
   @path.`//`.`/*.*/`.`/** foo */`
   @path2.`/**`.`*/`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.1.18
+version=28.1.19
 sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
 sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 org.gradle.configureondemand=true


### PR DESCRIPTION
Allow PDL parser and encoder to support property keys with special characters.
Also sort properties by key before encoding them to ensure ordering consistency.