### PR TITLE
Enforce schema properties order in JsonBuilder so Pegasus schema and Avro schema properties would have deterministic order

### DIFF
--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -1238,7 +1238,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"failure\" : null, \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\" } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1261,7 +1261,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"failure\" : null, \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\" } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1308,7 +1308,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"null\", \"success\" : null, \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"failure\" : null, \"fieldDiscriminator\" : \"null\", \"success\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": null, \"failure\": null, \"fieldDiscriminator\": ##Q_STARTnull##Q_END}}"
@@ -1657,6 +1657,46 @@ public class TestSchemaTranslator
                   "}",
               allModes,
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              null,
+              null,
+              null
+          },
+          {
+              " { " +
+              "   \"type\" : \"record\", " +
+              "   \"name\" : \"Foo\", " +
+              "   \"fields\" : [ { " +
+              "     \"name\" : \"field1\", " +
+              "     \"type\" : \"int\", " +
+              "     \"b_customerAnnotation\" : \"f1\", " +
+              "     \"c_customerAnnotation\" : \"f1\", " +
+              "     \"a_customerAnnotation\" : \"f1\" " +
+              "   } ] " +
+              " } ",
+              allModes,
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customerAnnotation\" : \"f1\", \"b_customerAnnotation\" : \"f1\", \"c_customerAnnotation\" : \"f1\" } ] }",
+              null,
+              null,
+              null
+          },
+          {
+              " { " +
+              "   \"type\" : \"record\", " +
+              "   \"name\" : \"Foo\", " +
+              "   \"fields\" : [ { " +
+              "     \"name\" : \"field1\", " +
+              "     \"type\" : \"int\", " +
+              "     \"c_customerAnnotation\" : { " +
+              "       \"b_nested\" : \"a\", " +
+              "       \"a_nested\" : \"a\", " +
+              "       \"c_nested\" : \"a\" " +
+              "     }, " +
+              "     \"a_customerAnnotation\" : \"f1\", " +
+              "     \"b_customerAnnotation\" : \"f1\" " +
+              "   } ] " +
+              " } ",
+              allModes,
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customerAnnotation\" : \"f1\", \"b_customerAnnotation\" : \"f1\", \"c_customerAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
               null,
               null,
               null

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -1238,7 +1238,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"failure\" : null, \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1261,7 +1261,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"failure\" : null, \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1308,7 +1308,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"failure\" : null, \"fieldDiscriminator\" : \"null\", \"success\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"null\", \"success\" : null, \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": null, \"failure\": null, \"fieldDiscriminator\": ##Q_STARTnull##Q_END}}"
@@ -1668,13 +1668,13 @@ public class TestSchemaTranslator
               "   \"fields\" : [ { " +
               "     \"name\" : \"field1\", " +
               "     \"type\" : \"int\", " +
-              "     \"b_customerAnnotation\" : \"f1\", " +
-              "     \"c_customerAnnotation\" : \"f1\", " +
-              "     \"a_customerAnnotation\" : \"f1\" " +
+              "     \"b_customAnnotation\" : \"f1\", " +
+              "     \"c_customAnnotation\" : \"f1\", " +
+              "     \"a_customAnnotation\" : \"f1\" " +
               "   } ] " +
               " } ",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customerAnnotation\" : \"f1\", \"b_customerAnnotation\" : \"f1\", \"c_customerAnnotation\" : \"f1\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : \"f1\" } ] }",
               null,
               null,
               null
@@ -1686,17 +1686,17 @@ public class TestSchemaTranslator
               "   \"fields\" : [ { " +
               "     \"name\" : \"field1\", " +
               "     \"type\" : \"int\", " +
-              "     \"c_customerAnnotation\" : { " +
+              "     \"c_customAnnotation\" : { " +
               "       \"b_nested\" : \"a\", " +
               "       \"a_nested\" : \"a\", " +
               "       \"c_nested\" : \"a\" " +
               "     }, " +
-              "     \"a_customerAnnotation\" : \"f1\", " +
-              "     \"b_customerAnnotation\" : \"f1\" " +
+              "     \"a_customAnnotation\" : \"f1\", " +
+              "     \"b_customAnnotation\" : \"f1\" " +
               "   } ] " +
               " } ",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customerAnnotation\" : \"f1\", \"b_customerAnnotation\" : \"f1\", \"c_customerAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
               null,
               null,
               null

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -297,10 +297,18 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
     }
 
     @Override
+    public Iterable<Map.Entry<String, Object>> orderMap(DataMap map)
+    {
+      return Data.orderMapEntries(map);
+    }
+
+    @Override
     public void key(String key) throws IOException
     {
       _generator.writeFieldName(key);
     }
+
+
 
     @Override
     public void endMap() throws IOException

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -308,8 +308,6 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
       _generator.writeFieldName(key);
     }
 
-
-
     @Override
     public void endMap() throws IOException
     {

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -139,12 +139,12 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
   /**
    * Create {@link JacksonTraverseCallback} instance for Data object traverse
    * @param generator JsonGenerator
-   * @param mapKeyOrdered whether want the callBack to traverse the data map with map key sorted order
+   * @param traverseMapBySortedKeyOrder indicate whether want the callBack to traverse the data map within data object using the sorted map key order
    * @return
    */
-  protected Data.TraverseCallback createTraverseCallback(JsonGenerator generator, boolean mapKeyOrdered)
+  protected Data.TraverseCallback createTraverseCallback(JsonGenerator generator, boolean traverseMapBySortedKeyOrder)
   {
-    return mapKeyOrdered? new JacksonTraverseCallbackMapKeyOrdered(generator): new JacksonTraverseCallback(generator);
+    return traverseMapBySortedKeyOrder? new JacksonTraverseCallbackMapKeyOrdered(generator): new JacksonTraverseCallback(generator);
   }
 
   @Override

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -137,14 +137,15 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
   }
 
   /**
-   * Create {@link JacksonTraverseCallback} instance for Data object traverse
-   * @param generator JsonGenerator
+   * Create {@link Data.TraverseCallback} interface instance for Data object traverse
+   * @param generator JsonGenerator used during traverse
    * @param traverseMapBySortedKeyOrder indicate whether want the callBack to traverse the data map within data object using the sorted map key order
    * @return
    */
   protected Data.TraverseCallback createTraverseCallback(JsonGenerator generator, boolean traverseMapBySortedKeyOrder)
   {
-    return traverseMapBySortedKeyOrder? new JacksonTraverseCallbackMapKeyOrdered(generator): new JacksonTraverseCallback(generator);
+    return traverseMapBySortedKeyOrder ? new JacksonTraverseCallbackMapKeyOrdered(generator)
+        : new JacksonTraverseCallback(generator);
   }
 
   @Override
@@ -224,17 +225,22 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
     return parse(_factory.createParser(in), mesg, locationMap);
   }
 
+  public void objectToJsonGenerator(Object object, JsonGenerator generator) throws IOException
+  {
+    objectToJsonGenerator(object, generator, false);
+  }
+
   /**
    * Convert an object to Json format representation.
    * @param object the object that needs to be converted
    * @param generator the generator that could generate Json output based on the object
-   * @param mapKeyOrdered if the object contains map element (which could be nested map), can set this flag to order the
-   *                      map entries in the output according to sorted map key.
+   * @param orderMapByKey if true, map elements in the object (can be the object itself or its nested elements)
+   *                      will have their entries sorted by keys in the generated Json.
    * @throws IOException
    */
-  public void objectToJsonGenerator(Object object, JsonGenerator generator, boolean mapKeyOrdered) throws IOException
+  public void objectToJsonGenerator(Object object, JsonGenerator generator, boolean orderMapByKey) throws IOException
   {
-    Data.TraverseCallback callback = createTraverseCallback(generator, mapKeyOrdered);
+    Data.TraverseCallback callback = createTraverseCallback(generator, orderMapByKey);
     Data.traverse(object, callback);
   }
 

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -144,8 +144,7 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
    */
   protected Data.TraverseCallback createTraverseCallback(JsonGenerator generator, boolean traverseMapBySortedKeyOrder)
   {
-    return traverseMapBySortedKeyOrder ? new JacksonTraverseCallbackMapKeyOrdered(generator)
-        : new JacksonTraverseCallback(generator);
+    return new JacksonTraverseCallback(generator, traverseMapBySortedKeyOrder);
   }
 
   @Override
@@ -244,28 +243,20 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
     Data.traverse(object, callback);
   }
 
-  public static class JacksonTraverseCallbackMapKeyOrdered extends JacksonTraverseCallback
-  {
-
-    protected JacksonTraverseCallbackMapKeyOrdered(JsonGenerator generator)
-    {
-      super(generator);
-    }
-
-    @Override
-    public Iterable<Map.Entry<String, Object>> orderMap(DataMap map)
-    {
-      return Data.orderMapEntries(map);
-    }
-  }
-
   public static class JacksonTraverseCallback implements Data.TraverseCallback
   {
     protected final JsonGenerator _generator;
+    private final boolean _orderMapEntriesByKey;
 
     protected JacksonTraverseCallback(JsonGenerator generator)
     {
+      this(generator, false);
+    }
+
+    protected JacksonTraverseCallback(JsonGenerator generator, boolean orderMapEntriesByKey)
+    {
       _generator = generator;
+      _orderMapEntriesByKey = orderMapEntriesByKey;
     }
 
     @Override
@@ -340,6 +331,19 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
     public void key(String key) throws IOException
     {
       _generator.writeFieldName(key);
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, Object>> orderMap(DataMap map)
+    {
+      if (_orderMapEntriesByKey)
+      {
+        return Data.orderMapEntries(map);
+      }
+      else
+      {
+        return map.entrySet();
+      }
     }
 
     @Override

--- a/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
@@ -278,7 +278,7 @@ public class JsonBuilder
    */
   public void writeDataWithMapEntriesSorted(Object object) throws IOException
   {
-    _jacksonDataCodec.objectToJsonGenerator(object, _jsonGenerator,true);
+    _jacksonDataCodec.objectToJsonGenerator(object, _jsonGenerator, true);
   }
 
 

--- a/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
@@ -16,22 +16,16 @@
 
 package com.linkedin.data.schema;
 
-
-import com.linkedin.data.codec.JacksonDataCodec;
-import com.linkedin.data.template.DataTemplate;
-import com.linkedin.data.template.JacksonDataTemplateCodec;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.PrettyPrinter;
+import com.linkedin.data.codec.JacksonDataCodec;
+import com.linkedin.data.template.DataTemplate;
+import com.linkedin.data.template.JacksonDataTemplateCodec;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 

--- a/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
@@ -23,12 +23,16 @@ import com.linkedin.data.template.JacksonDataTemplateCodec;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.PrettyPrinter;
+import java.util.stream.Collectors;
 
 
 /**
@@ -282,7 +286,10 @@ public class JsonBuilder
   {
     if (value.isEmpty() == false)
     {
-      for (Map.Entry<String, ?> entry : value.entrySet())
+      List<Map.Entry<String, ?>> orderedProperties =  value.entrySet().stream()
+                                                                     .sorted(Map.Entry.comparingByKey())
+                                                                     .collect(Collectors.toList());
+        for (Map.Entry<String, ?> entry : orderedProperties)
       {
         _jsonGenerator.writeFieldName(entry.getKey());
         writeData(entry.getValue());

--- a/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
@@ -267,7 +267,7 @@ public class JsonBuilder
    */
   public void writeData(Object object) throws IOException
   {
-    _jacksonDataCodec.objectToJsonGenerator(object, _jsonGenerator, false);
+    _jacksonDataCodec.objectToJsonGenerator(object, _jsonGenerator);
   }
 
   /**

--- a/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
@@ -271,7 +271,8 @@ public class JsonBuilder
   }
 
   /**
-   * Write Data object. But if the Data Object contains DataMap, the result would output the map entries using sorted key order.
+   * Write Data object. But if the Data Object contains DataMap or itself is a DataMap,
+   * the result would output the map entries using sorted key order.
    *
    * @param object is the Data object to write.
    */

--- a/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
@@ -267,11 +267,24 @@ public class JsonBuilder
    */
   public void writeData(Object object) throws IOException
   {
-    _jacksonDataCodec.objectToJsonGenerator(object, _jsonGenerator);
+    _jacksonDataCodec.objectToJsonGenerator(object, _jsonGenerator, false);
   }
 
   /**
+   * Write Data object. But if the Data Object contains DataMap, the output would have the map keys ordered.
+   *
+   * @param object is the Data object to write.
+   */
+  public void writeOrderedData(Object object) throws IOException
+  {
+    _jacksonDataCodec.objectToJsonGenerator(object, _jsonGenerator,true);
+  }
+
+
+  /**
    * Write properties by adding each property as a field to current JSON object.
+   * The property would be key value pair with keys sorted
+   * Of the property's value contains Data Map, its output would have those map keys sorted as well
    *
    * @param value provides the properties to be written.
    * @throws IOException if there is an error writing.
@@ -286,7 +299,7 @@ public class JsonBuilder
         for (Map.Entry<String, ?> entry : orderedProperties)
       {
         _jsonGenerator.writeFieldName(entry.getKey());
-        writeData(entry.getValue());
+        writeOrderedData(entry.getValue());
       }
     }
   }

--- a/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/JsonBuilder.java
@@ -271,11 +271,11 @@ public class JsonBuilder
   }
 
   /**
-   * Write Data object. But if the Data Object contains DataMap, the output would have the map keys ordered.
+   * Write Data object. But if the Data Object contains DataMap, the result would output the map entries using sorted key order.
    *
    * @param object is the Data object to write.
    */
-  public void writeOrderedData(Object object) throws IOException
+  public void writeDataWithMapEntriesSorted(Object object) throws IOException
   {
     _jacksonDataCodec.objectToJsonGenerator(object, _jsonGenerator,true);
   }
@@ -299,7 +299,7 @@ public class JsonBuilder
         for (Map.Entry<String, ?> entry : orderedProperties)
       {
         _jsonGenerator.writeFieldName(entry.getKey());
-        writeOrderedData(entry.getValue());
+        writeDataWithMapEntriesSorted(entry.getValue());
       }
     }
   }

--- a/data/src/main/java/com/linkedin/data/template/JacksonDataTemplateCodec.java
+++ b/data/src/main/java/com/linkedin/data/template/JacksonDataTemplateCodec.java
@@ -87,7 +87,7 @@ public class JacksonDataTemplateCodec extends JacksonDataCodec
     }
     else
     {
-      objectToJsonGenerator(data, generator);
+      objectToJsonGenerator(data, generator, false);
     }
   }
 

--- a/data/src/main/java/com/linkedin/data/template/JacksonDataTemplateCodec.java
+++ b/data/src/main/java/com/linkedin/data/template/JacksonDataTemplateCodec.java
@@ -87,7 +87,7 @@ public class JacksonDataTemplateCodec extends JacksonDataCodec
     }
     else
     {
-      objectToJsonGenerator(data, generator, false);
+      objectToJsonGenerator(data, generator);
     }
   }
 


### PR DESCRIPTION
Currently when translating to Avro or Pegasus schema, nested properties wouldn't have deterministic and based on its implementation (DataMap type), the order is given from HashMap, which is indeterministic.

This change would affect [pegasus to avro] translation AND [avro to peagsus] translation when outputting string (only for properties encoding). It wouldn't affect memory representation.


wc-test:
https://crt.prod.linkedin.com/#/testing/executions/7037b41c-8501-4db9-9237-1f54c5964c68/execution