### PR TITLE
Switch from commons-lang3 to commons-text.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ project.ext.externalDependency = [
   'commonsHttpClient': 'commons-httpclient:commons-httpclient:3.1',
   'commonsIo': 'commons-io:commons-io:2.4',
   'commonsLang': 'commons-lang:commons-lang:2.6',
-  'commonsLang3': 'org.apache.commons:commons-lang3:3.4',
+  'commonsText': 'org.apache.commons:commons-text:1.8',
   'disruptor': 'com.lmax:disruptor:3.2.0',
   'easymock': 'org.easymock:easymock:4.0.2',
   'mockito': 'org.mockito:mockito-all:1.9.5',

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -5,7 +5,7 @@ dependencies {
   compile project(':li-protobuf')
   compile project(':pegasus-common')
   compile externalDependency.antlrRuntime
-  compile externalDependency.commonsLang3
+  compile externalDependency.commonsText
   compile externalDependency.jacksonCore
   compile externalDependency.jacksonSmile
   runtime externalDependency.javaxAnnotation

--- a/data/src/main/java/com/linkedin/data/schema/PdlBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/PdlBuilder.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 
 /**

--- a/data/src/main/java/com/linkedin/data/schema/grammar/PdlParseUtils.java
+++ b/data/src/main/java/com/linkedin/data/schema/grammar/PdlParseUtils.java
@@ -21,8 +21,8 @@ import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 
 /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.2.7
+version=28.2.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
StringEscapeUtils is deprecated in the latest version of commons-lang3
with recommendation to move to commons-text.