### PR TITLE
Change ValidateSchemaAnnotationTask to ignore exception or errors durng initializaing class by classLoader

### DIFF
--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateSchemaAnnotationTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateSchemaAnnotationTask.java
@@ -173,7 +173,7 @@ public class ValidateSchemaAnnotationTask extends DefaultTask
    * This method will check the java class annotation on the class instantiated by a className;
    * It will search if that class has an annotation matching {@link SCHEMA_HANDLER_JAVA_ANNOTATION},
    * if found, this class name will be added to "foundClasses" list.
-   * if exceptions or error detected during instantiation of the class, this method will return without doing anything.
+   * if exceptions or errors detected during instantiation of the class, this method will return without doing anything.
    *
    * @param name the name of class to be search annotation from.
    * @param foundClasses a list of class names of the classes that contains {@link SCHEMA_HANDLER_JAVA_ANNOTATION}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.1.28
+version=28.1.29
 sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
 sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 org.gradle.configureondemand=true


### PR DESCRIPTION
Current in ValidateSchemaAnnotationTask, we try to find annotation handler by searching a class with certain java annotation ("RestLiSchemaAnnotationHandler") inside the dependencies. Therefore we need to use "Class.forName(<className>)}" methods.

However there might be exception/errors raised during this period of time, such as java.lang.NoClassDefFoundError, java.lang.IllegalAccessError, java.lang.IllegalAccessError

This is mostly likely due to the fact the the user didn't config the grade dependencies properly. For those classes that failed to be instantiated, they will be ignored.