### PR TITLE
Introduce an object creation timeout to completely de-couple channel creation from channelPool

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.1.27
+version=28.1.28
 sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
 sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 org.gradle.configureondemand=true

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ObjectCreationTimeoutException.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ObjectCreationTimeoutException.java
@@ -1,0 +1,68 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.r2.transport.http.client;
+
+import com.linkedin.r2.RetriableRequestException;
+
+
+/**
+ * Represents object creation time out error while waiting for object from the pool.
+ *
+ * @author Nizar Mankulangara
+ */
+public class ObjectCreationTimeoutException extends RetriableRequestException
+{
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Construct a new instance.
+   */
+  public ObjectCreationTimeoutException()
+  {
+  }
+
+  /**
+   * Construct a new instance with specified message.
+   *
+   * @param message the message to be used for this exception.
+   */
+  public ObjectCreationTimeoutException(String message)
+  {
+    super(message);
+  }
+
+  /**
+   * Construct a new instance with specified message and cause.
+   *
+   * @param message the message to be used for this exception.
+   * @param cause the cause to be used for this exception.
+   */
+  public ObjectCreationTimeoutException(String message, Throwable cause)
+  {
+    super(message, cause);
+  }
+
+  /**
+   * Construct a new instance with specified cause.
+   *
+   * @param cause the cause to be used for this exception.
+   */
+  public ObjectCreationTimeoutException(Throwable cause)
+  {
+    super(cause);
+  }
+}

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/TimeoutCallback.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/TimeoutCallback.java
@@ -39,7 +39,7 @@ public class TimeoutCallback<T> implements Callback<T>
   public TimeoutCallback(ScheduledExecutorService executor, long timeout, TimeUnit timeoutUnit,
                                final Callback<T> callback)
   {
-    this(executor, timeout, timeoutUnit, callback, null);
+    this(executor, timeout, timeoutUnit, callback, "");
   }
 
   /**
@@ -55,9 +55,23 @@ public class TimeoutCallback<T> implements Callback<T>
   public TimeoutCallback(ScheduledExecutorService executor, long timeout, TimeUnit timeoutUnit,
                                final Callback<T> callback, final String timeoutMessage)
   {
-    _timeout = new SingleTimeout<>(executor, timeout, timeoutUnit, callback, () -> callback.onError(
-      new TimeoutException(
-        "Exceeded request timeout of " + timeoutUnit.toMillis(timeout) + "ms: " + timeoutMessage)));
+    this(executor, timeout, timeoutUnit, callback, new TimeoutException(
+        "Exceeded request timeout of " + timeoutUnit.toMillis(timeout) + "ms: " + timeoutMessage));
+  }
+
+  /**
+   * Construct a new instance.
+   *
+   * @param executor the {@link ScheduledExecutorService} used to schedule the timeout
+   * @param timeout the timeout delay, in the specified {@link TimeUnit}.
+   * @param timeoutUnit the {@link TimeUnit} for the timeout parameter.
+   * @param callback the {@link Callback} to be invoked on success or error.
+   * @param timeoutThrowable the custom exception that will be used during the timeout
+   */
+  public TimeoutCallback(ScheduledExecutorService executor, long timeout, TimeUnit timeoutUnit,
+      final Callback<T> callback, final Throwable timeoutThrowable)
+  {
+    _timeout = new SingleTimeout<>(executor, timeout, timeoutUnit, callback, () -> callback.onError(timeoutThrowable));
   }
 
   @Override

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyClient.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyClient.java
@@ -722,7 +722,7 @@ public class TestHttpNettyClient
         new SettableClock(),
         new LongTracking()
      );
-    HttpNettyClient client = new HttpNettyClient(address -> testPool, _scheduler, 500, 500);
+    HttpNettyClient client = new HttpNettyClient(address -> testPool, _scheduler, MAX_RATE_LIMITING_PERIOD * 2, 500);
 
     final RestRequest r = new RestRequestBuilder(URI.create("http://localhost:8080/")).setMethod("GET").build();
     final ExecutorService executor = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
Introduce an object creation timeout to completely de-couple channel creation from channelPooll
Remove retry during failure
Fix ssl handshake timeout isssue