### PR TITLE
Handle valueClass NPE issue and give warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.0.1
+version=29.0.1.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.0.1.1
+version=29.1.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.1.1
+version=29.0.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyStreamClient.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyStreamClient.java
@@ -48,6 +48,7 @@ import com.linkedin.r2.transport.http.client.stream.AbstractNettyStreamClient;
 import com.linkedin.r2.transport.http.client.stream.http.HttpNettyStreamClient;
 import com.linkedin.r2.transport.http.client.stream.http2.Http2NettyStreamClient;
 import com.linkedin.r2.transport.http.common.HttpProtocolVersion;
+import com.linkedin.test.util.retry.SingleRetry;
 import io.netty.channel.Channel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.TooLongFrameException;
@@ -606,7 +607,7 @@ public class TestHttpNettyStreamClient
     }
   }
 
-  @Test
+  @Test(retryAnalyzer = SingleRetry.class)
   public void testShutdownRequestOutstanding() throws Exception
   {
     // Test that it works when the shutdown kills the outstanding request...

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -2628,8 +2628,8 @@ public final class RestLiAnnotationReader
 
     if (valueClass == null)
     {
-      throw new ResourceConfigException("Class '" + resourceModel.getResourceClass().getName()
-          + "' is not supported @Finder method");
+      throw new ResourceConfigException("Class '" + resourceModel.getResourceClass().getSimpleName()
+          + "' does not support @Finder method");
     }
 
     Class<?> returnType, elementType;

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -2599,7 +2599,7 @@ public final class RestLiAnnotationReader
     {
       throw new ResourceConfigException("@Finder method '" + method.getName()
           + "' on class '" + resourceModel.getResourceClass().getName()
-          + "' has an invalid return type, The return type must be a RecordTemplate'");
+          + "' has an invalid return type. The return type must be a RecordTemplate");
     }
 
     Class<?> returnType, elementType;

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -565,8 +565,8 @@ public final class RestLiAnnotationReader
           {
             continue;
           }
-          throw new ResourceConfigException("Class '" + collectionResourceClass.getName() + "' of a"
-              + "KeyUnstructuredDataResource class does not support for @Finder methods");
+          throw new ResourceConfigException("Class '" + collectionResourceClass.getSimpleName() + "' of a"
+              + " KeyUnstructuredDataResource class does not support @Finder methods");
         }
       }
 
@@ -692,8 +692,8 @@ public final class RestLiAnnotationReader
         {
           continue;
         }
-        throw new ResourceConfigException("Class '" + resourceClass.getName() + "' of a SingleUnstructuredDataResource "
-            + "class does not support for @Finder methods");
+        throw new ResourceConfigException("Class '" + resourceClass.getSimpleName() + "' of a SingleUnstructuredDataResource "
+            + "class does not support @Finder methods");
       }
     }
 
@@ -2629,7 +2629,7 @@ public final class RestLiAnnotationReader
     if (valueClass == null)
     {
       throw new ResourceConfigException("Class '" + resourceModel.getResourceClass().getName()
-          + "' is not supported for @Finder method");
+          + "' is not supported @Finder method");
     }
 
     Class<?> returnType, elementType;

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -2597,9 +2597,8 @@ public final class RestLiAnnotationReader
 
     if (valueClass == null)
     {
-      throw new ResourceConfigException("@Finder method '" + method.getName()
-          + "' on class '" + resourceModel.getResourceClass().getName()
-          + "' has an invalid return type. The return type must be a RecordTemplate");
+      throw new ResourceConfigException("Class '" + resourceModel.getResourceClass().getName()
+          + "' where the class is a subtype of KeyUnstructuredDataResource is not supported for finders");
     }
 
     Class<?> returnType, elementType;

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -2595,6 +2595,13 @@ public final class RestLiAnnotationReader
     Method method = finderMethodDescriptor.getMethod();
     Class<?> valueClass = resourceModel.getValueClass();
 
+    if (valueClass == null)
+    {
+      throw new ResourceConfigException("@Finder method '" + method.getName()
+          + "' on class '" + resourceModel.getResourceClass().getName()
+          + "' has an invalid return type, The return type must be a RecordTemplate'");
+    }
+
     Class<?> returnType, elementType;
     try
     {

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -693,7 +693,7 @@ public final class RestLiAnnotationReader
           continue;
         }
         throw new ResourceConfigException("Class '" + resourceClass.getName() + "' of a SingleUnstructuredDataResource "
-            + "does not support for @Finder methods");
+            + "class does not support for @Finder methods");
       }
     }
 

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -554,20 +554,6 @@ public final class RestLiAnnotationReader
         @SuppressWarnings("unchecked")
         Class<? extends KeyUnstructuredDataResource<?>> clazz = (Class<? extends KeyUnstructuredDataResource<?>>) collectionResourceClass;
         actualTypeArguments = ReflectionUtils.getTypeArgumentsParametrized(KeyUnstructuredDataResource.class, clazz);
-        for (Method method : collectionResourceClass.getDeclaredMethods())
-        {
-          if (method.isSynthetic())
-          {
-            continue;
-          }
-          Finder finderAnno = method.getAnnotation(Finder.class);
-          if (finderAnno == null)
-          {
-            continue;
-          }
-          throw new ResourceConfigException("Class '" + collectionResourceClass.getSimpleName() + "' of a"
-              + " KeyUnstructuredDataResource class does not support @Finder methods");
-        }
       }
 
       keyClass = ReflectionUtils.getClass(actualTypeArguments.get(0));
@@ -678,23 +664,6 @@ public final class RestLiAnnotationReader
       Class<? extends SingleObjectResource<?>> clazz = (Class<? extends SingleObjectResource<?>>) resourceClass;
       List<Class<?>> kvParams = ReflectionUtils.getTypeArguments(SingleObjectResource.class, clazz);
       valueClass = kvParams.get(0).asSubclass(RecordTemplate.class);
-    }
-    else
-    {
-      for (Method method : resourceClass.getDeclaredMethods())
-      {
-        if (method.isSynthetic())
-        {
-          continue;
-        }
-        Finder finderAnno = method.getAnnotation(Finder.class);
-        if (finderAnno == null)
-        {
-          continue;
-        }
-        throw new ResourceConfigException("Class '" + resourceClass.getSimpleName() + "' of a SingleUnstructuredDataResource "
-            + "class does not support @Finder methods");
-      }
     }
 
     ResourceType resourceType = getResourceType(resourceClass);
@@ -2626,10 +2595,11 @@ public final class RestLiAnnotationReader
     Method method = finderMethodDescriptor.getMethod();
     Class<?> valueClass = resourceModel.getValueClass();
 
-    if (valueClass == null)
+    if (SingleUnstructuredDataResource.class.isAssignableFrom(resourceModel.getResourceClass())
+        || KeyUnstructuredDataResource.class.isAssignableFrom(resourceModel.getResourceClass()))
     {
       throw new ResourceConfigException("Class '" + resourceModel.getResourceClass().getSimpleName()
-          + "' does not support @Finder method");
+          + "' extends the '" + resourceModel.getResourceClass().getSuperclass().getSimpleName() + "' class does not support @Finder methods");
     }
 
     Class<?> returnType, elementType;

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -554,6 +554,20 @@ public final class RestLiAnnotationReader
         @SuppressWarnings("unchecked")
         Class<? extends KeyUnstructuredDataResource<?>> clazz = (Class<? extends KeyUnstructuredDataResource<?>>) collectionResourceClass;
         actualTypeArguments = ReflectionUtils.getTypeArgumentsParametrized(KeyUnstructuredDataResource.class, clazz);
+        for (Method method : collectionResourceClass.getDeclaredMethods())
+        {
+          if (method.isSynthetic())
+          {
+            continue;
+          }
+          Finder finderAnno = method.getAnnotation(Finder.class);
+          if (finderAnno == null)
+          {
+            continue;
+          }
+          throw new ResourceConfigException("Class '" + collectionResourceClass.getName() + "' of a"
+              + "KeyUnstructuredDataResource class does not support for @Finder methods");
+        }
       }
 
       keyClass = ReflectionUtils.getClass(actualTypeArguments.get(0));
@@ -664,6 +678,23 @@ public final class RestLiAnnotationReader
       Class<? extends SingleObjectResource<?>> clazz = (Class<? extends SingleObjectResource<?>>) resourceClass;
       List<Class<?>> kvParams = ReflectionUtils.getTypeArguments(SingleObjectResource.class, clazz);
       valueClass = kvParams.get(0).asSubclass(RecordTemplate.class);
+    }
+    else
+    {
+      for (Method method : resourceClass.getDeclaredMethods())
+      {
+        if (method.isSynthetic())
+        {
+          continue;
+        }
+        Finder finderAnno = method.getAnnotation(Finder.class);
+        if (finderAnno == null)
+        {
+          continue;
+        }
+        throw new ResourceConfigException("Class '" + resourceClass.getName() + "' of a SingleUnstructuredDataResource "
+            + "does not support for @Finder methods");
+      }
     }
 
     ResourceType resourceType = getResourceType(resourceClass);
@@ -2598,7 +2629,7 @@ public final class RestLiAnnotationReader
     if (valueClass == null)
     {
       throw new ResourceConfigException("Class '" + resourceModel.getResourceClass().getName()
-          + "' where the class is a subtype of KeyUnstructuredDataResource is not supported for finders");
+          + "' is not supported for @Finder method");
     }
 
     Class<?> returnType, elementType;

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -2595,11 +2595,10 @@ public final class RestLiAnnotationReader
     Method method = finderMethodDescriptor.getMethod();
     Class<?> valueClass = resourceModel.getValueClass();
 
-    if (SingleUnstructuredDataResource.class.isAssignableFrom(resourceModel.getResourceClass())
-        || KeyUnstructuredDataResource.class.isAssignableFrom(resourceModel.getResourceClass()))
+    if (ResourceEntityType.UNSTRUCTURED_DATA == resourceModel.getResourceEntityType())
     {
       throw new ResourceConfigException("Class '" + resourceModel.getResourceClass().getSimpleName()
-          + "' extends the '" + resourceModel.getResourceClass().getSuperclass().getSimpleName() + "' class does not support @Finder methods");
+          + "' does not support @Finder methods, because it's an unstructured data resource");
     }
 
     Class<?> returnType, elementType;

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -809,6 +809,12 @@ class SampleResources
     }
   }
 
-  @RestLiActions(name = "foo")
-  static class FinderWithActionResource {}
+  @RestLiCollection(name = "collectionAttachmentParamsFailureResource")
+  class ActionMethodCollectionResources extends CollectionResourceTemplate<String, EmptyRecord>
+  {
+    @Action(name = "AttachmentParamsIncorrectDataTypeAction")
+    public void AttachmentParamsIncorrectDataTypeAction(@RestLiAttachmentsParam RestLiAttachmentReader attachmentReader)
+    {
+    }
+  }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -776,9 +776,9 @@ class SampleResources
   public class UnsupportedReturnType2FinderResource extends UnstructuredDataCollectionResourceTemplate<Integer>
   {
     @Finder("findFooBar2")
-    public List<Long> findLucky(@PagingContextParam final PagingContext context, @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
+    public List<EmptyRecord> findLucky(@PagingContextParam final PagingContext context, @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
     {
-      return Collections.singletonList(0L);
+      return Collections.singletonList(new EmptyRecord());
     }
   }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -76,6 +76,7 @@ import com.linkedin.restli.server.resources.SimpleResourceTaskTemplate;
 import com.linkedin.restli.server.resources.SimpleResourceTemplate;
 import com.linkedin.restli.server.resources.unstructuredData.UnstructuredDataCollectionResourceReactiveTemplate;
 import com.linkedin.restli.server.resources.unstructuredData.UnstructuredDataCollectionResourceTemplate;
+import com.linkedin.restli.server.resources.unstructuredData.UnstructuredDataSimpleResourceTemplate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -762,23 +763,52 @@ class SampleResources
   @RestLiCollection(name = "collectionComplexKeyTask")
   class CollectionComplexKeyTask extends ComplexKeyResourceTaskTemplate<EmptyRecord, EmptyRecord, EmptyRecord> {}
 
-  @RestLiCollection(name = "lucky",keyName = "dayOfWeek")
-  public class UnsupportedReturnType1FinderResource extends UnstructuredDataCollectionResourceTemplate<Integer>
+  @RestLiCollection(name = "lucky", keyName = "dayOfWeek")
+  public class FinderUnsupportedKeyUnstructuredDataResource extends UnstructuredDataCollectionResourceTemplate<Integer>
   {
-    @Finder("findFooBar1")
-    public List<String> findLucky(@PagingContextParam final PagingContext context, @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
+    @Finder("key")
+    public List<String> findLucky(@PagingContextParam final PagingContext context,
+                                 @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
     {
       return Collections.singletonList("finderReturns");
     }
   }
 
-  @RestLiCollection(name = "lucky",keyName = "dayOfWeek")
-  public class UnsupportedReturnType2FinderResource extends UnstructuredDataCollectionResourceTemplate<Integer>
+  @RestLiSimpleResource(name="single")
+  public class FinderUnsupportedSingleUnstructuredDataResource extends UnstructuredDataSimpleResourceTemplate
   {
-    @Finder("findFooBar2")
-    public List<EmptyRecord> findLucky(@PagingContextParam final PagingContext context, @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
+    @Finder("single")
+    public List<EmptyRecord> findLucky(@PagingContextParam final PagingContext context,
+                                      @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
     {
       return Collections.singletonList(new EmptyRecord());
     }
   }
+
+  @RestLiAssociation(
+      name="associate",
+      assocKeys={@Key(name="followerID", type=long.class), @Key(name="followeeID", type=long.class)})
+  public class FinderSupportedAssociationDataResource extends AssociationResourceTemplate<EmptyRecord>
+  {
+    @Finder("associate")
+    public List<EmptyRecord> find(@PagingContextParam final PagingContext context,
+        @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
+    {
+      return Collections.singletonList(new EmptyRecord());
+    }
+  }
+
+  @RestLiCollection(name="collectionComplexKey")
+  public class FinderSupportedComplexKeyDataResource extends ComplexKeyResourceTemplate<EmptyRecord, EmptyRecord, EmptyRecord>
+  {
+    @Finder("complex")
+    public List<EmptyRecord> find(@PagingContextParam final PagingContext context,
+                                  @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
+    {
+      return Collections.singletonList(new EmptyRecord());
+    }
+  }
+
+  @RestLiActions(name = "foo")
+  static class FinderWithActionResource {}
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -808,13 +808,4 @@ class SampleResources
       return Collections.singletonList(new EmptyRecord());
     }
   }
-
-  @RestLiCollection(name = "collectionAttachmentParamsFailureResource")
-  class ActionMethodCollectionResources extends CollectionResourceTemplate<String, EmptyRecord>
-  {
-    @Action(name = "AttachmentParamsIncorrectDataTypeAction")
-    public void AttachmentParamsIncorrectDataTypeAction(@RestLiAttachmentsParam RestLiAttachmentReader attachmentReader)
-    {
-    }
-  }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -762,15 +762,23 @@ class SampleResources
   @RestLiCollection(name = "collectionComplexKeyTask")
   class CollectionComplexKeyTask extends ComplexKeyResourceTaskTemplate<EmptyRecord, EmptyRecord, EmptyRecord> {}
 
-  @RestLiCollection(name="lucky",keyName="dayOfWeek")
-  public class fooBarFinderResource extends UnstructuredDataCollectionResourceTemplate<Integer>
+  @RestLiCollection(name = "lucky",keyName = "dayOfWeek")
+  public class UnsupportedReturnType1FinderResource extends UnstructuredDataCollectionResourceTemplate<Integer>
   {
-    @Finder("findFooBar")
+    @Finder("findFooBar1")
     public List<String> findLucky(@PagingContextParam final PagingContext context, @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
     {
-      List<String> res = new LinkedList<>();
-      res.add("gotLuck!");
-      return res;
+      return Collections.singletonList("finderReturns");
+    }
+  }
+
+  @RestLiCollection(name = "lucky",keyName = "dayOfWeek")
+  public class UnsupportedReturnType2FinderResource extends UnstructuredDataCollectionResourceTemplate<Integer>
+  {
+    @Finder("findFooBar2")
+    public List<Long> findLucky(@PagingContextParam final PagingContext context, @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
+    {
+      return Collections.singletonList(0L);
     }
   }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -75,8 +75,10 @@ import com.linkedin.restli.server.resources.SimpleResourceAsyncTemplate;
 import com.linkedin.restli.server.resources.SimpleResourceTaskTemplate;
 import com.linkedin.restli.server.resources.SimpleResourceTemplate;
 import com.linkedin.restli.server.resources.unstructuredData.UnstructuredDataCollectionResourceReactiveTemplate;
+import com.linkedin.restli.server.resources.unstructuredData.UnstructuredDataCollectionResourceTemplate;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -759,4 +761,16 @@ class SampleResources
 
   @RestLiCollection(name = "collectionComplexKeyTask")
   class CollectionComplexKeyTask extends ComplexKeyResourceTaskTemplate<EmptyRecord, EmptyRecord, EmptyRecord> {}
+
+  @RestLiCollection(name="lucky",keyName="dayOfWeek")
+  public class fooBarFinderResource extends UnstructuredDataCollectionResourceTemplate<Integer>
+  {
+    @Finder("findFooBar")
+    public List<String> findLucky(@PagingContextParam final PagingContext context, @QueryParam("dayOfWeek") Integer dayOfWeek) throws Exception
+    {
+      List<String> res = new LinkedList<>();
+      res.add("gotLuck!");
+      return res;
+    }
+  }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -199,13 +199,13 @@ public class TestRestLiApiBuilder
     }
   }
 
-  @DataProvider(name = "unsupportedFinderReturnTypeData")
-  private Object[][] unsupportedFinderReturnTypeData()
+  @DataProvider(name = "unsupportedFinderResourceTypeData")
+  private Object[][] unsupportedFinderResourceTypeData()
   {
     return new Object[][]
         {
-            { UnsupportedReturnType1FinderResource.class, "The return type must be a RecordTemplate" },
-            { UnsupportedReturnType2FinderResource.class, "The return type must be a RecordTemplate" }
+            { UnsupportedReturnType1FinderResource.class, "subtype of KeyUnstructuredDataResource is not supported for finders" },
+            { UnsupportedReturnType2FinderResource.class, "subtype of KeyUnstructuredDataResource is not supported for finders" }
         };
   }
 
@@ -216,8 +216,8 @@ public class TestRestLiApiBuilder
    *
    * @param resourceClass resource used as an input
    */
-  @Test(dataProvider = "unsupportedFinderReturnTypeData")
-  public void testFinderUnsupportedReturnType(Class<?> resourceClass, String expectedPartialMessage)
+  @Test(dataProvider = "unsupportedFinderResourceTypeData")
+  public void testFinderUnsupportedResourceType(Class<?> resourceClass, String expectedPartialMessage)
   {
     try
     {

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -199,12 +199,13 @@ public class TestRestLiApiBuilder
     }
   }
 
-  @DataProvider(name = "unstructuredFinderReturnTypeData")
-  private Object[][] unstructuredFinderReturnTypeData()
+  @DataProvider(name = "unsupportedFinderReturnTypeData")
+  private Object[][] unsupportedFinderReturnTypeData()
   {
     return new Object[][]
         {
-            {fooBarFinderResource.class, "The return type must be a RecordTemplate"}
+            { UnsupportedReturnType1FinderResource.class, "The return type must be a RecordTemplate" },
+            { UnsupportedReturnType2FinderResource.class, "The return type must be a RecordTemplate" }
         };
   }
 
@@ -215,13 +216,16 @@ public class TestRestLiApiBuilder
    *
    * @param resourceClass resource used as an input
    */
-  @Test(dataProvider = "unstructuredFinderReturnTypeData")
+  @Test(dataProvider = "unsupportedFinderReturnTypeData")
   public void testFinderUnsupportedReturnType(Class<?> resourceClass, String expectedPartialMessage)
   {
-    try {
+    try
+    {
       RestLiApiBuilder.buildResourceModels(Collections.singleton(resourceClass));
       Assert.fail("For the finder resource class with a non RecordTemplate sub class, we shall throw an exception");
-    } catch (ResourceConfigException resourceConfigException) {
+    }
+    catch (ResourceConfigException resourceConfigException)
+    {
       Assert.assertTrue(resourceConfigException.getMessage().contains(expectedPartialMessage),
           String.format("Expected %s with message containing \"%s\" but instead found message \"%s\"",
               ResourceConfigException.class.getSimpleName(), expectedPartialMessage, resourceConfigException.getMessage()));

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -204,8 +204,8 @@ public class TestRestLiApiBuilder
   {
     return new Object[][]
         {
-            { FinderUnsupportedKeyUnstructuredDataResource.class, "KeyUnstructuredDataResource class does not support for @Finder methods" },
-            { FinderUnsupportedSingleUnstructuredDataResource.class, "SingleUnstructuredDataResource class does not support for @Finder methods" }
+            { FinderUnsupportedKeyUnstructuredDataResource.class, "KeyUnstructuredDataResource class does not support @Finder methods" },
+            { FinderUnsupportedSingleUnstructuredDataResource.class, "SingleUnstructuredDataResource class does not support @Finder methods" }
         };
   }
 
@@ -216,20 +216,13 @@ public class TestRestLiApiBuilder
    *
    * @param resourceClass resource used as an input
    */
-  @Test(dataProvider = "unsupportedFinderResourceTypeData")
+  @Test(dataProvider = "unsupportedFinderResourceTypeData",
+      expectedExceptions = ResourceConfigException.class,
+      expectedExceptionsMessageRegExp = "Class '.*' of a ((SingleUnstructuredDataResource)|(KeyUnstructuredDataResource)) class does not support @Finder methods")
   public void testFinderUnsupportedResourceType(Class<?> resourceClass, String expectedPartialMessage)
   {
-    try
-    {
-      RestLiApiBuilder.buildResourceModels(Collections.singleton(resourceClass));
-      Assert.fail("For the finder resource class with a non RecordTemplate sub class, we shall throw an exception");
-    }
-    catch (ResourceConfigException resourceConfigException)
-    {
-      Assert.assertTrue(resourceConfigException.getMessage().contains(expectedPartialMessage),
-          String.format("Expected %s with message containing \"%s\" but instead found message \"%s\"",
-              ResourceConfigException.class.getSimpleName(), expectedPartialMessage, resourceConfigException.getMessage()));
-    }
+    RestLiApiBuilder.buildResourceModels(Collections.singleton(resourceClass));
+    Assert.fail("For the finder resource class with a non RecordTemplate sub class, we shall throw an exception");
   }
 
   @DataProvider(name = "finderSupportedResourceTypeData")

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -222,7 +222,6 @@ public class TestRestLiApiBuilder
   public void testFinderUnsupportedResourceType(Class<?> resourceClass, String expectedPartialMessage)
   {
     RestLiApiBuilder.buildResourceModels(Collections.singleton(resourceClass));
-    Assert.fail("For the finder resource class with a non RecordTemplate sub class, we shall throw an exception");
   }
 
   @DataProvider(name = "finderSupportedResourceTypeData")

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -204,8 +204,8 @@ public class TestRestLiApiBuilder
   {
     return new Object[][]
         {
-            { UnsupportedReturnType1FinderResource.class, "subtype of KeyUnstructuredDataResource is not supported for finders" },
-            { UnsupportedReturnType2FinderResource.class, "subtype of KeyUnstructuredDataResource is not supported for finders" }
+            { FinderUnsupportedKeyUnstructuredDataResource.class, "KeyUnstructuredDataResource class does not support for @Finder methods" },
+            { FinderUnsupportedSingleUnstructuredDataResource.class, "SingleUnstructuredDataResource class does not support for @Finder methods" }
         };
   }
 
@@ -229,6 +229,31 @@ public class TestRestLiApiBuilder
       Assert.assertTrue(resourceConfigException.getMessage().contains(expectedPartialMessage),
           String.format("Expected %s with message containing \"%s\" but instead found message \"%s\"",
               ResourceConfigException.class.getSimpleName(), expectedPartialMessage, resourceConfigException.getMessage()));
+    }
+  }
+
+  @DataProvider(name = "finderSupportedResourceTypeData")
+  private Object[][] finderSupportedResourceTypeData()
+  {
+    return new Object[][]
+        {
+            { FinderSupportedAssociationDataResource.class },
+            { FinderSupportedComplexKeyDataResource.class },
+            { FinderWithActionResource.class }
+        };
+  }
+
+  @Test(dataProvider = "finderSupportedResourceTypeData")
+  public void testFinderSupportedResourceType(Class<?> resourceClass)
+  {
+    try
+    {
+      RestLiApiBuilder.buildResourceModels(Collections.singleton(resourceClass));
+    }
+    catch (Exception exception)
+    {
+      Assert.fail(String.format("Unexpected exception:  class: %s, message: \"%s\"",
+              resourceClass.getSimpleName(), exception.getMessage()));
     }
   }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -198,4 +198,33 @@ public class TestRestLiApiBuilder
       Assert.assertEquals(resourceMethodDescriptor.getActionReturnType(), expectedActionReturnType);
     }
   }
+
+  @DataProvider(name = "unstructuredFinderReturnTypeData")
+  private Object[][] unstructuredFinderReturnTypeData()
+  {
+    return new Object[][]
+        {
+            {fooBarFinderResource.class, "The return type must be a RecordTemplate"}
+        };
+  }
+
+  /**
+   * Ensures that when finder methods are processed, if the return type is not of a Record, then it will be warned.
+   * For instance, it should recognize that the "logical" return type for a method
+   * {@code Task<ActionResult<String>> doFoo();} is {@code String.class}.
+   *
+   * @param resourceClass resource used as an input
+   */
+  @Test(dataProvider = "unstructuredFinderReturnTypeData")
+  public void testFinderUnsupportedReturnType(Class<?> resourceClass, String expectedPartialMessage)
+  {
+    try {
+      RestLiApiBuilder.buildResourceModels(Collections.singleton(resourceClass));
+      Assert.fail("For the finder resource class with a non RecordTemplate sub class, we shall throw an exception");
+    } catch (ResourceConfigException resourceConfigException) {
+      Assert.assertTrue(resourceConfigException.getMessage().contains(expectedPartialMessage),
+          String.format("Expected %s with message containing \"%s\" but instead found message \"%s\"",
+              ResourceConfigException.class.getSimpleName(), expectedPartialMessage, resourceConfigException.getMessage()));
+    }
+  }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -204,22 +204,22 @@ public class TestRestLiApiBuilder
   {
     return new Object[][]
         {
-            { FinderUnsupportedKeyUnstructuredDataResource.class, "KeyUnstructuredDataResource class does not support @Finder methods" },
-            { FinderUnsupportedSingleUnstructuredDataResource.class, "SingleUnstructuredDataResource class does not support @Finder methods" }
+            { FinderUnsupportedKeyUnstructuredDataResource.class },
+            { FinderUnsupportedSingleUnstructuredDataResource.class }
         };
   }
 
   /**
-   * Ensures that when finder methods are processed, if the return type is not of a Record, then it will be warned.
-   * For instance, it should recognize that the "logical" return type for a method
+   * Ensures that when finder methods are processed, when the resource value class is a SingleUnstructuredDataResource
+   * or a KeyUnstructuredDataResource, we will end up with a ResourceConfigException because we don't support that righ tnow.
    * {@code Task<ActionResult<String>> doFoo();} is {@code String.class}.
    *
    * @param resourceClass resource used as an input
    */
   @Test(dataProvider = "unsupportedFinderResourceTypeData",
       expectedExceptions = ResourceConfigException.class,
-      expectedExceptionsMessageRegExp = "Class '.*' of a ((SingleUnstructuredDataResource)|(KeyUnstructuredDataResource)) class does not support @Finder methods")
-  public void testFinderUnsupportedResourceType(Class<?> resourceClass, String expectedPartialMessage)
+      expectedExceptionsMessageRegExp = "Class '.*' extends the '.*' class does not support @Finder methods")
+  public void testFinderUnsupportedResourceType(Class<?> resourceClass)
   {
     RestLiApiBuilder.buildResourceModels(Collections.singleton(resourceClass));
   }
@@ -231,7 +231,7 @@ public class TestRestLiApiBuilder
         {
             { FinderSupportedAssociationDataResource.class },
             { FinderSupportedComplexKeyDataResource.class },
-            { FinderWithActionResource.class }
+            { ActionMethodCollectionResources.class }
         };
   }
 

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -218,7 +218,7 @@ public class TestRestLiApiBuilder
    */
   @Test(dataProvider = "unsupportedFinderResourceTypeData",
       expectedExceptions = ResourceConfigException.class,
-      expectedExceptionsMessageRegExp = "Class '.*' extends the '.*' class does not support @Finder methods")
+      expectedExceptionsMessageRegExp = "Class '.*' does not support @Finder methods, because it's an unstructured data resource")
   public void testFinderUnsupportedResourceType(Class<?> resourceClass)
   {
     RestLiApiBuilder.buildResourceModels(Collections.singleton(resourceClass));

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -230,8 +230,7 @@ public class TestRestLiApiBuilder
     return new Object[][]
         {
             { FinderSupportedAssociationDataResource.class },
-            { FinderSupportedComplexKeyDataResource.class },
-            { ActionMethodCollectionResources.class }
+            { FinderSupportedComplexKeyDataResource.class }
         };
   }
 


### PR DESCRIPTION
When a finder resource class returns a non-record (Data type is POJO or not defined in PDL files) the restspec generation will be halted by seeing a NPE. The NPE is caused by `valueClass` being `null`. 