### PR TITLE
Fix for PDL schema cyclic referencing detection in "includes" and "typeref" 

### DIFF
--- a/data/src/main/java/com/linkedin/data/schema/AbstractSchemaParser.java
+++ b/data/src/main/java/com/linkedin/data/schema/AbstractSchemaParser.java
@@ -191,7 +191,7 @@ abstract public class AbstractSchemaParser implements PegasusSchemaParser
     return schema;
   }
 
-  private void checkForCycleWithInclude(String fullName)
+  protected void checkForCycleWithInclude(String fullName)
   {
     LinkedHashMap<String, Boolean> pendingSchemas = getResolver().getPendingSchemas();
     // Return if there is no cycle.

--- a/data/src/main/java/com/linkedin/data/schema/grammar/PdlSchemaParser.java
+++ b/data/src/main/java/com/linkedin/data/schema/grammar/PdlSchemaParser.java
@@ -578,6 +578,7 @@ public class PdlSchemaParser extends AbstractSchemaParser
       setDocAndProperties(context, schema);
       bindNameToSchema(name, schema.getAliases(), schema);
       DataSchema refSchema = toDataSchema(typeref.ref);
+      checkTyperefCycle(schema, refSchema);
       schema.setReferencedType(refSchema);
       schema.setRefDeclaredInline(isDeclaredInline(typeref.ref));
     }
@@ -1093,6 +1094,10 @@ public class PdlSchemaParser extends AbstractSchemaParser
     if (schema == null)
     {
       schema = getResolver().findDataSchema(fullName, errorMessageBuilder());
+      if (schema != null)
+      {
+        checkForCycleWithInclude(((NamedDataSchema) schema).getFullName());
+      }
     }
     return schema;
   }

--- a/data/src/main/java/com/linkedin/data/schema/grammar/PdlSchemaParser.java
+++ b/data/src/main/java/com/linkedin/data/schema/grammar/PdlSchemaParser.java
@@ -1082,26 +1082,6 @@ public class PdlSchemaParser extends AbstractSchemaParser
     }
   }
 
-  /**
-   * Look for {@link DataSchema} with the specified name.
-   *
-   * @param fullName to lookup.
-   * @return the {@link DataSchema} if lookup was successful else return null.
-   */
-  public DataSchema lookupName(String fullName)
-  {
-    DataSchema schema = DataSchemaUtil.typeStringToPrimitiveDataSchema(fullName);
-    if (schema == null)
-    {
-      schema = getResolver().findDataSchema(fullName, errorMessageBuilder());
-      if (schema != null)
-      {
-        checkForCycleWithInclude(((NamedDataSchema) schema).getFullName());
-      }
-    }
-    return schema;
-  }
-
   private DataSchema toDataSchema(TypeAssignmentContext typeAssignment) throws ParseException {
     TypeReferenceContext typeReference = typeAssignment.typeReference();
     if (typeReference != null)

--- a/data/src/test/java/com/linkedin/data/schema/annotation/TestSchemaAnnotationProcessor.java
+++ b/data/src/test/java/com/linkedin/data/schema/annotation/TestSchemaAnnotationProcessor.java
@@ -76,13 +76,6 @@ public class TestSchemaAnnotationProcessor
             "Annotation resolution processing failed at at least one of the handlers.\n"
         },
         {
-            "denormalizedsource/invalid/3_5_cyclic_from_include.pdl",
-            "Annotation processing encountered errors during resolution in \"customAnnotation\" handler. \n" +
-            "ERROR :: /com.linkedin.data.schema.annotation.denormalizedsource.invalid.A/f1/com.linkedin.data.schema.annotation.denormalizedsource.invalid.A :: Found overrides that forms a cyclic-referencing: Overrides entry in traverser path \"/com.linkedin.data.schema.annotation.denormalizedsource.invalid.A\" with its pathSpec value \"/f1/f2\" is pointing to the field with traverser path \"/com.linkedin.data.schema.annotation.denormalizedsource.invalid.A/f1/com.linkedin.data.schema.annotation.denormalizedsource.invalid.A\" and schema name \"com.linkedin.data.schema.annotation.denormalizedsource.invalid.A\", this is causing cyclic-referencing.\n" +
-            "ERROR :: /com.linkedin.data.schema.annotation.denormalizedsource.invalid.A :: Overriding pathSpec defined /f1/f2 does not point to a valid primitive field\n" +
-            "Annotation resolution processing failed at at least one of the handlers.\n"
-        },
-        {
           "denormalizedsource/invalid/5_pathSpec_invalid.pdl",
             "Annotation processing encountered errors during resolution in \"customAnnotation\" handler. \n" +
             "ERROR :: /com.linkedin.data.schema.annotation.denormalizedsource.invalid.rcd :: Overrides entries in record schema properties should be pointing to fields in included record schemas only. The pathSpec defined /nonInlucdeField is not pointing to a included field.\n" +

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
@@ -30,7 +30,6 @@ import com.linkedin.data.schema.SchemaFormatType;
 import com.linkedin.data.schema.SchemaParser;
 import com.linkedin.data.schema.SchemaParserFactory;
 import com.linkedin.data.schema.grammar.PdlSchemaParser;
-import com.linkedin.data.schema.grammar.PdlSchemaParserFactory;
 import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.data.template.RecordTemplate;
 import java.io.ByteArrayInputStream;
@@ -73,12 +72,11 @@ public class TestDataSchemaResolver
 
   public static class MapDataSchemaResolver extends AbstractDataSchemaResolver
   {
-    public MapDataSchemaResolver(DataSchemaParserFactory parserFactory,
-                                 List<String> paths, String extension, Map<String, String> map)
+    public MapDataSchemaResolver(DataSchemaParserFactory parserFactory, List<String> paths, Map<String, String> map)
     {
       super(parserFactory);
       _paths = paths;
-      _extension = extension;
+      _extension = "." + parserFactory.getLanguageExtension();
       _map = map;
     }
 
@@ -230,7 +228,7 @@ public class TestDataSchemaResolver
   {
     boolean debug = false;
 
-    DataSchemaResolver resolver = new MapDataSchemaResolver(SchemaParserFactory.instance(), _testPaths, ".pdsc", _testSchemas);
+    DataSchemaResolver resolver = new MapDataSchemaResolver(SchemaParserFactory.instance(), _testPaths, _testSchemas);
     lookup(resolver, _testLookupAndExpectedResults, File.separatorChar, debug);
   }
 
@@ -726,10 +724,10 @@ public class TestDataSchemaResolver
 
     for (String[] testLookupAndExpectedResult : testLookupAndExpectedResults)
     {
-      DataSchemaResolver schemaResolver = new MapDataSchemaResolver(
-          extension.equals(PDSC) ? SchemaParserFactory.instance() : PdlSchemaParserFactory.instance(),
-          Arrays.asList(buildSystemIndependentPath("a1")), "." + extension.toString().toLowerCase(), testSchemas);
-      lookup(schemaResolver, new String[][] { testLookupAndExpectedResult}, File.separatorChar, debug, extension);
+      DataSchemaResolver schemaResolver =
+          new MapDataSchemaResolver(extension.getSchemaParserFactory(), Arrays.asList(buildSystemIndependentPath("a1")),
+                                    testSchemas);
+      lookup(schemaResolver, new String[][]{testLookupAndExpectedResult}, File.separatorChar, debug, extension);
     }
   }
 

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
@@ -26,6 +26,7 @@ import com.linkedin.data.schema.DataSchemaResolver;
 import com.linkedin.data.schema.NamedDataSchema;
 import com.linkedin.data.schema.PegasusSchemaParser;
 import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.SchemaFormatType;
 import com.linkedin.data.schema.SchemaParser;
 import com.linkedin.data.schema.SchemaParserFactory;
 import com.linkedin.data.schema.grammar.PdlSchemaParser;
@@ -62,6 +63,8 @@ public class TestDataSchemaResolver
   static final String ERROR = "error";
   static final String FOUND = "found";
   static final String NOT_FOUND = "not found";
+  static final SchemaFormatType PDL = SchemaFormatType.PDL;
+  static final SchemaFormatType PDSC = SchemaFormatType.PDSC;
 
   @BeforeTest
   public void setup()
@@ -238,7 +241,7 @@ public class TestDataSchemaResolver
     {
         {
           "Two records including each other",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"include2\"], \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"string\" } ] }",
                   buildSystemIndependentPath("a1", "include2.pdsc"), "{ \"name\" : \"include2\", \"type\" : \"record\", \"include\": [\"include1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }"
             ),
@@ -257,7 +260,7 @@ public class TestDataSchemaResolver
         },
         {
             "Two records including each other",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes include2 {\n member1: string\n}",
                   buildSystemIndependentPath("a1", "include2.pdl"), "record include2 includes include1 {\n member2: string\n }"
                  ),
@@ -276,7 +279,7 @@ public class TestDataSchemaResolver
         },
         {
             "Two records including each other using aliases",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"aliases\" : [\"includeAlias1\"], \"type\" : \"record\", \"include\": [\"include2\"], \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"string\" } ] }",
                 buildSystemIndependentPath("a1", "include2.pdsc"), "{ \"name\" : \"include2\", \"type\" : \"record\", \"include\": [\"includeAlias1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }"
             ),
@@ -291,7 +294,7 @@ public class TestDataSchemaResolver
         },
         {
             "Two records including each other using aliases",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "include1.pdl"), "@aliases = [\"includeAlias1\"] record include1 includes include2 { member1: string }",
                   buildSystemIndependentPath("a1", "include2.pdl"), "record include2 includes includeAlias1 {member2: string}"),
             new String[][]
@@ -305,7 +308,7 @@ public class TestDataSchemaResolver
         },
         {
             "First record has a record field, and that record includes the first record",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"include1\" } ] }",
                 buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"record1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }"
             ),
@@ -325,7 +328,7 @@ public class TestDataSchemaResolver
         },
         {
             "First record has a record field, and that record includes the first record",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: include1 }",
                   buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes record1 { member2: string } "
                  ),
@@ -345,7 +348,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving only fields",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"record2\" } ] }",
                 buildSystemIndependentPath("a1", "record2.pdsc"), "{ \"name\" : \"record2\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"record1\" } ] }"
             ),
@@ -367,7 +370,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving only fields",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: record2 }",
                   buildSystemIndependentPath("a1", "record2.pdl"), "record record2 { member2: record1 }"
                  ),
@@ -389,7 +392,7 @@ public class TestDataSchemaResolver
         },
         {
             "Three records with one include in the cycle",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"record1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }",
                 buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"record2\" } ] }",
                 buildSystemIndependentPath("a1", "record2.pdsc"), "{ \"name\" : \"record2\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"include1\" } ] }"
@@ -416,7 +419,7 @@ public class TestDataSchemaResolver
 
         {
             "Three records with one include in the cycle",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes record1 { member2: string }",
                   buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: record2 }",
                   buildSystemIndependentPath("a1", "record2.pdl"), "record record2 { member1: include1 }"
@@ -442,7 +445,7 @@ public class TestDataSchemaResolver
         },
         {
             "Three records with one include not in the cycle",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"record1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }",
                 buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"record2\" } ] }",
                 buildSystemIndependentPath("a1", "record2.pdsc"), "{ \"name\" : \"record2\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"record1\" } ] }"
@@ -471,7 +474,7 @@ public class TestDataSchemaResolver
         },
         {
             "Three records with one include not in the cycle",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes record1 { member2: string }",
                   buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: record2 }",
                   buildSystemIndependentPath("a1", "record2.pdl"), "record record2 { member1: record1 }"
@@ -500,7 +503,7 @@ public class TestDataSchemaResolver
         },
         {
             "Self including record",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "include.pdsc"), "{ \"name\" : \"include\", \"type\" : \"record\", \"include\": [\"include\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }"
             ),
             new String[][]
@@ -514,7 +517,7 @@ public class TestDataSchemaResolver
         },
         {
             "Self including record",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "include.pdl"), "record include includes include { member2: string }"
                  ),
             new String[][]
@@ -528,7 +531,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving include, typeref and a record",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"record1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }",
                 buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"typeref1\" } ] }",
                 buildSystemIndependentPath("a1", "typeref1.pdsc"), "{ \"name\" : \"typeref1\", \"type\" : \"typeref\", \"ref\" : \"include1\" }"
@@ -554,7 +557,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving include, typeref and a record",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes record1 { member2: string }",
                   buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: typeref1 }",
                   buildSystemIndependentPath("a1", "typeref1.pdl"), "typeref typeref1 = include1"
@@ -580,7 +583,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving typerefs",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "typeref1.pdsc"), "{ \"name\" : \"typeref1\", \"type\" : \"typeref\", \"ref\": \"typeref2\" }",
                 buildSystemIndependentPath("a1", "typeref2.pdsc"), "{ \"name\" : \"typeref2\", \"type\" : \"typeref\", \"ref\" : \"typeref3\" }",
                 buildSystemIndependentPath("a1", "typeref3.pdsc"), "{ \"name\" : \"typeref3\", \"type\" : \"typeref\", \"ref\" : { \"type\" : \"array\", \"items\" : \"typeref1\" } }"
@@ -606,7 +609,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving typerefs",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "typeref1.pdl"), "typeref typeref1 = typeref2",
                   buildSystemIndependentPath("a1", "typeref2.pdl"), "typeref typeref2 = typeref3",
                   buildSystemIndependentPath("a1", "typeref3.pdl"), "typeref typeref3 = array[typeref1]"
@@ -632,7 +635,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving typerefs, with a record outside cycle",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"typeref1\" } ] }",
                 buildSystemIndependentPath("a1", "typeref1.pdsc"), "{ \"name\" : \"typeref1\", \"type\" : \"typeref\", \"ref\" : \"typeref2\" }",
                 buildSystemIndependentPath("a1", "typeref2.pdsc"), "{ \"name\" : \"typeref2\", \"type\" : \"typeref\", \"ref\" : \"typeref1\" }"
@@ -659,7 +662,7 @@ public class TestDataSchemaResolver
 
         {
             "Circular reference involving typerefs, with a record outside cycle",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: typeref1 }",
                   buildSystemIndependentPath("a1", "typeref1.pdl"), "typeref typeref1 = typeref2",
                   buildSystemIndependentPath("a1", "typeref2.pdl"), "typeref typeref2 = typeref1"
@@ -685,7 +688,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving typerefs, using alias",
-            "pdsc",
+            PDSC,
             asMap(buildSystemIndependentPath("a1", "typeref1.pdsc"), "{ \"name\" : \"typeref1\", \"aliases\" : [\"typerefAlias1\"], \"type\" : \"typeref\", \"ref\" : \"typeref2\" }",
                 buildSystemIndependentPath("a1", "typeref2.pdsc"), "{ \"name\" : \"typeref2\", \"type\" : \"typeref\", \"ref\" : \"typerefAlias1\" }"
             ),
@@ -700,7 +703,7 @@ public class TestDataSchemaResolver
         },
         {
             "Circular reference involving typerefs, using alias",
-            "pdl",
+            PDL,
             asMap(buildSystemIndependentPath("a1", "typeref1.pdl"), "@aliases = [\"typerefAlias1\"] typeref typeref1 = typeref2",
                   buildSystemIndependentPath("a1", "typeref2.pdl"), "typeref typeref2 = typerefAlias1"
                  ),
@@ -717,15 +720,15 @@ public class TestDataSchemaResolver
   }
 
   @Test(dataProvider = "circularReferenceData")
-  public void testCircularReferences(String desc, String extension, Map<String, String> testSchemas, String[][] testLookupAndExpectedResults)
+  public void testCircularReferences(String desc, SchemaFormatType extension, Map<String, String> testSchemas, String[][] testLookupAndExpectedResults)
   {
     boolean debug = false;
 
     for (String[] testLookupAndExpectedResult : testLookupAndExpectedResults)
     {
       DataSchemaResolver schemaResolver = new MapDataSchemaResolver(
-          extension.equals("pdsc") ? SchemaParserFactory.instance() : PdlSchemaParserFactory.instance(),
-          Arrays.asList(buildSystemIndependentPath("a1")), "." + extension, testSchemas);
+          extension.equals(PDSC) ? SchemaParserFactory.instance() : PdlSchemaParserFactory.instance(),
+          Arrays.asList(buildSystemIndependentPath("a1")), "." + extension.toString().toLowerCase(), testSchemas);
       lookup(schemaResolver, new String[][] { testLookupAndExpectedResult}, File.separatorChar, debug, extension);
     }
   }
@@ -832,12 +835,12 @@ public class TestDataSchemaResolver
 
   public void lookup(DataSchemaResolver resolver, String[][] lookups, char separator, boolean debug)
   {
-    lookup(resolver, lookups, separator, debug, "pdsc");
+    lookup(resolver, lookups, separator, debug, PDSC);
   }
 
-  public void lookup(DataSchemaResolver resolver, String[][] lookups, char separator, boolean debug, String extension)
+  public void lookup(DataSchemaResolver resolver, String[][] lookups, char separator, boolean debug, SchemaFormatType extension)
   {
-    PegasusSchemaParser parser = extension.equals("pdsc") ? new SchemaParser(resolver): new PdlSchemaParser(resolver);
+    PegasusSchemaParser parser = extension.equals(PDSC) ? new SchemaParser(resolver): new PdlSchemaParser(resolver);
 
     for (String[] entry : lookups)
     {

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
@@ -16,18 +16,20 @@
 
 package com.linkedin.data.schema.resolver;
 
-
 import com.linkedin.data.Data;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.TestUtil;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaLocation;
+import com.linkedin.data.schema.DataSchemaParserFactory;
 import com.linkedin.data.schema.DataSchemaResolver;
 import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.PegasusSchemaParser;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.SchemaParser;
 import com.linkedin.data.schema.SchemaParserFactory;
-import com.linkedin.data.schema.PegasusSchemaParser;
+import com.linkedin.data.schema.grammar.PdlSchemaParser;
+import com.linkedin.data.schema.grammar.PdlSchemaParserFactory;
 import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.data.template.RecordTemplate;
 import java.io.ByteArrayInputStream;
@@ -68,7 +70,7 @@ public class TestDataSchemaResolver
 
   public static class MapDataSchemaResolver extends AbstractDataSchemaResolver
   {
-    public MapDataSchemaResolver(SchemaParserFactory parserFactory,
+    public MapDataSchemaResolver(DataSchemaParserFactory parserFactory,
                                  List<String> paths, String extension, Map<String, String> map)
     {
       super(parserFactory);
@@ -236,6 +238,7 @@ public class TestDataSchemaResolver
     {
         {
           "Two records including each other",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"include2\"], \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"string\" } ] }",
                   buildSystemIndependentPath("a1", "include2.pdsc"), "{ \"name\" : \"include2\", \"type\" : \"record\", \"include\": [\"include1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }"
             ),
@@ -253,7 +256,27 @@ public class TestDataSchemaResolver
             }
         },
         {
+            "Two records including each other",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes include2 {\n member1: string\n}",
+                  buildSystemIndependentPath("a1", "include2.pdl"), "record include2 includes include1 {\n member2: string\n }"
+                 ),
+            new String[][]
+                {
+                    {
+                        "include1",
+                        ERROR,
+                        "circular reference involving includes"
+                    },
+                    { "include2",
+                        ERROR,
+                        "circular reference involving includes"
+                    }
+                }
+        },
+        {
             "Two records including each other using aliases",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"aliases\" : [\"includeAlias1\"], \"type\" : \"record\", \"include\": [\"include2\"], \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"string\" } ] }",
                 buildSystemIndependentPath("a1", "include2.pdsc"), "{ \"name\" : \"include2\", \"type\" : \"record\", \"include\": [\"includeAlias1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }"
             ),
@@ -267,7 +290,22 @@ public class TestDataSchemaResolver
                 }
         },
         {
+            "Two records including each other using aliases",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "include1.pdl"), "@aliases = [\"includeAlias1\"] record include1 includes include2 { member1: string }",
+                  buildSystemIndependentPath("a1", "include2.pdl"), "record include2 includes includeAlias1 {member2: string}"),
+            new String[][]
+                {
+                    {
+                        "include1",
+                        ERROR,
+                        "circular reference involving includes"
+                    }
+                }
+        },
+        {
             "First record has a record field, and that record includes the first record",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"include1\" } ] }",
                 buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"record1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }"
             ),
@@ -286,7 +324,28 @@ public class TestDataSchemaResolver
             }
         },
         {
+            "First record has a record field, and that record includes the first record",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: include1 }",
+                  buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes record1 { member2: string } "
+                 ),
+            new String[][]
+                {
+                    {
+                        "record1",
+                        ERROR,
+                        "circular reference involving includes"
+                    },
+                    {
+                        "include1",
+                        ERROR,
+                        "circular reference involving includes"
+                    }
+                }
+        },
+        {
             "Circular reference involving only fields",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"record2\" } ] }",
                 buildSystemIndependentPath("a1", "record2.pdsc"), "{ \"name\" : \"record2\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"record1\" } ] }"
             ),
@@ -307,7 +366,30 @@ public class TestDataSchemaResolver
             }
         },
         {
+            "Circular reference involving only fields",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: record2 }",
+                  buildSystemIndependentPath("a1", "record2.pdl"), "record record2 { member2: record1 }"
+                 ),
+            new String[][]
+                {
+                    {
+                        "record1",
+                        FOUND,
+                        "\"name\" : \"record1\"",
+                        buildSystemIndependentPath("a1", "record1.pdl")
+                    },
+                    {
+                        "record2",
+                        FOUND,
+                        "\"name\" : \"record2\"",
+                        buildSystemIndependentPath("a1", "record2.pdl")
+                    }
+                }
+        },
+        {
             "Three records with one include in the cycle",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"record1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }",
                 buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"record2\" } ] }",
                 buildSystemIndependentPath("a1", "record2.pdsc"), "{ \"name\" : \"record2\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"include1\" } ] }"
@@ -331,8 +413,36 @@ public class TestDataSchemaResolver
                     }
                 }
         },
+
+        {
+            "Three records with one include in the cycle",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes record1 { member2: string }",
+                  buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: record2 }",
+                  buildSystemIndependentPath("a1", "record2.pdl"), "record record2 { member1: include1 }"
+                 ),
+            new String[][]
+                {
+                    {
+                        "include1",
+                        ERROR,
+                        "circular reference involving includes"
+                    },
+                    {
+                        "record1",
+                        ERROR,
+                        "circular reference involving includes"
+                    },
+                    {
+                        "record2",
+                        ERROR,
+                        "circular reference involving includes"
+                    }
+                }
+        },
         {
             "Three records with one include not in the cycle",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"record1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }",
                 buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"record2\" } ] }",
                 buildSystemIndependentPath("a1", "record2.pdsc"), "{ \"name\" : \"record2\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"record1\" } ] }"
@@ -360,7 +470,37 @@ public class TestDataSchemaResolver
                 }
         },
         {
+            "Three records with one include not in the cycle",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes record1 { member2: string }",
+                  buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: record2 }",
+                  buildSystemIndependentPath("a1", "record2.pdl"), "record record2 { member1: record1 }"
+                 ),
+            new String[][]
+                {
+                    {
+                        "include1",
+                        FOUND,
+                        "\"name\" : \"include1\"",
+                        buildSystemIndependentPath("a1", "include1.pdl")
+                    },
+                    {
+                        "record1",
+                        FOUND,
+                        "\"name\" : \"record1\"",
+                        buildSystemIndependentPath("a1", "record1.pdl")
+                    },
+                    {
+                        "record2",
+                        FOUND,
+                        "\"name\" : \"record2\"",
+                        buildSystemIndependentPath("a1", "record2.pdl")
+                    }
+                }
+        },
+        {
             "Self including record",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "include.pdsc"), "{ \"name\" : \"include\", \"type\" : \"record\", \"include\": [\"include\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }"
             ),
             new String[][]
@@ -373,7 +513,22 @@ public class TestDataSchemaResolver
                 }
         },
         {
+            "Self including record",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "include.pdl"), "record include includes include { member2: string }"
+                 ),
+            new String[][]
+                {
+                    {
+                        "include",
+                        ERROR,
+                        "circular reference involving includes"
+                    }
+                }
+        },
+        {
             "Circular reference involving include, typeref and a record",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "include1.pdsc"), "{ \"name\" : \"include1\", \"type\" : \"record\", \"include\": [\"record1\"], \"fields\" : [ { \"name\" : \"member2\", \"type\" : \"string\" } ] }",
                 buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"typeref1\" } ] }",
                 buildSystemIndependentPath("a1", "typeref1.pdsc"), "{ \"name\" : \"typeref1\", \"type\" : \"typeref\", \"ref\" : \"include1\" }"
@@ -398,7 +553,34 @@ public class TestDataSchemaResolver
                 }
         },
         {
+            "Circular reference involving include, typeref and a record",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "include1.pdl"), "record include1 includes record1 { member2: string }",
+                  buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: typeref1 }",
+                  buildSystemIndependentPath("a1", "typeref1.pdl"), "typeref typeref1 = include1"
+                 ),
+            new String[][]
+                {
+                    {
+                        "include1",
+                        ERROR,
+                        "circular reference involving includes"
+                    },
+                    {
+                        "typeref1",
+                        ERROR,
+                        "circular reference involving includes"
+                    },
+                    {
+                        "record1",
+                        ERROR,
+                        "circular reference involving includes"
+                    }
+                }
+        },
+        {
             "Circular reference involving typerefs",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "typeref1.pdsc"), "{ \"name\" : \"typeref1\", \"type\" : \"typeref\", \"ref\": \"typeref2\" }",
                 buildSystemIndependentPath("a1", "typeref2.pdsc"), "{ \"name\" : \"typeref2\", \"type\" : \"typeref\", \"ref\" : \"typeref3\" }",
                 buildSystemIndependentPath("a1", "typeref3.pdsc"), "{ \"name\" : \"typeref3\", \"type\" : \"typeref\", \"ref\" : { \"type\" : \"array\", \"items\" : \"typeref1\" } }"
@@ -423,7 +605,34 @@ public class TestDataSchemaResolver
                 }
         },
         {
+            "Circular reference involving typerefs",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "typeref1.pdl"), "typeref typeref1 = typeref2",
+                  buildSystemIndependentPath("a1", "typeref2.pdl"), "typeref typeref2 = typeref3",
+                  buildSystemIndependentPath("a1", "typeref3.pdl"), "typeref typeref3 = array[typeref1]"
+                 ),
+            new String[][]
+                {
+                    {
+                        "typeref1",
+                        ERROR,
+                        "typeref has a circular reference to itself"
+                    },
+                    {
+                        "typeref2",
+                        ERROR,
+                        "typeref has a circular reference to itself"
+                    },
+                    {
+                        "typeref3",
+                        ERROR,
+                        "typeref has a circular reference to itself"
+                    }
+                }
+        },
+        {
             "Circular reference involving typerefs, with a record outside cycle",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "record1.pdsc"), "{ \"name\" : \"record1\", \"type\" : \"record\", \"fields\" : [ { \"name\" : \"member1\", \"type\" : \"typeref1\" } ] }",
                 buildSystemIndependentPath("a1", "typeref1.pdsc"), "{ \"name\" : \"typeref1\", \"type\" : \"typeref\", \"ref\" : \"typeref2\" }",
                 buildSystemIndependentPath("a1", "typeref2.pdsc"), "{ \"name\" : \"typeref2\", \"type\" : \"typeref\", \"ref\" : \"typeref1\" }"
@@ -447,11 +656,54 @@ public class TestDataSchemaResolver
                     }
                 }
         },
+
+        {
+            "Circular reference involving typerefs, with a record outside cycle",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "record1.pdl"), "record record1 { member1: typeref1 }",
+                  buildSystemIndependentPath("a1", "typeref1.pdl"), "typeref typeref1 = typeref2",
+                  buildSystemIndependentPath("a1", "typeref2.pdl"), "typeref typeref2 = typeref1"
+                 ),
+            new String[][]
+                {
+                    {
+                        "record1",
+                        ERROR,
+                        "typeref has a circular reference to itself"
+                    },
+                    {
+                        "typeref1",
+                        ERROR,
+                        "typeref has a circular reference to itself"
+                    },
+                    {
+                        "typeref2",
+                        ERROR,
+                        "typeref has a circular reference to itself"
+                    }
+                }
+        },
         {
             "Circular reference involving typerefs, using alias",
+            "pdsc",
             asMap(buildSystemIndependentPath("a1", "typeref1.pdsc"), "{ \"name\" : \"typeref1\", \"aliases\" : [\"typerefAlias1\"], \"type\" : \"typeref\", \"ref\" : \"typeref2\" }",
                 buildSystemIndependentPath("a1", "typeref2.pdsc"), "{ \"name\" : \"typeref2\", \"type\" : \"typeref\", \"ref\" : \"typerefAlias1\" }"
             ),
+            new String[][]
+                {
+                    {
+                        "typeref1",
+                        ERROR,
+                        "typeref has a circular reference to itself"
+                    }
+                }
+        },
+        {
+            "Circular reference involving typerefs, using alias",
+            "pdl",
+            asMap(buildSystemIndependentPath("a1", "typeref1.pdl"), "@aliases = [\"typerefAlias1\"] typeref typeref1 = typeref2",
+                  buildSystemIndependentPath("a1", "typeref2.pdl"), "typeref typeref2 = typerefAlias1"
+                 ),
             new String[][]
                 {
                     {
@@ -465,17 +717,16 @@ public class TestDataSchemaResolver
   }
 
   @Test(dataProvider = "circularReferenceData")
-  public void testCircularReferences(String desc, Map<String, String> testSchemas, String[][] testLookupAndExpectedResults)
+  public void testCircularReferences(String desc, String extension, Map<String, String> testSchemas, String[][] testLookupAndExpectedResults)
   {
     boolean debug = false;
 
     for (String[] testLookupAndExpectedResult : testLookupAndExpectedResults)
     {
-      DataSchemaResolver resolver = new MapDataSchemaResolver(
-          SchemaParserFactory.instance(),
-          Arrays.asList(buildSystemIndependentPath("a1")),
-          ".pdsc", testSchemas);
-      lookup(resolver, new String[][] { testLookupAndExpectedResult}, File.separatorChar, debug);
+      DataSchemaResolver schemaResolver = new MapDataSchemaResolver(
+          extension.equals("pdsc") ? SchemaParserFactory.instance() : PdlSchemaParserFactory.instance(),
+          Arrays.asList(buildSystemIndependentPath("a1")), "." + extension, testSchemas);
+      lookup(schemaResolver, new String[][] { testLookupAndExpectedResult}, File.separatorChar, debug, extension);
     }
   }
 
@@ -581,7 +832,12 @@ public class TestDataSchemaResolver
 
   public void lookup(DataSchemaResolver resolver, String[][] lookups, char separator, boolean debug)
   {
-    PegasusSchemaParser parser = new SchemaParser(resolver);
+    lookup(resolver, lookups, separator, debug, "pdsc");
+  }
+
+  public void lookup(DataSchemaResolver resolver, String[][] lookups, char separator, boolean debug, String extension)
+  {
+    PegasusSchemaParser parser = extension.equals("pdsc") ? new SchemaParser(resolver): new PdlSchemaParser(resolver);
 
     for (String[] entry : lookups)
     {

--- a/data/src/test/resources/com/linkedin/data/schema/annotation/denormalizedsource/invalid/3_5_cyclic_from_include.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/annotation/denormalizedsource/invalid/3_5_cyclic_from_include.pdl
@@ -1,5 +1,10 @@
 namespace com.linkedin.data.schema.annotation.denormalizedsource.invalid
 
+/**
+ * This schema does not need to be tested because it was invalid even when being parsed by the parser for following reason:
+ * ERROR: "com.linkedin.data.schema.annotation.denormalizedsource.invalid.A" cannot be parsed as it is part of circular reference involving includes. Record(s) with include in the cycle: [com.linkedin.data.schema.annotation.denormalizedsource.invalid.A, com.linkedin.data.schema.annotation.denormalizedsource.invalid.innerRcd]
+ */
+
 @customAnnotation={
   "/f1/f2": "thisWouldCauseCycle"
 }


### PR DESCRIPTION
Right now PDL parser wouldn't detect cyclic referencing for "includes" and "typeref"

This change will fix this issue so we have feature parity between PDL and PDSC on cyclic referencing detection.