### PR TITLE
Fixed length encoding support for floats and doubles in protobuf

### DIFF
--- a/data/src/main/java/com/linkedin/data/ByteString.java
+++ b/data/src/main/java/com/linkedin/data/ByteString.java
@@ -1551,6 +1551,52 @@ public final class ByteString
     }
 
     @Override
+    public int readFixedInt32() throws IOException
+    {
+      if (getCurrentRemaining() < ProtoWriter.FIXED32_SIZE)
+      {
+        return (((readRawByte() & 0xff))
+            | ((readRawByte() & 0xff) << 8)
+            | ((readRawByte() & 0xff) << 16)
+            | ((readRawByte() & 0xff) << 24));
+      }
+
+      final byte[] buffer = _currentSegment.getArray();
+
+      return (((buffer[_currentArrayOffset++] & 0xff))
+          | ((buffer[_currentArrayOffset++] & 0xff) << 8)
+          | ((buffer[_currentArrayOffset++] & 0xff) << 16)
+          | ((buffer[_currentArrayOffset++] & 0xff) << 24));
+    }
+
+    @Override
+    public long readFixedInt64() throws IOException
+    {
+      if (getCurrentRemaining() < ProtoWriter.FIXED64_SIZE)
+      {
+        return (((readRawByte() & 0xffL))
+            | ((readRawByte() & 0xffL) << 8)
+            | ((readRawByte() & 0xffL) << 16)
+            | ((readRawByte() & 0xffL) << 24)
+            | ((readRawByte() & 0xffL) << 32)
+            | ((readRawByte() & 0xffL) << 40)
+            | ((readRawByte() & 0xffL) << 48)
+            | ((readRawByte() & 0xffL) << 56));
+      }
+
+      final byte[] buffer = _currentSegment.getArray();
+
+      return (((buffer[_currentArrayOffset++] & 0xffL))
+          | ((buffer[_currentArrayOffset++] & 0xffL) << 8)
+          | ((buffer[_currentArrayOffset++] & 0xffL) << 16)
+          | ((buffer[_currentArrayOffset++] & 0xffL) << 24)
+          | ((buffer[_currentArrayOffset++] & 0xffL) << 32)
+          | ((buffer[_currentArrayOffset++] & 0xffL) << 40)
+          | ((buffer[_currentArrayOffset++] & 0xffL) << 48)
+          | ((buffer[_currentArrayOffset++] & 0xffL) << 56));
+    }
+
+    @Override
     public byte readRawByte() throws IOException
     {
       if (getCurrentRemaining() == 0)

--- a/data/src/main/java/com/linkedin/data/codec/ProtobufCodecOptions.java
+++ b/data/src/main/java/com/linkedin/data/codec/ProtobufCodecOptions.java
@@ -1,0 +1,178 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.data.codec;
+
+import com.linkedin.data.codec.symbol.EmptySymbolTable;
+import com.linkedin.data.codec.symbol.SymbolTable;
+
+
+/**
+ * Encapsulates options to configure the behavior of {@link ProtobufDataCodec}
+ *
+ * @author kramgopa
+ */
+public class ProtobufCodecOptions
+{
+  /**
+   * The symbol table to use for serialization and deserialization.
+   *
+   * <p>Set to {@link EmptySymbolTable#SHARED}, if unspecified.</p>
+   */
+  private final SymbolTable _symbolTable;
+
+  /**
+   * If true, then ASCII only strings are detected and encoded using a different ordinal. This serves as an
+   * indication to decoders to use an optimized code path for decoding such strings without having to account
+   * for multi-byte characters.
+   *
+   * <p>Disabled by default.</p>
+   */
+  private final boolean _enableASCIIOnlyStrings;
+
+  /**
+   * If true, then fixed length encoding is used for float and double values. If false, then variable length encoding
+   * is used. In order to maintain wire protocol semantics, different marker ordinals are used for floats and doubles
+   * depending on whether this is enabled or not.
+   *
+   * <p>This should be enabled ONLY when the payload comprises of a large number of high precision floating point
+   * numbers. In all other cases variable length encoding will result in a more compact payload with better
+   * performance.</p>
+   *
+   * <p>Disabled by default.</p>
+   */
+  private final boolean _enableFixedLengthFloatDoubles;
+
+  private ProtobufCodecOptions(SymbolTable symbolTable,
+                               boolean enableASCIIOnlyStrings,
+                               boolean enableFixedLengthFloatDoubles)
+  {
+    _symbolTable = symbolTable == null ? EmptySymbolTable.SHARED : symbolTable;
+    _enableASCIIOnlyStrings = enableASCIIOnlyStrings;
+    _enableFixedLengthFloatDoubles = enableFixedLengthFloatDoubles;
+  }
+
+  /**
+   * @return The symbol table to use for serialization and deserialization.
+   */
+  public SymbolTable getSymbolTable()
+  {
+    return _symbolTable;
+  }
+
+  /**
+   * @return If ASCII only strings should be detected and encoded using a different ordinal.
+   */
+  public boolean shouldEnableASCIIOnlyStrings()
+  {
+    return _enableASCIIOnlyStrings;
+  }
+
+  /**
+   * @return True if floats and doubles shoukd be encoded as fixed length integers, false if they should be
+   * encoded as variable length integers.
+   */
+  public boolean shouldEnableFixedLengthFloatDoubles()
+  {
+    return _enableFixedLengthFloatDoubles;
+  }
+
+  /**
+   * Builder to incrementally build options.
+   */
+  public static final class Builder
+  {
+
+    /**
+     * The symbol table to use for serialization and deserialization.
+     *
+     * <p>Default value is null.</p>
+     */
+    private SymbolTable _symbolTable;
+
+    /**
+     * If true, then ASCII only strings are detected and encoded using a different ordinal. This serves as an
+     * indication to decoders to use an optimized code path for decoding such strings without having to account
+     * for multi-byte characters.
+     *
+     * <p>Disabled by default.</p>
+     */
+    private boolean _enableASCIIOnlyStrings;
+
+    /**
+     * If true, then fixed length encoding is used for float and double values. If false, then variable length encoding
+     * is used. In order to maintain wire protocol semantics, different marker ordinals are used for floats and doubles
+     * depending on whether this is enabled or not.
+     *
+     * <p>This should be enabled ONLY when the payload comprises of a large number of high precision floating point
+     * numbers. In all other cases variable length encoding will result in a more compact payload with better
+     * performance.</p>
+     *
+     * <p>Disabled by default.</p>
+     */
+    private boolean _enableFixedLengthFloatDoubles;
+
+    public Builder()
+    {
+      _symbolTable = null;
+      _enableASCIIOnlyStrings = false;
+      _enableFixedLengthFloatDoubles = false;
+    }
+
+    /**
+     * Sets the symbol table to use for serialization and deserialization.
+     */
+    public Builder setSymbolTable(SymbolTable symbolTable)
+    {
+      this._symbolTable = symbolTable;
+      return this;
+    }
+
+    /**
+     * If set to true, then ASCII only strings are detected and encoded using a different ordinal. This serves as an
+     * indication to decoders to use an optimized code path for decoding such strings without having to account
+     * for multi-byte characters.
+     */
+    public Builder setEnableASCIIOnlyStrings(boolean enableASCIIOnlyStrings)
+    {
+      this._enableASCIIOnlyStrings = enableASCIIOnlyStrings;
+      return this;
+    }
+
+    /**
+     * If set to true, then fixed length encoding is used for float and double values. If false, then variable length encoding
+     * is used. In order to maintain wire protocol semantics, different marker ordinals are used for floats and doubles
+     * depending on whether this is enabled or not.
+     *
+     * <p>This should be enabled ONLY when the payload comprises of a large number of high precision floating point
+     * numbers. In all other cases variable length encoding will result in a more compact payload with better
+     * performance.</p>
+     */
+    public Builder setEnableFixedLengthFloatDoubles(boolean enableFixedLengthFloatDoubles)
+    {
+      this._enableFixedLengthFloatDoubles = enableFixedLengthFloatDoubles;
+      return this;
+    }
+
+    /**
+     * Build an options instance.
+     */
+    public ProtobufCodecOptions build()
+    {
+      return new ProtobufCodecOptions(_symbolTable, _enableASCIIOnlyStrings, _enableFixedLengthFloatDoubles);
+    }
+  }
+}

--- a/data/src/test/java/com/linkedin/data/codec/CodecDataProviders.java
+++ b/data/src/test/java/com/linkedin/data/codec/CodecDataProviders.java
@@ -55,8 +55,10 @@ public class CodecDataProviders
     List<Object[]> list = new ArrayList<>();
     for (Map.Entry<String, DataComplex> entry : codecDataInputs().entrySet())
     {
-      list.add(new Object[] {entry.getKey(), entry.getValue(), true});
-      list.add(new Object[] {entry.getKey(), entry.getValue(), false});
+      list.add(new Object[] {entry.getKey(), entry.getValue(), true, true});
+      list.add(new Object[] {entry.getKey(), entry.getValue(), false, false});
+      list.add(new Object[] {entry.getKey(), entry.getValue(), true, false});
+      list.add(new Object[] {entry.getKey(), entry.getValue(), false, true});
     }
 
     return list.toArray(new Object[][] {});

--- a/data/src/test/java/com/linkedin/data/codec/TestCodec.java
+++ b/data/src/test/java/com/linkedin/data/codec/TestCodec.java
@@ -277,7 +277,7 @@ public class TestCodec
     SymbolTableProviderHolder.INSTANCE.setSymbolTableProvider(provider);
     codecs.add(new JacksonLICORBinaryDataCodec(symbolTable));
     codecs.add(new JacksonLICORTextDataCodec(symbolTable));
-    codecs.add(new ProtobufDataCodec(symbolTable));
+    codecs.add(new ProtobufDataCodec(new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable).build()));
 
     for (DataCodec codec : codecs)
     {

--- a/data/src/test/java/com/linkedin/data/codec/TestProtobufCodec.java
+++ b/data/src/test/java/com/linkedin/data/codec/TestProtobufCodec.java
@@ -23,9 +23,13 @@ import org.testng.annotations.Test;
 public class TestProtobufCodec extends TestCodec
 {
   @Test(dataProvider = "protobufCodecData", dataProviderClass = CodecDataProviders.class)
-  public void testProtobufDataCodec(String testName, DataComplex dataComplex, boolean supportASCIIOnlyStrings) throws IOException
+  public void testProtobufDataCodec(String testName, DataComplex dataComplex,
+      boolean enableASCIIOnlyStrings, boolean enableFixedLengthFloatDoubles) throws IOException
   {
-    ProtobufDataCodec codec = new ProtobufDataCodec(null, supportASCIIOnlyStrings);
+    ProtobufDataCodec codec = new ProtobufDataCodec(
+        new ProtobufCodecOptions.Builder().setEnableASCIIOnlyStrings(enableASCIIOnlyStrings)
+            .setEnableFixedLengthFloatDoubles(enableFixedLengthFloatDoubles)
+            .build());
     testDataCodec(codec, dataComplex);
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.3.4
+version=28.3.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/li-protobuf/src/main/java/com/linkedin/data/protobuf/ByteArrayReader.java
+++ b/li-protobuf/src/main/java/com/linkedin/data/protobuf/ByteArrayReader.java
@@ -275,6 +275,36 @@ final class ByteArrayReader extends ProtoReader
     return readRawVarint64SlowPath();
   }
 
+  @Override
+  public int readFixedInt32() throws IOException
+  {
+    if (_limit - _pos < ProtoWriter.FIXED32_SIZE) {
+      throw new EOFException();
+    }
+
+    return (((_buffer[_pos++] & 0xff))
+        | ((_buffer[_pos++] & 0xff) << 8)
+        | ((_buffer[_pos++] & 0xff) << 16)
+        | ((_buffer[_pos++] & 0xff) << 24));
+  }
+
+  @Override
+  public long readFixedInt64() throws IOException
+  {
+    if (_limit - _pos < ProtoWriter.FIXED64_SIZE) {
+      throw new EOFException();
+    }
+
+    return (((_buffer[_pos++] & 0xffL))
+        | ((_buffer[_pos++] & 0xffL) << 8)
+        | ((_buffer[_pos++] & 0xffL) << 16)
+        | ((_buffer[_pos++] & 0xffL) << 24)
+        | ((_buffer[_pos++] & 0xffL) << 32)
+        | ((_buffer[_pos++] & 0xffL) << 40)
+        | ((_buffer[_pos++] & 0xffL) << 48)
+        | ((_buffer[_pos++] & 0xffL) << 56));
+  }
+
   long readRawVarint64SlowPath() throws IOException
   {
     long result = 0;

--- a/li-protobuf/src/main/java/com/linkedin/data/protobuf/InputStreamReader.java
+++ b/li-protobuf/src/main/java/com/linkedin/data/protobuf/InputStreamReader.java
@@ -339,6 +339,40 @@ final class InputStreamReader extends ProtoReader
     return readRawVarint64SlowPath();
   }
 
+  @Override
+  public int readFixedInt32() throws IOException
+  {
+    // Make sure we have enough space to read.
+    if (ProtoWriter.FIXED32_SIZE > (_bufferSize - _pos))
+    {
+      refillBuffer(ProtoWriter.FIXED32_SIZE);
+    }
+
+    return (((_buffer[_pos++] & 0xff))
+        | ((_buffer[_pos++] & 0xff) << 8)
+        | ((_buffer[_pos++] & 0xff) << 16)
+        | ((_buffer[_pos++] & 0xff) << 24));
+  }
+
+  @Override
+  public long readFixedInt64() throws IOException
+  {
+    // Make sure we have enough space to read.
+    if (ProtoWriter.FIXED64_SIZE > (_bufferSize - _pos))
+    {
+      refillBuffer(ProtoWriter.FIXED64_SIZE);
+    }
+
+    return (((_buffer[_pos++] & 0xffL))
+        | ((_buffer[_pos++] & 0xffL) << 8)
+        | ((_buffer[_pos++] & 0xffL) << 16)
+        | ((_buffer[_pos++] & 0xffL) << 24)
+        | ((_buffer[_pos++] & 0xffL) << 32)
+        | ((_buffer[_pos++] & 0xffL) << 40)
+        | ((_buffer[_pos++] & 0xffL) << 48)
+        | ((_buffer[_pos++] & 0xffL) << 56));
+  }
+
   long readRawVarint64SlowPath() throws IOException
   {
     long result = 0;

--- a/li-protobuf/src/main/java/com/linkedin/data/protobuf/ProtoReader.java
+++ b/li-protobuf/src/main/java/com/linkedin/data/protobuf/ProtoReader.java
@@ -125,6 +125,24 @@ public abstract class ProtoReader
   public abstract long readInt64() throws IOException;
 
   /**
+   * Read a fixed 32-bit int from the stream.
+   */
+  public int readFixedInt32() throws IOException
+  {
+    // For backward compatibility at build time, implement but throw an UnsupportedOperationException.
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Read a fixed 64-bit int from the stream.
+   */
+  public long readFixedInt64() throws IOException
+  {
+    // For backward compatibility at build time, implement but throw an UnsupportedOperationException.
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Read one byte from the _input.
    *
    * @throws EOFException The end of the stream or the current _limit was reached.

--- a/li-protobuf/src/main/java/com/linkedin/data/protobuf/ProtoWriter.java
+++ b/li-protobuf/src/main/java/com/linkedin/data/protobuf/ProtoWriter.java
@@ -57,6 +57,8 @@ import java.util.function.Function;
  */
 public class ProtoWriter
 {
+  public static final int FIXED32_SIZE = 4;
+  public static final int FIXED64_SIZE = 8;
   private static final int MAX_VARINT32_SIZE = 5;
   private static final int MAX_VARINT64_SIZE = 10;
   private static final int DEFAULT_BUFFER_SIZE = 4096;
@@ -137,7 +139,19 @@ public class ProtoWriter
   }
 
   /**
-   * Write a 32-bit signed integer.
+   * Write a fixed length 32-bit signed integer.
+   */
+  public final void writeFixedInt32(final int value) throws IOException
+  {
+    flushIfNotAvailable(FIXED32_SIZE);
+    _buffer[_position++] = (byte) (value & 0xFF);
+    _buffer[_position++] = (byte) ((value >> 8) & 0xFF);
+    _buffer[_position++] = (byte) ((value >> 16) & 0xFF);
+    _buffer[_position++] = (byte) ((value >> 24) & 0xFF);
+  }
+
+  /**
+   * Write a variable length 32-bit signed integer.
    */
   public final void writeInt32(final int value) throws IOException
   {
@@ -153,7 +167,23 @@ public class ProtoWriter
   }
 
   /**
-   * Write a 64-bit signed integer.
+   * Write a fixed length 64-bit signed integer.
+   */
+  public final void writeFixedInt64(final long value) throws IOException
+  {
+    flushIfNotAvailable(FIXED64_SIZE);
+    _buffer[_position++] = (byte) ((int) (value) & 0xFF);
+    _buffer[_position++] = (byte) ((int) (value >> 8) & 0xFF);
+    _buffer[_position++] = (byte) ((int) (value >> 16) & 0xFF);
+    _buffer[_position++] = (byte) ((int) (value >> 24) & 0xFF);
+    _buffer[_position++] = (byte) ((int) (value >> 32) & 0xFF);
+    _buffer[_position++] = (byte) ((int) (value >> 40) & 0xFF);
+    _buffer[_position++] = (byte) ((int) (value >> 48) & 0xFF);
+    _buffer[_position++] = (byte) ((int) (value >> 56) & 0xFF);
+  }
+
+  /**
+   * Write a variable length 64-bit signed integer.
    */
   public final void writeInt64(final long value) throws IOException
   {
@@ -211,7 +241,7 @@ public class ProtoWriter
   }
 
   /**
-   * Write a 32-bit unsigned integer.
+   * Write a variable length 32-bit unsigned integer.
    */
   public void writeUInt32(int value) throws IOException
   {
@@ -237,7 +267,7 @@ public class ProtoWriter
   }
 
   /**
-   * Write a 64-bit unsigned integer.
+   * Write a variable length 64-bit unsigned integer.
    */
   public void writeUInt64(long value) throws IOException
   {

--- a/restli-common/src/main/java/com/linkedin/restli/common/ContentType.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/ContentType.java
@@ -20,6 +20,7 @@ import com.linkedin.data.codec.DataCodec;
 import com.linkedin.data.codec.JacksonDataCodec;
 import com.linkedin.data.codec.JacksonLICORDataCodec;
 import com.linkedin.data.codec.JacksonSmileDataCodec;
+import com.linkedin.data.codec.ProtobufCodecOptions;
 import com.linkedin.data.codec.ProtobufDataCodec;
 import com.linkedin.data.codec.PsonDataCodec;
 import com.linkedin.data.codec.entitystream.JacksonLICORStreamDataCodec;
@@ -55,7 +56,8 @@ public class ContentType
   private static final JacksonLICORStreamDataCodec
       LICOR_BINARY_STREAM_DATA_CODEC = new JacksonLICORStreamDataCodec(R2Constants.DEFAULT_DATA_CHUNK_SIZE, true);
   private static final ProtobufDataCodec PROTOBUF_DATA_CODEC = new ProtobufDataCodec();
-  private static final ProtobufDataCodec PROTOBUF2_DATA_CODEC = new ProtobufDataCodec(null, true);
+  private static final ProtobufDataCodec PROTOBUF2_DATA_CODEC =
+      new ProtobufDataCodec(new ProtobufCodecOptions.Builder().setEnableASCIIOnlyStrings(true).build());
   private static final PsonDataCodec PSON_DATA_CODEC = new PsonDataCodec();
   private static final JacksonSmileDataCodec SMILE_DATA_CODEC = new JacksonSmileDataCodec();
   private static final JacksonSmileStreamDataCodec SMILE_STREAM_DATA_CODEC = new JacksonSmileStreamDataCodec(R2Constants.DEFAULT_DATA_CHUNK_SIZE);
@@ -103,10 +105,12 @@ public class ContentType
     SUPPORTED_TYPE_PROVIDERS.put(SMILE.getHeaderKey(), (rawMimeType, mimeType) -> SMILE);
     SUPPORTED_TYPE_PROVIDERS.put(PROTOBUF.getHeaderKey(),
         new SymbolTableBasedContentTypeProvider(PROTOBUF,
-            (rawMimeType, symbolTable) -> new ContentType(rawMimeType, new ProtobufDataCodec(symbolTable, false), null)));
+            (rawMimeType, symbolTable) -> new ContentType(rawMimeType,
+                new ProtobufDataCodec(new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable).build()), null)));
     SUPPORTED_TYPE_PROVIDERS.put(PROTOBUF2.getHeaderKey(),
         new SymbolTableBasedContentTypeProvider(PROTOBUF2,
-            (rawMimeType, symbolTable) -> new ContentType(rawMimeType, new ProtobufDataCodec(symbolTable, true), null)));
+            (rawMimeType, symbolTable) -> new ContentType(rawMimeType,
+                new ProtobufDataCodec(new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable).setEnableASCIIOnlyStrings(true).build()), null)));
     SUPPORTED_TYPE_PROVIDERS.put(LICOR_TEXT.getHeaderKey(),
         new SymbolTableBasedContentTypeProvider(LICOR_TEXT,
             (rawMimeType, symbolTable) -> new ContentType(rawMimeType,


### PR DESCRIPTION
This PR provides an option to serialize floats and doubles as fixed length values. 

Variable length encoding works well for a vast majority of use cases where float and double data are of limited precision, and hence is a sensible default.

However, there are use cases where we need to encode/decode several full precision float and double values (say tensor data for ML features), where the additional varint overhead (+1 byte for floats, +2 bytes for doubles), actually has a negative impact. In such cases, we want an option to fallback to fixed length encoding.