### PR TITLE
Enable tests in Travis, use retries for some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ dist: trusty
 install: true
 
 # Build commits to master, PRs to master, and release tags
-# TODO: enable testing once test flakiness is resolved
-script: ./gradlew build -x test
+script: ./scripts/travis/build.sh
 branches:
   only:
     - master

--- a/build.gradle
+++ b/build.gradle
@@ -290,6 +290,16 @@ subprojects {
     }
   }
 
+  // Exclude tests which are known to be flaky in the Travis CI environment
+  if (System.getenv('TRAVIS') == 'true' && System.getenv('USER') == 'travis') {
+    afterEvaluate {
+      project.tasks.withType(Test).forEach {
+        it.options.excludeGroups 'ci-flaky'
+        it.systemProperties['test.httpRequestTimeout'] = '20000'
+      }
+    }
+  }
+
   task asyncTests(type: Test) {
     useTestNG() {
       includeGroups 'async'
@@ -389,6 +399,14 @@ project.gradle.addListener(new TestListener() {
 
   @Override
   void afterTest(TestDescriptor testDescriptor, TestResult result) {
+    // Display test failure messages since these aren't shown by default
+    if (result.failures) {
+      logger.error "\nFailure message for ${testDescriptor.getClassName()} > ${testDescriptor.getDisplayName()}:"
+      result.failures.forEach {
+        logger.error "    ${it.getMessage()}"
+      }
+    }
+    // Accumulate info about skipped tests, display at the end of the build as a warning
     if (result.skippedTestCount > 0)
     {
       skippedTests[testDescriptor.className] << testDescriptor.name
@@ -399,10 +417,10 @@ project.gradle.addListener(new TestListener() {
 project.gradle.buildFinished { BuildResult result ->
   if (skippedTests.size() > 0)
   {
-    final StringBuilder msgBuilder = new StringBuilder("\nThe following tests should be executed but actually skipped. Please fix and try again.");
+    final StringBuilder msgBuilder = new StringBuilder("\nThe following tests were skipped or failed and had to retry.");
     skippedTests.each { className, methods ->
-      msgBuilder.append("\nClass: ${className} , Methods: ${methods}")
+      msgBuilder.append("\n    ${className} > ${methods}")
     }
-    throw new GradleException(msgBuilder.toString())
+    logger.warn msgBuilder.toString()
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/servers/ZookeeperConnectionManagerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/servers/ZookeeperConnectionManagerTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.d2.balancer.servers;
 
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
@@ -352,7 +353,7 @@ public class ZookeeperConnectionManagerTest
     shutdownManager(manager);
   }
 
-  @Test(invocationCount = 10, timeOut = 10000)
+  @Test(invocationCount = 10, timeOut = 10000, retryAnalyzer = ThreeRetries.class)
   public void testMarkUpDuringSessionExpirationManyCallbacks()
     throws Exception
   {
@@ -437,7 +438,7 @@ public class ZookeeperConnectionManagerTest
     executorService.shutdown();
   }
 
-  @Test(invocationCount = 10, timeOut = 10000)
+  @Test(invocationCount = 10, timeOut = 10000, retryAnalyzer = ThreeRetries.class)
   public void testMarkUpAndDownMultipleTimesFinalUp()
     throws Exception
   {

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -23,7 +23,6 @@ import com.linkedin.common.util.None;
 import com.linkedin.d2.DarkClusterConfig;
 import com.linkedin.d2.DarkClusterConfigMap;
 import com.linkedin.d2.balancer.KeyMapper;
-import com.linkedin.d2.balancer.LoadBalancerClusterListener;
 import com.linkedin.d2.balancer.LoadBalancerState;
 import com.linkedin.d2.balancer.LoadBalancerTestState;
 import com.linkedin.d2.balancer.PartitionedLoadBalancerTestState;
@@ -78,6 +77,7 @@ import com.linkedin.r2.transport.common.TransportClientFactory;
 import com.linkedin.r2.transport.common.bridge.client.TransportClient;
 import com.linkedin.r2.transport.common.bridge.common.TransportCallback;
 import com.linkedin.r2.util.NamedThreadFactory;
+import com.linkedin.test.util.retry.ThreeRetries;
 import com.linkedin.util.degrader.DegraderImpl;
 import java.io.File;
 import java.io.IOException;
@@ -1343,7 +1343,7 @@ public class SimpleLoadBalancerTest
     simulator.reset();
   }
 
-  @Test(groups = { "medium", "back-end" })
+  @Test(groups = { "medium", "back-end" }, retryAnalyzer = ThreeRetries.class)
   public void testLoadBalancerSimulationDegrader() throws URISyntaxException,
       IOException,
       ServiceUnavailableException,
@@ -1384,7 +1384,7 @@ public class SimpleLoadBalancerTest
     simulator.reset();
   }
 
-  @Test(groups = { "medium", "back-end" })
+  @Test(groups = { "medium", "back-end", "ci-flaky" })
   public void testLoadBalancerSimulationDegraderWithFileStore() throws URISyntaxException,
       IOException,
       ServiceUnavailableException,

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/degrader/DegraderLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/degrader/DegraderLoadBalancerTest.java
@@ -42,11 +42,11 @@ import com.linkedin.r2.message.stream.StreamRequest;
 import com.linkedin.r2.message.stream.StreamResponse;
 import com.linkedin.r2.transport.common.bridge.client.TransportClient;
 import com.linkedin.r2.transport.common.bridge.common.TransportCallback;
+import com.linkedin.test.util.retry.SingleRetry;
 import com.linkedin.util.clock.Clock;
 import com.linkedin.util.clock.SettableClock;
 import com.linkedin.util.clock.SystemClock;
 import com.linkedin.util.degrader.CallCompletion;
-import com.linkedin.util.degrader.CallTracker;
 import com.linkedin.util.degrader.DegraderControl;
 import com.linkedin.util.degrader.DegraderImpl;
 import com.linkedin.util.degrader.ErrorType;
@@ -517,7 +517,7 @@ public class DegraderLoadBalancerTest
     return map;
   }
 
-  @Test(groups = { "small", "back-end" })
+  @Test(groups = { "small", "back-end" }, retryAnalyzer = SingleRetry.class)
   public void testDegraderLoadBalancerHandlingExceptionInUpdate()
   {
     Map<String, Object> myMap = lbDefaultConfig();

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
@@ -99,7 +99,7 @@ public class WarmUpLoadBalancerTest
     Assert.assertEquals(VALID_FILES.size(), requestCount.get());
   }
 
-  @Test(timeOut = 10000)
+  @Test(timeOut = 10000, groups = { "ci-flaky" })
   public void testDeletingFilesAfterShutdown() throws InterruptedException, ExecutionException, TimeoutException
   {
     createDefaultServicesIniFiles();

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreWithFiltersTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreWithFiltersTest.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.discovery.stores.zk;
 
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -55,7 +56,7 @@ public class ZooKeeperEphemeralStoreWithFiltersTest
   private int _port;
   private ExecutorService _executor = Executors.newSingleThreadExecutor();
 
-  @Test(dataProvider = "dataD2ClusterWithNumberOfChildren")
+  @Test(dataProvider = "dataD2ClusterWithNumberOfChildren", groups = { "ci-flaky" })
   public void testPutWithoutPrefixAndFilter(String d2ClusterName, int numberOfChildren)
     throws IOException, InterruptedException, ExecutionException, PropertyStoreException
   {
@@ -85,7 +86,7 @@ public class ZooKeeperEphemeralStoreWithFiltersTest
     tearDown(store);
   }
 
-  @Test(dataProvider = "dataD2ClusterWithNumberOfChildrenAndHashCode")
+  @Test(dataProvider = "dataD2ClusterWithNumberOfChildrenAndHashCode", retryAnalyzer = ThreeRetries.class)
   public void testPutAndGetWithPrefixAndFilter(String d2ClusterName, List<String> childrenNames, int expectedPrefixDuplicates,
                                                List<ZookeeperEphemeralPrefixGenerator> prefixGenerators)
     throws IOException, InterruptedException, ExecutionException, PropertyStoreException

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterVerifierManager.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterVerifierManager.java
@@ -143,7 +143,7 @@ public class TestDarkClusterVerifierManager
     final CountDownLatch latch = new CountDownLatch(1);
     Runnable myCallable = latch::countDown;
     _executorService.submit(myCallable);
-    if (!latch.await(30, TimeUnit.SECONDS))
+    if (!latch.await(60, TimeUnit.SECONDS))
     {
       fail("unable to execute task on executor");
     }

--- a/multipart-mime/src/test/java/com/linkedin/multipart/TestMIMEReader.java
+++ b/multipart-mime/src/test/java/com/linkedin/multipart/TestMIMEReader.java
@@ -22,6 +22,7 @@ import com.linkedin.multipart.exceptions.SinglePartFinishedException;
 import com.linkedin.multipart.exceptions.MultiPartReaderFinishedException;
 import com.linkedin.r2.filter.R2Constants;
 
+import com.linkedin.test.util.retry.SingleRetry;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -90,7 +91,7 @@ public class TestMIMEReader extends AbstractMIMEUnitTest
     executeRequestAndAssert(trimTrailingCRLF(requestPayload), chunkSize, multiPartMimeBody);
   }
 
-  @Test(dataProvider = "eachSingleBodyDataSource")
+  @Test(dataProvider = "eachSingleBodyDataSource", retryAnalyzer = SingleRetry.class)
   public void testEachSingleBodyDataSourceMultipleTimes(final int chunkSize, final MimeBodyPart bodyPart)
       throws Exception
   {

--- a/r2-core/src/test/java/test/r2/transport/http/client/TestAsyncPool.java
+++ b/r2-core/src/test/java/test/r2/transport/http/client/TestAsyncPool.java
@@ -33,6 +33,7 @@ import com.linkedin.r2.transport.http.client.PoolStats;
 import com.linkedin.r2.util.Cancellable;
 import com.linkedin.test.util.AssertionMethods;
 import com.linkedin.test.util.ClockedExecutor;
+import com.linkedin.test.util.retry.SingleRetry;
 import com.linkedin.util.clock.SettableClock;
 import com.linkedin.util.clock.Time;
 import java.util.LinkedList;
@@ -334,7 +335,7 @@ public class TestAsyncPool
     }
   }
 
-  @Test
+  @Test(retryAnalyzer = SingleRetry.class)
   public void testGetStats() throws Exception
   {
     final int POOL_SIZE = 25;

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamEcho.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamEcho.java
@@ -20,6 +20,7 @@ import com.linkedin.r2.transport.common.StreamRequestHandlerAdapter;
 import com.linkedin.r2.transport.common.bridge.server.TransportDispatcher;
 import com.linkedin.r2.transport.common.bridge.server.TransportDispatcherBuilder;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Collections;
@@ -130,7 +131,7 @@ public class TestStreamEcho extends AbstractServiceTest
     Assert.assertTrue(reader.allBytesCorrect());
   }
 
-  @Test
+  @Test(groups = { "ci-flaky" })
   public void testBackPressureEcho() throws Exception
   {
     TimedBytesWriter writer = new TimedBytesWriter(SMALL_BYTES_NUM, BYTE);

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamResponse.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamResponse.java
@@ -20,6 +20,7 @@ import com.linkedin.r2.transport.common.StreamRequestHandler;
 import com.linkedin.r2.transport.common.bridge.server.TransportDispatcher;
 import com.linkedin.r2.transport.common.bridge.server.TransportDispatcherBuilder;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -148,7 +149,7 @@ public class TestStreamResponse extends AbstractServiceTest
     factoryShutdownCallback.get();
   }
 
-  @Test
+  @Test(retryAnalyzer = ThreeRetries.class)
   public void testBackpressure() throws Exception
   {
     StreamRequestBuilder builder = new StreamRequestBuilder(_clientProvider.createHttpURI(_port, SMALL_URI));

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestChannelPoolManagerFactorySharingConnection.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestChannelPoolManagerFactorySharingConnection.java
@@ -100,7 +100,7 @@ public class TestChannelPoolManagerFactorySharingConnection
    * End to end test. Testing all the client combinations (http/https stream/rest sharing/not sharing) and check they
    * are NOT using the same channelPoolManager
    */
-  @Test(dataProvider = "configsOpenedConnections")
+  @Test(dataProvider = "configsOpenedConnections", groups = { "ci-flaky" })
   public void testSuccessfulRequestds(boolean restOverStream, String protocolVersion, boolean shareConnection) throws Exception
   {
     makeRequestsWithClients(shareConnection, (clients, clientFactory) ->

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyClient.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyClient.java
@@ -35,6 +35,7 @@ import com.linkedin.r2.transport.common.bridge.common.TransportCallback;
 import com.linkedin.r2.transport.http.client.common.ChannelPoolFactory;
 import com.linkedin.r2.transport.http.client.rest.HttpNettyClient;
 import com.linkedin.r2.transport.http.common.HttpProtocolVersion;
+import com.linkedin.test.util.retry.SingleRetry;
 import com.linkedin.util.clock.SettableClock;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
@@ -428,7 +429,7 @@ public class TestHttpNettyClient
     }
   }
 
-  @Test
+  @Test(retryAnalyzer = SingleRetry.class)
   public void testShutdownRequestOutstanding()
       throws IOException, ExecutionException, TimeoutException, InterruptedException
   {

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/stream/http2/TestHttp2NettyStreamClient.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/stream/http2/TestHttp2NettyStreamClient.java
@@ -34,6 +34,7 @@ import com.linkedin.r2.transport.common.bridge.common.TransportResponse;
 import com.linkedin.r2.transport.http.client.HttpClientBuilder;
 import com.linkedin.r2.testutils.server.HttpServerBuilder;
 import com.linkedin.test.util.ExceptionTestUtil;
+import com.linkedin.test.util.retry.SingleRetry;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -175,7 +176,7 @@ public class TestHttp2NettyStreamClient
    * When a request fails due to {@link TimeoutException}, connection should not be destroyed.
    * @throws Exception
    */
-  @Test(timeOut = TEST_TIMEOUT)
+  @Test(timeOut = TEST_TIMEOUT, retryAnalyzer = SingleRetry.class)
   public void testChannelReusedAfterStreamingTimeout() throws Exception
   {
     final HttpServerBuilder.HttpServerStatsProvider statsProvider = new HttpServerBuilder.HttpServerStatsProvider();

--- a/restli-int-test/build.gradle
+++ b/restli-int-test/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   testCompile project(path: ':restli-int-test-api', configuration: 'restClient')
   testCompile project(path: project.path, configuration: 'testRestClient')
   testCompile project(path: ':d2', configuration: 'testArtifacts')
+  testCompile project(':test-util')
 }
 
 test {

--- a/restli-int-test/src/test/java/com/linkedin/restli/client/TestResponseDecoder.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/client/TestResponseDecoder.java
@@ -25,6 +25,7 @@ import com.linkedin.restli.examples.TestConstants;
 import com.linkedin.restli.examples.greetings.api.Message;
 import com.linkedin.restli.examples.greetings.client.StringKeysRequestBuilders;
 
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -67,7 +68,7 @@ public class TestResponseDecoder extends RestLiIntegrationTest
    * pass the 'new' error to its inner callback's onError method.
    * {@link CallbackAdapter#onError(java.lang.Throwable)}
    */
-  @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "dataProvider")
+  @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "dataProvider", retryAnalyzer = ThreeRetries.class)
   public void testNonRestliServerErrorHandling(RestliRequestOptions requestOptions) throws Exception
   {
     Set<String> keys = new HashSet<String>();

--- a/restli-int-test/src/test/java/com/linkedin/restli/client/TestRestLiD2Integration.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/client/TestRestLiD2Integration.java
@@ -41,6 +41,7 @@ import com.linkedin.restli.examples.groups.client.GroupsBuilders;
 import com.linkedin.restli.internal.common.AllProtocolVersions;
 import com.linkedin.restli.test.util.RootBuilderWrapper;
 
+import com.linkedin.test.util.retry.SingleRetry;
 import java.util.concurrent.CountDownLatch;
 
 import org.testng.Assert;
@@ -97,7 +98,7 @@ public class TestRestLiD2Integration extends RestLiIntegrationTest
     latch.await();
   }
 
-  @Test(dataProvider = "requestGreetingBuilderDataProvider")
+  @Test(dataProvider = "requestGreetingBuilderDataProvider", retryAnalyzer = SingleRetry.class) // Allow retry due to CI timeouts
   public void testSuccessfulCall(RootBuilderWrapper<Long, Greeting> builders) throws RemoteInvocationException
   {
     Request<Greeting> request = builders.get().id(1L).build();

--- a/restli-int-test/src/test/java/com/linkedin/restli/client/multiplexer/TestMultiplexerDelays.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/client/multiplexer/TestMultiplexerDelays.java
@@ -25,6 +25,7 @@ import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.examples.RestLiIntegrationTest;
 import com.linkedin.restli.examples.greetings.client.ActionsBuilders;
 
+import com.linkedin.test.util.retry.SingleRetry;
 import java.util.concurrent.ExecutionException;
 
 import org.testng.Assert;
@@ -58,7 +59,7 @@ public class TestMultiplexerDelays extends RestLiIntegrationTest
     super.shutdown();
   }
 
-  @Test
+  @Test(retryAnalyzer = SingleRetry.class) // Often fails the first invocation; needs warmup
   public void parallelTasksCreationDelay() throws Exception
   {
     MultiplexedRequestBuilder muxRequestBuilder = MultiplexedRequestBuilder.createParallelRequest();
@@ -73,7 +74,7 @@ public class TestMultiplexerDelays extends RestLiIntegrationTest
     assertInRange(actualTime, expectedTime, TOLERANCE);
   }
 
-  @Test
+  @Test(retryAnalyzer = SingleRetry.class) // Often fails the first invocation; needs warmup
   public void parallelTasksExecutionDelay() throws Exception
   {
     MultiplexedRequestBuilder muxRequestBuilder = MultiplexedRequestBuilder.createParallelRequest();

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/RestLiIntegrationTest.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/RestLiIntegrationTest.java
@@ -138,7 +138,8 @@ public class RestLiIntegrationTest
   {
     _clientFactory = new HttpClientFactory.Builder().setUsePipelineV2(false).build();
     _transportClients = new ArrayList<Client>();
-    Map<String, String> transportProperties = Collections.singletonMap(HttpClientFactory.HTTP_REQUEST_TIMEOUT, "10000");
+    final String httpRequestTimeout = System.getProperty("test.httpRequestTimeout", "10000");
+    Map<String, String> transportProperties = Collections.singletonMap(HttpClientFactory.HTTP_REQUEST_TIMEOUT, httpRequestTimeout);
     Client client = newTransportClient(transportProperties);
     RestLiClientConfig restLiClientConfig = new RestLiClientConfig();
     restLiClientConfig.setUseStreaming(Boolean.parseBoolean(System.getProperty("test.useStreamCodecClient", "false")));

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRequestCompression.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRequestCompression.java
@@ -50,6 +50,7 @@ import com.linkedin.restli.examples.greetings.client.GreetingsRequestBuilders;
 import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.test.util.RootBuilderWrapper;
 
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -215,7 +216,7 @@ public class TestRequestCompression extends RestLiIntegrationTest
     };
   }
 
-  @Test(dataProvider = "requestData")
+  @Test(dataProvider = "requestData", retryAnalyzer = ThreeRetries.class)
   public void testUpdate(CompressionConfig requestCompressionConfig,
                          String supportedEncodings,
                          RestliRequestOptions restliRequestOptions,

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestResponseCompression.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestResponseCompression.java
@@ -45,6 +45,7 @@ import com.linkedin.restli.examples.greetings.client.GreetingsBuilders;
 import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.server.filter.Filter;
 import com.linkedin.restli.server.filter.FilterRequestContext;
+import com.linkedin.test.util.retry.SingleRetry;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -188,7 +189,7 @@ public class TestResponseCompression extends RestLiIntegrationTest
     };
   }
 
-  @Test(dataProvider = "requestData")
+  @Test(dataProvider = "requestData", retryAnalyzer = SingleRetry.class) // Often fails in CI without a retry
   public void testResponseCompression(Boolean useResponseCompression, CompressionConfig responseCompressionConfig,
                                       RestliRequestOptions restliRequestOptions, int idCount, String expectedAcceptEncoding,
                                       String expectedCompressionThreshold, boolean responseShouldBeCompressed)
@@ -259,7 +260,7 @@ public class TestResponseCompression extends RestLiIntegrationTest
         };
   }
 
-  @Test(dataProvider = "encodingsData")
+  @Test(dataProvider = "encodingsData", retryAnalyzer = SingleRetry.class) // Often fails in CI without a retry
   public void testAcceptEncodingConfiguration(String responseContentEncodings, String expectedAcceptEncoding, String expectedContentEncoding) throws RemoteInvocationException
   {
     Map<String, Object> properties = new HashMap<String, Object>();

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Ensure that this is being run by Travis
+if [ "$TRAVIS" != "true" ] || [ "$USER" != "travis" ]; then
+  echo "This script should only be run by Travis CI."
+  exit 2
+fi
+
+# Output something every 9 minutes, otherwise Travis will abort after 10 minutes of no output
+while sleep 9m; do echo "[Ping] Keeping Travis job alive ($((SECONDS / 60)) minutes)"; done &
+WAITER_PID=$!
+
+# Skip tests if building a tag to prevent flaky releases
+if [ ! -z "$TRAVIS_TAG" ]; then
+  EXTRA_ARGS='-x test'
+else
+  EXTRA_ARGS=''
+fi
+
+# Run the actual build
+./gradlew build $EXTRA_ARGS
+EXIT_CODE=$?
+
+# Kill the waiter job
+kill $WAITER_PID
+
+if [ $EXIT_CODE != 0 ]; then
+  exit 1
+fi

--- a/test-util/src/main/java/com/linkedin/test/util/retry/Retries.java
+++ b/test-util/src/main/java/com/linkedin/test/util/retry/Retries.java
@@ -1,0 +1,47 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.test.util.retry;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+
+/**
+ * Allows N retries for a given test method. Subclass implementations must specify the value of N.
+ *
+ * Note that the same instance is used for all iterations of a test method, meaning that even if there are multiple
+ * iterations (e.g. data provider provides multiple sets of input) only N retries will be allowed.
+ *
+ * @author Evan Williams
+ */
+public abstract class Retries implements IRetryAnalyzer
+{
+  private final int _allowedRetries;
+  private int _numRetries;
+
+  protected Retries(int allowedRetries)
+  {
+    _allowedRetries = allowedRetries;
+    _numRetries = 0;
+  }
+
+  @Override
+  public boolean retry(ITestResult result)
+  {
+    return _numRetries++ < _allowedRetries;
+  }
+}

--- a/test-util/src/main/java/com/linkedin/test/util/retry/SingleRetry.java
+++ b/test-util/src/main/java/com/linkedin/test/util/retry/SingleRetry.java
@@ -1,0 +1,31 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.test.util.retry;
+
+
+/**
+ * Allows a single retry for a given test method. This is useful for tests that require a warmup or are flaky.
+ *
+ * @author Evan Williams
+ */
+public class SingleRetry extends Retries
+{
+  public SingleRetry()
+  {
+    super(1);
+  }
+}

--- a/test-util/src/main/java/com/linkedin/test/util/retry/ThreeRetries.java
+++ b/test-util/src/main/java/com/linkedin/test/util/retry/ThreeRetries.java
@@ -1,0 +1,31 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.test.util.retry;
+
+
+/**
+ * Allows three retries for a given test method. This is useful for tests that are especially flaky.
+ *
+ * @author Evan Williams
+ */
+public class ThreeRetries extends Retries
+{
+  public ThreeRetries()
+  {
+    super(3);
+  }
+}


### PR DESCRIPTION
Enabling tests in the Travis CI build to give us higher confidence in proposed changes. Addresses tests with CI flakiness:

- Tests that are flaky in Travis are added to the group `ci-flaky`, which is excluded only in the CI environment (i.e. they'll still run locally).
- Some flaky tests were given one retry using the `SingleRetry` class, though they should still be investigated (note that some tests might need a retry even when run locally).
- I've created two internal tracking tickets to track addressing the flaky tests: one for R2/D2-related tests, and one for everything else.

**Other changes:**
- Added a new script `scripts/travis/build.sh` which is run for each tag, master, and each PR. However, the tests are skipped when building on a tag to avoid flaky releases.
- Added extra logging for test failures to show the actual assertion message.
- Added an override in `RestLiIntegrationTest` for the client timeout to be increased from `10000` to `20000` when being run in the CI environment.