### PR TITLE
Feature/zk batch with jitter

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -163,7 +163,7 @@ public class D2ClientBuilder
                   _config.startUpExecutorService,
                   _config.jmxManager,
                   _config.d2JmxManagerPrefix,
-                  _config.readWindowMs);
+                  _config.zookeeperReadWindowMs);
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() :
@@ -407,8 +407,8 @@ public class D2ClientBuilder
     return this;
   }
 
-  public D2ClientBuilder setReadWindowMs(int readWindowMs){
-    _config.readWindowMs = readWindowMs;
+  public D2ClientBuilder setZookeeperReadWindowMs(int zookeeperReadWindowMs){
+    _config.zookeeperReadWindowMs = zookeeperReadWindowMs;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -162,7 +162,8 @@ public class D2ClientBuilder
                   _config.zkConnectionToUseForLB,
                   _config.startUpExecutorService,
                   _config.jmxManager,
-                  _config.d2JmxManagerPrefix);
+                  _config.d2JmxManagerPrefix,
+                  _config.readWindowMs);
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() :
@@ -403,6 +404,11 @@ public class D2ClientBuilder
 
   public D2ClientBuilder setWarmUpTimeoutSeconds(int warmUpTimeoutSeconds){
     _config.warmUpTimeoutSeconds = warmUpTimeoutSeconds;
+    return this;
+  }
+
+  public D2ClientBuilder setReadWindowMs(int readWindowMs){
+    _config.readWindowMs = readWindowMs;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -28,6 +28,7 @@ import com.linkedin.d2.balancer.zkfs.ZKFSTogglingLoadBalancerFactoryImpl;
 import com.linkedin.d2.balancer.zkfs.ZKFSTogglingLoadBalancerFactoryImpl.ComponentFactory;
 import com.linkedin.d2.discovery.stores.zk.ZKPersistentConnection;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeper;
+import com.linkedin.d2.discovery.stores.zk.ZooKeeperStore;
 import com.linkedin.d2.jmx.JmxManager;
 import com.linkedin.d2.jmx.NoOpJmxManager;
 import com.linkedin.r2.transport.common.TransportClientFactory;
@@ -71,6 +72,7 @@ public class D2ClientConfig
   int retryLimit = DEAULT_RETRY_LIMIT;
   boolean warmUp = false;
   int warmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
+  int readWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   int warmUpConcurrentRequests = WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS;
   DownstreamServicesFetcher downstreamServicesFetcher = null;
   boolean backupRequestsEnabled = true;
@@ -136,7 +138,8 @@ public class D2ClientConfig
                  ZKPersistentConnection zkConnection,
                  ScheduledExecutorService startUpExecutorService,
                  JmxManager jmxManager,
-                 String d2JmxManagerPrefix)
+                 String d2JmxManagerPrefix,
+                 int readWindowMs)
   {
     this.zkHosts = zkHosts;
     this.zkSessionTimeoutInMs = zkSessionTimeoutInMs;
@@ -181,5 +184,6 @@ public class D2ClientConfig
     this.startUpExecutorService = startUpExecutorService;
     this.jmxManager = jmxManager;
     this.d2JmxManagerPrefix = d2JmxManagerPrefix;
+    this.readWindowMs = readWindowMs;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -72,7 +72,7 @@ public class D2ClientConfig
   int retryLimit = DEAULT_RETRY_LIMIT;
   boolean warmUp = false;
   int warmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
-  int readWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
+  int zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   int warmUpConcurrentRequests = WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS;
   DownstreamServicesFetcher downstreamServicesFetcher = null;
   boolean backupRequestsEnabled = true;
@@ -139,7 +139,7 @@ public class D2ClientConfig
                  ScheduledExecutorService startUpExecutorService,
                  JmxManager jmxManager,
                  String d2JmxManagerPrefix,
-                 int readWindowMs)
+                 int zookeeperReadWindowMs)
   {
     this.zkHosts = zkHosts;
     this.zkSessionTimeoutInMs = zkSessionTimeoutInMs;
@@ -184,6 +184,6 @@ public class D2ClientConfig
     this.startUpExecutorService = startUpExecutorService;
     this.jmxManager = jmxManager;
     this.d2JmxManagerPrefix = d2JmxManagerPrefix;
-    this.readWindowMs = readWindowMs;
+    this.zookeeperReadWindowMs = zookeeperReadWindowMs;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -38,6 +38,8 @@ import com.linkedin.d2.discovery.stores.zk.builder.ZooKeeperEphemeralStoreBuilde
 import com.linkedin.d2.discovery.stores.zk.builder.ZooKeeperPermanentStoreBuilder;
 import com.linkedin.d2.jmx.D2ClientJmxManager;
 import java.io.File;
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,15 +75,21 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     }
 
     // init all the stores
-    LastSeenZKStore<ClusterProperties> lsClusterStore = getClusterPropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager);
+    LastSeenZKStore<ClusterProperties> lsClusterStore =
+      getClusterPropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager,
+                                          config._executorService, config.readWindowMs);
     PropertyEventBus<ClusterProperties> clusterBus = new PropertyEventBusImpl<>(config._executorService);
     clusterBus.setPublisher(lsClusterStore);
 
-    LastSeenZKStore<ServiceProperties> lsServiceStore = getServicePropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager);
+    LastSeenZKStore<ServiceProperties> lsServiceStore =
+      getServicePropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager,
+                                          config._executorService, config.readWindowMs);
     PropertyEventBus<ServiceProperties> serviceBus = new PropertyEventBusImpl<>(config._executorService);
     serviceBus.setPublisher(lsServiceStore);
 
-    LastSeenZKStore<UriProperties> lsUrisStore = getUriPropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager);
+    LastSeenZKStore<UriProperties> lsUrisStore =
+      getUriPropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager,
+                                      config._executorService, config.readWindowMs);
     PropertyEventBus<UriProperties> uriBus = new PropertyEventBusImpl<>(config._executorService);
     uriBus.setPublisher(lsUrisStore);
 
@@ -102,12 +110,15 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     return balancer;
   }
 
-  private LastSeenZKStore<UriProperties> getUriPropertiesLastSeenZKStore(D2ClientConfig config, ZKPersistentConnection zkPersistentConnection,
-                                                                         D2ClientJmxManager d2ClientJmxManager)
+  private LastSeenZKStore<UriProperties> getUriPropertiesLastSeenZKStore(
+    D2ClientConfig config, ZKPersistentConnection zkPersistentConnection, D2ClientJmxManager d2ClientJmxManager,
+    ScheduledExecutorService executorService, int readWindowMs)
   {
     ZooKeeperEphemeralStoreBuilder<UriProperties> zkUrisStoreBuilder = new ZooKeeperEphemeralStoreBuilder<UriProperties>()
       .setSerializer(new UriPropertiesJsonSerializer()).setPath(ZKFSUtil.uriPath(config.basePath)).setMerger(new UriPropertiesMerger())
       .setUseNewWatcher(config.useNewEphemeralStoreWatcher)
+      .setExecutorService(executorService)
+      .setReadWindowMs(readWindowMs)
       // register jmx every time the object is created
       .addOnBuildListener(d2ClientJmxManager::setZkUriRegistry);
 
@@ -128,12 +139,15 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     );
   }
 
-  private LastSeenZKStore<ServiceProperties> getServicePropertiesLastSeenZKStore(D2ClientConfig config, ZKPersistentConnection zkPersistentConnection,
-                                                                                 D2ClientJmxManager d2ClientJmxManager)
+  private LastSeenZKStore<ServiceProperties> getServicePropertiesLastSeenZKStore(
+    D2ClientConfig config, ZKPersistentConnection zkPersistentConnection, D2ClientJmxManager d2ClientJmxManager,
+    ScheduledExecutorService executorService, int readWindowMs)
   {
     ZooKeeperPermanentStoreBuilder<ServiceProperties> zkServiceStoreBuilder = new ZooKeeperPermanentStoreBuilder<ServiceProperties>()
       .setSerializer(new ServicePropertiesJsonSerializer(config.clientServicesConfig))
       .setPath(ZKFSUtil.servicePath(config.basePath, config.d2ServicePath))
+      .setExecutorService(executorService)
+      .setReadWindowMs(readWindowMs)
       // register jmx every time the object is created
       .addOnBuildListener(d2ClientJmxManager::setZkServiceRegistry);
 
@@ -149,11 +163,14 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     );
   }
 
-  private LastSeenZKStore<ClusterProperties> getClusterPropertiesLastSeenZKStore(D2ClientConfig config, ZKPersistentConnection zkPersistentConnection,
-                                                                                 D2ClientJmxManager d2ClientJmxManager)
+  private LastSeenZKStore<ClusterProperties> getClusterPropertiesLastSeenZKStore(
+    D2ClientConfig config, ZKPersistentConnection zkPersistentConnection, D2ClientJmxManager d2ClientJmxManager,
+    ScheduledExecutorService executorService, int readWindowMs)
   {
     ZooKeeperPermanentStoreBuilder<ClusterProperties> zkClusterStoreBuilder = new ZooKeeperPermanentStoreBuilder<ClusterProperties>()
       .setSerializer(new ClusterPropertiesJsonSerializer()).setPath(ZKFSUtil.clusterPath(config.basePath))
+      .setExecutorService(executorService)
+      .setReadWindowMs(readWindowMs)
       // register jmx every time the object is created
       .addOnBuildListener(d2ClientJmxManager::setZkClusterRegistry);
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -77,19 +77,19 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     // init all the stores
     LastSeenZKStore<ClusterProperties> lsClusterStore =
       getClusterPropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager,
-                                          config._executorService, config.readWindowMs);
+                                          config._executorService, config.zookeeperReadWindowMs);
     PropertyEventBus<ClusterProperties> clusterBus = new PropertyEventBusImpl<>(config._executorService);
     clusterBus.setPublisher(lsClusterStore);
 
     LastSeenZKStore<ServiceProperties> lsServiceStore =
       getServicePropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager,
-                                          config._executorService, config.readWindowMs);
+                                          config._executorService, config.zookeeperReadWindowMs);
     PropertyEventBus<ServiceProperties> serviceBus = new PropertyEventBusImpl<>(config._executorService);
     serviceBus.setPublisher(lsServiceStore);
 
     LastSeenZKStore<UriProperties> lsUrisStore =
       getUriPropertiesLastSeenZKStore(config, zkPersistentConnection, d2ClientJmxManager,
-                                      config._executorService, config.readWindowMs);
+                                      config._executorService, config.zookeeperReadWindowMs);
     PropertyEventBus<UriProperties> uriBus = new PropertyEventBusImpl<>(config._executorService);
     uriBus.setPublisher(lsUrisStore);
 
@@ -112,13 +112,13 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
 
   private LastSeenZKStore<UriProperties> getUriPropertiesLastSeenZKStore(
     D2ClientConfig config, ZKPersistentConnection zkPersistentConnection, D2ClientJmxManager d2ClientJmxManager,
-    ScheduledExecutorService executorService, int readWindowMs)
+    ScheduledExecutorService executorService, int zookeeperReadWindowMs)
   {
     ZooKeeperEphemeralStoreBuilder<UriProperties> zkUrisStoreBuilder = new ZooKeeperEphemeralStoreBuilder<UriProperties>()
       .setSerializer(new UriPropertiesJsonSerializer()).setPath(ZKFSUtil.uriPath(config.basePath)).setMerger(new UriPropertiesMerger())
       .setUseNewWatcher(config.useNewEphemeralStoreWatcher)
       .setExecutorService(executorService)
-      .setReadWindowMs(readWindowMs)
+      .setZookeeperReadWindowMs(zookeeperReadWindowMs)
       // register jmx every time the object is created
       .addOnBuildListener(d2ClientJmxManager::setZkUriRegistry);
 
@@ -141,13 +141,13 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
 
   private LastSeenZKStore<ServiceProperties> getServicePropertiesLastSeenZKStore(
     D2ClientConfig config, ZKPersistentConnection zkPersistentConnection, D2ClientJmxManager d2ClientJmxManager,
-    ScheduledExecutorService executorService, int readWindowMs)
+    ScheduledExecutorService executorService, int zookeeperReadWindowMs)
   {
     ZooKeeperPermanentStoreBuilder<ServiceProperties> zkServiceStoreBuilder = new ZooKeeperPermanentStoreBuilder<ServiceProperties>()
       .setSerializer(new ServicePropertiesJsonSerializer(config.clientServicesConfig))
       .setPath(ZKFSUtil.servicePath(config.basePath, config.d2ServicePath))
       .setExecutorService(executorService)
-      .setReadWindowMs(readWindowMs)
+      .setZookeeperReadWindowMs(zookeeperReadWindowMs)
       // register jmx every time the object is created
       .addOnBuildListener(d2ClientJmxManager::setZkServiceRegistry);
 
@@ -165,12 +165,12 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
 
   private LastSeenZKStore<ClusterProperties> getClusterPropertiesLastSeenZKStore(
     D2ClientConfig config, ZKPersistentConnection zkPersistentConnection, D2ClientJmxManager d2ClientJmxManager,
-    ScheduledExecutorService executorService, int readWindowMs)
+    ScheduledExecutorService executorService, int zookeeperReadWindowMs)
   {
     ZooKeeperPermanentStoreBuilder<ClusterProperties> zkClusterStoreBuilder = new ZooKeeperPermanentStoreBuilder<ClusterProperties>()
       .setSerializer(new ClusterPropertiesJsonSerializer()).setPath(ZKFSUtil.clusterPath(config.basePath))
       .setExecutorService(executorService)
-      .setReadWindowMs(readWindowMs)
+      .setZookeeperReadWindowMs(zookeeperReadWindowMs)
       // register jmx every time the object is created
       .addOnBuildListener(d2ClientJmxManager::setZkClusterRegistry);
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -91,7 +91,8 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    config.partitionAccessorRegistry,
                                                    config.enableSaveUriDataOnDisk,
                                                    config.sslSessionValidatorFactory,
-                                                   d2ClientJmxManager
+                                                   d2ClientJmxManager,
+                                                   config.readWindowMs
     );
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -92,7 +92,7 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    config.enableSaveUriDataOnDisk,
                                                    config.sslSessionValidatorFactory,
                                                    d2ClientJmxManager,
-                                                   config.readWindowMs
+                                                   config.zookeeperReadWindowMs
     );
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStore.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStore.java
@@ -35,6 +35,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.zookeeper.AsyncCallback;
@@ -80,6 +84,8 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
   //TODO: remove the following members after everybody has migrated to use EphemeralStoreWatcher.
   private final ZKStoreWatcher _zkStoreWatcher = new ZKStoreWatcher();
   private final boolean _useNewWatcher;
+  private final ScheduledExecutorService _executorService;
+  private final int _readWindowMs;
 
   public ZooKeeperEphemeralStore(ZKConnection client,
                                  PropertySerializer<T> serializer,
@@ -113,13 +119,33 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
    * @param ephemeralNodesFilePath if a FS path is specified, children nodes are considered unmodifiable,
    *                               and a local cache for children nodes is enabled
    */
+  @Deprecated
+  public ZooKeeperEphemeralStore(ZKConnection client,
+      PropertySerializer<T> serializer,
+      ZooKeeperPropertyMerger<T> merger,
+      String path,
+      boolean watchChildNodes,
+      boolean useNewWatcher,
+      String ephemeralNodesFilePath)
+  {
+    this (client, serializer, merger, path, watchChildNodes, useNewWatcher, ephemeralNodesFilePath,
+        null, DEFAULT_READ_WINDOW_MS);
+  }
+
+  /**
+   * @param watchChildNodes        if true, a watcher for each children node will be set (this have a large cost)
+   * @param ephemeralNodesFilePath if a FS path is specified, children nodes are considered unmodifiable,
+   *                               and a local cache for children nodes is enabled
+   */
   public ZooKeeperEphemeralStore(ZKConnection client,
                                  PropertySerializer<T> serializer,
                                  ZooKeeperPropertyMerger<T> merger,
                                  String path,
                                  boolean watchChildNodes,
                                  boolean useNewWatcher,
-                                 String ephemeralNodesFilePath)
+                                 String ephemeralNodesFilePath,
+                                 ScheduledExecutorService executorService,
+                                 int readWindowMs)
   {
     super(client, serializer, path);
 
@@ -144,6 +170,8 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
     _watchChildNodes = watchChildNodes;
     _useNewWatcher = useNewWatcher;
     _ephemeralNodesFilePath = ephemeralNodesFilePath;
+    _executorService = executorService;
+    _readWindowMs = readWindowMs;
   }
 
   @Override
@@ -610,7 +638,19 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
     protected void processWatch(String propertyName, WatchedEvent event)
     {
       // Reset the watch
-      _zk.getChildren(getPath(propertyName), this, this, false);
+      if (_readWindowMs > 0 && _executorService != null)
+      {
+        // Delay setting the watch based on configured _readWindowMs
+        int midPoint = _readWindowMs / 2;
+        int delay = midPoint + ThreadLocalRandom.current().nextInt(midPoint);
+        _executorService.schedule(() -> _zk.getChildren(getPath(propertyName), this, this, false),
+            delay, TimeUnit.MILLISECONDS);
+      }
+      else
+      {
+        // Set watch Immediately
+        _zk.getChildren(getPath(propertyName), this, this, false);
+      }
     }
 
     /**

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStore.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStore.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -85,7 +84,7 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
   private final ZKStoreWatcher _zkStoreWatcher = new ZKStoreWatcher();
   private final boolean _useNewWatcher;
   private final ScheduledExecutorService _executorService;
-  private final int _readWindowMs;
+  private final int _zookeeperReadWindowMs;
 
   public ZooKeeperEphemeralStore(ZKConnection client,
                                  PropertySerializer<T> serializer,
@@ -145,7 +144,7 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
                                  boolean useNewWatcher,
                                  String ephemeralNodesFilePath,
                                  ScheduledExecutorService executorService,
-                                 int readWindowMs)
+                                 int zookeeperReadWindowMs)
   {
     super(client, serializer, path);
 
@@ -171,7 +170,7 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
     _useNewWatcher = useNewWatcher;
     _ephemeralNodesFilePath = ephemeralNodesFilePath;
     _executorService = executorService;
-    _readWindowMs = readWindowMs;
+    _zookeeperReadWindowMs = zookeeperReadWindowMs;
   }
 
   @Override
@@ -638,10 +637,10 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
     protected void processWatch(String propertyName, WatchedEvent event)
     {
       // Reset the watch
-      if (_readWindowMs > 0 && _executorService != null)
+      if (_zookeeperReadWindowMs > 0 && _executorService != null)
       {
         // Delay setting the watch based on configured _readWindowMs
-        int midPoint = _readWindowMs / 2;
+        int midPoint = _zookeeperReadWindowMs / 2;
         int delay = midPoint + ThreadLocalRandom.current().nextInt(midPoint);
         _executorService.schedule(() -> _zk.getChildren(getPath(propertyName), this, this, false),
             delay, TimeUnit.MILLISECONDS);

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStore.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStore.java
@@ -16,6 +16,10 @@
 
 package com.linkedin.d2.discovery.stores.zk;
 
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.util.None;
 import com.linkedin.d2.discovery.PropertySerializationException;
@@ -35,13 +39,23 @@ public class ZooKeeperPermanentStore<T> extends ZooKeeperStore<T>
                                                                         LoggerFactory.getLogger(ZooKeeperPermanentStore.class);
 
   private final ZKStoreWatcher _zkStoreWatcher = new ZKStoreWatcher();
+  private final ScheduledExecutorService _executorService;
+  private int _readWindowMs;
 
   public ZooKeeperPermanentStore(ZKConnection client,
                                  PropertySerializer<T> serializer,
                                  String path)
   {
-    super(client, serializer, path);
+    this(client, serializer, path, null, DEFAULT_READ_WINDOW_MS);
+  }
 
+  public ZooKeeperPermanentStore(ZKConnection client,
+                                 PropertySerializer<T> serializer,
+                                 String path, ScheduledExecutorService executorService, int readWindowMs)
+  {
+    super(client, serializer, path);
+    _executorService = executorService;
+    _readWindowMs = readWindowMs;
   }
 
   @Override
@@ -144,8 +158,19 @@ public class ZooKeeperPermanentStore<T> extends ZooKeeperStore<T>
     @Override
     protected void processWatch(String propertyName, WatchedEvent watchedEvent)
     {
+      // Reset the watch
+      if (_readWindowMs > 0 && _executorService != null)
+      {
+        // for the static config we can spread the read across the read Window
+        int delay = ThreadLocalRandom.current().nextInt(_readWindowMs);
+        _executorService.schedule(() -> _zk.getData(watchedEvent.getPath(), this, this, false),
+                                  delay, TimeUnit.MILLISECONDS);
+      }
+      else
+      {
         // Reset the watch and read the data
         _zk.getData(watchedEvent.getPath(), this, this, false);
+      }
     }
 
     /**

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStore.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStore.java
@@ -40,7 +40,7 @@ public class ZooKeeperPermanentStore<T> extends ZooKeeperStore<T>
 
   private final ZKStoreWatcher _zkStoreWatcher = new ZKStoreWatcher();
   private final ScheduledExecutorService _executorService;
-  private int _readWindowMs;
+  private int _zookeeperReadWindowMs;
 
   public ZooKeeperPermanentStore(ZKConnection client,
                                  PropertySerializer<T> serializer,
@@ -51,11 +51,11 @@ public class ZooKeeperPermanentStore<T> extends ZooKeeperStore<T>
 
   public ZooKeeperPermanentStore(ZKConnection client,
                                  PropertySerializer<T> serializer,
-                                 String path, ScheduledExecutorService executorService, int readWindowMs)
+                                 String path, ScheduledExecutorService executorService, int zookeeperReadWindowMs)
   {
     super(client, serializer, path);
     _executorService = executorService;
-    _readWindowMs = readWindowMs;
+    _zookeeperReadWindowMs = zookeeperReadWindowMs;
   }
 
   @Override
@@ -159,10 +159,10 @@ public class ZooKeeperPermanentStore<T> extends ZooKeeperStore<T>
     protected void processWatch(String propertyName, WatchedEvent watchedEvent)
     {
       // Reset the watch
-      if (_readWindowMs > 0 && _executorService != null)
+      if (_zookeeperReadWindowMs > 0 && _executorService != null)
       {
         // for the static config we can spread the read across the read Window
-        int delay = ThreadLocalRandom.current().nextInt(_readWindowMs);
+        int delay = ThreadLocalRandom.current().nextInt(_zookeeperReadWindowMs);
         _executorService.schedule(() -> _zk.getData(watchedEvent.getPath(), this, this, false),
                                   delay, TimeUnit.MILLISECONDS);
       }

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperStore.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperStore.java
@@ -42,8 +42,9 @@ public abstract class ZooKeeperStore<T> extends AbstractPropertyStoreAsync<T>
     PropertyEventPublisher<T>,
     PropertyStore<T>
 {
-  private static final Logger           _log =
-                                                 LoggerFactory.getLogger(ZooKeeperStore.class);
+  private static final Logger           _log = LoggerFactory.getLogger(ZooKeeperStore.class);
+
+  public static final int DEFAULT_READ_WINDOW_MS = -1; //disabled by default
 
   protected PropertyEventBus<T>         _eventBus;
   protected final ZKConnection          _zkConn;

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperEphemeralStoreBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperEphemeralStoreBuilder.java
@@ -20,9 +20,12 @@ import com.linkedin.d2.discovery.PropertySerializer;
 import com.linkedin.d2.discovery.stores.zk.ZKConnection;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperEphemeralStore;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperPropertyMerger;
+import com.linkedin.d2.discovery.stores.zk.ZooKeeperStore;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
@@ -42,6 +45,8 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
   private boolean _watchChildNodes = false;
   private boolean _useNewWatcher = false;
   private String _fsD2DirPathForBackup = null;
+  private ScheduledExecutorService executorService;
+  private int readWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   private List<Consumer<ZooKeeperEphemeralStore<T>>> _onBuildListeners = new ArrayList<>();
 
   @Override
@@ -89,6 +94,18 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
     return this;
   }
 
+  public ZooKeeperEphemeralStoreBuilder<T> setExecutorService(ScheduledExecutorService executorService)
+  {
+    this.executorService = executorService;
+    return this;
+  }
+
+  public ZooKeeperEphemeralStoreBuilder<T> setReadWindowMs(int readWindowMs)
+  {
+    this.readWindowMs = readWindowMs;
+    return this;
+  }
+
   @Override
   public ZooKeeperEphemeralStoreBuilder<T> addOnBuildListener(Consumer<ZooKeeperEphemeralStore<T>> onBuildListener)
   {
@@ -105,7 +122,8 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
     }
 
     ZooKeeperEphemeralStore<T> zooKeeperEphemeralStore =
-      new ZooKeeperEphemeralStore<>(_client, _serializer, _merger, _path, _watchChildNodes, _useNewWatcher, backupStoreFilePath);
+      new ZooKeeperEphemeralStore<>(_client, _serializer, _merger, _path, _watchChildNodes, _useNewWatcher,
+                                    backupStoreFilePath, executorService, readWindowMs);
 
     for (Consumer<ZooKeeperEphemeralStore<T>> onBuildListener : _onBuildListeners)
     {

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperEphemeralStoreBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperEphemeralStoreBuilder.java
@@ -46,7 +46,7 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
   private boolean _useNewWatcher = false;
   private String _fsD2DirPathForBackup = null;
   private ScheduledExecutorService executorService;
-  private int readWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
+  private int zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   private List<Consumer<ZooKeeperEphemeralStore<T>>> _onBuildListeners = new ArrayList<>();
 
   @Override
@@ -100,9 +100,9 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
     return this;
   }
 
-  public ZooKeeperEphemeralStoreBuilder<T> setReadWindowMs(int readWindowMs)
+  public ZooKeeperEphemeralStoreBuilder<T> setZookeeperReadWindowMs(int zookeeperReadWindowMs)
   {
-    this.readWindowMs = readWindowMs;
+    this.zookeeperReadWindowMs = zookeeperReadWindowMs;
     return this;
   }
 
@@ -123,7 +123,7 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
 
     ZooKeeperEphemeralStore<T> zooKeeperEphemeralStore =
       new ZooKeeperEphemeralStore<>(_client, _serializer, _merger, _path, _watchChildNodes, _useNewWatcher,
-                                    backupStoreFilePath, executorService, readWindowMs);
+                                    backupStoreFilePath, executorService, zookeeperReadWindowMs);
 
     for (Consumer<ZooKeeperEphemeralStore<T>> onBuildListener : _onBuildListeners)
     {

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperPermanentStoreBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperPermanentStoreBuilder.java
@@ -23,7 +23,6 @@ import com.linkedin.d2.discovery.stores.zk.ZooKeeperStore;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
@@ -38,7 +37,7 @@ public class ZooKeeperPermanentStoreBuilder<T> implements ZooKeeperStoreBuilder<
   private PropertySerializer<T> serializer;
   private String path;
   private ScheduledExecutorService executorService;
-  private int readWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
+  private int zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   private List<Consumer<ZooKeeperPermanentStore<T>>> _onBuildListeners = new ArrayList<>();
 
   public void setZkConnection(ZKConnection client)
@@ -64,9 +63,9 @@ public class ZooKeeperPermanentStoreBuilder<T> implements ZooKeeperStoreBuilder<
     return this;
   }
 
-  public ZooKeeperPermanentStoreBuilder<T> setReadWindowMs(int readWindowMs)
+  public ZooKeeperPermanentStoreBuilder<T> setZookeeperReadWindowMs(int zookeeperReadWindowMs)
   {
-    this.readWindowMs = readWindowMs;
+    this.zookeeperReadWindowMs = zookeeperReadWindowMs;
     return this;
   }
 
@@ -81,7 +80,7 @@ public class ZooKeeperPermanentStoreBuilder<T> implements ZooKeeperStoreBuilder<
   public ZooKeeperPermanentStore<T> build()
   {
     ZooKeeperPermanentStore<T> zooKeeperPermanentStore =
-      new ZooKeeperPermanentStore<>(client, serializer, path, executorService, readWindowMs);
+      new ZooKeeperPermanentStore<>(client, serializer, path, executorService, zookeeperReadWindowMs);
 
     for (Consumer<ZooKeeperPermanentStore<T>> onBuildListener : _onBuildListeners)
     {

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperPermanentStoreBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperPermanentStoreBuilder.java
@@ -19,8 +19,12 @@ package com.linkedin.d2.discovery.stores.zk.builder;
 import com.linkedin.d2.discovery.PropertySerializer;
 import com.linkedin.d2.discovery.stores.zk.ZKConnection;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperPermanentStore;
+import com.linkedin.d2.discovery.stores.zk.ZooKeeperStore;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
 /**
@@ -33,6 +37,8 @@ public class ZooKeeperPermanentStoreBuilder<T> implements ZooKeeperStoreBuilder<
   private ZKConnection client;
   private PropertySerializer<T> serializer;
   private String path;
+  private ScheduledExecutorService executorService;
+  private int readWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   private List<Consumer<ZooKeeperPermanentStore<T>>> _onBuildListeners = new ArrayList<>();
 
   public void setZkConnection(ZKConnection client)
@@ -52,6 +58,18 @@ public class ZooKeeperPermanentStoreBuilder<T> implements ZooKeeperStoreBuilder<
     return this;
   }
 
+  public ZooKeeperPermanentStoreBuilder<T> setExecutorService(ScheduledExecutorService executorService)
+  {
+    this.executorService = executorService;
+    return this;
+  }
+
+  public ZooKeeperPermanentStoreBuilder<T> setReadWindowMs(int readWindowMs)
+  {
+    this.readWindowMs = readWindowMs;
+    return this;
+  }
+
   @Override
   public ZooKeeperPermanentStoreBuilder<T> addOnBuildListener(Consumer<ZooKeeperPermanentStore<T>> onBuildListener)
   {
@@ -62,7 +80,8 @@ public class ZooKeeperPermanentStoreBuilder<T> implements ZooKeeperStoreBuilder<
   @Override
   public ZooKeeperPermanentStore<T> build()
   {
-    ZooKeeperPermanentStore<T> zooKeeperPermanentStore = new ZooKeeperPermanentStore<>(client, serializer, path);
+    ZooKeeperPermanentStore<T> zooKeeperPermanentStore =
+      new ZooKeeperPermanentStore<>(client, serializer, path, executorService, readWindowMs);
 
     for (Consumer<ZooKeeperPermanentStore<T>> onBuildListener : _onBuildListeners)
     {

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenDelayedWatcherTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenDelayedWatcherTest.java
@@ -1,0 +1,364 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.discovery.stores.zk;
+
+import com.linkedin.common.callback.Callback;
+import com.linkedin.common.callback.FutureCallback;
+import com.linkedin.common.util.None;
+import com.linkedin.d2.balancer.util.LoadBalancerUtil;
+import com.linkedin.d2.discovery.event.PropertyEventBusImpl;
+import com.linkedin.d2.discovery.event.PropertyEventSubscriber;
+import com.linkedin.d2.discovery.stores.PropertySetStringMerger;
+import com.linkedin.d2.discovery.stores.PropertySetStringSerializer;
+import com.linkedin.test.util.AssertionMethods;
+import com.linkedin.test.util.ClockedExecutor;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for the Publisher part of the EphemeralStore, which keeps track of children of a node
+ * with batched read/watch
+ *
+ * @author Nizar Mankulangara (nmankulangara@linkedin.com)
+ */
+public class ZooKeeperEphemeralStoreChildrenDelayedWatcherTest
+{
+  private ZKConnection _zkClient;
+  private ZKServer _zkServer;
+  private int _port;
+  private ClockedExecutor _clockedExecutor = new ClockedExecutor();
+  private PropertyEventBusImpl<Set<String>> _eventBus;
+
+  @BeforeSuite
+  public void setup()
+    throws InterruptedException
+  {
+    try
+    {
+      _zkServer = new ZKServer();
+      _zkServer.startup();
+      _port = _zkServer.getPort();
+      _zkClient = getZookeeperConnection();
+      _zkClient.start();
+    }
+    catch (IOException e)
+    {
+      Assert.fail("unable to instantiate real zk server on port " + _port);
+    }
+  }
+
+  @AfterSuite
+  public void tearDown()
+    throws IOException, InterruptedException
+  {
+    _zkClient.shutdown();
+    _zkServer.shutdown();
+    _clockedExecutor.shutdown();
+  }
+
+  @BeforeMethod
+  public void setupMethod()
+    throws ExecutionException, InterruptedException, TimeoutException
+  {
+    FutureCallback<None> callback = new FutureCallback<>();
+    _zkClient.ensurePersistentNodeExists("/bucket", callback);
+    callback.get(5, TimeUnit.SECONDS);
+  }
+
+  private void addNodeInZookeeper(String key, String value)
+    throws InterruptedException, KeeperException
+  {
+    _zkClient.getZooKeeper().create(key, value.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+  }
+
+  @AfterMethod
+  public void tearDownMethod()
+    throws ExecutionException, InterruptedException
+  {
+    FutureCallback<None> callback = new FutureCallback<>();
+    _zkClient.removeNodeUnsafeRecursive("/bucket", callback);
+    callback.get();
+  }
+
+  @DataProvider
+  public Object[][] dataNumOfChildrenReadWindow()
+  {
+    Object[][] data = new Object[100][2];
+    for (int i = 0; i < 100; i++)
+    {
+      data[i][0] = ThreadLocalRandom.current().nextInt(100) + 1;
+      data[i][1] = ThreadLocalRandom.current().nextInt(120000);
+    }
+
+    return data;
+  }
+
+  @DataProvider
+  public Object[][] dataNumOfchildrenToAddToRemoveReadWindow()
+  {
+    ThreadLocalRandom localRandom = ThreadLocalRandom.current();
+
+    Object[][] data = new Object[100][3];
+    for (int i = 0; i < 100; i++)
+    {
+      int numberOfChildren = localRandom.nextInt(100) + 2;
+      data[i][0] = numberOfChildren;
+      data[i][1] = localRandom.nextInt(Math.max(numberOfChildren - 1, 0)) + 1;
+      data[i][2] = localRandom.nextInt(120000);
+    }
+
+    return data;
+  }
+
+  @Test(dataProvider = "dataNumOfChildrenReadWindow")
+  public void testChildNodeAdded(int numberOfAdditionalChildren, int readWindowMs)
+    throws Exception
+  {
+
+    ZKConnection client = getZookeeperConnection();
+    client.start();
+
+    final ZooKeeperEphemeralStore<Set<String>> publisher = getEphemeralStorePublisher(readWindowMs, client);
+
+    final CountDownLatch initLatch = new CountDownLatch(1);
+    final CountDownLatch addLatch = new CountDownLatch(1);
+    final CountDownLatch startLatch = new CountDownLatch(1);
+
+    final Set<String> childrenFromZookeeperPublisher = new HashSet<>();
+    final PropertyEventSubscriber<Set<String>> subscriber = new PropertyEventSubscriber<Set<String>>()
+    {
+      @Override
+      public void onInitialize(String propertyName, Set<String> propertyValue)
+      {
+        if (propertyValue != null)
+        {
+          childrenFromZookeeperPublisher.addAll(propertyValue);
+        }
+
+        initLatch.countDown();
+      }
+
+      @Override
+      public void onAdd(String propertyName, Set<String> propertyValue)
+      {
+        childrenFromZookeeperPublisher.clear();
+        childrenFromZookeeperPublisher.addAll(propertyValue);
+
+        if (propertyValue.size() == numberOfAdditionalChildren)
+        {
+          addLatch.countDown();
+        }
+      }
+
+      @Override
+      public void onRemove(String propertyName)
+      {
+      }
+    };
+
+    publisher.start(new Callback<None>()
+    {
+      @Override
+      public void onError(Throwable e)
+      {
+      }
+
+      @Override
+      public void onSuccess(None result)
+      {
+        _eventBus = new PropertyEventBusImpl<>(_clockedExecutor, publisher);
+        _eventBus.register(Collections.singleton("bucket"), subscriber);
+        startLatch.countDown();
+      }
+    });
+
+    if (!startLatch.await(5, TimeUnit.SECONDS))
+    {
+      Assert.fail("unable to start ZookeeperChildrenDataPublisher");
+    }
+
+    AssertionMethods.assertWithTimeout(5000, () -> {
+      _clockedExecutor.runFor(0);
+      Assert.assertEquals(initLatch.getCount(), 0, "unable to publish initial property value");
+    });
+
+    Map<String, String> childrenAddedToZookeeper = new HashMap<>();
+    for (int i = 0; i < numberOfAdditionalChildren; i++)
+    {
+      addNodeInZookeeper("/bucket/child-" + i, Integer.toString(i));
+      childrenAddedToZookeeper.put("/bucket/child-" + i, Integer.toString(i));
+      _clockedExecutor.runFor(readWindowMs);
+    }
+
+    AssertionMethods.assertWithTimeout(5000, () -> {
+      _clockedExecutor.runFor(readWindowMs);
+      Assert.assertEquals(addLatch.getCount(), 0, "didn't get notified for the new node");
+    });
+
+    Assert.assertEquals(childrenFromZookeeperPublisher, new HashSet<>(childrenAddedToZookeeper.values()));
+    _eventBus.unregister(Collections.singleton("bucket"), subscriber);
+    client.shutdown();
+  }
+
+  @Test(dataProvider = "dataNumOfchildrenToAddToRemoveReadWindow")
+  public void testChildNodeRemoved(int numberOfAdditionalChildren, int numberOfRemove, int readWindowMs)
+    throws Exception
+  {
+    ZKConnection client = getZookeeperConnection();
+    client.start();
+
+    final ZooKeeperEphemeralStore<Set<String>> publisher = getEphemeralStorePublisher(readWindowMs, client);
+
+    final CountDownLatch initLatch = new CountDownLatch(1);
+    final CountDownLatch addLatch = new CountDownLatch(1);
+    final CountDownLatch removeLatch = new CountDownLatch(1);
+    final CountDownLatch startLatch = new CountDownLatch(1);
+
+    final Set<String> childrenFromZookeeperPublisher = new HashSet<>();
+
+    final PropertyEventSubscriber<Set<String>> subscriber = new PropertyEventSubscriber<Set<String>>()
+    {
+      @Override
+      public void onInitialize(String propertyName, Set<String> propertyValue)
+      {
+        if (propertyValue != null)
+        {
+          childrenFromZookeeperPublisher.addAll(propertyValue);
+        }
+
+        initLatch.countDown();
+      }
+
+      @Override
+      public void onAdd(String propertyName, Set<String> propertyValue)
+      {
+        childrenFromZookeeperPublisher.clear();
+        childrenFromZookeeperPublisher.addAll(propertyValue);
+
+        if (propertyValue.size() == numberOfAdditionalChildren)
+        {
+          addLatch.countDown();
+        }
+
+        if (addLatch.getCount() == 0 && propertyValue.size() == (numberOfAdditionalChildren - numberOfRemove))
+        {
+          removeLatch.countDown();
+        }
+      }
+
+      @Override
+      public void onRemove(String propertyName)
+      {
+      }
+    };
+
+    publisher.start(new Callback<None>()
+    {
+      @Override
+      public void onError(Throwable e)
+      {
+      }
+
+      @Override
+      public void onSuccess(None result)
+      {
+        _eventBus = new PropertyEventBusImpl<>(_clockedExecutor, publisher);
+        _eventBus.register(Collections.singleton("bucket"), subscriber);
+        startLatch.countDown();
+      }
+    });
+
+    if (!startLatch.await(5, TimeUnit.SECONDS))
+    {
+      Assert.fail("unable to start ZookeeperChildrenDataPublisher");
+    }
+
+    AssertionMethods.assertWithTimeout(5000, () -> {
+      _clockedExecutor.runFor(0);
+      Assert.assertEquals(initLatch.getCount(), 0, "unable to publish initial property value");
+    });
+
+    Map<String, String> childrenAddedToZookeeper = new HashMap<>();
+    for (int i = 0; i < numberOfAdditionalChildren; i++)
+    {
+      addNodeInZookeeper("/bucket/child-" + i, Integer.toString(i));
+      childrenAddedToZookeeper.put("/bucket/child-" + i, Integer.toString(i));
+      _clockedExecutor.runFor(readWindowMs);
+    }
+
+    AssertionMethods.assertWithTimeout(5000, () -> {
+      _clockedExecutor.runFor(readWindowMs);
+      Assert.assertEquals(addLatch.getCount(), 0, "didn't get notified for the new node");
+    });
+
+    Assert.assertEquals(childrenFromZookeeperPublisher, new HashSet<>(childrenAddedToZookeeper.values()));
+
+    for (int i = 0; i < numberOfRemove; i++)
+    {
+      String childName = "/bucket/child-" + i;
+      FutureCallback<None> callback = new FutureCallback<>();
+      _zkClient.removeNodeUnsafe(childName, callback);
+      childrenAddedToZookeeper.remove(childName);
+      callback.get();
+
+      _clockedExecutor.runFor(readWindowMs);
+    }
+
+    AssertionMethods.assertWithTimeout(5000, () -> {
+      _clockedExecutor.runFor(readWindowMs);
+      Assert.assertEquals(removeLatch.getCount(), 0, "didn't get notified for the removed nodes");
+    });
+
+    Assert.assertEquals(childrenFromZookeeperPublisher, new HashSet<>(childrenAddedToZookeeper.values()));
+    _eventBus.unregister(Collections.singleton("bucket"), subscriber);
+    client.shutdown();
+  }
+
+  private ZKConnection getZookeeperConnection()
+  {
+    return new ZKConnection("localhost:" + _port, 5000);
+  }
+
+  private ZooKeeperEphemeralStore<Set<String>> getEphemeralStorePublisher(int readWindowMs, ZKConnection client)
+    throws IOException
+  {
+    String tmpDataPath = LoadBalancerUtil.createTempDirectory("EphemeralStoreFileStore").getAbsolutePath();
+    return new ZooKeeperEphemeralStore<>(client, new PropertySetStringSerializer(), new PropertySetStringMerger(), "/", false, true, tmpDataPath,
+                                         _clockedExecutor, readWindowMs);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenDelayedWatcherTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenDelayedWatcherTest.java
@@ -146,14 +146,14 @@ public class ZooKeeperEphemeralStoreChildrenDelayedWatcherTest
   }
 
   @Test(dataProvider = "dataNumOfChildrenReadWindow")
-  public void testChildNodeAdded(int numberOfAdditionalChildren, int readWindowMs)
+  public void testChildNodeAdded(int numberOfAdditionalChildren, int zookeeperReadWindowMs)
     throws Exception
   {
 
     ZKConnection client = getZookeeperConnection();
     client.start();
 
-    final ZooKeeperEphemeralStore<Set<String>> publisher = getEphemeralStorePublisher(readWindowMs, client);
+    final ZooKeeperEphemeralStore<Set<String>> publisher = getEphemeralStorePublisher(zookeeperReadWindowMs, client);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
@@ -222,11 +222,11 @@ public class ZooKeeperEphemeralStoreChildrenDelayedWatcherTest
     {
       addNodeInZookeeper("/bucket/child-" + i, Integer.toString(i));
       childrenAddedToZookeeper.put("/bucket/child-" + i, Integer.toString(i));
-      _clockedExecutor.runFor(readWindowMs);
+      _clockedExecutor.runFor(zookeeperReadWindowMs);
     }
 
     AssertionMethods.assertWithTimeout(5000, () -> {
-      _clockedExecutor.runFor(readWindowMs);
+      _clockedExecutor.runFor(zookeeperReadWindowMs);
       Assert.assertEquals(addLatch.getCount(), 0, "didn't get notified for the new node");
     });
 
@@ -236,13 +236,13 @@ public class ZooKeeperEphemeralStoreChildrenDelayedWatcherTest
   }
 
   @Test(dataProvider = "dataNumOfchildrenToAddToRemoveReadWindow")
-  public void testChildNodeRemoved(int numberOfAdditionalChildren, int numberOfRemove, int readWindowMs)
+  public void testChildNodeRemoved(int numberOfAdditionalChildren, int numberOfRemove, int zookeeperReadWindowMs)
     throws Exception
   {
     ZKConnection client = getZookeeperConnection();
     client.start();
 
-    final ZooKeeperEphemeralStore<Set<String>> publisher = getEphemeralStorePublisher(readWindowMs, client);
+    final ZooKeeperEphemeralStore<Set<String>> publisher = getEphemeralStorePublisher(zookeeperReadWindowMs, client);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
@@ -318,11 +318,11 @@ public class ZooKeeperEphemeralStoreChildrenDelayedWatcherTest
     {
       addNodeInZookeeper("/bucket/child-" + i, Integer.toString(i));
       childrenAddedToZookeeper.put("/bucket/child-" + i, Integer.toString(i));
-      _clockedExecutor.runFor(readWindowMs);
+      _clockedExecutor.runFor(zookeeperReadWindowMs);
     }
 
     AssertionMethods.assertWithTimeout(5000, () -> {
-      _clockedExecutor.runFor(readWindowMs);
+      _clockedExecutor.runFor(zookeeperReadWindowMs);
       Assert.assertEquals(addLatch.getCount(), 0, "didn't get notified for the new node");
     });
 
@@ -336,11 +336,11 @@ public class ZooKeeperEphemeralStoreChildrenDelayedWatcherTest
       childrenAddedToZookeeper.remove(childName);
       callback.get();
 
-      _clockedExecutor.runFor(readWindowMs);
+      _clockedExecutor.runFor(zookeeperReadWindowMs);
     }
 
     AssertionMethods.assertWithTimeout(5000, () -> {
-      _clockedExecutor.runFor(readWindowMs);
+      _clockedExecutor.runFor(zookeeperReadWindowMs);
       Assert.assertEquals(removeLatch.getCount(), 0, "didn't get notified for the removed nodes");
     });
 
@@ -354,11 +354,11 @@ public class ZooKeeperEphemeralStoreChildrenDelayedWatcherTest
     return new ZKConnection("localhost:" + _port, 5000);
   }
 
-  private ZooKeeperEphemeralStore<Set<String>> getEphemeralStorePublisher(int readWindowMs, ZKConnection client)
+  private ZooKeeperEphemeralStore<Set<String>> getEphemeralStorePublisher(int zookeeperReadWindowMs, ZKConnection client)
     throws IOException
   {
     String tmpDataPath = LoadBalancerUtil.createTempDirectory("EphemeralStoreFileStore").getAbsolutePath();
     return new ZooKeeperEphemeralStore<>(client, new PropertySetStringSerializer(), new PropertySetStringMerger(), "/", false, true, tmpDataPath,
-                                         _clockedExecutor, readWindowMs);
+                                         _clockedExecutor, zookeeperReadWindowMs);
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStoreDelayedWatcherTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStoreDelayedWatcherTest.java
@@ -1,0 +1,246 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.discovery.stores.zk;
+
+import com.linkedin.common.callback.Callback;
+import com.linkedin.common.callback.FutureCallback;
+import com.linkedin.common.util.None;
+import com.linkedin.d2.discovery.PropertySerializationException;
+import com.linkedin.d2.discovery.PropertySerializer;
+import com.linkedin.d2.discovery.event.PropertyEventBusImpl;
+import com.linkedin.d2.discovery.event.PropertyEventSubscriber;
+import com.linkedin.test.util.AssertionMethods;
+import com.linkedin.test.util.ClockedExecutor;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for the Publisher part of the PermanentStore (ServiceProperties and ClusterProperties),
+ * which keeps track of children of a node with randomized read/watch to avoid thundering herd
+ *
+ * @author Nizar Mankulangara (nmankulangara@linkedin.com)
+ */
+public class ZooKeeperPermanentStoreDelayedWatcherTest
+{
+  private ZKConnection _zkClient;
+  private ZKServer _zkServer;
+  private int _port;
+  private ClockedExecutor _clockedExecutor = new ClockedExecutor();
+  private PropertyEventBusImpl<String> _eventBus;
+
+  @BeforeSuite
+  public void setup()
+    throws InterruptedException
+  {
+    try
+    {
+      _zkServer = new ZKServer();
+      _zkServer.startup();
+      _port = _zkServer.getPort();
+      _zkClient = getZookeeperConnection();
+      _zkClient.start();
+    }
+    catch (IOException e)
+    {
+      Assert.fail("unable to instantiate real zk server on port " + _port);
+    }
+  }
+
+  @AfterSuite
+  public void tearDown()
+    throws IOException, InterruptedException
+  {
+    _zkClient.shutdown();
+    _zkServer.shutdown();
+    _clockedExecutor.shutdown();
+  }
+
+  @BeforeMethod
+  public void setupMethod()
+    throws ExecutionException, InterruptedException, TimeoutException
+  {
+    FutureCallback<None> callback = new FutureCallback<>();
+    _zkClient.ensurePersistentNodeExists("/bucket", callback);
+    callback.get(5, TimeUnit.SECONDS);
+  }
+
+  private void updateNodeData(String key, String value)
+    throws InterruptedException, KeeperException
+  {
+    Stat stat = _zkClient.getZooKeeper().exists(key, false);
+    _zkClient.getZooKeeper().setData(key, value.getBytes(), stat.getVersion());
+  }
+
+  @AfterMethod
+  public void tearDownMethod()
+    throws ExecutionException, InterruptedException
+  {
+    FutureCallback<None> callback = new FutureCallback<>();
+    _zkClient.removeNodeUnsafeRecursive("/bucket", callback);
+    callback.get();
+  }
+
+  @DataProvider
+  public Object[][] dataNumOfChangesReadWindow()
+  {
+    Object[][] data = new Object[100][2];
+    for (int i = 0; i < 100; i++)
+    {
+      data[i][0] = ThreadLocalRandom.current().nextInt(100) + 1;
+      data[i][1] = ThreadLocalRandom.current().nextInt(120000);
+    }
+
+    return data;
+  }
+
+  @Test(dataProvider = "dataNumOfChangesReadWindow")
+  public void testNodeValueChangedWatchUpdates(int numberOfDataChanges, int readWindowMs)
+    throws Exception
+  {
+
+    ZKConnection client = getZookeeperConnection();
+    client.start();
+
+    final ZooKeeperPermanentStore<String> publisher = getPermanentStorePublisher(readWindowMs, client);
+
+    final CountDownLatch initLatch = new CountDownLatch(1);
+    final CountDownLatch addLatch = new CountDownLatch(1);
+    final CountDownLatch startLatch = new CountDownLatch(1);
+
+    final AtomicReference<String> dataFromZookeeperPublisher = new AtomicReference<>();
+    final PropertyEventSubscriber<String> subscriber = new PropertyEventSubscriber<String>()
+    {
+      @Override
+      public void onInitialize(String propertyName, String propertyValue)
+      {
+        if (propertyValue != null)
+        {
+          dataFromZookeeperPublisher.set(propertyValue);
+        }
+
+        initLatch.countDown();
+      }
+
+      @Override
+      public void onAdd(String propertyName, String propertyValue)
+      {
+        dataFromZookeeperPublisher.set(propertyValue);
+        if (propertyValue.equals(Integer.toString(numberOfDataChanges)))
+        {
+          addLatch.countDown();
+        }
+      }
+
+      @Override
+      public void onRemove(String propertyName)
+      {
+      }
+    };
+
+    publisher.start(new Callback<None>()
+    {
+      @Override
+      public void onError(Throwable e)
+      {
+      }
+
+      @Override
+      public void onSuccess(None result)
+      {
+        _eventBus = new PropertyEventBusImpl<>(_clockedExecutor, publisher);
+        _eventBus.register(Collections.singleton("bucket"), subscriber);
+        startLatch.countDown();
+      }
+    });
+
+    if (!startLatch.await(5, TimeUnit.SECONDS))
+    {
+      Assert.fail("unable to start ZookeeperChildrenDataPublisher");
+    }
+
+    AssertionMethods.assertWithTimeout(5000, () -> {
+      _clockedExecutor.runFor(0);
+      Assert.assertEquals(initLatch.getCount(), 0, "unable to publish initial property value");
+    });
+
+    String valueUpdatedInZookeeper = null;
+    for (int i = 1; i <= numberOfDataChanges; i++)
+    {
+      updateNodeData("/bucket", Integer.toString(i));
+      valueUpdatedInZookeeper = Integer.toString(i);
+      _clockedExecutor.runFor(readWindowMs);
+    }
+
+    AssertionMethods.assertWithTimeout(5000, () -> {
+      _clockedExecutor.runFor(readWindowMs);
+      Assert.assertEquals(addLatch.getCount(), 0, "didn't get notified for the updated node");
+    });
+
+    Assert.assertEquals(dataFromZookeeperPublisher.get(), valueUpdatedInZookeeper);
+    _eventBus.unregister(Collections.singleton("bucket"), subscriber);
+    client.shutdown();
+  }
+
+  private ZKConnection getZookeeperConnection()
+  {
+    return new ZKConnection("localhost:" + _port, 5000);
+  }
+
+  private ZooKeeperPermanentStore<String> getPermanentStorePublisher(int readWindowMs, ZKConnection client)
+    throws IOException
+  {
+    PropertySerializer<String> stringPropertySerializer = new PropertySerializer<String>()
+    {
+      @Override
+      public byte[] toBytes(String property)
+      {
+        return property.getBytes();
+      }
+
+      @Override
+      public String fromBytes(byte[] bytes)
+        throws PropertySerializationException
+      {
+        if (bytes == null)
+        {
+          return "";
+        }
+
+        return new String(bytes);
+      }
+    };
+
+    return new ZooKeeperPermanentStore<>(client, stringPropertySerializer, "/", _clockedExecutor, readWindowMs);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStoreDelayedWatcherTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStoreDelayedWatcherTest.java
@@ -125,14 +125,14 @@ public class ZooKeeperPermanentStoreDelayedWatcherTest
   }
 
   @Test(dataProvider = "dataNumOfChangesReadWindow")
-  public void testNodeValueChangedWatchUpdates(int numberOfDataChanges, int readWindowMs)
+  public void testNodeValueChangedWatchUpdates(int numberOfDataChanges, int zookeeperReadWindowMs)
     throws Exception
   {
 
     ZKConnection client = getZookeeperConnection();
     client.start();
 
-    final ZooKeeperPermanentStore<String> publisher = getPermanentStorePublisher(readWindowMs, client);
+    final ZooKeeperPermanentStore<String> publisher = getPermanentStorePublisher(zookeeperReadWindowMs, client);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
@@ -199,11 +199,11 @@ public class ZooKeeperPermanentStoreDelayedWatcherTest
     {
       updateNodeData("/bucket", Integer.toString(i));
       valueUpdatedInZookeeper = Integer.toString(i);
-      _clockedExecutor.runFor(readWindowMs);
+      _clockedExecutor.runFor(zookeeperReadWindowMs);
     }
 
     AssertionMethods.assertWithTimeout(5000, () -> {
-      _clockedExecutor.runFor(readWindowMs);
+      _clockedExecutor.runFor(zookeeperReadWindowMs);
       Assert.assertEquals(addLatch.getCount(), 0, "didn't get notified for the updated node");
     });
 
@@ -217,7 +217,7 @@ public class ZooKeeperPermanentStoreDelayedWatcherTest
     return new ZKConnection("localhost:" + _port, 5000);
   }
 
-  private ZooKeeperPermanentStore<String> getPermanentStorePublisher(int readWindowMs, ZKConnection client)
+  private ZooKeeperPermanentStore<String> getPermanentStorePublisher(int zookeeperReadWindowMs, ZKConnection client)
     throws IOException
   {
     PropertySerializer<String> stringPropertySerializer = new PropertySerializer<String>()
@@ -241,6 +241,6 @@ public class ZooKeeperPermanentStoreDelayedWatcherTest
       }
     };
 
-    return new ZooKeeperPermanentStore<>(client, stringPropertySerializer, "/", _clockedExecutor, readWindowMs);
+    return new ZooKeeperPermanentStore<>(client, stringPropertySerializer, "/", _clockedExecutor, zookeeperReadWindowMs);
   }
 }


### PR DESCRIPTION
One of the major problems identified during Zookeeper Capacity investigation is the read storm created during deployments.  During deployment, nodes in the cluster de-announce and announce to zookeeper and this can create thousands of watch notifications based on the number of nodes in the deploying cluster. This can create read storms in Zookeeper if all the upstream nodes started reading for every watch update. This read storm is more visible for big clusters with large numbers of upstreams like identity-mt.

This pull request is to batch or delay setting the watch by the configured threshold duration along with applying jitter to randomize the point in which the actual watch is set.