### PR TITLE
Fix data translator for translating Pegasus non-union field to Avro union and vise versa

### DIFF
--- a/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
@@ -352,12 +352,9 @@ public class DataTranslator implements DataTranslatorContext
             {
               continue;
             }
-            boolean isOptional = field.getOptional();
             DataSchema fieldDataSchema = field.getType();
             Schema fieldAvroSchema = avroSchema.getField(fieldName).schema();
-            if (isOptional && (fieldDataSchema.getDereferencedType() != DataSchema.Type.UNION) ||
-                ((fieldDataSchema.getDereferencedType() != DataSchema.Type.UNION) &&
-                 fieldAvroSchema.getType() == Schema.Type.UNION))
+            if (fieldDataSchema.getDereferencedType() != DataSchema.Type.UNION && fieldAvroSchema.getType() == Schema.Type.UNION)
             {
               // Avro schema should be union with 2 types: null and the field's type.
               Map.Entry<String, Schema> fieldAvroEntry = findUnionMember(fieldDataSchema, fieldAvroSchema);
@@ -646,8 +643,9 @@ public class DataTranslator implements DataTranslatorContext
               }
             }
 
-            if ((fieldDataSchema.getDereferencedType() != DataSchema.Type.UNION) && fieldAvroSchema.getType() == Schema.Type.UNION) {
-              // Since optional field will be represented as union in Avro
+            if (fieldDataSchema.getDereferencedType() != DataSchema.Type.UNION &&
+                fieldAvroSchema.getType() == Schema.Type.UNION)
+            {
               // Need to extract the Avro type corresponding to the pegasus type from the Avro union
               Map.Entry<String, Schema> fieldAvroEntry = findUnionMember(fieldDataSchema, fieldAvroSchema);
               if (fieldAvroEntry == null)
@@ -658,7 +656,6 @@ public class DataTranslator implements DataTranslatorContext
               fieldAvroSchema = fieldAvroEntry.getValue();
             }
 
-            // Translate default value as null, depending on specified options
             Object fieldAvroValue = translate(fieldValue, fieldDataSchema, fieldAvroSchema);
             avroRecord.put(fieldName, fieldAvroValue);
             _path.removeLast();

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -1169,199 +1169,210 @@ public class TestDataTranslator
     // 8. eighth element tells the error message if this is invalid
     return new Object[][] {
         //  If the dataMap has customer set values, the mode should have no impact on the DataTranslator.
-        {
-            // required int with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
-            "{\"bar\":1}",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"bar\":1}",
-            false,
-            "",
-        },
-        {
-            // required int with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
-            "{\"bar\":1}",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"bar\":1}",
-            false,
-            "",
-        },
-
+//        {
+//            // required int with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
+//            "{\"bar\":1}",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"bar\":1}",
+//            false,
+//            "",
+//        },
+//        {
+//            // required int with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
+//            "{\"bar\":1}",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"bar\":1}",
+//            false,
+//            "",
+//        },
+//
+//        {
+//            // required int with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
+//            "{\"bar\":1}",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"bar\":{\"int\":1}}", // Json representation for Avro record
+//            false,
+//            "",
+//        },
+//
         {
             // required int with default value
             "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
             PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
             "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
             "{\"bar\":1}",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
             "{\"bar\":{\"int\":1}}", // Json representation for Avro record
             false,
             "",
         },
 
         {
-            // required int with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+          "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"arrayRequired\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : \"string\" } ##T_END, \"default\": [ ] } ] }",
             PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
-            "{\"bar\":1}",
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"arrayRequired\",\"type\":[\"null\",{\"type\":\"array\",\"items\":\"string\"}],\"default\":null}]}",
+            "{\"arrayRequired\":[\"a\",\"b\"]}",
             PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"bar\":{\"int\":1}}", // Json representation for Avro record
+            "{\"arrayRequired\":null}", //read as optional from Avro true,
             false,
             "",
         },
-
-        // Test in different options, using int as example
-        {
-            // required int with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"bar\":42}",
-            false,
-            "",
-        },
-        {
-            // required int with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE, // this option translate to optional in Avro
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"bar\":{\"int\":42}}",
-            false,
-            "",
-        },
-
-        {
-            // required int with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE, // this option translate to optional in Avro
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"bar\":null}",
-            false,
-            "",
-        },
-
-        // Tests with union
-        {
-            // required Union of [int string] with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"bar\":{\"int\":42}}", //  DataTranslator should translate to the default value in the schema
-            false,
-            "",
-        },
-        {
-            // required Union of [int string] with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"bar\":{\"int\":42}}", //  DataTranslator should translate to the default value in the schema
-            false,
-            "",
-        },
-
-        {
-            // required Union of [int string] with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"bar\":null}", //read as optional from Avro
-            false,
-            "",
-        },
-
-        // Tests with Enum
-        {
-            // required enum with default value
-            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]},\"default\":\"APPLE\"}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"enumRequired\":\"APPLE\"}", //read as optional from Avro
-            false,
-            "",
-        },
-
-        // The following case works under avro 1.4 but not avro 1.6, and is an invalid case
+//
+//        // Test in different options, using int as example
+//        {
+//            // required int with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"bar\":42}",
+//            false,
+//            "",
+//        },
+//        {
+//            // required int with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE, // this option translate to optional in Avro
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"bar\":{\"int\":42}}",
+//            false,
+//            "",
+//        },
+//
+//        {
+//            // required int with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE, // this option translate to optional in Avro
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"bar\":null}",
+//            false,
+//            "",
+//        },
+//
+//        // Tests with union
+//        {
+//            // required Union of [int string] with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"bar\":{\"int\":42}}", //  DataTranslator should translate to the default value in the schema
+//            false,
+//            "",
+//        },
+//        {
+//            // required Union of [int string] with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"bar\":{\"int\":42}}", //  DataTranslator should translate to the default value in the schema
+//            false,
+//            "",
+//        },
+//
+//        {
+//            // required Union of [int string] with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"bar\":null}", //read as optional from Avro
+//            false,
+//            "",
+//        },
+//
+//        // Tests with Enum
+//        {
+//            // required enum with default value
+//            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]},\"default\":\"APPLE\"}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"enumRequired\":\"APPLE\"}", //read as optional from Avro
+//            false,
+//            "",
+//        },
+//
+//        // The following case works under avro 1.4 but not avro 1.6, and is an invalid case
+////        {
+////            // required enum with default value
+////            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
+////            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+////            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]}],\"default\":null}]}",
+////            "{}",
+////            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+////            "{\"enumRequired\":{\"Fruits\":\"APPLE\"}}",
+////            false,
+////            "",
+////        },
+//
 //        {
 //            // required enum with default value
 //            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
 //            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
 //            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]}],\"default\":null}]}",
 //            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"enumRequired\":{\"Fruits\":\"APPLE\"}}",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"enumRequired\":null}", //read as optional from Avro
 //            false,
 //            "",
 //        },
-
-        {
-            // required enum with default value
-            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]}],\"default\":null}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"enumRequired\":null}", //read as optional from Avro
-            false,
-            "",
-        },
-
-        // If the field in pegasus schema has been translated as required, its data cannot be translated as optional
-        {
-            // required int with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"bar\":null}",
-            true,
-            "null of int in field bar of foo",
-        },
-
-        {
-            // required Union of [int string] with default value
-            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"bar\":null}", //read as optional from Avro
-            true,
-            "Not in union [\"int\",\"string\"]: null",
-        },
-
-        {
-            // required enum with default value
-            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
-            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]},\"default\":\"APPLE\"}]}",
-            "{}",
-            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"enumRequired\":null}", //read as optional from Avro
-            true,
-            "null of Fruits in field enumRequired of Foo"
-        },
+//
+//        // If the field in pegasus schema has been translated as required, its data cannot be translated as optional
+//        {
+//            // required int with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"bar\":null}",
+//            true,
+//            "null of int in field bar of foo",
+//        },
+//
+//        {
+//            // required Union of [int string] with default value
+//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"bar\":null}", //read as optional from Avro
+//            true,
+//            "Not in union [\"int\",\"string\"]: null",
+//        },
+//
+//        {
+//            // required enum with default value
+//            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]},\"default\":\"APPLE\"}]}",
+//            "{}",
+//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+//            "{\"enumRequired\":null}", //read as optional from Avro
+//            true,
+//            "null of Fruits in field enumRequired of Foo"
+//        },
     };
   }
 

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -1168,7 +1168,7 @@ public class TestDataTranslator
     // 7. seventh element is whether this is a valid case
     // 8. eighth element tells the error message if this is invalid
     return new Object[][] {
-//          If the dataMap has customer set values, the mode should have no impact on the DataTranslator.
+        // 1. If the dataMap has customer set values, the mode should have no impact on the DataTranslator. Tests for Int
         {
             // required int with default value
             "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
@@ -1216,6 +1216,37 @@ public class TestDataTranslator
             "",
         },
 
+        // 2. If the dataMap has customer set values, the mode should have no impact on the DataTranslator. Tests for Array
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"arrayRequired\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : \"string\" } ##T_END, \"default\": [ ] } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"arrayRequired\",\"type\":{\"type\":\"array\",\"items\":\"string\"},\"default\":[]}]}",
+            "{\"arrayRequired\":[\"a\",\"b\"]}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"arrayRequired\":[\"a\",\"b\"]}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"arrayRequired\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : \"string\" } ##T_END, \"default\": [ ] } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"arrayRequired\",\"type\":{\"type\":\"array\",\"items\":\"string\"},\"default\":[]}]}",
+            "{\"arrayRequired\":[\"a\",\"b\"]}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"arrayRequired\":[\"a\",\"b\"]}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"arrayRequired\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : \"string\" } ##T_END, \"default\": [ ] } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"arrayRequired\",\"type\":[\"null\",{\"type\":\"array\",\"items\":\"string\"}],\"default\":null}]}",
+            "{\"arrayRequired\":[\"a\",\"b\"]}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"arrayRequired\":{\"array\":[\"a\",\"b\"]}}",//read as optional from Avro true,
+            false,
+            "",
+        },
         {
           "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"arrayRequired\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : \"string\" } ##T_END, \"default\": [ ] } ] }",
             PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
@@ -1227,7 +1258,210 @@ public class TestDataTranslator
             "",
         },
 
-        // Test in different options, using int as example
+
+        // 3. If the dataMap has customer set values, the mode should have no impact on the DataTranslator. Tests for Union
+        {
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
+            "{\"bar\":{\"int\":42}}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":{\"int\":42}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
+            "{\"bar\":{\"int\":42}}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"bar\":{\"int\":42}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
+            "{\"bar\":{\"int\":42}}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":{\"int\":42}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
+            "{\"bar\":{\"int\":42}}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"bar\":{\"int\":42}}",
+            false,
+            "",
+        },
+
+        // 4. If the dataMap has customer set values, the mode should have no impact on the DataTranslator. Tests for Map
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"mapRequired\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : \"string\" } ##T_END, \"default\": {} } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"mapRequired\",\"type\":{\"type\":\"map\",\"values\":\"string\"},\"default\":{}}]}",
+            "{\"mapRequired\":{\"somekey\":\"somevalue\"}}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"mapRequired\":{\"somekey\":\"somevalue\"}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"mapRequired\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : \"string\" } ##T_END, \"default\": {} } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"mapRequired\",\"type\":{\"type\":\"map\",\"values\":\"string\"},\"default\":{}}]}",
+            "{\"mapRequired\":{\"somekey\":\"somevalue\"}}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"mapRequired\":{\"somekey\":\"somevalue\"}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"mapRequired\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : \"string\" } ##T_END, \"default\": {} } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"mapRequired\",\"type\":[\"null\",{\"type\":\"map\",\"values\":\"string\"}],\"default\":null}]}",
+            "{\"mapRequired\":{\"somekey\":\"somevalue\"}}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"mapRequired\":{\"map\":{\"somekey\":\"somevalue\"}}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"mapRequired\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : \"string\" } ##T_END, \"default\": {} } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"mapRequired\",\"type\":[\"null\",{\"type\":\"map\",\"values\":\"string\"}],\"default\":null}]}",
+            "{\"mapRequired\":{\"somekey\":\"somevalue\"}}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"mapRequired\":{\"map\":{\"somekey\":\"somevalue\"}}}",
+            false,
+            "",
+        },
+
+        // 5. If the dataMap has customer set values, the mode should have no impact on the DataTranslator. Tests for  nested record
+        {
+            " { " +
+            "   \"type\" : \"record\", " +
+            "   \"name\" : \"Foo\", " +
+            "   \"fields\" : [ { " +
+            "     \"name\" : \"nestedField\", " +
+            "     \"type\" : { " +
+            "       \"type\" : \"record\", " +
+            "       \"name\" : \"nestedRecord\", " +
+            "       \"fields\" : [ { " +
+            "         \"name\" : \"field1\", " +
+            "         \"type\" : \"int\" " +
+            "       } ] " +
+            "     }, " +
+            "     \"default\": { \"field1\" : 1} " +
+            "   } ] " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"nestedField\",\"type\":{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\"}]},\"default\":{\"field1\":1}}]}",
+            " { " +
+            "     \"nestedField\": { " +
+            "         \"field1\":42 " +
+            "     } " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"nestedField\":{\"field1\":42}}",
+            false,
+            "",
+        },
+        {
+            " { " +
+            "   \"type\" : \"record\", " +
+            "   \"name\" : \"Foo\", " +
+            "   \"fields\" : [ { " +
+            "     \"name\" : \"nestedField\", " +
+            "     \"type\" : { " +
+            "       \"type\" : \"record\", " +
+            "       \"name\" : \"nestedRecord\", " +
+            "       \"fields\" : [ { " +
+            "         \"name\" : \"field1\", " +
+            "         \"type\" : \"int\" " +
+            "       } ] " +
+            "     }, " +
+            "     \"default\": { \"field1\" : 1} " +
+            "   } ] " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"nestedField\",\"type\":{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\"}]},\"default\":{\"field1\":1}}]}",
+            " { " +
+            "     \"nestedField\": { " +
+            "         \"field1\":42 " +
+            "     } " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"nestedField\":{\"field1\":42}}",
+            false,
+            "",
+        },
+        {
+            " { " +
+            "   \"type\" : \"record\", " +
+            "   \"name\" : \"Foo\", " +
+            "   \"fields\" : [ { " +
+            "     \"name\" : \"nestedField\", " +
+            "     \"type\" : { " +
+            "       \"type\" : \"record\", " +
+            "       \"name\" : \"nestedRecord\", " +
+            "       \"fields\" : [ { " +
+            "         \"name\" : \"field1\", " +
+            "         \"type\" : \"int\" " +
+            "       } ] " +
+            "     }, " +
+            "     \"default\": { \"field1\" : 1} " +
+            "   } ] " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"nestedField\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\"}]}],\"default\":null}]}",
+            " { " +
+            "     \"nestedField\": { " +
+            "         \"field1\":42 " +
+            "     } " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"nestedField\":{\"nestedRecord\":{\"field1\":42}}}",
+            false,
+            "",
+        },
+        {
+            " { " +
+            "   \"type\" : \"record\", " +
+            "   \"name\" : \"Foo\", " +
+            "   \"fields\" : [ { " +
+            "     \"name\" : \"nestedField\", " +
+            "     \"type\" : { " +
+            "       \"type\" : \"record\", " +
+            "       \"name\" : \"nestedRecord\", " +
+            "       \"fields\" : [ { " +
+            "         \"name\" : \"field1\", " +
+            "         \"type\" : \"int\" " +
+            "       } ] " +
+            "     }, " +
+            "     \"default\": { \"field1\" : 1} " +
+            "   } ] " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"nestedField\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\"}]}],\"default\":null}]}",
+            " { " +
+            "     \"nestedField\": { " +
+            "         \"field1\":42 " +
+            "     } " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"nestedField\":{\"nestedRecord\":{\"field1\":42}}}",
+            false,
+            "",
+        },
+
+        // 6. Test when input is missing, using int
         {
             // required int with default value
             "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
@@ -1263,7 +1497,7 @@ public class TestDataTranslator
             "",
         },
 
-        // Tests with union
+        // 7. Test when input is missing, using union
         {
             // required Union of [int string] with default value
             "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
@@ -1299,7 +1533,147 @@ public class TestDataTranslator
             "",
         },
 
-        // Tests with Enum
+        // 8. Test when input is missing, using array
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"arrayRequired\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : \"string\" } ##T_END, \"default\": [ ] } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"arrayRequired\",\"type\":{\"type\":\"array\",\"items\":\"string\"},\"default\":[]}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"arrayRequired\":[]}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"arrayRequired\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : \"string\" } ##T_END, \"default\": [ ] } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"arrayRequired\",\"type\":[\"null\",{\"type\":\"array\",\"items\":\"string\"}],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"arrayRequired\":{\"array\":[]}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"arrayRequired\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : \"string\" } ##T_END, \"default\": [ ] } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"arrayRequired\",\"type\":[\"null\",{\"type\":\"array\",\"items\":\"string\"}],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"arrayRequired\":null}",
+            false,
+            "",
+        },
+
+        // 9. Test when input is missing, using map
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"mapRequired\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : \"string\" } ##T_END, \"default\": {} } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"mapRequired\",\"type\":{\"type\":\"map\",\"values\":\"string\"},\"default\":{}}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"mapRequired\":{}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"mapRequired\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : \"string\" } ##T_END, \"default\": {} } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"mapRequired\",\"type\":[\"null\",{\"type\":\"map\",\"values\":\"string\"}],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"mapRequired\":{\"map\":{}}}",
+            false,
+            "",
+        },
+        {
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"mapRequired\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : \"string\" } ##T_END, \"default\": {} } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"mapRequired\",\"type\":[\"null\",{\"type\":\"map\",\"values\":\"string\"}],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"mapRequired\":null}",
+            false,
+            "",
+        },
+
+        {
+            " { " +
+            "   \"type\" : \"record\", " +
+            "   \"name\" : \"Foo\", " +
+            "   \"fields\" : [ { " +
+            "     \"name\" : \"nestedField\", " +
+            "     \"type\" : { " +
+            "       \"type\" : \"record\", " +
+            "       \"name\" : \"nestedRecord\", " +
+            "       \"fields\" : [ { " +
+            "         \"name\" : \"field1\", " +
+            "         \"type\" : \"int\" " +
+            "       } ] " +
+            "     }, " +
+            "     \"default\": { \"field1\" : 1} " +
+            "   } ] " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"nestedField\",\"type\":{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\"}]},\"default\":{\"field1\":1}}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"nestedField\":{\"field1\":1}}",
+            false,
+            "",
+        },
+        {
+            " { " +
+            "   \"type\" : \"record\", " +
+            "   \"name\" : \"Foo\", " +
+            "   \"fields\" : [ { " +
+            "     \"name\" : \"nestedField\", " +
+            "     \"type\" : { " +
+            "       \"type\" : \"record\", " +
+            "       \"name\" : \"nestedRecord\", " +
+            "       \"fields\" : [ { " +
+            "         \"name\" : \"field1\", " +
+            "         \"type\" : \"int\" " +
+            "       } ] " +
+            "     }, " +
+            "     \"default\": { \"field1\" : 1} " +
+            "   } ] " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"nestedField\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\"}]}],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"nestedField\":{\"nestedRecord\":{\"field1\":1}}}",
+            false,
+            "",
+        },
+        {
+            " { " +
+            "   \"type\" : \"record\", " +
+            "   \"name\" : \"Foo\", " +
+            "   \"fields\" : [ { " +
+            "     \"name\" : \"nestedField\", " +
+            "     \"type\" : { " +
+            "       \"type\" : \"record\", " +
+            "       \"name\" : \"nestedRecord\", " +
+            "       \"fields\" : [ { " +
+            "         \"name\" : \"field1\", " +
+            "         \"type\" : \"int\" " +
+            "       } ] " +
+            "     }, " +
+            "     \"default\": { \"field1\" : 1} " +
+            "   } ] " +
+            " } ",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"nestedField\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"nestedRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\"}]}],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"nestedField\":null}",
+            false,
+            "",
+        },
+
+        // 11. Test when input is missing, using enum
         {
             // required enum with default value
             "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
@@ -1337,6 +1711,7 @@ public class TestDataTranslator
             "",
         },
 
+        // Below are test case example for invalid option combination:
         // If the field in pegasus schema has been translated as required, its data cannot be translated as optional
         {
             // required int with default value

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -1168,42 +1168,42 @@ public class TestDataTranslator
     // 7. seventh element is whether this is a valid case
     // 8. eighth element tells the error message if this is invalid
     return new Object[][] {
-        //  If the dataMap has customer set values, the mode should have no impact on the DataTranslator.
-//        {
-//            // required int with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
-//            "{\"bar\":1}",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"bar\":1}",
-//            false,
-//            "",
-//        },
-//        {
-//            // required int with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
-//            "{\"bar\":1}",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"bar\":1}",
-//            false,
-//            "",
-//        },
-//
-//        {
-//            // required int with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
-//            "{\"bar\":1}",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"bar\":{\"int\":1}}", // Json representation for Avro record
-//            false,
-//            "",
-//        },
-//
+//          If the dataMap has customer set values, the mode should have no impact on the DataTranslator.
+        {
+            // required int with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
+            "{\"bar\":1}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":1}",
+            false,
+            "",
+        },
+        {
+            // required int with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
+            "{\"bar\":1}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"bar\":1}",
+            false,
+            "",
+        },
+
+        {
+            // required int with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
+            "{\"bar\":1}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":{\"int\":1}}", // Json representation for Avro record
+            false,
+            "",
+        },
+
         {
             // required int with default value
             "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
@@ -1222,157 +1222,157 @@ public class TestDataTranslator
             "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"arrayRequired\",\"type\":[\"null\",{\"type\":\"array\",\"items\":\"string\"}],\"default\":null}]}",
             "{\"arrayRequired\":[\"a\",\"b\"]}",
             PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-            "{\"arrayRequired\":null}", //read as optional from Avro true,
+            "{\"arrayRequired\":{\"array\":[\"a\",\"b\"]}}",//read as optional from Avro true,
             false,
             "",
         },
-//
-//        // Test in different options, using int as example
-//        {
-//            // required int with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"bar\":42}",
-//            false,
-//            "",
-//        },
-//        {
-//            // required int with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE, // this option translate to optional in Avro
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"bar\":{\"int\":42}}",
-//            false,
-//            "",
-//        },
-//
-//        {
-//            // required int with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE, // this option translate to optional in Avro
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"bar\":null}",
-//            false,
-//            "",
-//        },
-//
-//        // Tests with union
-//        {
-//            // required Union of [int string] with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"bar\":{\"int\":42}}", //  DataTranslator should translate to the default value in the schema
-//            false,
-//            "",
-//        },
-//        {
-//            // required Union of [int string] with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"bar\":{\"int\":42}}", //  DataTranslator should translate to the default value in the schema
-//            false,
-//            "",
-//        },
-//
-//        {
-//            // required Union of [int string] with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"bar\":null}", //read as optional from Avro
-//            false,
-//            "",
-//        },
-//
-//        // Tests with Enum
-//        {
-//            // required enum with default value
-//            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]},\"default\":\"APPLE\"}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"enumRequired\":\"APPLE\"}", //read as optional from Avro
-//            false,
-//            "",
-//        },
-//
-//        // The following case works under avro 1.4 but not avro 1.6, and is an invalid case
-////        {
-////            // required enum with default value
-////            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
-////            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-////            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]}],\"default\":null}]}",
-////            "{}",
-////            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-////            "{\"enumRequired\":{\"Fruits\":\"APPLE\"}}",
-////            false,
-////            "",
-////        },
-//
+
+        // Test in different options, using int as example
+        {
+            // required int with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":42}",
+            false,
+            "",
+        },
+        {
+            // required int with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE, // this option translate to optional in Avro
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":{\"int\":42}}",
+            false,
+            "",
+        },
+
+        {
+            // required int with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE, // this option translate to optional in Avro
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"bar\":null}",
+            false,
+            "",
+        },
+
+        // Tests with union
+        {
+            // required Union of [int string] with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":{\"int\":42}}", //  DataTranslator should translate to the default value in the schema
+            false,
+            "",
+        },
+        {
+            // required Union of [int string] with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":{\"int\":42}}", //  DataTranslator should translate to the default value in the schema
+            false,
+            "",
+        },
+
+        {
+            // required Union of [int string] with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"bar\":null}", //read as optional from Avro
+            false,
+            "",
+        },
+
+        // Tests with Enum
+        {
+            // required enum with default value
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]},\"default\":\"APPLE\"}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"enumRequired\":\"APPLE\"}", //read as optional from Avro
+            false,
+            "",
+        },
+
+        // The following case works under avro 1.4 but not avro 1.6, and is an invalid case
 //        {
 //            // required enum with default value
 //            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
 //            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
 //            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]}],\"default\":null}]}",
 //            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"enumRequired\":null}", //read as optional from Avro
+//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+//            "{\"enumRequired\":{\"Fruits\":\"APPLE\"}}",
 //            false,
 //            "",
 //        },
-//
-//        // If the field in pegasus schema has been translated as required, its data cannot be translated as optional
-//        {
-//            // required int with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"bar\":null}",
-//            true,
-//            "null of int in field bar of foo",
-//        },
-//
-//        {
-//            // required Union of [int string] with default value
-//            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"bar\":null}", //read as optional from Avro
-//            true,
-//            "Not in union [\"int\",\"string\"]: null",
-//        },
-//
-//        {
-//            // required enum with default value
-//            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
-//            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
-//            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]},\"default\":\"APPLE\"}]}",
-//            "{}",
-//            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
-//            "{\"enumRequired\":null}", //read as optional from Avro
-//            true,
-//            "null of Fruits in field enumRequired of Foo"
-//        },
+
+        {
+            // required enum with default value
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]}],\"default\":null}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"enumRequired\":null}", //read as optional from Avro
+            false,
+            "",
+        },
+
+        // If the field in pegasus schema has been translated as required, its data cannot be translated as optional
+        {
+            // required int with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":\"int\",\"default\":42}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"bar\":null}",
+            true,
+            "null of int in field bar of foo",
+        },
+
+        {
+            // required Union of [int string] with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"bar\",\"type\":[\"int\",\"string\"],\"default\":42}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"bar\":null}", //read as optional from Avro
+            true,  // This case is wrong because expecting "null" for avro record but the avro schema doesn't contain null
+            "Error processing /bar\n" + "ERROR :: /bar :: cannot find null in union [\"int\",\"string\"]",
+        },
+
+        {
+            // required enum with default value
+            "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"enumRequired\", \"type\" : ##T_START { \"name\" : \"Fruits\", \"type\" : \"enum\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"default\": \"APPLE\" } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"enumRequired\",\"type\":{\"type\":\"enum\",\"name\":\"Fruits\",\"symbols\":[\"APPLE\",\"ORANGE\"]},\"default\":\"APPLE\"}]}",
+            "{}",
+            PegasusToAvroDefaultFieldTranslationMode.DO_NOT_TRANSLATE,
+            "{\"enumRequired\":null}", //read as optional from Avro
+            true,
+            "null of Fruits in field enumRequired of Foo"
+        },
     };
   }
 


### PR DESCRIPTION
Due to introduction of PegasusToAvroDefaultFieldTranslationMode, some of the translation from (Pegasus required with default) to (Avro optional) or (Avro optional) to (Pegasus required with default) cannot be performed correctly.

This PR is for that fix. Also added test cases.