### PR TITLE
change errors in ChannelPoolLifecycle to warn

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.3.8
+version=28.3.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolLifecycle.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolLifecycle.java
@@ -136,7 +136,7 @@ public class ChannelPoolLifecycle implements AsyncPool.Lifecycle<Channel>
 
   private void onError(Callback<Channel> channelCallback, Throwable cause)
   {
-    LOG.error("Failed to create channel, remote={}", _remoteAddress, cause);
+    LOG.warn("Failed to create channel, remote={}", _remoteAddress, cause);
     if (cause instanceof ConnectException)
     {
       channelCallback.onError(new RetriableRequestException(cause));
@@ -172,7 +172,7 @@ public class ChannelPoolLifecycle implements AsyncPool.Lifecycle<Channel>
         else
         {
           final Throwable cause = channelFuture.cause();
-          LOG.error("Failed to destroy channel, remote={}", _remoteAddress, cause);
+          LOG.warn("Failed to destroy channel, remote={}", _remoteAddress, cause);
           channelCallback.onError(HttpNettyStreamClient.toException(cause));
         }
       });


### PR DESCRIPTION
Errors in dark canary dispatchers can throw off validation frameworks. In ChannelPoolLifecycle, if the dark canary is unreachable, you will get errors from netty that are logged in this class. By changing this to warn, it still logs the problem, but at a warn level. If it's truly a problem, such as failing a call, that can and will be detected higher up and can be recorded as an error there. For instance, even outside of dark canary, if it's a RetriableException, a new channel can be created to service the request, so this shouldn't be logged as an error. I will send further details separately.