### PR TITLE
Exclude 2 flaky tests in Travis CI

### DIFF
--- a/d2/src/test/java/com/linkedin/d2/balancer/servers/ZookeeperConnectionManagerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/servers/ZookeeperConnectionManagerTest.java
@@ -438,7 +438,7 @@ public class ZookeeperConnectionManagerTest
     executorService.shutdown();
   }
 
-  @Test(invocationCount = 10, timeOut = 10000, retryAnalyzer = ThreeRetries.class)
+  @Test(invocationCount = 10, timeOut = 10000, groups = { "ci-flaky" })
   public void testMarkUpAndDownMultipleTimesFinalUp()
     throws Exception
   {

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamResponse.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamResponse.java
@@ -20,7 +20,6 @@ import com.linkedin.r2.transport.common.StreamRequestHandler;
 import com.linkedin.r2.transport.common.bridge.server.TransportDispatcher;
 import com.linkedin.r2.transport.common.bridge.server.TransportDispatcherBuilder;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
-import com.linkedin.test.util.retry.ThreeRetries;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -149,7 +148,7 @@ public class TestStreamResponse extends AbstractServiceTest
     factoryShutdownCallback.get();
   }
 
-  @Test(retryAnalyzer = ThreeRetries.class)
+  @Test(groups = { "ci-flaky" })
   public void testBackpressure() throws Exception
   {
     StreamRequestBuilder builder = new StreamRequestBuilder(_clientProvider.createHttpURI(_port, SMALL_URI));


### PR DESCRIPTION
Excludes:
- `ZookeeperConnectionManagerTest > testMarkUpAndDownMultipleTimesFinalUp`
- `TestStreamResponse > testBackpressure`