### PR TITLE
Creating a light-weight representation of InJarFileDataSchemaLocation

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   testCompile externalDependency.commonsIo
   testCompile externalDependency.testng
   testCompile externalDependency.junit
+  testCompile externalDependency.mockito
 
   antlr externalDependency.antlr
 }

--- a/data/src/main/java/com/linkedin/data/schema/DataSchemaLocation.java
+++ b/data/src/main/java/com/linkedin/data/schema/DataSchemaLocation.java
@@ -36,6 +36,19 @@ public interface DataSchemaLocation
    */
   File getSourceFile();
 
+  /**
+   * Return {@link DataSchemaLocation} that is a lightweight representation of this location for storing in-memory.
+   *
+   * For example, {@link com.linkedin.data.schema.resolver.InJarFileDataSchemaLocation}
+   * contains an entire Jar-file in it's impl; this isn't necessary for storing as a {@link DataSchemaLocation},
+   * so it could return a lighter-weight implementation.
+   *
+   * @return a light-weight representation of this DataSchemaLocation. Default is {@code this}
+   */
+  default DataSchemaLocation getLightweightRepresentation() {
+    return this;
+  }
+
   final DataSchemaLocation NO_LOCATION = new DataSchemaLocation()
   {
     @Override

--- a/data/src/main/java/com/linkedin/data/schema/resolver/AbstractDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/AbstractDataSchemaResolver.java
@@ -186,12 +186,12 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
 
   protected boolean isBadLocation(DataSchemaLocation location)
   {
-    return _badLocations.contains(location);
+    return _badLocations.contains(location.getLightweightRepresentation());
   }
 
   protected boolean addBadLocation(DataSchemaLocation location)
   {
-    return _badLocations.add(location);
+    return _badLocations.add(location.getLightweightRepresentation());
   }
 
   @Override
@@ -349,7 +349,7 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
       errorMessageBuilder.append(parser.errorMessageBuilder());
       errorMessageBuilder.append("Done parsing ").append(location).append(".\n");
 
-      _badLocations.add(location);
+      addBadLocation(location);
     }
     else
     {
@@ -366,7 +366,7 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
   private final Map<String, NamedDataSchema> _nameToDataSchema = new HashMap<String, NamedDataSchema>();
   private final Map<String, DataSchemaLocation> _nameToDataSchemaLocations = new HashMap<String, DataSchemaLocation>();
   private final DataSchemaParserFactory _parserFactory;
-  private final Set<DataSchemaLocation> _badLocations = new HashSet<DataSchemaLocation>();
+  private final Set<DataSchemaLocation> _badLocations = new HashSet<>();
   private final Set<DataSchemaLocation> _resolvedLocations = new HashSet<DataSchemaLocation>();
   // Map of pending records with the boolean flag indicating if includes are being processed for that schema.
   private final LinkedHashMap<String, Boolean> _pendingSchemas = new LinkedHashMap<>();

--- a/data/src/main/java/com/linkedin/data/schema/resolver/InJarFileDataSchemaLocation.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/InJarFileDataSchemaLocation.java
@@ -33,6 +33,8 @@ public class InJarFileDataSchemaLocation implements DataSchemaLocation, InputStr
   private final JarFile _jarFile;
   private final String _pathInJar;
 
+  private LightweightInJarFileDataSchemaLocation _lightweightInJarFileDataSchemaLocation = null;
+
   public InJarFileDataSchemaLocation(JarFile jarFile, String pathInJar)
   {
     _jarFile = jarFile;
@@ -86,5 +88,54 @@ public class InJarFileDataSchemaLocation implements DataSchemaLocation, InputStr
       errorMessageBuilder.append(_pathInJar).append(" not found in ").append(getSourceFile().toString()).append("\n");
     }
     return inputStream;
+  }
+
+  @Override
+  public DataSchemaLocation getLightweightRepresentation() {
+    if (_lightweightInJarFileDataSchemaLocation == null) {
+      _lightweightInJarFileDataSchemaLocation = new LightweightInJarFileDataSchemaLocation(_jarFile.getName(), _pathInJar);
+    }
+    return _lightweightInJarFileDataSchemaLocation;
+  }
+
+  private static class LightweightInJarFileDataSchemaLocation implements DataSchemaLocation {
+    private final String _jarFileName;
+    private final String _pathInJar;
+
+    public LightweightInJarFileDataSchemaLocation(String jarFileName, String pathInJar)
+    {
+      _jarFileName = jarFileName;
+      _pathInJar = pathInJar;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o)
+        return true;
+      if (!(o instanceof LightweightInJarFileDataSchemaLocation))
+        return false;
+      LightweightInJarFileDataSchemaLocation other = (LightweightInJarFileDataSchemaLocation) o;
+      return (_jarFileName.equals(other._jarFileName) && _pathInJar.equals(other._pathInJar));
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return _jarFileName.hashCode() ^ _pathInJar.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+      return getSourceFile().getPath() + ":" + _pathInJar;
+
+    }
+
+    @Override
+    public File getSourceFile()
+    {
+      return new File(_jarFileName);
+    }
   }
 }

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
@@ -43,6 +43,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarFile;
+import org.mockito.Mockito;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -147,6 +149,8 @@ public class TestDataSchemaResolver
     private String _extension;
     private Map<String,String> _map;
   };
+
+
 
   List<String> _testPaths = Arrays.asList
   (
@@ -835,6 +839,21 @@ public class TestDataSchemaResolver
 
     final DataSchema nonExistSchema = parser.lookupName(nonExistSchemaName);
     assertNull(nonExistSchema);
+  }
+
+  @Test
+  public void testAddBadLocation()
+  {
+    MapDataSchemaResolver resolver = new MapDataSchemaResolver(SchemaParserFactory.instance(), _testPaths, _testSchemas);
+    JarFile jarFile = Mockito.mock(JarFile.class);
+    Mockito.when(jarFile.getName()).thenReturn("jarFile");
+    InJarFileDataSchemaLocation location = new InJarFileDataSchemaLocation(jarFile, "samplePath");
+    InJarFileDataSchemaLocation otherLocation = new InJarFileDataSchemaLocation(jarFile, "otherPath");
+    resolver.addBadLocation(location);
+    assertTrue(resolver.isBadLocation(location));
+    assertTrue(resolver.isBadLocation(location.getLightweightRepresentation()));
+    assertFalse(resolver.isBadLocation(otherLocation));
+    assertFalse(resolver.isBadLocation(otherLocation.getLightweightRepresentation()));
   }
 
   public void lookup(DataSchemaResolver resolver, String[][] lookups, char separator, boolean debug)


### PR DESCRIPTION
When parsing schemas, the AbstractDataSchemaResolver stores bad schema locations in an instance variable. If the DataSchemaLocation is a InJarFileDataSchemaLocation, that means we are storing the entire jar in the _badLocations set, and not allowing it to be garbage collected.
We have seen this cause undue memory pressure / OOMs when resolving Schemas.

This introduces a light-weight representation of InJarFileDataSchemaLocation, by just storing the path to the jar and the path once inside the jar. This fulfills the equals and hashCode requirements of DataSchemaLocation without the overhead of the entire jar.

Discovered by analyzing a heap dump using jxray:
![Screen Shot 2020-05-13 at 12 50 12 PM](https://user-images.githubusercontent.com/7559846/81858344-769d5e80-9518-11ea-8768-ae4b5756e03c.png)