### PR TITLE
Bump spring dependencies to 3.2.18.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,10 @@ project.ext.externalDependency = [
   'xchart': 'org.knowm.xchart:xchart:3.2.2',
 
   // for restli-spring-bridge ONLY, we must keep these dependencies isolated
-  'springCore': 'org.springframework:spring-core:3.2.3.RELEASE',
-  'springContext': 'org.springframework:spring-context:3.2.3.RELEASE',
-  'springWeb': 'org.springframework:spring-web:3.2.3.RELEASE',
-  'springBeans': 'org.springframework:spring-beans:3.2.3.RELEASE',
+  'springCore': 'org.springframework:spring-core:3.2.18.RELEASE',
+  'springContext': 'org.springframework:spring-context:3.2.18.RELEASE',
+  'springWeb': 'org.springframework:spring-web:3.2.18.RELEASE',
+  'springBeans': 'org.springframework:spring-beans:3.2.18.RELEASE',
 
   // for restli-guice-bridge ONLY, we should keep these dependencies isolated
   'guice': 'com.google.inject:guice:3.0',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,5 @@
 version=28.2.4
 group=com.linkedin.pegasus
-sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
-sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx4096M


### PR DESCRIPTION
To avoid security vulnerabilities in spring 3.2.0 - 3.2.14

This is a patch version bump, so there should theoretically be minimal side effects.