### PR TITLE
Add local-release script

### DIFF
--- a/local-release
+++ b/local-release
@@ -1,0 +1,22 @@
+#!/bin/sh
+# The purpose of this script is to publish artifacts to ~/local-repo
+
+LOCAL_REPO="${HOME}/local-repo"
+
+if [ ! -d $LOCAL_REPO ]; then
+  # If this error is encountered, then (1) $HOME is not set correctly or (2) ~/local-repo doesn't exist
+  echo "Cannot perform local release, '$LOCAL_REPO' is not a valid directory"
+  exit 1
+fi
+
+VERSION=$(awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties)
+echo "Publishing pegasus $VERSION to $LOCAL_REPO"
+
+./gradlew -Dmaven.repo.local=$LOCAL_REPO publishReleasePublicationToMavenLocal
+
+if [ $? -eq 0 ]; then
+  echo "Published pegasus $VERSION to $LOCAL_REPO"
+else
+  exit 1
+fi
+

--- a/local-release
+++ b/local-release
@@ -1,16 +1,19 @@
 #!/bin/sh
 # The purpose of this script is to publish artifacts to ~/local-repo
 
-LOCAL_REPO="${HOME}/local-repo"
-
-if [ ! -d $LOCAL_REPO ]; then
-  # If this error is encountered, then (1) $HOME is not set correctly or (2) ~/local-repo doesn't exist
-  echo "Cannot perform local release, '$LOCAL_REPO' is not a valid directory"
+if [ ! -d "$HOME" ]; then
+  echo 'Cannot perform local release, $HOME is not set to a valid directory'
   exit 1
 fi
 
-VERSION=$(awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties)
-echo "Publishing pegasus $VERSION to $LOCAL_REPO"
+LOCAL_REPO="${HOME}/local-repo"
+
+if [ ! -d $LOCAL_REPO ]; then
+  mkdir $LOCAL_REPO
+fi
+
+VERSION=$(awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties | awk '{ print $1 }')
+echo "Publishing pegasus $VERSION to ${LOCAL_REPO}..."
 
 ./gradlew -Dmaven.repo.local=$LOCAL_REPO publishReleasePublicationToMavenLocal
 

--- a/pre-release-check
+++ b/pre-release-check
@@ -10,7 +10,7 @@ then
 fi
 
 # Determine version to be released
-VERSION=`awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties`
+VERSION=`awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties | awk '{ print $1 }'`
 echo "Running pre-release job for version $VERSION..."
 
 # Check that there are no uncommitted changes

--- a/prepare-release
+++ b/prepare-release
@@ -32,7 +32,7 @@ then
 fi
 
 # Determine version to be released
-VERSION=`awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties`
+VERSION=`awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties | awk '{ print $1 }'`
 if [ -z "$VERSION" ]
 then
   echo 'Could not read the version from gradle.properties, please fix it and try again.'


### PR DESCRIPTION
Publishes Maven artifacts to `~/local-repo`

How to use: `./local-release`

Tested that internal projects can build against these locally released artifacts, and they can.