### PR TITLE
Use manifest-only JAR for TranslateSchemasTask

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.1.33
+version=28.1.34
 sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
 sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 org.gradle.configureondemand=true


### PR DESCRIPTION
Use PathingJarUtil to prepare manifest-only JAR for invocations of TranslateSchemasTask

Avoids "error=7, Argument list too long" error