### PR TITLE
change transportClientProperties to optional

### DIFF
--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
@@ -30,5 +30,5 @@ record DarkClusterConfig {
   /**
    * The transport client properties to use for this dark cluster
    */
-  transportClientProperties: D2TransportClientProperties = {}
+  transportClientProperties: optional D2TransportClientProperties
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.3.6
+version=28.3.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
turns out transportClientProperties has some required fields and putting it into other repos can fail validation because those required fields aren't in the default {}. So the two choices are to either:
1. set the default to include every required field in transportClientProperties, or
2. make the field optional.
I chose the latter. (#2), as it seems cleaner from the pdl perspective.

I've been working with Karthik on this. Karthik, can you review?

Chris, this is just fyi.