### PR TITLE
Expose an additional constructor that can accept pre-generated response symbol table

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.2.1
+version=29.2.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/symbol/RestLiSymbolTableProvider.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/symbol/RestLiSymbolTableProvider.java
@@ -144,6 +144,31 @@ public class RestLiSymbolTableProvider implements SymbolTableProvider, ResourceD
     }
   }
 
+  /**
+   * Constructor
+   *
+   * @param client               The {@link Client} to use to make requests to remote services to fetch their symbol tables.
+   * @param uriPrefix            The URI prefix to use when invoking remote services by name (and not by hostname:port)
+   * @param cacheSize            The size of the caches used to store symbol tables.
+   * @param serverNodeUri        The URI on which the current service is running. This should also include the context
+   *                             and servlet path (if applicable).
+   * @param responseSymbolTable  The pre-generated response symbol table.
+   */
+  public RestLiSymbolTableProvider(Client client,
+      String uriPrefix,
+      int cacheSize,
+      String serverNodeUri,
+      SymbolTable responseSymbolTable)
+  {
+    _client = client;
+    _uriPrefix = uriPrefix;
+    _symbolTableNameHandler = new SymbolTableNameHandler(responseSymbolTable.getName(), serverNodeUri);
+    _serviceNameToSymbolTableCache = Caffeine.newBuilder().maximumSize(cacheSize).build();
+    _symbolTableNameToSymbolTableCache = Caffeine.newBuilder().maximumSize(cacheSize).build();
+    _defaultResponseSymbolTable = responseSymbolTable;
+    _defaultResponseSymbolTableName = responseSymbolTable.getName();
+  }
+
   @Override
   public SymbolTable getSymbolTable(String symbolTableName)
   {


### PR DESCRIPTION
There are a few instances where we may want to use a pre-generated response symbol table (Say in services talking to remote mobile/web clients where symbol order and name needs to be determined at build time). Add a constructor in the symbol table provider to account for such use cases.