### PR TITLE
add protobuf stream data codec and use in PROTOBUF2

### DIFF
--- a/data/src/main/java/com/linkedin/data/codec/entitystream/AbstractDataDecoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/AbstractDataDecoder.java
@@ -42,7 +42,7 @@ import static com.linkedin.data.parser.NonBlockingDataParser.Token.*;
  *
  * @author kramgopa, xma, amgupta1
  */
-abstract class AbstractDataDecoder<T extends DataComplex> implements DataDecoder<T>
+public abstract class AbstractDataDecoder<T extends DataComplex> implements DataDecoder<T>
 {
   private static final EnumSet<NonBlockingDataParser.Token> SIMPLE_VALUE =
       EnumSet.of(STRING, RAW_BYTES, INTEGER, LONG, FLOAT, DOUBLE, BOOL_TRUE, BOOL_FALSE, NULL);
@@ -54,8 +54,8 @@ abstract class AbstractDataDecoder<T extends DataComplex> implements DataDecoder
   protected static final EnumSet<NonBlockingDataParser.Token> NONE = EnumSet.noneOf(NonBlockingDataParser.Token.class);
   protected static final EnumSet<NonBlockingDataParser.Token> START_TOKENS =
       EnumSet.of(NonBlockingDataParser.Token.START_OBJECT, NonBlockingDataParser.Token.START_ARRAY);
-  protected static final EnumSet<NonBlockingDataParser.Token> START_ARRAY_TOKEN = EnumSet.of(NonBlockingDataParser.Token.START_ARRAY);
-  protected static final EnumSet<NonBlockingDataParser.Token> START_OBJECT_TOKEN = EnumSet.of(NonBlockingDataParser.Token.START_OBJECT);
+  public static final EnumSet<NonBlockingDataParser.Token> START_ARRAY_TOKEN = EnumSet.of(NonBlockingDataParser.Token.START_ARRAY);
+  public static final EnumSet<NonBlockingDataParser.Token> START_OBJECT_TOKEN = EnumSet.of(NonBlockingDataParser.Token.START_OBJECT);
 
   static
   {

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/AbstractDataEncoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/AbstractDataEncoder.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author kramgopa, xma
  */
-abstract class AbstractDataEncoder implements DataEncoder
+public abstract class AbstractDataEncoder implements DataEncoder
 {
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDataEncoder.class);
 

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/ProtobufStreamDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/ProtobufStreamDataCodec.java
@@ -1,0 +1,79 @@
+/*
+    Copyright (c) 2020 LinkedIn Corp.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.linkedin.data.codec.entitystream;
+
+import com.linkedin.data.ByteString;
+import com.linkedin.data.DataList;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.codec.ProtobufCodecOptions;
+import com.linkedin.entitystream.EntityStream;
+import com.linkedin.entitystream.EntityStreams;
+import java.util.concurrent.CompletionStage;
+
+
+/**
+ * An {@link StreamDataCodec} for Protocol Buffers backed by Non-blocking protobuf parser and generator.
+ *
+ * @author amgupta1
+ */
+public class ProtobufStreamDataCodec implements StreamDataCodec
+{
+  protected final int _bufferSize;
+  protected final ProtobufCodecOptions _options;
+
+  public ProtobufStreamDataCodec(int bufferSize)
+  {
+    this(bufferSize, new ProtobufCodecOptions.Builder().setEnableASCIIOnlyStrings(true).build());
+  }
+
+  public ProtobufStreamDataCodec(int bufferSize, ProtobufCodecOptions options)
+  {
+    _bufferSize = bufferSize;
+    _options = options;
+  }
+
+  @Override
+  public CompletionStage<DataMap> decodeMap(EntityStream<ByteString> entityStream)
+  {
+    ProtobufDataDecoder<DataMap> decoder =
+        new ProtobufDataDecoder<>(_options.getSymbolTable(), AbstractDataDecoder.START_OBJECT_TOKEN);
+    entityStream.setReader(decoder);
+    return decoder.getResult();
+  }
+
+  @Override
+  public CompletionStage<DataList> decodeList(EntityStream<ByteString> entityStream)
+  {
+    ProtobufDataDecoder<DataList> decoder =
+        new ProtobufDataDecoder<>(_options.getSymbolTable(), AbstractDataDecoder.START_ARRAY_TOKEN);
+    entityStream.setReader(decoder);
+    return decoder.getResult();
+  }
+
+  @Override
+  public EntityStream<ByteString> encodeMap(DataMap map)
+  {
+    return EntityStreams.newEntityStream(new ProtobufDataEncoder(map, _bufferSize, _options));
+  }
+
+  @Override
+  public EntityStream<ByteString> encodeList(DataList list)
+  {
+    return EntityStreams.newEntityStream(new ProtobufDataEncoder(list, _bufferSize, _options));
+  }
+}

--- a/data/src/test/java/com/linkedin/data/codec/CodecDataProviders.java
+++ b/data/src/test/java/com/linkedin/data/codec/CodecDataProviders.java
@@ -17,7 +17,7 @@ import org.testng.annotations.DataProvider;
 public class CodecDataProviders
 {
   @DataProvider
-  public static Object[][] tempCodecData()
+  public static Object[][] smallCodecData()
   {
     final Map<String, DataComplex> inputs = new TreeMap<>();
 
@@ -28,6 +28,11 @@ public class CodecDataProviders
       map1.put("map11", map11);
       map1.put("list11", list11);
       inputs.put("Map with empty map and list", map1);
+
+      DataList list1 = new DataList();
+      list1.add(map1);
+      list1.add(map1);
+      inputs.put("List with nested empty map", list1);
     }
 
     return inputs.entrySet().stream()

--- a/data/src/test/java/com/linkedin/data/codec/entitystream/TestStreamCodec.java
+++ b/data/src/test/java/com/linkedin/data/codec/entitystream/TestStreamCodec.java
@@ -1,0 +1,136 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.linkedin.data.codec.entitystream;
+
+import com.linkedin.data.ByteString;
+import com.linkedin.data.DataComplex;
+import com.linkedin.data.DataList;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.TestUtil;
+import com.linkedin.data.codec.CodecDataProviders;
+import com.linkedin.data.codec.ProtobufCodecOptions;
+import com.linkedin.data.codec.symbol.InMemorySymbolTable;
+import com.linkedin.data.codec.symbol.SymbolTable;
+import com.linkedin.entitystream.EntityStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import org.testng.annotations.Test;
+
+
+public class TestStreamCodec
+{
+
+  @Test(dataProvider = "smallCodecData", dataProviderClass = CodecDataProviders.class)
+  public void testDecoder(String testName, DataComplex dataComplex)
+      throws Exception {
+    List<StreamDataCodec> codecs = getCodecs(1, dataComplex);
+    for (StreamDataCodec codec : codecs)
+    {
+      testDataCodec(codec, dataComplex);
+    }
+  }
+
+  private void testDataCodec(StreamDataCodec codec, DataComplex value) throws Exception
+  {
+    if (value.getClass() == DataMap.class)
+    {
+      testDataCodec(codec, (DataMap) value);
+    }
+    else
+    {
+      testDataCodec(codec, (DataList) value);
+    }
+  }
+
+  private void testDataCodec(StreamDataCodec codec, DataMap map) throws Exception
+  {
+    // test encoder
+    EntityStream<ByteString> byteStream = codec.encodeMap(map);
+
+    // test decoder
+    CompletionStage<DataMap> result = codec.decodeMap(byteStream);
+    TestUtil.assertEquivalent(result.toCompletableFuture().get(), map);
+  }
+
+  private void testDataCodec(StreamDataCodec codec, DataList list) throws Exception
+  {
+    // test listToBytes
+    EntityStream<ByteString> byteStream = codec.encodeList(list);
+
+    // test bytesToList
+    CompletionStage<DataList> result = codec.decodeList(byteStream);
+    TestUtil.assertEquivalent(result.toCompletableFuture().get(), list);
+  }
+
+  private List<StreamDataCodec> getCodecs(int bufferSize, DataComplex data)
+  {
+    List<StreamDataCodec> codecs = new ArrayList<>();
+    codecs.add(new JacksonSmileStreamDataCodec(bufferSize));
+    codecs.add(new JacksonStreamDataCodec(bufferSize));
+    codecs.add(new ProtobufStreamDataCodec(bufferSize));
+    Set<String> symbols = new HashSet<>();
+    if (data instanceof DataMap) {
+      collectSymbols(symbols, (DataMap) data);
+    } else {
+      collectSymbols(symbols, (DataList) data);
+    }
+    final String sharedSymbolTableName = "SHARED";
+    SymbolTable symbolTable = new InMemorySymbolTable(sharedSymbolTableName, new ArrayList<>(symbols));
+
+    codecs.add(new JacksonLICORStreamDataCodec(bufferSize, true, symbolTable));
+    codecs.add(new ProtobufStreamDataCodec(bufferSize,
+        new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable).setEnableASCIIOnlyStrings(true).build()));
+    return codecs;
+  }
+
+  private static void collectSymbols(Set<String> symbols, DataMap map)
+  {
+    for (Map.Entry<String, Object> entry : map.entrySet())
+    {
+      symbols.add(entry.getKey());
+
+      Object value = entry.getValue();
+      if (value instanceof DataMap)
+      {
+        collectSymbols(symbols, (DataMap) value);
+      }
+      else if (value instanceof DataList)
+      {
+        collectSymbols(symbols, (DataList) value);
+      }
+    }
+  }
+
+  private static void collectSymbols(Set<String> symbols, DataList list)
+  {
+    for (Object element : list)
+    {
+      if (element instanceof DataMap)
+      {
+        collectSymbols(symbols, (DataMap) element);
+      }
+      else if (element instanceof DataList)
+      {
+        collectSymbols(symbols, (DataList) element);
+      }
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.0.1
+version=29.0.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/java/com/linkedin/restli/common/ContentType.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/ContentType.java
@@ -26,6 +26,7 @@ import com.linkedin.data.codec.PsonDataCodec;
 import com.linkedin.data.codec.entitystream.JacksonLICORStreamDataCodec;
 import com.linkedin.data.codec.entitystream.JacksonSmileStreamDataCodec;
 import com.linkedin.data.codec.entitystream.JacksonStreamDataCodec;
+import com.linkedin.data.codec.entitystream.ProtobufStreamDataCodec;
 import com.linkedin.data.codec.entitystream.StreamDataCodec;
 import com.linkedin.r2.filter.R2Constants;
 import java.net.URI;
@@ -56,8 +57,13 @@ public class ContentType
   private static final JacksonLICORStreamDataCodec
       LICOR_BINARY_STREAM_DATA_CODEC = new JacksonLICORStreamDataCodec(R2Constants.DEFAULT_DATA_CHUNK_SIZE, true);
   private static final ProtobufDataCodec PROTOBUF_DATA_CODEC = new ProtobufDataCodec();
+  private static final ProtobufStreamDataCodec PROTOBUF_STREAM_DATA_CODEC =
+      new ProtobufStreamDataCodec(R2Constants.DEFAULT_DATA_CHUNK_SIZE,
+          new ProtobufCodecOptions.Builder().setEnableASCIIOnlyStrings(false).build());
   private static final ProtobufDataCodec PROTOBUF2_DATA_CODEC =
       new ProtobufDataCodec(new ProtobufCodecOptions.Builder().setEnableASCIIOnlyStrings(true).build());
+  private static final ProtobufStreamDataCodec PROTOBUF2_STREAM_DATA_CODEC =
+      new ProtobufStreamDataCodec(R2Constants.DEFAULT_DATA_CHUNK_SIZE);
   private static final PsonDataCodec PSON_DATA_CODEC = new PsonDataCodec();
   private static final JacksonSmileDataCodec SMILE_DATA_CODEC = new JacksonSmileDataCodec();
   private static final JacksonSmileStreamDataCodec SMILE_STREAM_DATA_CODEC = new JacksonSmileStreamDataCodec(R2Constants.DEFAULT_DATA_CHUNK_SIZE);
@@ -82,7 +88,7 @@ public class ContentType
    */
   @Deprecated
   public static final ContentType PROTOBUF =
-      new ContentType(RestConstants.HEADER_VALUE_APPLICATION_PROTOBUF, PROTOBUF_DATA_CODEC, null);
+      new ContentType(RestConstants.HEADER_VALUE_APPLICATION_PROTOBUF, PROTOBUF_DATA_CODEC, PROTOBUF_STREAM_DATA_CODEC);
 
   /**
    * Protocol buffers codec that supports marking ASCII only strings separately, as a hint to decoders
@@ -90,7 +96,8 @@ public class ContentType
    * {@link #PROTOBUF} codec.
    */
   public static final ContentType PROTOBUF2 =
-      new ContentType(RestConstants.HEADER_VALUE_APPLICATION_PROTOBUF2, PROTOBUF2_DATA_CODEC, null);
+      new ContentType(RestConstants.HEADER_VALUE_APPLICATION_PROTOBUF2, PROTOBUF2_DATA_CODEC,
+          PROTOBUF2_STREAM_DATA_CODEC);
 
   // Content type to be used only as an accept type.
   public static final ContentType ACCEPT_TYPE_ANY =
@@ -106,11 +113,16 @@ public class ContentType
     SUPPORTED_TYPE_PROVIDERS.put(PROTOBUF.getHeaderKey(),
         new SymbolTableBasedContentTypeProvider(PROTOBUF,
             (rawMimeType, symbolTable) -> new ContentType(rawMimeType,
-                new ProtobufDataCodec(new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable).build()), null)));
-    SUPPORTED_TYPE_PROVIDERS.put(PROTOBUF2.getHeaderKey(),
-        new SymbolTableBasedContentTypeProvider(PROTOBUF2,
-            (rawMimeType, symbolTable) -> new ContentType(rawMimeType,
-                new ProtobufDataCodec(new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable).setEnableASCIIOnlyStrings(true).build()), null)));
+                new ProtobufDataCodec(new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable).build()),
+                new ProtobufStreamDataCodec(R2Constants.DEFAULT_DATA_CHUNK_SIZE,
+                    new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable)
+                        .setEnableASCIIOnlyStrings(false).build()))));
+    SUPPORTED_TYPE_PROVIDERS.put(PROTOBUF2.getHeaderKey(), new SymbolTableBasedContentTypeProvider(PROTOBUF2,
+        (rawMimeType, symbolTable) -> new ContentType(rawMimeType, new ProtobufDataCodec(
+            new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable).setEnableASCIIOnlyStrings(true).build()),
+            new ProtobufStreamDataCodec(R2Constants.DEFAULT_DATA_CHUNK_SIZE,
+                new ProtobufCodecOptions.Builder().setSymbolTable(symbolTable)
+                    .setEnableASCIIOnlyStrings(true).build()))));
     SUPPORTED_TYPE_PROVIDERS.put(LICOR_TEXT.getHeaderKey(),
         new SymbolTableBasedContentTypeProvider(LICOR_TEXT,
             (rawMimeType, symbolTable) -> new ContentType(rawMimeType,


### PR DESCRIPTION
1. Add streamProtobuf data codec and use it in content type
2. Expose codec interfaces required to extend for application specific value ordinals