### PR TITLE
Update avroUtil to com.linkedin.avroutil1:helper-all:0.1.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ project.ext.externalDependency = [
   'avro': 'org.apache.avro:avro:1.4.0',
   'avro_1_6': 'org.apache.avro:avro:1.6.3',
    // avro compatibility layer
-  'avroUtil': 'com.linkedin.avroutil1:helper-all:0.1.8',
+  'avroUtil': 'com.linkedin.avroutil1:helper-all:0.1.11',
   'caffeine': 'com.github.ben-manes.caffeine:caffeine:2.7.0',
   'cglib': 'cglib:cglib-nodep:2.2',
   'codemodel': 'com.sun.codemodel:codemodel:2.2',


### PR DESCRIPTION
Update avroUtil to com.linkedin.avroutil1:helper-all:0.1.11

There was an issue -"java.lang.NoSuchMethodError:setValidateDefaults(Z) exception on holdem & war" in avroUtil, it has been fixed in 0.1.11. To avoid customers encountering this issue, bump avroUtil version.