### PR TITLE
Reclassify -all as -with-generated for restli-int-test-api

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.1.0
+version=29.2.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-int-test-api/build.gradle
+++ b/restli-int-test-api/build.gradle
@@ -17,7 +17,7 @@ test {
 
 task fatjar(type: Jar) {
   description 'Creating a fat jar from 3 sources: src/main, src/mainGeneratedTemplate, src/mainGeneratedRest.'
-  classifier = 'all'
+  classifier = 'with-generated'
   from sourceSets.main.output
   from sourceSets.mainGeneratedDataTemplate.output
   from sourceSets.mainGeneratedRest.output


### PR DESCRIPTION
In order to avoid failures in LinkedIn's external dependency system, we
have to get rid of the `all` classifier since apparently it causes
failures.

For context: the `all` classifier of `:restli-int-test-api` contains the main classes along with generated data templates and rest classes