### PR TITLE
Implement Host Override List feature in D2.

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/util/HostOverrideList.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/HostOverrideList.java
@@ -1,0 +1,103 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.util;
+
+import com.linkedin.util.ArgumentUtil;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+
+/**
+ * Stores the list of host overrides for cluster and services. The order of the overrides are stored in the same
+ * order as the additions. Checks for the first match and return the overridden {@link URI}.
+ */
+public class HostOverrideList
+{
+  private Map<Key, URI> _overrides = new LinkedHashMap<>();
+
+  public void addClusterOverride(String cluster, URI uri) {
+    ArgumentUtil.notNull(cluster, "cluster");
+    ArgumentUtil.notNull(uri, "uri");
+    _overrides.put(new Key(cluster, null), uri);
+  }
+
+  public void addServiceOverride(String service, URI uri) {
+    ArgumentUtil.notNull(service, "service");
+    ArgumentUtil.notNull(uri, "uri");
+    _overrides.put(new Key(null, service), uri);
+  }
+
+  public void addOverride(URI uri) {
+    ArgumentUtil.notNull(uri, "uri");
+    _overrides.put(Key.WILDCARD_KEY, uri);
+  }
+
+  /**
+   * Gets the overridden URI for the given cluster and service.
+   * @param cluster Cluster name of the override.
+   * @param service Service name of the override.
+   * @return The overridden URI for the given cluster and service; {@code null} otherwise.
+   */
+  public URI getOverride(String cluster, String service)
+  {
+    for (Map.Entry<Key, URI> override : _overrides.entrySet())
+    {
+      if (override.getKey().match(cluster, service)) {
+        return override.getValue();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Key implementation of the override map. Key includes a cluster and a service name. If either cluster or
+   * service is {@code null}, then the null cluster or service is treated as a wildcard.
+   */
+  private static class Key {
+    private static final Key WILDCARD_KEY = new Key(null, null);
+    private final String _cluster;
+    private final String _service;
+
+    public Key(String cluster, String service) {
+      _cluster = cluster;
+      _service = service;
+    }
+
+    /**
+     * Checks if the provided cluster and service names match this key.
+     * @param cluster Cluster name to check against.
+     * @param service Service name to check against.
+     * @return {@code True} if provided cluster and service name match the key; {@code false} otherwise.
+     */
+    public boolean match(String cluster, String service) {
+      if (this == WILDCARD_KEY) {
+        return true;
+      }
+      else if (_cluster == null) {
+        return Objects.equals(_service, service);
+      }
+      else if (_service == null) {
+        return Objects.equals(_cluster, cluster);
+      }
+      else {
+        return Objects.equals(_cluster, cluster) && Objects.equals(_service, service);
+      }
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/LoadBalancerUtil.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/LoadBalancerUtil.java
@@ -211,10 +211,13 @@ public class LoadBalancerUtil
     }
   }
 
+  /**
+   * @deprecated Use {@link HostOverrideList} instead.
+   */
+  @Deprecated
   public static class TargetHints
   {
     public static final String TARGET_SERVICE_KEY_NAME = "D2-Hint-TargetService";
-
 
     /**
      * Inserts a hint in RequestContext instructing D2 to bypass normal hashing behavior

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/TestHostOverrideList.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/TestHostOverrideList.java
@@ -1,0 +1,72 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.util;
+
+import java.net.URI;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestHostOverrideList {
+  private static final String CLUSTER1 = "Cluster1";
+  private static final String CLUSTER2 = "Cluster2";
+  private static final String SERVICE1 = "Service1";
+  private static final String SERVICE2 = "Service2";
+  private static final URI URI1 = URI.create("https://uri1/path");
+  private static final URI URI2 = URI.create("https://uri2/path");
+
+  @Test
+  public void testClusterOverride() {
+    HostOverrideList overrides = new HostOverrideList();
+    overrides.addClusterOverride(CLUSTER1, URI1);
+
+    Assert.assertEquals(overrides.getOverride(CLUSTER1, SERVICE1), URI1);
+    Assert.assertEquals(overrides.getOverride(CLUSTER1, SERVICE2), URI1);
+    Assert.assertNull(overrides.getOverride(CLUSTER2, SERVICE1));
+    Assert.assertNull(overrides.getOverride(CLUSTER2, SERVICE2));
+  }
+
+  @Test
+  public void testServiceOverride() {
+    HostOverrideList overrides = new HostOverrideList();
+    overrides.addServiceOverride(SERVICE1, URI1);
+
+    Assert.assertEquals(overrides.getOverride(CLUSTER1, SERVICE1), URI1);
+    Assert.assertEquals(overrides.getOverride(CLUSTER2, SERVICE1), URI1);
+    Assert.assertNull(overrides.getOverride(CLUSTER1, SERVICE2));
+    Assert.assertNull(overrides.getOverride(CLUSTER2, SERVICE2));
+  }
+
+  @Test
+  public void testOverride() {
+    HostOverrideList overrides = new HostOverrideList();
+    overrides.addOverride(URI1);
+
+    Assert.assertEquals(overrides.getOverride(CLUSTER1, SERVICE1), URI1);
+    Assert.assertEquals(overrides.getOverride(CLUSTER1, SERVICE2), URI1);
+    Assert.assertEquals(overrides.getOverride(CLUSTER2, SERVICE1), URI1);
+    Assert.assertEquals(overrides.getOverride(CLUSTER2, SERVICE2), URI1);
+  }
+
+  @Test
+  public void testOverrideOrder() {
+    HostOverrideList overrides = new HostOverrideList();
+    overrides.addServiceOverride(SERVICE1, URI1);
+    overrides.addServiceOverride(SERVICE1, URI2);
+    Assert.assertEquals(overrides.getOverride(CLUSTER1, SERVICE1), URI1);
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.0.0
+version=29.0.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
**Requirements**
To support features like Fullstack Hovr, D2 needs to support the following routing override scenarios.
  1. Route requests going to a given cluster to a specific host.
  2. Route requests going to a given service to a specific host.
  3. Provide route overrides for multiple clusters and services.

D2 provides an existing override mechanism called TargetHints. However, TargetHints does not meet the above requirements due to the following restrictions.
TargetHints does not allow multiple overrides for different clusters and services.
TargetHints requires users to provide a full URL as opposed to a URL prefix like the D2 announcer. Therefore, we lose the flexibility of appending the service paths for different D2 services.

**Implementation**
Similar to TargetHints, HostOverrideList is also specified and passed through the RequestContext. HostOverrideList allows the user to add an arbitrary number of overrides for different clusters and services. When the request gets to the SimpleLoadBalancer, the implementation will look for the first matching override for the current cluster and service names. The request URI will be rewritten to be the override URI provided.
  1. hostOverrideList.addClusterOverride(“Cluster1”, “https://host:8080/context/”);
  2. hostOverrideList.addServiceOverride(“Service1”, “https://host:8080/context/”);

The provided override URI is a prefix, similar to the announced URI, as opposed to a full URI in the TargetHints mechanism. The service path will be appended to the end of the URI by the SimpleLoadBalancer when the request URI is rewritten. In the above examples, the written URI will be “https://host:8080/context/service1path”.

The TargetHints mechanism will be deprecated but backward compatibility will be kept. To achieve the original TargetHints behavior, one can add generic override without providing a cluster or service name.
  1. hostOverrideList.addOverride(“https://host:8080/context/”);