### PR TITLE
Fix maxContentLength Issue & Log HttpProtocol used per Service

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=28.3.7
+version=28.3.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelInitializer.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelInitializer.java
@@ -72,8 +72,8 @@ class HttpChannelInitializer extends ChannelInitializer<NioSocketChannel>
   private final int _maxInitialLineLength;
   private final int _maxHeaderSize;
   private final int _maxChunkSize;
-  private final int _maxContentLength;
   private final int _sslHandShakeTimeout;
+  private final long _maxContentLength;
   private final boolean _ssl;
   private final boolean _enableSSLSessionResumption;
 
@@ -86,7 +86,7 @@ class HttpChannelInitializer extends ChannelInitializer<NioSocketChannel>
     _maxInitialLineLength = maxInitialLineLength;
     _maxHeaderSize = maxHeaderSize;
     _maxChunkSize = maxChunkSize;
-    _maxContentLength = maxContentLength > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) maxContentLength;
+    _maxContentLength = maxContentLength;
     _sslHandShakeTimeout = sslHandShakeTimeout;
     _ssl = _sslContext != null && _sslParameters != null;
     _enableSSLSessionResumption = enableSSLSessionResumption;

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
@@ -1334,9 +1334,6 @@ public class HttpClientFactory implements TransportClientFactory
     ChannelPoolManagerKey key = createChannelPoolManagerKey(properties, null, null);
     ChannelPoolManagerKey sslKey = createChannelPoolManagerKey(properties, sslContext, sslParameters);
 
-    String httpServiceName = (String) properties.get(HTTP_SERVICE_NAME);
-    LOG.info("The service '{}' has been assigned to the ChannelPoolManager with key '{}' ", httpServiceName, key.getName());
-
     // Raw Client properties
     int shutdownTimeout = chooseNewOverDefault(getIntValue(properties, HTTP_SHUTDOWN_TIMEOUT), DEFAULT_SHUTDOWN_TIMEOUT);
     int requestTimeout = chooseNewOverDefault(getIntValue(properties, HTTP_REQUEST_TIMEOUT), DEFAULT_REQUEST_TIMEOUT);
@@ -1351,8 +1348,12 @@ public class HttpClientFactory implements TransportClientFactory
       }
     }
 
+    String httpServiceName = (String) properties.get(HTTP_SERVICE_NAME);
     HttpProtocolVersion httpProtocolVersion =
       chooseNewOverDefault(getHttpProtocolVersion(properties, HTTP_PROTOCOL_VERSION), _defaultHttpVersion);
+
+    LOG.info("The service '{}' has been assigned to the ChannelPoolManager with key '{}', http.protocolVersion={}, usePipelineV2={}, requestTimeout={}ms, streamingTimeout={}ms",
+             httpServiceName, key.getName(), httpProtocolVersion, _usePipelineV2, requestTimeout, streamingTimeout);
 
     if (_usePipelineV2)
     {


### PR DESCRIPTION
1. Fix MaxContentLength bug in HttpChannelInitializer
2. Add info log to log information on http protocol used 