### PR TITLE
Add check to prepare-release script to prevent branch conflicts

### DIFF
--- a/pre-release-check
+++ b/pre-release-check
@@ -1,18 +1,17 @@
 #!/bin/sh
 # The purpose of this script is to perform some checks before the release process
 
-remote="origin"
-branch="master"
+REMOTE="origin"
+BRANCH="master"
 if [ $# -eq 2 ]
 then
-    remote=$1
-    branch=$2
+    REMOTE=$1
+    BRANCH=$2
 fi
 
 # Determine version to be released
-version=`awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties`
-echo "Attempting to publish: $version"
-echo
+VERSION=`awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties`
+echo "Running pre-release job for version $VERSION..."
 
 # Check that there are no uncommitted changes
 DIRTY=`git status --porcelain --untracked-files=no 2>&1 || echo FAIL`
@@ -24,24 +23,24 @@ then
 fi
 
 # Ensure that the current branch is consistent with the remote target
-INCONSISTENT=`git diff --quiet $remote/$branch >/dev/null 2>&1 ; echo $?`
+INCONSISTENT=`git diff --quiet $REMOTE/$BRANCH >/dev/null 2>&1 ; echo $?`
 if [ $INCONSISTENT -ne 0 ]
 then
-    echo "$remote/$branch and current branch are inconsistent."
-    echo "Use git diff $remote/$branch to see changes."
+    echo "$REMOTE/$BRANCH and current branch are inconsistent."
+    echo "Use git diff $REMOTE/$BRANCH to see changes."
     echo "Rebase or push, as appropriate, and run this command again."
     exit 1
 fi
 
 # Ensure that a tag exists for this version
-EXPECTED_TAG="v$version"
+EXPECTED_TAG="v$VERSION"
 if [ -z `git tag | grep $EXPECTED_TAG` ]
 then
     echo "Could not find tag $EXPECTED_TAG, please create it then run this command again."
     echo "This release process expects release tags to be manually created beforehand."
     echo
     echo "Use './prepare-release' to create and push a release tag."
-    echo "Optionally, use './prepare-release [TARGET]' to tag a particular commit."
+    echo "Optionally, use './prepare-release [TARGET_COMMIT]' to tag a particular commit."
     exit 1
 fi
 
@@ -54,4 +53,4 @@ then
     exit 1
 fi
 
-echo "All pre-release checks passed, attempting to build and release..."
+echo "All pre-release checks passed, ready to build and release..."

--- a/prepare-release
+++ b/prepare-release
@@ -10,7 +10,7 @@ elif [ $# -eq 1 ]
 then
     TARGET="$1"
 else
-  echo 'usage: ./prepare-release [TARGET_BRANCH_OR_COMMIT]'
+  echo 'usage: ./prepare-release [TARGET_COMMIT]'
   exit 2
 fi
 
@@ -22,6 +22,15 @@ then
   exit 1
 fi
 
+# Ensure that the target commit is an ancestor of master
+git merge-base --is-ancestor $TARGET_COMMIT master
+if [ $? -ne 0 ]
+then
+  echo "Invalid target: $TARGET"
+  echo 'Please select a target commit which is an ancestor of master.'
+  exit 1
+fi
+
 # Determine version to be released
 VERSION=`awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties`
 if [ -z "$VERSION" ]
@@ -30,8 +39,18 @@ then
   exit 1
 fi
 
-# Create release tag
+# Ensure that release tag name wouldn't conflict with a local branch
 TAG_NAME="v$VERSION"
+git show-ref --verify refs/heads/$TAG_NAME >/dev/null 2>&1
+if [ $? -eq 0 ]
+then
+  echo "Cannot create tag $TAG_NAME, as it would conflict with a local branch of the same name."
+  echo 'Please delete this branch and avoid naming branches like this in the future.'
+  echo "Hint: 'git branch -D $TAG_NAME' (WARNING: you will lose all local changes on this branch)"
+  exit 1
+fi
+
+# Create release tag
 git tag -a $TAG_NAME $TARGET_COMMIT -m "$TAG_NAME"
 if [ $? -ne 0 ]
 then
@@ -51,3 +70,5 @@ then
   git tag -d $TAG_NAME
   exit 1
 fi
+
+echo 'Complete'


### PR DESCRIPTION
Necessary in case someone names their feature branch using the
release tag naming convention (e.g. `v*.*.*`). Also adds a check
to ensure that the target commit is an ancestor of master, and
cleans up the pre-release-check script a little bit.