### PR TITLE
publish the test artifacts for darkcluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,10 @@ subprojects {
     configurations.testArtifacts.visible = true
   }
 
+  if (it.name == 'darkcluster') {
+    configurations.testArtifacts.visible = true
+  }
+
   if (!(it.name in ['data-avro', 'restli-int-test'])) {
     configurations {
       // Prevent Guava from creeping in to avoid incompatibilities in multiple classloader environments.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.2.5
+version=28.2.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Publish the darkcluster test artifacts so the Mock test classes can be reused.
This isn't testable in snapshot, as all artifacts were available in local snapshot.