### PR TITLE
DarkCluster schema changes: adding multiplierStrategyList and transportClientProperties

### DIFF
--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
@@ -21,24 +21,6 @@ record DarkClusterConfig {
   dispatcherOutboundMaxRate: int = 2147483647
 
   /**
-   * There are 2 types of strategy: RELATIVE_TRAFFIC, CONSTANT_QPS. These can be specified in prioritized order and
-   * will be picked in that order depending on availability.
-   */
-  enum multiplierStrategyType {
-
-    /**
-     * This strategy will try to keep the level of traffic on a dark cluster instance relative to the dispatching instance,
-     * as indicated by the multiplier.
-     */
-    RELATIVE_TRAFFIC
-
-    /**
-     * This strategy will try to maintain a certain queries per second, as specified by dispatcherOutboundTargetRate.
-     */
-    CONSTANT_QPS
-  }
-
-  /**
    * Prioritized order of dark cluster multiplier strategies.
    */
   multiplierStrategyList: array[multiplierStrategyType] = ["RELATIVE_TRAFFIC"]
@@ -46,5 +28,5 @@ record DarkClusterConfig {
   /**
    * The transport client properties to use for this dark cluster
    */
-  transportClientProperties: D2TransportClientProperties
+  transportClientProperties: D2TransportClientProperties = {}
 }

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
@@ -21,9 +21,11 @@ record DarkClusterConfig {
   dispatcherOutboundMaxRate: int = 2147483647
 
   /**
-   * Prioritized order of dark cluster multiplier strategies.
+   * Prioritized order of dark cluster multiplier strategies. This is a list to support adding new strategies and having the strategy users
+   * pick it up as they upgrade code versions, versus waiting for all strategy users to upgrade first. This is the same reason
+   * DegraderLoadBalancerStrategyName was replaced by DegraderLoadBalancerStrategyList.
    */
-  multiplierStrategyList: array[multiplierStrategyType] = ["RELATIVE_TRAFFIC"]
+  multiplierStrategyList: array[DarkClusterStrategyName] = ["RELATIVE_TRAFFIC"]
 
   /**
    * The transport client properties to use for this dark cluster

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
@@ -19,4 +19,32 @@ record DarkClusterConfig {
    * Max rate dispatcher can send to dark canary. Measured in qps. Will act as upper bound to protect canaries in case of traffic spikes
    */
   dispatcherOutboundMaxRate: int = 2147483647
+
+  /**
+   * There are 2 types of strategy: RELATIVE_TRAFFIC, CONSTANT_QPS. These can be specified in prioritized order and
+   * will be picked in that order depending on availability.
+   */
+  enum multiplierStrategyType {
+
+    /**
+     * This strategy will try to keep the level of traffic on a dark cluster instance relative to the dispatching instance,
+     * as indicated by the multiplier.
+     */
+    RELATIVE_TRAFFIC
+
+    /**
+     * This strategy will try to maintain a certain queries per second, as specified by dispatcherOutboundTargetRate.
+     */
+    CONSTANT_QPS
+  }
+
+  /**
+   * Prioritized order of dark cluster multiplier strategies.
+   */
+  multiplierStrategyList: array[multiplierStrategyType] = ["RELATIVE_TRAFFIC"]
+
+  /**
+   * The transport client properties to use for this dark cluster
+   */
+  transportClientProperties: D2TransportClientProperties
 }

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
@@ -25,7 +25,7 @@ record DarkClusterConfig {
    * pick it up as they upgrade code versions, versus waiting for all strategy users to upgrade first. This is the same reason
    * DegraderLoadBalancerStrategyName was replaced by DegraderLoadBalancerStrategyList.
    */
-  multiplierStrategyList: array[DarkClusterStrategyName] = ["RELATIVE_TRAFFIC"]
+  DarkClusterStrategyPrioritizedList: array[DarkClusterStrategyName] = ["RELATIVE_TRAFFIC"]
 
   /**
    * The transport client properties to use for this dark cluster

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterStrategyName.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterStrategyName.pdl
@@ -3,6 +3,8 @@ namespace com.linkedin.d2
 /**
  * There are 2 types of strategy: RELATIVE_TRAFFIC, CONSTANT_QPS. These can be specified in prioritized order and
  * will be picked in that order depending on availability.
+ * A strategy may not be available when a new strategy is introduced but the client has not upgraded to a code version
+ * that supports that strategy.
  */
 enum DarkClusterStrategyName {
 

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterStrategyName.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterStrategyName.pdl
@@ -4,7 +4,7 @@ namespace com.linkedin.d2
  * There are 2 types of strategy: RELATIVE_TRAFFIC, CONSTANT_QPS. These can be specified in prioritized order and
  * will be picked in that order depending on availability.
  */
-enum multiplierStrategyType {
+enum DarkClusterStrategyName {
 
   /**
    * This strategy aims to maintain a proportional amount of incoming QPS at the host level between the source and dark clusters.
@@ -14,7 +14,7 @@ enum multiplierStrategyType {
   RELATIVE_TRAFFIC
 
   /**
-   * This strategy will try to maintain a certain queries per second, as specified by dispatcherOutboundTargetRate.
+   * This strategy will try to maintain a certain queries per second to the entire dark cluster. Configured with "dispatcherOutboundTargetRate".
    */
   CONSTANT_QPS
 }

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/multiplierStrategyType.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/multiplierStrategyType.pdl
@@ -1,0 +1,19 @@
+namespace com.linkedin.d2
+
+/**
+ * There are 2 types of strategy: RELATIVE_TRAFFIC, CONSTANT_QPS. These can be specified in prioritized order and
+ * will be picked in that order depending on availability.
+ */
+enum multiplierStrategyType {
+
+  /**
+   * This strategy will try to keep the level of traffic on a dark cluster instance relative to the dispatching instance,
+   * as indicated by the multiplier.
+   */
+  RELATIVE_TRAFFIC
+
+  /**
+   * This strategy will try to maintain a certain queries per second, as specified by dispatcherOutboundTargetRate.
+   */
+  CONSTANT_QPS
+}

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/multiplierStrategyType.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/multiplierStrategyType.pdl
@@ -7,8 +7,9 @@ namespace com.linkedin.d2
 enum multiplierStrategyType {
 
   /**
-   * This strategy will try to keep the level of traffic on a dark cluster instance relative to the dispatching instance,
-   * as indicated by the multiplier.
+   * This strategy aims to maintain a proportional amount of incoming QPS at the host level between the source and dark clusters.
+   * Configured with "multiplier". For example a multiplier of 1 would mean the average incoming QPS for a source host equals that
+   * of a dark host. A multiplier of 2 means on average a dark host will receive 2x more traffic than a source host.
    */
   RELATIVE_TRAFFIC
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
@@ -16,17 +16,24 @@
 
 package com.linkedin.d2.balancer.config;
 
+import com.linkedin.d2.D2TransportClientProperties;
+import com.linkedin.d2.DarkClusterConfig;
 import com.linkedin.d2.DarkClusterConfigMap;
-import com.linkedin.d2.balancer.util.JacksonUtil;
+import com.linkedin.d2.MultiplierStrategyTypeArray;
+import com.linkedin.d2.balancer.properties.PropertyKeys;
+import com.linkedin.d2.balancer.properties.util.PropertyUtil;
+import com.linkedin.d2.multiplierStrategyType;
+import com.linkedin.data.DataList;
 import com.linkedin.data.codec.JacksonDataCodec;
 import com.linkedin.data.schema.validation.CoercionMode;
 import com.linkedin.data.schema.validation.RequiredMode;
-import com.linkedin.data.schema.validation.ValidateDataAgainstSchema;
 import com.linkedin.data.schema.validation.ValidationOptions;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class converts {@link DarkClusterConfigMap} into a Map
@@ -39,6 +46,9 @@ public class DarkClustersConverter
   private static final JacksonDataCodec CODEC = new JacksonDataCodec();
   private static final ValidationOptions VALIDATION_OPTIONS =
       new ValidationOptions(RequiredMode.FIXUP_ABSENT_WITH_DEFAULT, CoercionMode.STRING_TO_PRIMITIVE);
+  private static final float DARK_CLUSTER_MULTIPLIER_DEFAULT = 0;
+  private static final int DARK_CLUSTER_DISPATCHER_OUTBOUND_MAX_RATE = Integer.MAX_VALUE;
+  private static final int DARK_CLUSTER_DISPATCHER_TARGET_RATE = 0;
 
   @SuppressWarnings("unchecked")
   public static Map<String, Object> toProperties(DarkClusterConfigMap config)
@@ -49,36 +59,115 @@ public class DarkClustersConverter
     }
     else
     {
-      try
+      Map<String, Object> darkProps = new HashMap<>();
+      for (Map.Entry<String,DarkClusterConfig> entry : config.entrySet())
       {
-        String json = CODEC.mapToString(config.data());
-        return JacksonUtil.getObjectMapper().readValue(json, Map.class);
+        String darkClusterName = entry.getKey();
+        DarkClusterConfig darkClusterConfig = entry.getValue();
+        Map<String, Object> prop = new HashMap<>();
+        if (darkClusterConfig.hasMultiplier())
+        {
+          prop.put(PropertyKeys.DARK_CLUSTER_MULTIPLIER, darkClusterConfig.getMultiplier().toString());
+        }
+
+        if (darkClusterConfig.hasDispatcherOutboundMaxRate())
+        {
+          prop.put(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE, darkClusterConfig.getDispatcherOutboundMaxRate().toString());
+        }
+
+        if (darkClusterConfig.hasDispatcherOutboundTargetRate())
+        {
+          prop.put(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE, darkClusterConfig.getDispatcherOutboundTargetRate().toString());
+        }
+
+        if (darkClusterConfig.hasMultiplierStrategyList())
+        {
+          MultiplierStrategyTypeArray myArray = darkClusterConfig.getMultiplierStrategyList();
+          List<String> strategyList = new ArrayList<>();
+          for (multiplierStrategyType type : myArray)
+          {
+            strategyList.add(type.toString());
+          }
+          prop.put(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST, strategyList);
+        }
+
+        if (darkClusterConfig.hasTransportClientProperties())
+        {
+          // transportClientProperties needs special serialization, as the keys that are written to zookeeper are not
+          // the same as the field names.
+          prop.put(PropertyKeys.DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES,
+                   TransportClientPropertiesConverter.toProperties(darkClusterConfig.getTransportClientProperties()));
+        }
+        darkProps.put(darkClusterName, prop);
       }
-      catch (IOException e)
-      {
-        throw new RuntimeException(e);
-      }
+      return darkProps;
     }
   }
 
   public static DarkClusterConfigMap toConfig(Map<String, Object> properties)
   {
-    try
+    DarkClusterConfigMap configMap = new DarkClusterConfigMap();
+    for (Map.Entry<String, Object> entry : properties.entrySet())
     {
-      if (properties == null)
+      String darkClusterName = entry.getKey();
+      DarkClusterConfig darkClusterConfig = new DarkClusterConfig();
+      @SuppressWarnings("unchecked")
+      Map<String, Object> props = (Map<String, Object>) entry.getValue();
+      if (props.containsKey(PropertyKeys.DARK_CLUSTER_MULTIPLIER))
       {
-        return new DarkClusterConfigMap();
+        darkClusterConfig.setMultiplier(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_MULTIPLIER), Float.class));
       }
-      String json = JacksonUtil.getObjectMapper().writeValueAsString(properties);
-      DarkClusterConfigMap darkClusterConfigMap = new DarkClusterConfigMap(CODEC.stringToMap(json));
-      //fixes are applied in place
-      ValidateDataAgainstSchema.validate(darkClusterConfigMap, VALIDATION_OPTIONS);
+      else
+      {
+        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
+        darkClusterConfig.setMultiplier(DARK_CLUSTER_MULTIPLIER_DEFAULT);
+      }
 
-      return darkClusterConfigMap;
+      if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE))
+      {
+        darkClusterConfig.setDispatcherOutboundMaxRate(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE), Integer.class));
+      }
+      else
+      {
+        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
+        darkClusterConfig.setDispatcherOutboundMaxRate(DARK_CLUSTER_DISPATCHER_OUTBOUND_MAX_RATE);
+      }
+
+      if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE))
+      {
+        darkClusterConfig.setDispatcherOutboundTargetRate(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE), Integer.class));
+      }
+      else
+      {
+        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
+        darkClusterConfig.setDispatcherOutboundTargetRate(DARK_CLUSTER_DISPATCHER_TARGET_RATE);
+      }
+
+      // the multiplier strategy list is a list instead of a single value because rolling out a new strategy
+      // can be decoupled from upgrading a service if you use a list that has a prioritized list with new
+      // strategies and old (existing) strategies.
+      if (props.containsKey(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST))
+      {
+        DataList dataList = new DataList();
+        @SuppressWarnings("unchecked")
+        List<String> strategyList = (List<String>)props.get(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST);
+        dataList.addAll(strategyList);
+
+        // note that unknown strategyTypes can be added here. This can happen for new strategies as they are rolling
+        // out, or for bad strategy types. The converter and client code should be resilient to these.
+        MultiplierStrategyTypeArray multiplierStrategyTypeArray = new MultiplierStrategyTypeArray(dataList);
+        darkClusterConfig.setMultiplierStrategyList(multiplierStrategyTypeArray);
+
+      }
+      if (props.containsKey(PropertyKeys.DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES))
+      {
+        @SuppressWarnings("unchecked")
+        D2TransportClientProperties transportClientProperties = TransportClientPropertiesConverter.toConfig(
+          (Map<String, Object>)props.get(PropertyKeys.DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES));
+        darkClusterConfig.setTransportClientProperties(transportClientProperties);
+      }
+      configMap.put(darkClusterName, darkClusterConfig);
     }
-    catch (IOException e)
-    {
-      throw new RuntimeException(e);
-    }
+    return configMap;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
@@ -61,16 +61,6 @@ public class DarkClustersConverter
           prop.put(PropertyKeys.DARK_CLUSTER_MULTIPLIER, darkClusterConfig.getMultiplier().toString());
         }
 
-//        if (darkClusterConfig.hasDispatcherOutboundMaxRate())
-//        {
-//          prop.put(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE, darkClusterConfig.getDispatcherOutboundMaxRate().toString());
-//        }
-//
-//        if (darkClusterConfig.hasDispatcherOutboundTargetRate())
-//        {
-//          prop.put(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE, darkClusterConfig.getDispatcherOutboundTargetRate().toString());
-//        }
-
         if (darkClusterConfig.hasDarkClusterStrategyPrioritizedList())
         {
           DarkClusterStrategyNameArray myArray = darkClusterConfig.getDarkClusterStrategyPrioritizedList();
@@ -111,26 +101,6 @@ public class DarkClustersConverter
         // to maintain backwards compatibility with previously ser/de, set the default on deserialization
         darkClusterConfig.setMultiplier(DARK_CLUSTER_DEFAULT_MULTIPLIER);
       }
-//
-//      if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE))
-//      {
-//        darkClusterConfig.setDispatcherOutboundMaxRate(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE), Integer.class));
-//      }
-//      else
-//      {
-//        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
-//        darkClusterConfig.setDispatcherOutboundMaxRate(DARK_CLUSTER_DEFAULT_MAX_RATE);
-//      }
-//
-//      if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE))
-//      {
-//        darkClusterConfig.setDispatcherOutboundTargetRate(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE), Integer.class));
-//      }
-//      else
-//      {
-//        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
-//        darkClusterConfig.setDispatcherOutboundTargetRate(DARK_CLUSTER_DEFAULT_TARGET_RATE);
-//      }
 
       if (props.containsKey(PropertyKeys.DARK_CLUSTER_STRATEGY_LIST))
       {
@@ -141,8 +111,8 @@ public class DarkClustersConverter
 
         DarkClusterStrategyNameArray darkClusterStrategyNameArray = new DarkClusterStrategyNameArray(dataList);
         darkClusterConfig.setDarkClusterStrategyPrioritizedList(darkClusterStrategyNameArray);
-
       }
+
       if (props.containsKey(PropertyKeys.DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES))
       {
         @SuppressWarnings("unchecked")

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
@@ -63,9 +63,9 @@ public class DarkClustersConverter
 
         if (darkClusterConfig.hasDarkClusterStrategyPrioritizedList())
         {
-          DarkClusterStrategyNameArray myArray = darkClusterConfig.getDarkClusterStrategyPrioritizedList();
+          DarkClusterStrategyNameArray strategyNameArray = darkClusterConfig.getDarkClusterStrategyPrioritizedList();
           List<String> strategyList = new ArrayList<>();
-          for (DarkClusterStrategyName type : myArray)
+          for (DarkClusterStrategyName type : strategyNameArray)
           {
             strategyList.add(type.toString());
           }

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
@@ -19,10 +19,10 @@ package com.linkedin.d2.balancer.config;
 import com.linkedin.d2.D2TransportClientProperties;
 import com.linkedin.d2.DarkClusterConfig;
 import com.linkedin.d2.DarkClusterConfigMap;
-import com.linkedin.d2.MultiplierStrategyTypeArray;
+import com.linkedin.d2.DarkClusterStrategyName;
+import com.linkedin.d2.DarkClusterStrategyNameArray;
 import com.linkedin.d2.balancer.properties.PropertyKeys;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
-import com.linkedin.d2.multiplierStrategyType;
 import com.linkedin.data.DataList;
 import com.linkedin.data.codec.JacksonDataCodec;
 import com.linkedin.data.schema.validation.CoercionMode;
@@ -82,9 +82,9 @@ public class DarkClustersConverter
 
         if (darkClusterConfig.hasMultiplierStrategyList())
         {
-          MultiplierStrategyTypeArray myArray = darkClusterConfig.getMultiplierStrategyList();
+          DarkClusterStrategyNameArray myArray = darkClusterConfig.getMultiplierStrategyList();
           List<String> strategyList = new ArrayList<>();
-          for (multiplierStrategyType type : myArray)
+          for (DarkClusterStrategyName type : myArray)
           {
             strategyList.add(type.toString());
           }
@@ -155,8 +155,8 @@ public class DarkClustersConverter
 
         // note that unknown strategyTypes can be added here. This can happen for new strategies as they are rolling
         // out, or for bad strategy types. The converter and client code should be resilient to these.
-        MultiplierStrategyTypeArray multiplierStrategyTypeArray = new MultiplierStrategyTypeArray(dataList);
-        darkClusterConfig.setMultiplierStrategyList(multiplierStrategyTypeArray);
+        DarkClusterStrategyNameArray darkClusterStrategyNameArray = new DarkClusterStrategyNameArray(dataList);
+        darkClusterConfig.setMultiplierStrategyList(darkClusterStrategyNameArray);
 
       }
       if (props.containsKey(PropertyKeys.DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES))

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
@@ -24,16 +24,14 @@ import com.linkedin.d2.DarkClusterStrategyNameArray;
 import com.linkedin.d2.balancer.properties.PropertyKeys;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.data.DataList;
-import com.linkedin.data.codec.JacksonDataCodec;
-import com.linkedin.data.schema.validation.CoercionMode;
-import com.linkedin.data.schema.validation.RequiredMode;
-import com.linkedin.data.schema.validation.ValidationOptions;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.linkedin.d2.balancer.properties.ClusterProperties.DARK_CLUSTER_DEFAULT_MULTIPLIER;
 
 /**
  * This class converts {@link DarkClusterConfigMap} into a Map
@@ -43,13 +41,6 @@ import java.util.Map;
  */
 public class DarkClustersConverter
 {
-  private static final JacksonDataCodec CODEC = new JacksonDataCodec();
-  private static final ValidationOptions VALIDATION_OPTIONS =
-      new ValidationOptions(RequiredMode.FIXUP_ABSENT_WITH_DEFAULT, CoercionMode.STRING_TO_PRIMITIVE);
-  private static final float DARK_CLUSTER_MULTIPLIER_DEFAULT = 0;
-  private static final int DARK_CLUSTER_DISPATCHER_OUTBOUND_MAX_RATE = Integer.MAX_VALUE;
-  private static final int DARK_CLUSTER_DISPATCHER_TARGET_RATE = 0;
-
   @SuppressWarnings("unchecked")
   public static Map<String, Object> toProperties(DarkClusterConfigMap config)
   {
@@ -70,31 +61,29 @@ public class DarkClustersConverter
           prop.put(PropertyKeys.DARK_CLUSTER_MULTIPLIER, darkClusterConfig.getMultiplier().toString());
         }
 
-        if (darkClusterConfig.hasDispatcherOutboundMaxRate())
-        {
-          prop.put(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE, darkClusterConfig.getDispatcherOutboundMaxRate().toString());
-        }
+//        if (darkClusterConfig.hasDispatcherOutboundMaxRate())
+//        {
+//          prop.put(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE, darkClusterConfig.getDispatcherOutboundMaxRate().toString());
+//        }
+//
+//        if (darkClusterConfig.hasDispatcherOutboundTargetRate())
+//        {
+//          prop.put(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE, darkClusterConfig.getDispatcherOutboundTargetRate().toString());
+//        }
 
-        if (darkClusterConfig.hasDispatcherOutboundTargetRate())
+        if (darkClusterConfig.hasDarkClusterStrategyPrioritizedList())
         {
-          prop.put(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE, darkClusterConfig.getDispatcherOutboundTargetRate().toString());
-        }
-
-        if (darkClusterConfig.hasMultiplierStrategyList())
-        {
-          DarkClusterStrategyNameArray myArray = darkClusterConfig.getMultiplierStrategyList();
+          DarkClusterStrategyNameArray myArray = darkClusterConfig.getDarkClusterStrategyPrioritizedList();
           List<String> strategyList = new ArrayList<>();
           for (DarkClusterStrategyName type : myArray)
           {
             strategyList.add(type.toString());
           }
-          prop.put(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST, strategyList);
+          prop.put(PropertyKeys.DARK_CLUSTER_STRATEGY_LIST, strategyList);
         }
 
         if (darkClusterConfig.hasTransportClientProperties())
         {
-          // transportClientProperties needs special serialization, as the keys that are written to zookeeper are not
-          // the same as the field names.
           prop.put(PropertyKeys.DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES,
                    TransportClientPropertiesConverter.toProperties(darkClusterConfig.getTransportClientProperties()));
         }
@@ -120,43 +109,38 @@ public class DarkClustersConverter
       else
       {
         // to maintain backwards compatibility with previously ser/de, set the default on deserialization
-        darkClusterConfig.setMultiplier(DARK_CLUSTER_MULTIPLIER_DEFAULT);
+        darkClusterConfig.setMultiplier(DARK_CLUSTER_DEFAULT_MULTIPLIER);
       }
+//
+//      if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE))
+//      {
+//        darkClusterConfig.setDispatcherOutboundMaxRate(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE), Integer.class));
+//      }
+//      else
+//      {
+//        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
+//        darkClusterConfig.setDispatcherOutboundMaxRate(DARK_CLUSTER_DEFAULT_MAX_RATE);
+//      }
+//
+//      if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE))
+//      {
+//        darkClusterConfig.setDispatcherOutboundTargetRate(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE), Integer.class));
+//      }
+//      else
+//      {
+//        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
+//        darkClusterConfig.setDispatcherOutboundTargetRate(DARK_CLUSTER_DEFAULT_TARGET_RATE);
+//      }
 
-      if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE))
-      {
-        darkClusterConfig.setDispatcherOutboundMaxRate(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_MAX_RATE), Integer.class));
-      }
-      else
-      {
-        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
-        darkClusterConfig.setDispatcherOutboundMaxRate(DARK_CLUSTER_DISPATCHER_OUTBOUND_MAX_RATE);
-      }
-
-      if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE))
-      {
-        darkClusterConfig.setDispatcherOutboundTargetRate(PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE), Integer.class));
-      }
-      else
-      {
-        // to maintain backwards compatibility with previously ser/de, set the default on deserialization
-        darkClusterConfig.setDispatcherOutboundTargetRate(DARK_CLUSTER_DISPATCHER_TARGET_RATE);
-      }
-
-      // the multiplier strategy list is a list instead of a single value because rolling out a new strategy
-      // can be decoupled from upgrading a service if you use a list that has a prioritized list with new
-      // strategies and old (existing) strategies.
-      if (props.containsKey(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST))
+      if (props.containsKey(PropertyKeys.DARK_CLUSTER_STRATEGY_LIST))
       {
         DataList dataList = new DataList();
         @SuppressWarnings("unchecked")
-        List<String> strategyList = (List<String>)props.get(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST);
+        List<String> strategyList = (List<String>)props.get(PropertyKeys.DARK_CLUSTER_STRATEGY_LIST);
         dataList.addAll(strategyList);
 
-        // note that unknown strategyTypes can be added here. This can happen for new strategies as they are rolling
-        // out, or for bad strategy types. The converter and client code should be resilient to these.
         DarkClusterStrategyNameArray darkClusterStrategyNameArray = new DarkClusterStrategyNameArray(dataList);
-        darkClusterConfig.setMultiplierStrategyList(darkClusterStrategyNameArray);
+        darkClusterConfig.setDarkClusterStrategyPrioritizedList(darkClusterStrategyNameArray);
 
       }
       if (props.containsKey(PropertyKeys.DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES))

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/TransportClientPropertiesConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/TransportClientPropertiesConverter.java
@@ -35,6 +35,11 @@ import static com.linkedin.d2.balancer.properties.util.PropertyUtil.coerce;
 /**
  * This class converts {@link D2TransportClientProperties} into a map from String to Object
  * that can be stored in zookeeper and vice versa.
+ *
+ * Note that this Converter uses different key names than the field names (e.g. http.queryPostThreshold instead of queryPostThreshold),
+ * so all serialization should go through toProperties first, and deserialization should go through toConfig afterwards
+ * to properly convert to and from the pegasus objects.
+ *
  * @author Ang Xu
  */
 public class TransportClientPropertiesConverter

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterProperties.java
@@ -27,6 +27,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * ClusterProperties is the serialized cluster object that is stored in zookeeper.
+ *
+ * Most likely you want POJO's here, and not include pegasus generated objects, because
+ * certain objects, like transportClientProperties, are serialized differently than
+ * how Jackson would serialize the object (for instance, using different key names), and
+ * that will cause problems in serialization/deserialization. This is the reason _darkClusters
+ * is a Map<String, Object> and not DarkClusterConfigMap. For simple objects that won't ever be
+ * expanded it may be ok to reuse the pegasus objects.
+ */
 public class ClusterProperties
 {
   public static final float DARK_CLUSTER_DEFAULT_MULTIPLIER = 0.0f;

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
@@ -16,9 +16,6 @@
 
 package com.linkedin.d2.balancer.properties;
 
-
-import com.linkedin.d2.DarkClusterConfigMap;
-import com.linkedin.d2.balancer.config.DarkClustersConverter;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.util.JacksonUtil;
 import com.linkedin.d2.discovery.PropertyBuilder;
@@ -154,7 +151,6 @@ public class ClusterPropertiesJsonSerializer implements
 
     @SuppressWarnings("unchecked")
     Map<String, Object> darkClusterProperty = (Map<String, Object>) map.get(PropertyKeys.DARK_CLUSTER_MAP);
-    DarkClusterConfigMap darkClusterConfigMap = DarkClustersConverter.toConfig(darkClusterProperty);
 
     boolean delegated = false;
     if (map.containsKey(PropertyKeys.DELEGATED)) {
@@ -162,6 +158,6 @@ public class ClusterPropertiesJsonSerializer implements
     }
 
     return new ClusterProperties(clusterName, prioritizedSchemes, properties, banned, partitionProperties, validationList,
-        darkClusterConfigMap, delegated);
+        darkClusterProperty, delegated);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -179,6 +179,8 @@ public class PropertyKeys
   public static final String DARK_CLUSTER_MULTIPLIER = "multiplier";
   public static final String DARK_CLUSTER_OUTBOUND_TARGET_RATE = "dispatcherOutboundTargetRate";
   public static final String DARK_CLUSTER_OUTBOUND_MAX_RATE = "dispatcherOutboundMaxRate";
+  public static final String DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST = "multiplierStrategyList";
+  public static final String DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES = "transportClientProperties";
 
   // used by ClusterInfoProvider
   public static final String HTTP_SCHEME = "http";

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -179,7 +179,7 @@ public class PropertyKeys
   public static final String DARK_CLUSTER_MULTIPLIER = "multiplier";
   public static final String DARK_CLUSTER_OUTBOUND_TARGET_RATE = "dispatcherOutboundTargetRate";
   public static final String DARK_CLUSTER_OUTBOUND_MAX_RATE = "dispatcherOutboundMaxRate";
-  public static final String DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST = "multiplierStrategyList";
+  public static final String DARK_CLUSTER_STRATEGY_LIST = "darkClusterStrategyList";
   public static final String DARK_CLUSTER_TRANSPORT_CLIENT_PROPERTIES = "transportClientProperties";
 
   // used by ClusterInfoProvider

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -911,7 +911,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     {
       ClusterProperties clusterProperties = _state.getClusterProperties(clusterName).getProperty();
       DarkClusterConfigMap darkClusterConfigMap = clusterProperties != null ?
-        clusterProperties.getDarkClusters() : new DarkClusterConfigMap();
+        clusterProperties.accessDarkClusters() : new DarkClusterConfigMap();
       darkClusterConfigMapFutureCallback.onSuccess(darkClusterConfigMap);
     });
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/StaticLoadBalancerState.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/StaticLoadBalancerState.java
@@ -95,7 +95,10 @@ public class StaticLoadBalancerState implements LoadBalancerState
             TEST_SERVICE_DEGRADER_PROPERTIES, TEST_SERVICE_PRIORITIZED_SCHEMES, TEST_SERVICE_BANNED_URIS,
             TEST_SERVICE_META_PROPERTIES, TEST_SERVICE_BACKUP_REQUEST_PROPERTIES));
 
-    _clusterPropertie.put(TEST_CLUSTER, new ClusterProperties(TEST_CLUSTER, TEST_SERVICE_PRIORITIZED_SCHEMES, TEST_CLUSTER_PROPERTIES, TEST_CLUSTER_BANNED_URIS, TEST_CLUSTER_PARTITION_PROPERTIES, TEST_CLUSTER_SSL_VALIDATION_STRINGS));
+    _clusterPropertie.put(TEST_CLUSTER, new ClusterProperties(TEST_CLUSTER, TEST_SERVICE_PRIORITIZED_SCHEMES, TEST_CLUSTER_PROPERTIES,
+                                                              TEST_CLUSTER_BANNED_URIS, TEST_CLUSTER_PARTITION_PROPERTIES,
+                                                              TEST_CLUSTER_SSL_VALIDATION_STRINGS,
+                                                              (Map<String, Object>)null, false));
     _uriProperties.put(TEST_CLUSTER, new UriProperties(TEST_CLUSTER, TEST_URIS_PARTITIONDESCRIPTIONS, TEST_URI_PROPERTIES));
   }
 
@@ -109,7 +112,10 @@ public class StaticLoadBalancerState implements LoadBalancerState
             TEST_SERVICE_LB_STRATEGY_PROPERTIES, TEST_SERVICE_TRANSPORT_CLIENT_PROPERTIES,
             TEST_SERVICE_DEGRADER_PROPERTIES, TEST_SERVICE_PRIORITIZED_SCHEMES, TEST_SERVICE_BANNED_URIS,
             TEST_SERVICE_META_PROPERTIES, TEST_SERVICE_BACKUP_REQUEST_PROPERTIES));
-    _clusterPropertie.replace(TEST_CLUSTER, new ClusterProperties(TEST_CLUSTER, TEST_SERVICE_PRIORITIZED_SCHEMES, TEST_CLUSTER_PROPERTIES, TEST_CLUSTER_BANNED_URIS, TEST_CLUSTER_PARTITION_PROPERTIES, TEST_CLUSTER_SSL_VALIDATION_STRINGS));
+    _clusterPropertie.replace(TEST_CLUSTER, new ClusterProperties(TEST_CLUSTER, TEST_SERVICE_PRIORITIZED_SCHEMES, TEST_CLUSTER_PROPERTIES,
+                                                                  TEST_CLUSTER_BANNED_URIS, TEST_CLUSTER_PARTITION_PROPERTIES,
+                                                                  TEST_CLUSTER_SSL_VALIDATION_STRINGS,
+                                                                  (Map<String, Object>)null, false));
     _uriProperties.replace(TEST_CLUSTER, new UriProperties(TEST_CLUSTER, TEST_URIS_PARTITIONDESCRIPTIONS, TEST_URI_PROPERTIES));
   }
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
@@ -16,8 +16,19 @@
 
 package com.linkedin.d2.balancer.config;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.linkedin.d2.D2TransportClientProperties;
 import com.linkedin.d2.DarkClusterConfig;
 import com.linkedin.d2.DarkClusterConfigMap;
+import com.linkedin.d2.MultiplierStrategyTypeArray;
+import com.linkedin.d2.balancer.properties.PropertyKeys;
+import com.linkedin.d2.multiplierStrategyType;
+
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -44,7 +55,7 @@ public class DarkClustersConverterTest
         new Object[] {true, new DarkClusterConfig().setMultiplier(0.0f).setDispatcherOutboundTargetRate(0).setDispatcherOutboundMaxRate(0)},
         // negative multiplier not allowed
         new Object[] {false, new DarkClusterConfig().setMultiplier(-1.0f).setDispatcherOutboundTargetRate(0).setDispatcherOutboundMaxRate(1234566)},
-        // netative target rate not allowed
+        // negative target rate not allowed
         new Object[] {false, new DarkClusterConfig().setMultiplier(0.0f).setDispatcherOutboundTargetRate(-1).setDispatcherOutboundMaxRate(1234566)},
         // negative max rate not allowed
         new Object[] {false, new DarkClusterConfig().setMultiplier(1.0f).setDispatcherOutboundTargetRate(0).setDispatcherOutboundMaxRate(-1)},
@@ -92,16 +103,23 @@ public class DarkClustersConverterTest
     Assert.assertEquals(resultConfig.getMultiplier(), DARK_CLUSTER_DEFAULT_MULTIPLIER);
     Assert.assertEquals((int)resultConfig.getDispatcherOutboundTargetRate(), DARK_CLUSTER_DEFAULT_TARGET_RATE);
     Assert.assertEquals((int)resultConfig.getDispatcherOutboundMaxRate(), DARK_CLUSTER_DEFAULT_MAX_RATE);
+    Assert.assertEquals(resultConfig.getMultiplierStrategyList().size(), 1, "default strategy list should be size 1");
+    Assert.assertFalse(resultConfig.hasTransportClientProperties(), "default shouldn't have transportProperties");
   }
 
   @Test
   public void testEntriesInClusterConfig()
   {
     DarkClusterConfigMap configMap = new DarkClusterConfigMap();
+    MultiplierStrategyTypeArray multiplierStrategyTypeArray = new MultiplierStrategyTypeArray();
+    multiplierStrategyTypeArray.add(multiplierStrategyType.RELATIVE_TRAFFIC);
+    D2TransportClientProperties transportClientProperties = new D2TransportClientProperties()
+      .setRequestTimeout(1000);
     DarkClusterConfig config = new DarkClusterConfig()
         .setDispatcherOutboundTargetRate(454)
-        .setDispatcherOutboundMaxRate(1234566);
-    config.data().put("blahblah", "random string");
+        .setDispatcherOutboundMaxRate(1234566)
+        .setMultiplierStrategyList(multiplierStrategyTypeArray)
+        .setTransportClientProperties(transportClientProperties);
 
     configMap.put(DARK_CLUSTER_KEY, config);
 
@@ -111,11 +129,69 @@ public class DarkClustersConverterTest
     expectedConfigMap.put(DARK_CLUSTER_KEY, expectedConfig);
     DarkClusterConfigMap resultConfigMap = DarkClustersConverter.toConfig(DarkClustersConverter.toProperties(configMap));
     Assert.assertEquals(resultConfigMap, expectedConfigMap);
-    // random entries in the map are carried over because of the pass thru nature of dataMaps.
-    Assert.assertTrue(resultConfigMap.get(DARK_CLUSTER_KEY).data().containsKey("blahblah"));
     // verify values are converted properly.
-    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplier(),0.0f, "unexpected multiplier");
-    Assert.assertEquals((int)resultConfigMap.get(DARK_CLUSTER_KEY).getDispatcherOutboundTargetRate(), 454, "unexpected target rate");
-    Assert.assertEquals((int)resultConfigMap.get(DARK_CLUSTER_KEY).getDispatcherOutboundMaxRate(), 1234566, "unexpected maxRate");
+    DarkClusterConfig darkClusterConfig = resultConfigMap.get(DARK_CLUSTER_KEY);
+    Assert.assertEquals(darkClusterConfig.getMultiplier(),0.0f, "unexpected multiplier");
+    Assert.assertEquals((int)darkClusterConfig.getDispatcherOutboundTargetRate(), 454, "unexpected target rate");
+    Assert.assertEquals((int)darkClusterConfig.getDispatcherOutboundMaxRate(), 1234566, "unexpected maxRate");
+    Assert.assertEquals(darkClusterConfig.getMultiplierStrategyList().size(), 1, "there should be one strategy");
+    Assert.assertEquals(darkClusterConfig.getMultiplierStrategyList().get(0), multiplierStrategyType.RELATIVE_TRAFFIC,
+                        "expected RELATIVE_TRAFFIC strategy");
+    Assert.assertTrue(darkClusterConfig.hasTransportClientProperties());
+    D2TransportClientProperties returnedTransportClientProperties = darkClusterConfig.getTransportClientProperties();
+    Assert.assertNotNull(returnedTransportClientProperties);
+    Assert.assertTrue(returnedTransportClientProperties.hasRequestTimeout());
+    Assert.assertEquals(Objects.requireNonNull(returnedTransportClientProperties.getRequestTimeout()).longValue(),
+                        1000, "expected 1000 request Timeout");
+
+  }
+
+  @Test
+  public void testMultipleStrategies()
+  {
+    DarkClusterConfigMap configMap = new DarkClusterConfigMap();
+    MultiplierStrategyTypeArray multiplierStrategyTypeArray = new MultiplierStrategyTypeArray();
+    multiplierStrategyTypeArray.add(multiplierStrategyType.RELATIVE_TRAFFIC);
+    multiplierStrategyTypeArray.add(multiplierStrategyType.CONSTANT_QPS);
+    DarkClusterConfig config = new DarkClusterConfig()
+      .setMultiplierStrategyList(multiplierStrategyTypeArray);
+
+    configMap.put(DARK_CLUSTER_KEY, config);
+
+    // these are defaults that will be set if the fields are missing.
+    config.setMultiplier(0.0f);
+    config.setDispatcherOutboundTargetRate(0);
+    config.setDispatcherOutboundMaxRate(Integer.MAX_VALUE);
+    DarkClusterConfigMap expectedConfigMap = new DarkClusterConfigMap();
+    DarkClusterConfig expectedConfig = new DarkClusterConfig(config.data());
+    expectedConfig.setMultiplier(0);
+    expectedConfigMap.put(DARK_CLUSTER_KEY, expectedConfig);
+    DarkClusterConfigMap resultConfigMap = DarkClustersConverter.toConfig(DarkClustersConverter.toProperties(configMap));
+    Assert.assertEquals(resultConfigMap, expectedConfigMap);
+    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList().get(0), multiplierStrategyType.RELATIVE_TRAFFIC,
+                        "expected first strategy to be RELATIVE_TRAFFIC");
+    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList().get(1), multiplierStrategyType.CONSTANT_QPS,
+                        "expected first strategy to be CONSTANT_QPS");
+  }
+
+  @Test
+  public void testBadStrategies()
+  {
+    Map<String, Object> props = new HashMap<>();
+    List<String> myStrategyList = new ArrayList<>();
+    myStrategyList.add("RELATIVE_TRAFFIC");
+    myStrategyList.add("BLAH_BLAH");
+
+    Map<String, Object> darkClusterMap = new HashMap<>();
+    darkClusterMap.put(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST, myStrategyList);
+    props.put(DARK_CLUSTER_KEY, darkClusterMap);
+    DarkClusterConfigMap configMap = DarkClustersConverter.toConfig(props);
+    MultiplierStrategyTypeArray strategyList = configMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList();
+    Assert.assertEquals(strategyList.get(0), multiplierStrategyType.RELATIVE_TRAFFIC, "first strategy should be RELATIVE_TRAFFIC");
+
+    // the bad strategy BLAH_BLAH gets converted to unknown on access
+    Assert.assertEquals(strategyList.get(1), multiplierStrategyType.$UNKNOWN, "second strategy should be unknown");
   }
 }
+
+

--- a/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
@@ -103,7 +103,7 @@ public class DarkClustersConverterTest
     Assert.assertEquals(resultConfig.getMultiplier(), DARK_CLUSTER_DEFAULT_MULTIPLIER);
     Assert.assertEquals((int)resultConfig.getDispatcherOutboundTargetRate(), DARK_CLUSTER_DEFAULT_TARGET_RATE);
     Assert.assertEquals((int)resultConfig.getDispatcherOutboundMaxRate(), DARK_CLUSTER_DEFAULT_MAX_RATE);
-    Assert.assertEquals(resultConfig.getMultiplierStrategyList().size(), 1, "default strategy list should be size 1");
+    Assert.assertEquals(resultConfig.getDarkClusterStrategyPrioritizedList().size(), 1, "default strategy list should be size 1");
     Assert.assertFalse(resultConfig.hasTransportClientProperties(), "default shouldn't have transportProperties");
   }
 
@@ -118,7 +118,7 @@ public class DarkClustersConverterTest
     DarkClusterConfig config = new DarkClusterConfig()
         .setDispatcherOutboundTargetRate(454)
         .setDispatcherOutboundMaxRate(1234566)
-        .setMultiplierStrategyList(multiplierStrategyTypeArray)
+        .setDarkClusterStrategyPrioritizedList(multiplierStrategyTypeArray)
         .setTransportClientProperties(transportClientProperties);
 
     configMap.put(DARK_CLUSTER_KEY, config);
@@ -131,11 +131,11 @@ public class DarkClustersConverterTest
     Assert.assertEquals(resultConfigMap, expectedConfigMap);
     // verify values are converted properly.
     DarkClusterConfig darkClusterConfig = resultConfigMap.get(DARK_CLUSTER_KEY);
-    Assert.assertEquals(darkClusterConfig.getMultiplier(),0.0f, "unexpected multiplier");
+    Assert.assertEquals(darkClusterConfig.getMultiplier(),DARK_CLUSTER_DEFAULT_MULTIPLIER, "unexpected multiplier");
     Assert.assertEquals((int)darkClusterConfig.getDispatcherOutboundTargetRate(), 454, "unexpected target rate");
     Assert.assertEquals((int)darkClusterConfig.getDispatcherOutboundMaxRate(), 1234566, "unexpected maxRate");
-    Assert.assertEquals(darkClusterConfig.getMultiplierStrategyList().size(), 1, "there should be one strategy");
-    Assert.assertEquals(darkClusterConfig.getMultiplierStrategyList().get(0), DarkClusterStrategyName.RELATIVE_TRAFFIC,
+    Assert.assertEquals(darkClusterConfig.getDarkClusterStrategyPrioritizedList().size(), 1, "there should be one strategy");
+    Assert.assertEquals(darkClusterConfig.getDarkClusterStrategyPrioritizedList().get(0), DarkClusterStrategyName.RELATIVE_TRAFFIC,
                         "expected RELATIVE_TRAFFIC strategy");
     Assert.assertTrue(darkClusterConfig.hasTransportClientProperties());
     D2TransportClientProperties returnedTransportClientProperties = darkClusterConfig.getTransportClientProperties();
@@ -150,27 +150,27 @@ public class DarkClustersConverterTest
   public void testMultipleStrategies()
   {
     DarkClusterConfigMap configMap = new DarkClusterConfigMap();
-    DarkClusterStrategyNameArray multiplierStrategyTypeArray = new DarkClusterStrategyNameArray();
-    multiplierStrategyTypeArray.add(DarkClusterStrategyName.RELATIVE_TRAFFIC);
-    multiplierStrategyTypeArray.add(DarkClusterStrategyName.CONSTANT_QPS);
+    DarkClusterStrategyNameArray darkClusterStrategyNameArray = new DarkClusterStrategyNameArray();
+    darkClusterStrategyNameArray.add(DarkClusterStrategyName.RELATIVE_TRAFFIC);
+    darkClusterStrategyNameArray.add(DarkClusterStrategyName.CONSTANT_QPS);
     DarkClusterConfig config = new DarkClusterConfig()
-      .setMultiplierStrategyList(multiplierStrategyTypeArray);
+      .setDarkClusterStrategyPrioritizedList(darkClusterStrategyNameArray);
 
     configMap.put(DARK_CLUSTER_KEY, config);
 
     // these are defaults that will be set if the fields are missing.
-    config.setMultiplier(0.0f);
-    config.setDispatcherOutboundTargetRate(0);
-    config.setDispatcherOutboundMaxRate(Integer.MAX_VALUE);
+    config.setMultiplier(DARK_CLUSTER_DEFAULT_MULTIPLIER);
+    config.setDispatcherOutboundTargetRate(DARK_CLUSTER_DEFAULT_TARGET_RATE);
+    config.setDispatcherOutboundMaxRate(DARK_CLUSTER_DEFAULT_MAX_RATE);
     DarkClusterConfigMap expectedConfigMap = new DarkClusterConfigMap();
     DarkClusterConfig expectedConfig = new DarkClusterConfig(config.data());
     expectedConfig.setMultiplier(0);
     expectedConfigMap.put(DARK_CLUSTER_KEY, expectedConfig);
     DarkClusterConfigMap resultConfigMap = DarkClustersConverter.toConfig(DarkClustersConverter.toProperties(configMap));
     Assert.assertEquals(resultConfigMap, expectedConfigMap);
-    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList().get(0), DarkClusterStrategyName.RELATIVE_TRAFFIC,
+    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getDarkClusterStrategyPrioritizedList().get(0), DarkClusterStrategyName.RELATIVE_TRAFFIC,
                         "expected first strategy to be RELATIVE_TRAFFIC");
-    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList().get(1), DarkClusterStrategyName.CONSTANT_QPS,
+    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getDarkClusterStrategyPrioritizedList().get(1), DarkClusterStrategyName.CONSTANT_QPS,
                         "expected first strategy to be CONSTANT_QPS");
   }
 
@@ -183,10 +183,10 @@ public class DarkClustersConverterTest
     myStrategyList.add("BLAH_BLAH");
 
     Map<String, Object> darkClusterMap = new HashMap<>();
-    darkClusterMap.put(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST, myStrategyList);
+    darkClusterMap.put(PropertyKeys.DARK_CLUSTER_STRATEGY_LIST, myStrategyList);
     props.put(DARK_CLUSTER_KEY, darkClusterMap);
     DarkClusterConfigMap configMap = DarkClustersConverter.toConfig(props);
-    DarkClusterStrategyNameArray strategyList = configMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList();
+    DarkClusterStrategyNameArray strategyList = configMap.get(DARK_CLUSTER_KEY).getDarkClusterStrategyPrioritizedList();
     Assert.assertEquals(strategyList.get(0), DarkClusterStrategyName.RELATIVE_TRAFFIC, "first strategy should be RELATIVE_TRAFFIC");
 
     // the bad strategy BLAH_BLAH gets converted to unknown on access

--- a/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
@@ -25,9 +25,9 @@ import java.util.Objects;
 import com.linkedin.d2.D2TransportClientProperties;
 import com.linkedin.d2.DarkClusterConfig;
 import com.linkedin.d2.DarkClusterConfigMap;
-import com.linkedin.d2.MultiplierStrategyTypeArray;
+import com.linkedin.d2.DarkClusterStrategyName;
+import com.linkedin.d2.DarkClusterStrategyNameArray;
 import com.linkedin.d2.balancer.properties.PropertyKeys;
-import com.linkedin.d2.multiplierStrategyType;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -111,8 +111,8 @@ public class DarkClustersConverterTest
   public void testEntriesInClusterConfig()
   {
     DarkClusterConfigMap configMap = new DarkClusterConfigMap();
-    MultiplierStrategyTypeArray multiplierStrategyTypeArray = new MultiplierStrategyTypeArray();
-    multiplierStrategyTypeArray.add(multiplierStrategyType.RELATIVE_TRAFFIC);
+    DarkClusterStrategyNameArray multiplierStrategyTypeArray = new DarkClusterStrategyNameArray();
+    multiplierStrategyTypeArray.add(DarkClusterStrategyName.RELATIVE_TRAFFIC.RELATIVE_TRAFFIC);
     D2TransportClientProperties transportClientProperties = new D2TransportClientProperties()
       .setRequestTimeout(1000);
     DarkClusterConfig config = new DarkClusterConfig()
@@ -135,7 +135,7 @@ public class DarkClustersConverterTest
     Assert.assertEquals((int)darkClusterConfig.getDispatcherOutboundTargetRate(), 454, "unexpected target rate");
     Assert.assertEquals((int)darkClusterConfig.getDispatcherOutboundMaxRate(), 1234566, "unexpected maxRate");
     Assert.assertEquals(darkClusterConfig.getMultiplierStrategyList().size(), 1, "there should be one strategy");
-    Assert.assertEquals(darkClusterConfig.getMultiplierStrategyList().get(0), multiplierStrategyType.RELATIVE_TRAFFIC,
+    Assert.assertEquals(darkClusterConfig.getMultiplierStrategyList().get(0), DarkClusterStrategyName.RELATIVE_TRAFFIC,
                         "expected RELATIVE_TRAFFIC strategy");
     Assert.assertTrue(darkClusterConfig.hasTransportClientProperties());
     D2TransportClientProperties returnedTransportClientProperties = darkClusterConfig.getTransportClientProperties();
@@ -150,9 +150,9 @@ public class DarkClustersConverterTest
   public void testMultipleStrategies()
   {
     DarkClusterConfigMap configMap = new DarkClusterConfigMap();
-    MultiplierStrategyTypeArray multiplierStrategyTypeArray = new MultiplierStrategyTypeArray();
-    multiplierStrategyTypeArray.add(multiplierStrategyType.RELATIVE_TRAFFIC);
-    multiplierStrategyTypeArray.add(multiplierStrategyType.CONSTANT_QPS);
+    DarkClusterStrategyNameArray multiplierStrategyTypeArray = new DarkClusterStrategyNameArray();
+    multiplierStrategyTypeArray.add(DarkClusterStrategyName.RELATIVE_TRAFFIC);
+    multiplierStrategyTypeArray.add(DarkClusterStrategyName.CONSTANT_QPS);
     DarkClusterConfig config = new DarkClusterConfig()
       .setMultiplierStrategyList(multiplierStrategyTypeArray);
 
@@ -168,9 +168,9 @@ public class DarkClustersConverterTest
     expectedConfigMap.put(DARK_CLUSTER_KEY, expectedConfig);
     DarkClusterConfigMap resultConfigMap = DarkClustersConverter.toConfig(DarkClustersConverter.toProperties(configMap));
     Assert.assertEquals(resultConfigMap, expectedConfigMap);
-    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList().get(0), multiplierStrategyType.RELATIVE_TRAFFIC,
+    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList().get(0), DarkClusterStrategyName.RELATIVE_TRAFFIC,
                         "expected first strategy to be RELATIVE_TRAFFIC");
-    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList().get(1), multiplierStrategyType.CONSTANT_QPS,
+    Assert.assertEquals(resultConfigMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList().get(1), DarkClusterStrategyName.CONSTANT_QPS,
                         "expected first strategy to be CONSTANT_QPS");
   }
 
@@ -186,11 +186,11 @@ public class DarkClustersConverterTest
     darkClusterMap.put(PropertyKeys.DARK_CLUSTER_MULTIPLIER_STRATEGY_LIST, myStrategyList);
     props.put(DARK_CLUSTER_KEY, darkClusterMap);
     DarkClusterConfigMap configMap = DarkClustersConverter.toConfig(props);
-    MultiplierStrategyTypeArray strategyList = configMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList();
-    Assert.assertEquals(strategyList.get(0), multiplierStrategyType.RELATIVE_TRAFFIC, "first strategy should be RELATIVE_TRAFFIC");
+    DarkClusterStrategyNameArray strategyList = configMap.get(DARK_CLUSTER_KEY).getMultiplierStrategyList();
+    Assert.assertEquals(strategyList.get(0), DarkClusterStrategyName.RELATIVE_TRAFFIC, "first strategy should be RELATIVE_TRAFFIC");
 
     // the bad strategy BLAH_BLAH gets converted to unknown on access
-    Assert.assertEquals(strategyList.get(1), multiplierStrategyType.$UNKNOWN, "second strategy should be unknown");
+    Assert.assertEquals(strategyList.get(1), DarkClusterStrategyName.$UNKNOWN, "second strategy should be unknown");
   }
 }
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/properties/ClusterPropertiesSerializerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/properties/ClusterPropertiesSerializerTest.java
@@ -18,6 +18,7 @@ package com.linkedin.d2.balancer.properties;
 
 import com.linkedin.d2.DarkClusterConfig;
 import com.linkedin.d2.DarkClusterConfigMap;
+import com.linkedin.d2.balancer.config.DarkClustersConverter;
 import com.linkedin.d2.discovery.PropertySerializationException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -78,7 +79,7 @@ public class ClusterPropertiesSerializerTest
     assertEquals(jsonSerializer.fromBytes(jsonSerializer.toBytes(property)), property);
 
     property = new ClusterProperties("test", schemes, supProperties, new HashSet<URI>(), NullPartitionProperties.getInstance(),
-        Arrays.asList("principal1", "principal2"));
+        Arrays.asList("principal1", "principal2"), (Map<String, Object>)null, false);
     assertEquals(jsonSerializer.fromBytes(jsonSerializer.toBytes(property)), property);
 
     try
@@ -101,7 +102,7 @@ public class ClusterPropertiesSerializerTest
     DarkClusterConfigMap darkClusterConfigMap = new DarkClusterConfigMap();
     darkClusterConfigMap.put(DARK_CLUSTER1_KEY, darkCluster1);
     ClusterProperties property = new ClusterProperties("test", new ArrayList<String>(), Collections.emptyMap(), new HashSet<URI>(), NullPartitionProperties.getInstance(),
-        Arrays.asList("principal1", "principal2"), darkClusterConfigMap);
+        Arrays.asList("principal1", "principal2"), DarkClustersConverter.toProperties(darkClusterConfigMap), false);
     assertEquals(jsonSerializer.fromBytes(jsonSerializer.toBytes(property)), property);
   }
 
@@ -121,8 +122,10 @@ public class ClusterPropertiesSerializerTest
         .setDispatcherOutboundTargetRate(50)
         .setMultiplier(0);
     darkClusterConfigMap.put(DARK_CLUSTER2_KEY, darkCluster2);
-    ClusterProperties property = new ClusterProperties("test", new ArrayList<String>(), new HashMap<String, String>(), new HashSet<URI>(), NullPartitionProperties.getInstance(),
-        Arrays.asList("principal1", "principal2"), darkClusterConfigMap);
+    ClusterProperties property = new ClusterProperties("test", new ArrayList<>(), new HashMap<>(), new HashSet<>(),
+                                                       NullPartitionProperties.getInstance(),
+                                                       Arrays.asList("principal1", "principal2"),
+                                                       DarkClustersConverter.toProperties(darkClusterConfigMap), false);
     assertEquals(jsonSerializer.fromBytes(jsonSerializer.toBytes(property)), property);
   }
 
@@ -133,8 +136,10 @@ public class ClusterPropertiesSerializerTest
 
 
     DarkClusterConfigMap darkClusterConfigMap = new DarkClusterConfigMap();
-    ClusterProperties property = new ClusterProperties("test", new ArrayList<>(), new HashMap<>(), new HashSet<URI>(), NullPartitionProperties.getInstance(),
-        Arrays.asList("principal1", "principal2"), darkClusterConfigMap);
+    ClusterProperties property = new ClusterProperties("test", new ArrayList<>(), new HashMap<>(), new HashSet<>(),
+                                                       NullPartitionProperties.getInstance(),
+                                                       Arrays.asList("principal1", "principal2"),
+                                                       DarkClustersConverter.toProperties(darkClusterConfigMap), false);
     assertEquals(jsonSerializer.fromBytes(jsonSerializer.toBytes(property)), property);
   }
 
@@ -143,7 +148,8 @@ public class ClusterPropertiesSerializerTest
   {
     ClusterPropertiesJsonSerializer jsonSerializer = new ClusterPropertiesJsonSerializer();
     ClusterProperties property = new ClusterProperties("test", new ArrayList<>(), new HashMap<>(), new HashSet<URI>(), NullPartitionProperties.getInstance(),
-        Arrays.asList("principal1", "principal2"), null);
+                                                       Arrays.asList("principal1", "principal2"),
+                                                       (Map<String, Object>) null, false);
     assertEquals(jsonSerializer.fromBytes(jsonSerializer.toBytes(property)), property);
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerStateTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerStateTest.java
@@ -1252,7 +1252,8 @@ public class SimpleLoadBalancerStateTest
 
     final List<String> sslValidationList = Arrays.asList("validation1", "validation2");
     _clusterRegistry.put("cluster-1", new ClusterProperties("cluster-1", Collections.emptyList(),
-        Collections.emptyMap(), Collections.emptySet(), NullPartitionProperties.getInstance(), sslValidationList));
+        Collections.emptyMap(), Collections.emptySet(), NullPartitionProperties.getInstance(), sslValidationList,
+                                                            (Map<String, Object>)null, false));
     _serviceRegistry.put("service-1", new ServiceProperties("service-1", "cluster-1",
         "/test", Arrays.asList("random"), Collections.<String, Object>emptyMap(),
         transportClientProperties, null, schemes, null));

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -31,6 +31,7 @@ import com.linkedin.d2.balancer.ServiceUnavailableException;
 import com.linkedin.d2.balancer.clients.RewriteClient;
 import com.linkedin.d2.balancer.clients.RewriteLoadBalancerClient;
 import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.config.DarkClustersConverter;
 import com.linkedin.d2.balancer.properties.ClusterProperties;
 import com.linkedin.d2.balancer.properties.ClusterPropertiesJsonSerializer;
 import com.linkedin.d2.balancer.properties.HashBasedPartitionProperties;
@@ -265,7 +266,8 @@ public class SimpleLoadBalancerTest
     darkClusterConfigMap.put(DARK_CLUSTER1_NAME, darkClusterConfig);
 
     clusterRegistry.put(CLUSTER1_NAME, new ClusterProperties(CLUSTER1_NAME, Collections.emptyList(), Collections.emptyMap(),
-        Collections.emptySet(), NullPartitionProperties.getInstance(), Collections.emptyList(), darkClusterConfigMap));
+                                                             Collections.emptySet(), NullPartitionProperties.getInstance(), Collections.emptyList(),
+                                                             DarkClustersConverter.toProperties(darkClusterConfigMap), false));
 
     populateUriRegistry(numHttp, numHttps, partitionIdForAdd, uriRegistry);
 
@@ -288,7 +290,8 @@ public class SimpleLoadBalancerTest
     darkClusterConfigMap.put(DARK_CLUSTER1_NAME, darkClusterConfig);
 
     clusterRegistry.put(CLUSTER1_NAME, new ClusterProperties(CLUSTER1_NAME, Collections.emptyList(), Collections.emptyMap(),
-        Collections.emptySet(), NullPartitionProperties.getInstance(), Collections.emptyList(), darkClusterConfigMap));
+        Collections.emptySet(), NullPartitionProperties.getInstance(), Collections.emptyList(),
+                                                             DarkClustersConverter.toProperties(darkClusterConfigMap), false));
 
     DarkClusterConfigMap returnedDarkClusterConfigMap = loadBalancer.getDarkClusterConfigMap(CLUSTER1_NAME);
     Assert.assertEquals(returnedDarkClusterConfigMap, darkClusterConfigMap, "dark cluster configs should be equal");
@@ -328,7 +331,7 @@ public class SimpleLoadBalancerTest
     loadBalancer.listenToCluster(CLUSTER1_NAME, false, new LoadBalancerState.NullStateListenerCallback());
     clusterRegistry.put(CLUSTER1_NAME, new ClusterProperties(CLUSTER1_NAME, Collections.emptyList(), Collections.emptyMap(),
                                                              Collections.emptySet(), NullPartitionProperties.getInstance(), Collections.emptyList(),
-                                                             new DarkClusterConfigMap()));
+                                                             new HashMap<>(), false));
     Assert.assertEquals(testClusterListener.getClusterAddedCount(CLUSTER1_NAME), 1, "expected add count of 1");
     Assert.assertEquals(testClusterListener.getClusterRemovedCount(CLUSTER1_NAME), 0, "expected remove count of 0");
 
@@ -359,7 +362,7 @@ public class SimpleLoadBalancerTest
     loadBalancer.listenToCluster(CLUSTER1_NAME, false, new LoadBalancerState.NullStateListenerCallback());
     clusterRegistry.put(CLUSTER1_NAME, new ClusterProperties(CLUSTER1_NAME, Collections.emptyList(), Collections.emptyMap(),
                                                              Collections.emptySet(), NullPartitionProperties.getInstance(), Collections.emptyList(),
-                                                             new DarkClusterConfigMap()));
+                                                             new HashMap<>(), false));
     Assert.assertEquals(testClusterListener.getClusterAddedCount(CLUSTER1_NAME), 1, "expected add count of 1");
     Assert.assertEquals(testClusterListener.getClusterRemovedCount(CLUSTER1_NAME), 0, "expected remove count of 0");
 
@@ -367,7 +370,7 @@ public class SimpleLoadBalancerTest
     loadBalancer.unregisterClusterListener(testClusterListener);
     clusterRegistry.put(CLUSTER1_NAME, new ClusterProperties(CLUSTER1_NAME, Collections.emptyList(), Collections.emptyMap(),
                                                              Collections.emptySet(), NullPartitionProperties.getInstance(), Collections.emptyList(),
-                                                             new DarkClusterConfigMap()));
+                                                             new HashMap<>(), false));
     Assert.assertEquals(testClusterListener.getClusterAddedCount(CLUSTER1_NAME), 1, "expected unchanged add count of 1 because unregistered ");
     Assert.assertEquals(testClusterListener.getClusterRemovedCount(CLUSTER1_NAME), 0, "expected unchanged remove count of 0 because unregistered");
   }

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
@@ -117,28 +117,25 @@ public class DarkClusterStrategyFactoryImpl implements DarkClusterStrategyFactor
       MultiplierStrategyTypeArray strategyList = darkClusterConfig.getMultiplierStrategyList();
       for (com.linkedin.d2.multiplierStrategyType multiplierStrategyType : strategyList)
       {
-        if (RELATIVE_TRAFFIC.equals(multiplierStrategyType) && darkClusterConfig.getMultiplier() > 0)
+        switch(multiplierStrategyType)
         {
-          if (darkClusterConfig.getMultiplier() <= 0)
-          {
-            // it is a valid case to set RELATIVE_TRAFFIC but set the multiplier to zero to
-            // temporarily set the traffic to zero; don't log anything.
+          case RELATIVE_TRAFFIC:
+            if (darkClusterConfig.getMultiplier() <= 0)
+            {
+              // it is a valid case to set RELATIVE_TRAFFIC but set the multiplier to zero to
+              // temporarily set the traffic to zero; don't log anything.
+              return new NoOpDarkClusterStrategy();
+            }
+            BaseDarkClusterDispatcher baseDarkClusterDispatcher =
+              new BaseDarkClusterDispatcherImpl(darkClusterName, _darkClusterDispatcher, _notifier, _verifierManager);
+            return new RelativeTrafficMultiplierDarkClusterStrategy(_sourceClusterName, darkClusterName, darkClusterConfig.getMultiplier(),
+                                                                    baseDarkClusterDispatcher, _notifier, _facilities.getClusterInfoProvider(),
+                                                                    _random);
+          case CONSTANT_QPS:
+            // the constant qps strategy is not yet implemented, continue to the next strategy if it exists
+            break;
+          default:
             return new NoOpDarkClusterStrategy();
-          }
-          BaseDarkClusterDispatcher baseDarkClusterDispatcher =
-            new BaseDarkClusterDispatcherImpl(darkClusterName, _darkClusterDispatcher, _notifier, _verifierManager);
-          return new RelativeTrafficMultiplierDarkClusterStrategy(_sourceClusterName, darkClusterName, darkClusterConfig.getMultiplier(),
-                                                                  baseDarkClusterDispatcher, _notifier, _facilities.getClusterInfoProvider(),
-                                                                  _random);
-        }
-        else if (CONSTANT_QPS.equals(multiplierStrategyType))
-        {
-          // the constant qps strategy is not yet implemented, continue to the next strategy if it exists
-        }
-        else
-        {
-          // Falling into this clause means that the user does not want traffic to be sent to the dark cluster, temporary or otherwise.
-          return new NoOpDarkClusterStrategy();
         }
       }
     }

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
@@ -109,34 +109,31 @@ public class DarkClusterStrategyFactoryImpl implements DarkClusterStrategyFactor
    */
   private DarkClusterStrategy createStrategy(String darkClusterName, DarkClusterConfig darkClusterConfig)
   {
-    if (darkClusterConfig.hasMultiplierStrategyList())
+    if (darkClusterConfig.hasDarkClusterStrategyPrioritizedList())
     {
-      DarkClusterStrategyNameArray strategyList = darkClusterConfig.getMultiplierStrategyList();
-      for (com.linkedin.d2.DarkClusterStrategyName multiplierStrategyType : strategyList)
+      DarkClusterStrategyNameArray strategyList = darkClusterConfig.getDarkClusterStrategyPrioritizedList();
+      for (com.linkedin.d2.DarkClusterStrategyName darkClusterStrategyName : strategyList)
       {
-        switch(multiplierStrategyType)
+        switch(darkClusterStrategyName)
         {
           case RELATIVE_TRAFFIC:
-            if (darkClusterConfig.getMultiplier() <= 0)
+            if (RelativeTrafficMultiplierDarkClusterStrategy.isValidConfig(darkClusterConfig))
             {
-              // it is a valid case to set RELATIVE_TRAFFIC but set the multiplier to zero to
-              // temporarily set the traffic to zero; don't log anything.
-              return new NoOpDarkClusterStrategy();
+              BaseDarkClusterDispatcher baseDarkClusterDispatcher =
+                new BaseDarkClusterDispatcherImpl(darkClusterName, _darkClusterDispatcher, _notifier, _verifierManager);
+              return new RelativeTrafficMultiplierDarkClusterStrategy(_sourceClusterName, darkClusterName, darkClusterConfig.getMultiplier(),
+                                                                      baseDarkClusterDispatcher, _notifier, _facilities.getClusterInfoProvider(),
+                                                                      _random);
             }
-            BaseDarkClusterDispatcher baseDarkClusterDispatcher =
-              new BaseDarkClusterDispatcherImpl(darkClusterName, _darkClusterDispatcher, _notifier, _verifierManager);
-            return new RelativeTrafficMultiplierDarkClusterStrategy(_sourceClusterName, darkClusterName, darkClusterConfig.getMultiplier(),
-                                                                    baseDarkClusterDispatcher, _notifier, _facilities.getClusterInfoProvider(),
-                                                                    _random);
+            break;
           case CONSTANT_QPS:
             // the constant qps strategy is not yet implemented, continue to the next strategy if it exists
             break;
           default:
-            return new NoOpDarkClusterStrategy();
+            break;
         }
       }
     }
-    // Reaching here means that the user has not specified a strategy. return the NoOp Strategy.
     return new NoOpDarkClusterStrategy();
   }
 

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
@@ -133,8 +133,7 @@ public class DarkClusterStrategyFactoryImpl implements DarkClusterStrategyFactor
         }
         else if (CONSTANT_QPS.equals(multiplierStrategyType))
         {
-          // the constant qps strategy is not yet implemented, return the NoOpDarkClusterStrategy
-          return new NoOpDarkClusterStrategy();
+          // the constant qps strategy is not yet implemented, continue to the next strategy if it exists
         }
         else
         {

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 import com.linkedin.common.util.Notifier;
 import com.linkedin.d2.DarkClusterConfig;
 import com.linkedin.d2.DarkClusterConfigMap;
-import com.linkedin.d2.MultiplierStrategyTypeArray;
+import com.linkedin.d2.DarkClusterStrategyNameArray;
 import com.linkedin.d2.balancer.Facilities;
 import com.linkedin.d2.balancer.LoadBalancerClusterListener;
 import com.linkedin.d2.balancer.ServiceUnavailableException;
@@ -36,9 +36,6 @@ import com.linkedin.darkcluster.api.DarkClusterStrategy;
 import com.linkedin.darkcluster.api.DarkClusterStrategyFactory;
 import com.linkedin.darkcluster.api.DarkClusterVerifierManager;
 import com.linkedin.darkcluster.api.NoOpDarkClusterStrategy;
-
-import static com.linkedin.d2.multiplierStrategyType.CONSTANT_QPS;
-import static com.linkedin.d2.multiplierStrategyType.RELATIVE_TRAFFIC;
 
 /**
  * DarkClusterStrategyFactoryImpl creates and maintains the strategies needed for dark clusters. This involves refreshing
@@ -114,8 +111,8 @@ public class DarkClusterStrategyFactoryImpl implements DarkClusterStrategyFactor
   {
     if (darkClusterConfig.hasMultiplierStrategyList())
     {
-      MultiplierStrategyTypeArray strategyList = darkClusterConfig.getMultiplierStrategyList();
-      for (com.linkedin.d2.multiplierStrategyType multiplierStrategyType : strategyList)
+      DarkClusterStrategyNameArray strategyList = darkClusterConfig.getMultiplierStrategyList();
+      for (com.linkedin.d2.DarkClusterStrategyName multiplierStrategyType : strategyList)
       {
         switch(multiplierStrategyType)
         {

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/RelativeTrafficMultiplierDarkClusterStrategy.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/RelativeTrafficMultiplierDarkClusterStrategy.java
@@ -21,6 +21,7 @@ import java.util.Random;
 import javax.annotation.Nonnull;
 
 import com.linkedin.common.util.Notifier;
+import com.linkedin.d2.DarkClusterConfig;
 import com.linkedin.d2.balancer.ServiceUnavailableException;
 import com.linkedin.d2.balancer.util.ClusterInfoProvider;
 import com.linkedin.darkcluster.api.BaseDarkClusterDispatcher;
@@ -67,6 +68,11 @@ public class RelativeTrafficMultiplierDarkClusterStrategy implements DarkCluster
   {
     int numRequestDuplicates = getNumDuplicateRequests();
     return _baseDarkClusterDispatcher.sendRequest(originalRequest, darkRequest, requestContext, numRequestDuplicates);
+  }
+
+  public static boolean isValidConfig(DarkClusterConfig darkClusterConfig)
+  {
+    return darkClusterConfig.hasMultiplier() && darkClusterConfig.getMultiplier() > 0;
   }
 
   /**

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/RelativeTrafficMultiplierDarkClusterStrategy.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/RelativeTrafficMultiplierDarkClusterStrategy.java
@@ -70,6 +70,16 @@ public class RelativeTrafficMultiplierDarkClusterStrategy implements DarkCluster
     return _baseDarkClusterDispatcher.sendRequest(originalRequest, darkRequest, requestContext, numRequestDuplicates);
   }
 
+  /**
+   * We won't create this strategy if this config isn't valid for this strategy. For instance, we don't want to create
+   * the RelativeTrafficMultiplierDarkClusterStrategy if there's no multiplier or if the multiplier is zero, because we'd
+   * be doing pointless work on every getOrCreate. Instead if will go to the next strategy (or NoOpDarkClusterStrategy).
+   *
+   * This is a static method defined here because we don't want to instantiate a strategy to check this. It cannot be a
+   * method that is on the interface because static methods on an interface cannot be overridden by implementations.
+   * @param darkClusterConfig
+   * @return
+   */
   public static boolean isValidConfig(DarkClusterConfig darkClusterConfig)
   {
     return darkClusterConfig.hasMultiplier() && darkClusterConfig.getMultiplier() > 0;

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/DarkClusterTestUtil.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/DarkClusterTestUtil.java
@@ -17,8 +17,8 @@
 package com.linkedin.darkcluster;
 
 import com.linkedin.d2.DarkClusterConfig;
-import com.linkedin.d2.MultiplierStrategyTypeArray;
-import com.linkedin.d2.multiplierStrategyType;
+import com.linkedin.d2.DarkClusterStrategyName;
+import com.linkedin.d2.DarkClusterStrategyNameArray;
 import com.linkedin.darkcluster.api.DarkClusterStrategy;
 
 /**
@@ -32,10 +32,10 @@ public class DarkClusterTestUtil
    */
   public static DarkClusterConfig createRelativeTrafficMultiplierConfig(float multiplier)
   {
-    MultiplierStrategyTypeArray multiplierStrategyArray = new MultiplierStrategyTypeArray();
-    multiplierStrategyArray.add(multiplierStrategyType.RELATIVE_TRAFFIC);
+    DarkClusterStrategyNameArray darkClusterStrategyArray = new DarkClusterStrategyNameArray();
+    darkClusterStrategyArray.add(DarkClusterStrategyName.RELATIVE_TRAFFIC);
     return new DarkClusterConfig()
-      .setMultiplierStrategyList(multiplierStrategyArray)
+      .setMultiplierStrategyList(darkClusterStrategyArray)
       .setMultiplier(multiplier);
   }
 }

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/DarkClusterTestUtil.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/DarkClusterTestUtil.java
@@ -35,7 +35,7 @@ public class DarkClusterTestUtil
     DarkClusterStrategyNameArray darkClusterStrategyArray = new DarkClusterStrategyNameArray();
     darkClusterStrategyArray.add(DarkClusterStrategyName.RELATIVE_TRAFFIC);
     return new DarkClusterConfig()
-      .setMultiplierStrategyList(darkClusterStrategyArray)
+      .setDarkClusterStrategyPrioritizedList(darkClusterStrategyArray)
       .setMultiplier(multiplier);
   }
 }

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/DarkClusterTestUtil.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/DarkClusterTestUtil.java
@@ -17,6 +17,8 @@
 package com.linkedin.darkcluster;
 
 import com.linkedin.d2.DarkClusterConfig;
+import com.linkedin.d2.MultiplierStrategyTypeArray;
+import com.linkedin.d2.multiplierStrategyType;
 import com.linkedin.darkcluster.api.DarkClusterStrategy;
 
 /**
@@ -30,7 +32,10 @@ public class DarkClusterTestUtil
    */
   public static DarkClusterConfig createRelativeTrafficMultiplierConfig(float multiplier)
   {
+    MultiplierStrategyTypeArray multiplierStrategyArray = new MultiplierStrategyTypeArray();
+    multiplierStrategyArray.add(multiplierStrategyType.RELATIVE_TRAFFIC);
     return new DarkClusterConfig()
+      .setMultiplierStrategyList(multiplierStrategyArray)
       .setMultiplier(multiplier);
   }
 }

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
@@ -26,10 +26,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import com.linkedin.d2.DarkClusterConfig;
-import com.linkedin.d2.MultiplierStrategyTypeArray;
+import com.linkedin.d2.DarkClusterStrategyNameArray;
 import com.linkedin.d2.balancer.Facilities;
 import com.linkedin.d2.balancer.LoadBalancerClusterListener;
-import com.linkedin.d2.multiplierStrategyType;
 import com.linkedin.darkcluster.api.DarkClusterDispatcher;
 import com.linkedin.darkcluster.api.DarkClusterStrategy;
 import com.linkedin.darkcluster.api.DarkClusterStrategyFactory;
@@ -41,8 +40,8 @@ import com.linkedin.r2.message.RequestContext;
 import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestRequestBuilder;
 
-import static com.linkedin.d2.multiplierStrategyType.CONSTANT_QPS;
-import static com.linkedin.d2.multiplierStrategyType.RELATIVE_TRAFFIC;
+import static com.linkedin.d2.DarkClusterStrategyName.CONSTANT_QPS;
+import static com.linkedin.d2.DarkClusterStrategyName.RELATIVE_TRAFFIC;
 import static com.linkedin.darkcluster.DarkClusterTestUtil.createRelativeTrafficMultiplierConfig;
 import static org.testng.Assert.fail;
 import org.testng.Assert;
@@ -200,9 +199,9 @@ public class TestDarkClusterStrategyFactory
   public void testStrategyFallThru()
   {
     DarkClusterConfig darkClusterConfig1 = createRelativeTrafficMultiplierConfig(0.5f);
-    MultiplierStrategyTypeArray multiplierStrategyList = new MultiplierStrategyTypeArray();
-    multiplierStrategyList.addAll(Arrays.asList(CONSTANT_QPS, RELATIVE_TRAFFIC));
-    darkClusterConfig1.setMultiplierStrategyList(multiplierStrategyList);
+    DarkClusterStrategyNameArray darkClusterStrategyList = new DarkClusterStrategyNameArray();
+    darkClusterStrategyList.addAll(Arrays.asList(CONSTANT_QPS, RELATIVE_TRAFFIC));
+    darkClusterConfig1.setMultiplierStrategyList(darkClusterStrategyList);
 
     _clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, DARK_CLUSTER_NAME, darkClusterConfig1);
     DarkClusterStrategy strategy = _strategyFactory.getOrCreate(DARK_CLUSTER_NAME, darkClusterConfig1);
@@ -216,10 +215,10 @@ public class TestDarkClusterStrategyFactory
   public void testStrategyFallThruWithNoFallback()
   {
     DarkClusterConfig darkClusterConfig1 = createRelativeTrafficMultiplierConfig(0.5f);
-    MultiplierStrategyTypeArray multiplierStrategyList = new MultiplierStrategyTypeArray();
+    DarkClusterStrategyNameArray darkClusterStrategyList = new DarkClusterStrategyNameArray();
     // Only ConstantQPS strategy is present, with no alternative.
-    multiplierStrategyList.addAll(Collections.singletonList(CONSTANT_QPS));
-    darkClusterConfig1.setMultiplierStrategyList(multiplierStrategyList);
+    darkClusterStrategyList.addAll(Collections.singletonList(CONSTANT_QPS));
+    darkClusterConfig1.setMultiplierStrategyList(darkClusterStrategyList);
 
     _clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, DARK_CLUSTER_NAME, darkClusterConfig1);
     DarkClusterStrategy strategy = _strategyFactory.getOrCreate(DARK_CLUSTER_NAME, darkClusterConfig1);
@@ -232,9 +231,9 @@ public class TestDarkClusterStrategyFactory
   public void testStrategyZeroMultiplier()
   {
     DarkClusterConfig darkClusterConfig1 = createRelativeTrafficMultiplierConfig(0f);
-    MultiplierStrategyTypeArray multiplierStrategyList = new MultiplierStrategyTypeArray();
-    multiplierStrategyList.addAll(Collections.singletonList(RELATIVE_TRAFFIC));
-    darkClusterConfig1.setMultiplierStrategyList(multiplierStrategyList);
+    DarkClusterStrategyNameArray darkClusterStrategyList = new DarkClusterStrategyNameArray();
+    darkClusterStrategyList.addAll(Collections.singletonList(RELATIVE_TRAFFIC));
+    darkClusterConfig1.setMultiplierStrategyList(darkClusterStrategyList);
 
     _clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, DARK_CLUSTER_NAME, darkClusterConfig1);
     DarkClusterStrategy strategy = _strategyFactory.getOrCreate(DARK_CLUSTER_NAME, darkClusterConfig1);

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
@@ -201,7 +201,7 @@ public class TestDarkClusterStrategyFactory
     DarkClusterConfig darkClusterConfig1 = createRelativeTrafficMultiplierConfig(0.5f);
     DarkClusterStrategyNameArray darkClusterStrategyList = new DarkClusterStrategyNameArray();
     darkClusterStrategyList.addAll(Arrays.asList(CONSTANT_QPS, RELATIVE_TRAFFIC));
-    darkClusterConfig1.setMultiplierStrategyList(darkClusterStrategyList);
+    darkClusterConfig1.setDarkClusterStrategyPrioritizedList(darkClusterStrategyList);
 
     _clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, DARK_CLUSTER_NAME, darkClusterConfig1);
     DarkClusterStrategy strategy = _strategyFactory.getOrCreate(DARK_CLUSTER_NAME, darkClusterConfig1);
@@ -218,7 +218,7 @@ public class TestDarkClusterStrategyFactory
     DarkClusterStrategyNameArray darkClusterStrategyList = new DarkClusterStrategyNameArray();
     // Only ConstantQPS strategy is present, with no alternative.
     darkClusterStrategyList.addAll(Collections.singletonList(CONSTANT_QPS));
-    darkClusterConfig1.setMultiplierStrategyList(darkClusterStrategyList);
+    darkClusterConfig1.setDarkClusterStrategyPrioritizedList(darkClusterStrategyList);
 
     _clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, DARK_CLUSTER_NAME, darkClusterConfig1);
     DarkClusterStrategy strategy = _strategyFactory.getOrCreate(DARK_CLUSTER_NAME, darkClusterConfig1);
@@ -233,7 +233,7 @@ public class TestDarkClusterStrategyFactory
     DarkClusterConfig darkClusterConfig1 = createRelativeTrafficMultiplierConfig(0f);
     DarkClusterStrategyNameArray darkClusterStrategyList = new DarkClusterStrategyNameArray();
     darkClusterStrategyList.addAll(Collections.singletonList(RELATIVE_TRAFFIC));
-    darkClusterConfig1.setMultiplierStrategyList(darkClusterStrategyList);
+    darkClusterConfig1.setDarkClusterStrategyPrioritizedList(darkClusterStrategyList);
 
     _clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, DARK_CLUSTER_NAME, darkClusterConfig1);
     DarkClusterStrategy strategy = _strategyFactory.getOrCreate(DARK_CLUSTER_NAME, darkClusterConfig1);


### PR DESCRIPTION
Adding multiplierStrategyList and transportClientProperties for dark clusters.

multiplierStrategyList - this is a list instead of a single value to decoupling adding a new strategy from the rollout. Esp in large services or where a client side dispatching mechanism is chosen, this will allow the new strategy to be picked up as its available, instead of requiring all dark clients to be upgraded first before turning it on. This is a lesson learned from when DegraderLoadBalancerStrategyName was deprecated in favor of DegraderLoadBalancerStrategyList for the same reason.

There are two strategies: RELATIVE_TRAFFIC and CONSTANT_QPS. only RELATIVE_TRAFFIC is implemented so far. The Javadocs in the corresponding classes have more details on how those strategies work.

transportClientProperties - by specifying the transportClientProperties, and having them make their way into the dark service transportClientProperties, the d2 client will automatically use these properties.

Because transportClientProperties has it's own Converter and uses different keys for serialization than what the pegasus object (D2TransportClientProperties) uses, I had to make a change away from using the pegasus object (DarkClusterConfigMap) in both the in-mem and serialized-for-zookeeper representation. Map<String, Object> is the new serialized form, and the DarkClusterConfigMap can still be used in-mem. I tried to minimize the changes required by adding a method accessDarkClusters (which won't be used by Jackson) to do the conversion for users expecting a DarkClusterConfigMap. This also has the benefit of not exposing the underlying Map for threadsafety.

After approval, I will initiate schema review.