### PR TITLE
Disable Request Waiter Timeout if not within fail fast threshold and Optimize SingleTimeout runnable to not capture callback to deal with the future.cancel behaviour in ScheduledExecutor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.2.0
+version=28.2.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolImpl.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/AsyncPoolImpl.java
@@ -850,7 +850,7 @@ public class AsyncPoolImpl<T> implements AsyncPool<T>
 
     private WaiterTimeoutCallback(final Callback<T> callback)
     {
-      _timeout = new SingleTimeout<>(_timeoutExecutor, _waiterTimeout, TimeUnit.MILLISECONDS, callback, (callback1) -> {
+      _timeout = new SingleTimeout<>(_timeoutExecutor, _waiterTimeout, TimeUnit.MILLISECONDS, callback, (callbackIfTimeout) -> {
 
         synchronized (_lock)
         {
@@ -858,7 +858,7 @@ public class AsyncPoolImpl<T> implements AsyncPool<T>
           _statsTracker.incrementWaiterTimedOut();
         }
         LOG.debug("{}: failing waiter due to waiter timeout", _poolName);
-        callback1.onError(
+        callbackIfTimeout.onError(
             new WaiterTimeoutException(
                 "Exceeded waiter timeout of " + _waiterTimeout + "ms: in Pool: "+ _poolName));
       });

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/TimeoutCallback.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/TimeoutCallback.java
@@ -71,7 +71,7 @@ public class TimeoutCallback<T> implements Callback<T>
   public TimeoutCallback(ScheduledExecutorService executor, long timeout, TimeUnit timeoutUnit,
       final Callback<T> callback, final Throwable timeoutThrowable)
   {
-    _timeout = new SingleTimeout<>(executor, timeout, timeoutUnit, callback, () -> callback.onError(timeoutThrowable));
+    _timeout = new SingleTimeout<>(executor, timeout, timeoutUnit, callback, (callback1) -> callback1.onError(timeoutThrowable));
   }
 
   @Override

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/TimeoutCallback.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/TimeoutCallback.java
@@ -71,7 +71,7 @@ public class TimeoutCallback<T> implements Callback<T>
   public TimeoutCallback(ScheduledExecutorService executor, long timeout, TimeUnit timeoutUnit,
       final Callback<T> callback, final Throwable timeoutThrowable)
   {
-    _timeout = new SingleTimeout<>(executor, timeout, timeoutUnit, callback, (callback1) -> callback1.onError(timeoutThrowable));
+    _timeout = new SingleTimeout<>(executor, timeout, timeoutUnit, callback, (callbackIfTimeout) -> callbackIfTimeout.onError(timeoutThrowable));
   }
 
   @Override

--- a/r2-core/src/main/java/com/linkedin/r2/util/SingleTimeout.java
+++ b/r2-core/src/main/java/com/linkedin/r2/util/SingleTimeout.java
@@ -21,6 +21,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +50,7 @@ public class SingleTimeout<T>
    * @param item the item to be retrieved.
    * @param timeoutAction the action to be executed in case of timeout.
    */
-  public SingleTimeout(ScheduledExecutorService executor, long timeout, TimeUnit timeoutUnit, T item, Runnable timeoutAction)
+  public SingleTimeout(ScheduledExecutorService executor, long timeout, TimeUnit timeoutUnit, T item, Consumer<T> timeoutAction)
   {
     ArgumentUtil.ensureNotNull(item,"item");
     ArgumentUtil.ensureNotNull(timeoutAction,"timeoutAction");
@@ -60,7 +62,7 @@ public class SingleTimeout<T>
       {
         try
         {
-          timeoutAction.run();
+          timeoutAction.accept(item1);
         } catch (Throwable e)
         {
           LOG.error("Failed to execute timeout action", e);

--- a/r2-core/src/test/java/test/r2/transport/http/client/TestAsyncPool.java
+++ b/r2-core/src/test/java/test/r2/transport/http/client/TestAsyncPool.java
@@ -902,6 +902,9 @@ public class TestAsyncPool
       int numbOfObjectsToBeReturnedInPhaseC = randomNumberGenerator.nextInt(numberOfCheckoutsInPhaseB);
       int poolSize = randomNumberGenerator.nextInt(numberOfCheckoutsInPhaseA)+numberOfCheckoutsInPhaseA*2;
       int concurrency = randomNumberGenerator.nextInt(Math.min(numberOfCheckoutsInPhaseB,499))+1;
+      int waiterTimeout = randomNumberGenerator.nextInt(AsyncPoolImpl.MAX_WAITER_TIMEOUT);
+      waiterTimeout = Math.max(waiterTimeout, AsyncPoolImpl.MIN_WAITER_TIMEOUT);
+
       concurrency = Math.min(concurrency, numberOfCheckoutsInPhaseB);
 
       data[i][0] = numberOfCheckoutsInPhaseA;
@@ -909,7 +912,7 @@ public class TestAsyncPool
       data[i][2] = numbOfObjectsToBeReturnedInPhaseC;
       data[i][3] = poolSize;
       data[i][4] = concurrency;
-      data[i][5] = randomNumberGenerator.nextInt(500)+100;
+      data[i][5] = waiterTimeout;
     }
 
     return data;


### PR DESCRIPTION
Disable Request Waiter Timeout if not within failfast threshold