### PR TITLE
Allowing for actions to have typerefs as return types.

### DIFF
--- a/restli-common/src/main/java/com/linkedin/restli/internal/common/URIMaskUtil.java
+++ b/restli-common/src/main/java/com/linkedin/restli/internal/common/URIMaskUtil.java
@@ -121,161 +121,159 @@ public class URIMaskUtil
     ParseState state = ParseState.PARSE_FIELDS;
 
     DataMap result = new DataMap();
-    Deque<DataMap> stack = new ArrayDeque<DataMap>();
+    Deque<DataMap> stack = new ArrayDeque<>();
     stack.addLast(result);
+    int pos = 0;
 
-    while (toparse.length() > 0)
+    while (pos < toparse.length())
     {
       switch (state)
       {
-      case TRAVERSE:
-        if (toparse.indexOf(",") != 0)
-        {
-          throw new IllegalStateException("Internal Error parsing mask: unexpected parse buffer '"
-              + toparse + "' while traversing");
-        }
-        toparse.delete(0, 1);
-        state = ParseState.PARSE_FIELDS;
-        break;
-      case DESCEND:
-        if (toparse.indexOf(":(") != 0)
-        {
-          throw new IllegalStateException("Internal Error parsing mask: unexpected parse buffer '"
-              + toparse + "' while descending");
-        }
-        toparse.delete(0, 2);
-        state = ParseState.PARSE_FIELDS;
-        break;
-      case PARSE_FIELDS:
-
-        Integer maskValue = null;
-        if (toparse.charAt(0) == '-')
-        {
-          maskValue = MaskOperation.NEGATIVE_MASK_OP.getRepresentation();
-          toparse.delete(0, 1);
-        }
-        else
-        {
-          maskValue = MaskOperation.POSITIVE_MASK_OP.getRepresentation();
-        }
-
-        int nextToken = -1;
-        StringBuilder field = new StringBuilder();
-        for (int ii = 0; ii < toparse.length(); ++ii)
-        {
-          char c = toparse.charAt(ii);
-          switch (c)
+        case TRAVERSE:
+          if (toparse.charAt(pos) != ',')
           {
-          case ',':
-            state = ParseState.TRAVERSE;
-            nextToken = ii;
-            break;
-          case ':':
-            if (field.length() > 0 && (FilterConstants.START.equals(field.toString()) || FilterConstants.COUNT.equals(field.toString())))
+            throw new IllegalStateException("Internal Error parsing mask: unexpected parse buffer '"
+                + toparse + "' while traversing");
+          }
+          pos++;
+          state = ParseState.PARSE_FIELDS;
+          break;
+        case DESCEND:
+          if (toparse.charAt(pos) != ':' || toparse.charAt(pos+1) != '(')
+          {
+            throw new IllegalStateException("Internal Error parsing mask: unexpected parse buffer '"
+                + toparse + "' while descending");
+          }
+          pos += 2;
+          state = ParseState.PARSE_FIELDS;
+          break;
+        case PARSE_FIELDS:
+
+          Integer maskValue;
+          if (toparse.charAt(pos) == '-')
+          {
+            maskValue = MaskOperation.NEGATIVE_MASK_OP.getRepresentation();
+            pos++;
+          }
+          else
+          {
+            maskValue = MaskOperation.POSITIVE_MASK_OP.getRepresentation();
+          }
+
+          int nextToken = -1;
+          StringBuilder field = new StringBuilder();
+          for (int ii = pos; ii < toparse.length(); ++ii)
+          {
+            char c = toparse.charAt(ii);
+            switch (c)
             {
-              if (!Character.isDigit(toparse.charAt(ii + 1)))
-              {
-                throw new IllegalMaskException("Malformed mask syntax: unexpected range value");
-              }
+              case ',':
+                state = ParseState.TRAVERSE;
+                nextToken = ii;
+                break;
+              case ':':
+                if (field.length() > 0 && (stringBuilderEquals(FilterConstants.START, field) || stringBuilderEquals(FilterConstants.COUNT, field)))
+                {
+                  if (!Character.isDigit(toparse.charAt(ii + 1)))
+                  {
+                    throw new IllegalMaskException("Malformed mask syntax: unexpected range value");
+                  }
 
-              ii++;
+                  ii++;
 
-              // Aggressively consume the numerical value for the range parameter as this is a special case.
-              StringBuilder rangeValue = new StringBuilder();
-              while (ii < toparse.length())
-              {
-                char ch = toparse.charAt(ii);
-                if (ch == ',')
-                {
-                  state = ParseState.TRAVERSE;
-                  nextToken = ii;
-                  break;
-                }
-                else if (ch == ')')
-                {
-                  state = ParseState.ASCEND;
-                  nextToken = ii;
-                  break;
-                }
-                else if (Character.isDigit(ch))
-                {
-                  rangeValue.append(ch);
+                  // Aggressively consume the numerical value for the range parameter as this is a special case.
+                  maskValue = 0;
+                  while (ii < toparse.length())
+                  {
+                    char ch = toparse.charAt(ii);
+                    if (ch == ',')
+                    {
+                      state = ParseState.TRAVERSE;
+                      nextToken = ii;
+                      break;
+                    }
+                    else if (ch == ')')
+                    {
+                      state = ParseState.ASCEND;
+                      nextToken = ii;
+                      break;
+                    }
+                    else if (Character.isDigit(ch))
+                    {
+                      maskValue = maskValue * 10 + Character.getNumericValue(ch);
+                    }
+                    else
+                    {
+                      throw new IllegalMaskException("Malformed mask syntax: unexpected range value");
+                    }
+                    ii++;
+                  }
                 }
                 else
                 {
-                  throw new IllegalMaskException("Malformed mask syntax: unexpected range value");
+                  if (toparse.charAt(ii + 1) != '(')
+                  {
+                    throw new IllegalMaskException("Malformed mask syntax: expected '(' token");
+                  }
+
+                  state = ParseState.DESCEND;
+                  nextToken = ii;
                 }
-                ii++;
-              }
-
-              // Set the mask value to the range value specified for the parameter
-              maskValue = Integer.valueOf(rangeValue.toString());
+                break;
+              case ')':
+                state = ParseState.ASCEND;
+                nextToken = ii;
+                break;
+              default:
+                field.append(c);
+                break;
             }
-            else
+            if (nextToken != -1)
             {
-              if (toparse.charAt(ii + 1) != '(')
-              {
-                throw new IllegalMaskException("Malformed mask syntax: expected '(' token");
-              }
-
-              state = ParseState.DESCEND;
-              nextToken = ii;
+              break;
             }
-            break;
-          case ')':
-            state = ParseState.ASCEND;
-            nextToken = ii;
-            break;
-          default:
-            field.append(c);
-            break;
           }
-          if (nextToken != -1)
+          if (toparse.length() - pos != field.length())
           {
-            break;
+            if (nextToken == -1)
+            {
+              throw new IllegalMaskException("Malformed mask syntax: expected closing token");
+            }
+            pos = nextToken;
           }
-        }
-        if (toparse.length() != field.length())
-        {
-          if (nextToken == -1)
+          else
           {
-            throw new IllegalMaskException("Malformed mask syntax: expected closing token");
+            pos = toparse.length();
           }
-          toparse.delete(0, nextToken);
-        }
-        else
-        {
-          toparse.delete(0, toparse.length());
-        }
-        if (state == ParseState.DESCEND)
-        {
-          if (field.length() == 0)
+          if (state == ParseState.DESCEND)
           {
-            throw new IllegalMaskException("Malformed mask syntax: empty parent field name");
+            if (field.length() == 0)
+            {
+              throw new IllegalMaskException("Malformed mask syntax: empty parent field name");
+            }
+            DataMap subTree = new DataMap();
+            stack.peekLast().put(field.toString().trim(), subTree);
+            stack.addLast(subTree);
           }
-          DataMap subTree = new DataMap();
-          stack.peekLast().put(field.toString().trim(), subTree);
-          stack.addLast(subTree);
-        }
-        else if (field.length() != 0)
-        {
-          stack.peekLast().put(field.toString().trim(), maskValue);
-        }
-        break;
-      case ASCEND:
-        if (toparse.indexOf(")") != 0)
-        {
-          throw new IllegalStateException("Internal Error parsing mask: unexpected parse buffer '"
-              + toparse + "' while ascending");
-        }
-        if (stack.isEmpty())
-        {
-          throw new IllegalMaskException("Malformed mask syntax: unexpected ')' token");
-        }
-        toparse.delete(0, 1);
-        stack.removeLast();
-        state = ParseState.PARSE_FIELDS;
-        break;
+          else if (field.length() != 0)
+          {
+            stack.peekLast().put(field.toString().trim(), maskValue);
+          }
+          break;
+        case ASCEND:
+          if (toparse.charAt(pos) != ')')
+          {
+            throw new IllegalStateException("Internal Error parsing mask: unexpected parse buffer '"
+                + toparse + "' while ascending");
+          }
+          if (stack.isEmpty())
+          {
+            throw new IllegalMaskException("Malformed mask syntax: unexpected ')' token");
+          }
+          pos++;
+          stack.removeLast();
+          state = ParseState.PARSE_FIELDS;
+          break;
       }
     }
     if (stack.size() != 1)
@@ -284,6 +282,24 @@ public class URIMaskUtil
     }
     result = stack.removeLast();
     return new MaskTree(result);
+  }
+
+  private static boolean stringBuilderEquals(String string, StringBuilder stringBuilder)
+  {
+    if (string.length() != stringBuilder.length())
+    {
+      return false;
+    }
+
+    for (int i = 0; i < string.length(); i++)
+    {
+      if (string.charAt(i) != stringBuilder.charAt(i))
+      {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   private enum ParseState


### PR DESCRIPTION
Currently, you can't use a typeref as a return type for an action. There doesn't seem to be a good reason for this, since Action can return primitives and RecordTemplates.