### PR TITLE
Fix Maven publication for extra artifacts again

### DIFF
--- a/build_script/bintrayRelease.gradle
+++ b/build_script/bintrayRelease.gradle
@@ -108,16 +108,18 @@ publishing {
     release(MavenPublication) {
       from components.java
 
-      // Add all extra archives (sources, javadoc, any custom archives e.g. all)
-      project.configurations.archives.allArtifacts.forEach {
-        if (it.classifier) {
-          artifact it
+      afterEvaluate {
+        // Add all extra archives (sources, javadoc, any custom archives e.g. all)
+        project.configurations.archives.allArtifacts.forEach {
+          if (it.classifier) {
+            artifact it
+          }
         }
-      }
-      // Add test artifacts for sub-projects that explicitly make them visible
-      if (project.configurations.testArtifacts.visible) {
-        project.configurations.testArtifacts.allArtifacts.forEach {
-          artifact it
+        // Add test artifacts for sub-projects that explicitly make them visible
+        if (project.configurations.testArtifacts.visible) {
+          project.configurations.testArtifacts.allArtifacts.forEach {
+            artifact it
+          }
         }
       }
 


### PR DESCRIPTION
Although the previous fix solved the issue for test artifacts, the fix
didn't actually add extra artifacts to the publication. This fix waits
until sub-projects are evaluated to add the extra artifacts, since this
is when they're defined.

Where "extra artifacts" are artifacts with non-standard classifiers (e.g. `-all` for "far JARs").

**Note:** The diff looks weird, but all I did was wrap the relevant logic in an `afterEvaluate` closure.