### PR TITLE
Release 29.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.0.2
+version=29.1.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
There are no code changes between this release and the previous release.
Bumping because this version will be the first to be released only as an
external library.