### PR TITLE
Add Streaming Timeout to TransportClient Properties

### DIFF
--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/D2TransportClientProperties.pdsc
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/D2TransportClientProperties.pdsc
@@ -17,6 +17,12 @@
       "optional": true
     },
     {
+      "name": "streamingTimeout",
+      "type": "long",
+      "doc": "Streaming Timeout in ms for this transport client. Disabled by default (-1)",
+      "optional": true
+    },
+    {
       "name": "maxResponseSize",
       "type": "long",
       "doc": "Max payload that this transport client can carry in bytes. Defaults to 2MB.",

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/TransportClientPropertiesConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/TransportClientPropertiesConverter.java
@@ -55,6 +55,10 @@ public class TransportClientPropertiesConverter
     {
       prop.put(PropertyKeys.HTTP_REQUEST_TIMEOUT, config.getRequestTimeout().toString());
     }
+    if (config.hasStreamingTimeout())
+    {
+      prop.put(PropertyKeys.HTTP_STREAMING_TIMEOUT, config.getStreamingTimeout().toString());
+    }
     if (config.hasMaxResponseSize())
     {
       prop.put(PropertyKeys.HTTP_MAX_RESPONSE_SIZE, config.getMaxResponseSize().toString());
@@ -152,6 +156,10 @@ public class TransportClientPropertiesConverter
     if (properties.containsKey(PropertyKeys.HTTP_REQUEST_TIMEOUT))
     {
       config.setRequestTimeout(coerce(properties.get(PropertyKeys.HTTP_REQUEST_TIMEOUT), Long.class));
+    }
+    if (properties.containsKey(PropertyKeys.HTTP_STREAMING_TIMEOUT))
+    {
+      config.setStreamingTimeout(coerce(properties.get(PropertyKeys.HTTP_STREAMING_TIMEOUT), Long.class));
     }
     if (properties.containsKey(PropertyKeys.HTTP_MAX_RESPONSE_SIZE))
     {

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -125,6 +125,7 @@ public class PropertyKeys
   //used by transport client creation
   public static final String HTTP_POOL_WAITER_SIZE = HttpClientFactory.HTTP_POOL_WAITER_SIZE;
   public static final String HTTP_REQUEST_TIMEOUT = HttpClientFactory.HTTP_REQUEST_TIMEOUT;
+  public static final String HTTP_STREAMING_TIMEOUT = HttpClientFactory.HTTP_STREAMING_TIMEOUT;
   public static final String HTTP_MAX_RESPONSE_SIZE = HttpClientFactory.HTTP_MAX_RESPONSE_SIZE;
   public static final String HTTP_POOL_SIZE = HttpClientFactory.HTTP_POOL_SIZE;
   public static final String HTTP_IDLE_TIMEOUT = HttpClientFactory.HTTP_IDLE_TIMEOUT;


### PR DESCRIPTION
Add Streaming Timeout to Transport Client Properties Converter so that these properties get serialized and deserialized properly. 