### PR TITLE
Fix typo in typeref example

### DIFF
--- a/src/pdl_schema.md
+++ b/src/pdl_schema.md
@@ -808,7 +808,7 @@ For example:
 ```pdl
 namespace com.example.models
 
-typeref PhoneNumber = union[
+typeref PhoneContact = union[
   /** A mobile phone number */
   mobile: PhoneNumber,
 
@@ -828,8 +828,8 @@ Typerefs can then be referred to by name from any other type:
 namespace com.example.models
 
 record Contacts {
-  primaryPhone: PhoneNumber
-  secondaryPhone: PhoneNumber
+  primaryPhone: PhoneContact
+  secondaryPhone: PhoneContact
 }
 ```
 


### PR DESCRIPTION
Update the example for typeref to remove the confusion about it being a cyclic reference.