### PR TITLE
Exposing projection information to AbstractVerifiers through the context

### DIFF
--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -241,6 +241,7 @@ public final class ValidateDataAgainstSchema
            validatorElement = new SimpleDataElement(fixed, element.getName(), schema, element.getParent());
         }
         _context._dataElement = validatorElement;
+        _context._dataSchema = schema;
         _validator.validate(_context);
       }
       return fixed;
@@ -836,11 +837,17 @@ public final class ValidateDataAgainstSchema
     private class Context implements ValidatorContext
     {
       private DataElement _dataElement;
+      private DataSchema _dataSchema;
 
       @Override
       public DataElement dataElement()
       {
         return _dataElement;
+      }
+
+      @Override
+      public DataSchema dataSchema() {
+        return _dataSchema;
       }
 
       @Override

--- a/data/src/main/java/com/linkedin/data/schema/validator/ValidatorContext.java
+++ b/data/src/main/java/com/linkedin/data/schema/validator/ValidatorContext.java
@@ -16,9 +16,9 @@
 
 package com.linkedin.data.schema.validator;
 
-
 import com.linkedin.data.element.DataElement;
 import com.linkedin.data.message.Message;
+import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.validation.ValidationOptions;
 
 
@@ -40,6 +40,17 @@ public interface ValidatorContext
    * @return the {@link DataElement} providing the value to be validated.
    */
   DataElement dataElement();
+
+  /**
+   * The schema to validate against.
+   * This is important when REST.li projections are present, because not all fields in the original schema could be present.
+   * The default is null for backwards compatibility.
+   *
+   * @return the {@link DataSchema} after the REST.li projection has been applied
+   */
+  default DataSchema dataSchema() {
+    return null;
+  }
 
   /**
    * Add a {@link Message} to the result.


### PR DESCRIPTION
This was a feature request (tracked internally by SI-8229), so that developers could write custom schema verifiers which were aware of the rest.li projections being applied to the model for the given request.