### PR TITLE
Fix the pathSpec generated for typeRef DataElement

### DIFF
--- a/data/src/main/java/com/linkedin/data/element/AbstractDataElement.java
+++ b/data/src/main/java/com/linkedin/data/element/AbstractDataElement.java
@@ -187,9 +187,7 @@ public abstract class AbstractDataElement implements DataElement
       }
       index--;
       DataSchema parentDataSchema = element.getParent().getSchema();
-      if (parentDataSchema != null && (parentDataSchema.getType() == DataSchema.Type.MAP ||
-                                       parentDataSchema.getDereferencedType() == DataSchema.Type.MAP ||
-                                       parentDataSchema.getType() == DataSchema.Type.ARRAY ||
+      if (parentDataSchema != null && (parentDataSchema.getDereferencedType() == DataSchema.Type.MAP ||
                                        parentDataSchema.getDereferencedType() == DataSchema.Type.ARRAY))
       {
         pathSpec[index] = PathSpec.WILDCARD;

--- a/data/src/main/java/com/linkedin/data/element/AbstractDataElement.java
+++ b/data/src/main/java/com/linkedin/data/element/AbstractDataElement.java
@@ -188,7 +188,9 @@ public abstract class AbstractDataElement implements DataElement
       index--;
       DataSchema parentDataSchema = element.getParent().getSchema();
       if (parentDataSchema != null && (parentDataSchema.getType() == DataSchema.Type.MAP ||
-                                       parentDataSchema.getType() == DataSchema.Type.ARRAY))
+                                       parentDataSchema.getDereferencedType() == DataSchema.Type.MAP ||
+                                       parentDataSchema.getType() == DataSchema.Type.ARRAY ||
+                                       parentDataSchema.getDereferencedType() == DataSchema.Type.ARRAY))
       {
         pathSpec[index] = PathSpec.WILDCARD;
       }


### PR DESCRIPTION
User can generate pathspec from dataelement, based on the element's schema.

For map type and array type, the pathspec is supposed to be a wildcard (asteriod sign), but for now if the element's schema is a typeref to a map, it is still using the element key (instead of a wildcard)

This change is to fix and add test to show the change.