### PR TITLE
Fix the way schema files get moved to the build directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,9 +273,13 @@ subprojects {
     testOutputDir = sourceSets.test.output.classesDirs.getSingleFile()
   }
 
-  test {
+  task junitTests(type: Test) {
     maxHeapSize = '4g'
+    useJUnit()
+  }
 
+  task testngTests(type: Test) {
+    maxHeapSize = '4g'
     useTestNG() {
       excludeGroups 'not_implemented'
       excludeGroups 'integration'
@@ -284,6 +288,11 @@ subprojects {
       excludeGroups 'known_issue'
       excludeGroups 'withoutAssertion'
     }
+  }
+
+  test {
+    dependsOn junitTests
+    dependsOn testngTests
   }
 
   // Exclude tests which are known to be flaky in the Travis CI environment

--- a/build.gradle
+++ b/build.gradle
@@ -295,10 +295,10 @@ subprojects {
     dependsOn testngTests
   }
 
-  // Exclude tests which are known to be flaky in the Travis CI environment
+  // Exclude tests (of testNG) which are known to be flaky in the Travis CI environment
   if (System.getenv('TRAVIS') == 'true' && System.getenv('USER') == 'travis') {
     afterEvaluate {
-      project.tasks.withType(Test).forEach {
+      project.tasks.withType(Test).withName("testngTests").forEach {
         it.options.excludeGroups 'ci-flaky'
         it.systemProperties['test.httpRequestTimeout'] = '20000'
       }

--- a/gradle-plugins/build.gradle
+++ b/gradle-plugins/build.gradle
@@ -1,10 +1,13 @@
 apply plugin: 'java'
+apply plugin: 'java-gradle-plugin'
 
 dependencies {
   compile gradleApi()
 
   testCompile externalDependency.testng
   testCompile externalDependency.junit
+
+  testCompile gradleTestKit()
 }
 
 // This is done so that the plugin can know which version of restli should be used when creating the pegasus configuration.

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -57,6 +57,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.Sync;
@@ -1644,7 +1645,7 @@ public class PegasusPlugin implements Plugin<Project>
 
     // Dummy task to maintain backward compatibility, as this task was replaced by SyncSchemas
     // TODO: Delete this task once use cases have had time to reference the new task
-    Task copySchemasTask = project.getTasks().create(sourceSet.getName() + "CopySchemas");
+    Task copySchemasTask = project.getTasks().create(sourceSet.getName() + "CopySchemas", Copy.class);
     copySchemasTask.dependsOn(copyPdscSchemasTask);
     copySchemasTask.doLast(new CacheableAction<>(t -> project.getLogger().lifecycle("CopySchemas task has been deprecated.")));
 

--- a/gradle-plugins/src/test/java/com/linkedin/pegasus/gradle/PegasusPluginFunctionalTest.java
+++ b/gradle-plugins/src/test/java/com/linkedin/pegasus/gradle/PegasusPluginFunctionalTest.java
@@ -1,0 +1,131 @@
+package com.linkedin.pegasus.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
+import static org.junit.Assert.*;
+
+
+public class PegasusPluginFunctionalTest {
+    private static final String MAIN_SYNC_SCHEMAS = ":mainSyncSchemas";
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Test
+    public void testApplyPluginToProject() throws IOException {
+        // Given: Default project with PegasusPlugin.
+        setupProject(testProjectDir);
+
+        // When: Run the build.
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withPluginClasspath()
+                .withArguments("tasks")
+                .build();
+
+        // Then: Validate plugin was applied successfully.
+        assertNotNull(result.getOutput());
+    }
+
+    @Test
+    public void testMainSyncSchemas_whenTaskIsUpToDate() throws IOException {
+        // Given: Default project with PegasusPlugin and one schema file.
+        setupProject(testProjectDir);
+        File schemasDir = createSchemaDirectory(testProjectDir);
+        String schemaFilename = "A.pdsc";
+        new File(schemasDir, schemaFilename).createNewFile();
+
+        // When: Run the mainSyncSchemas task.
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments(MAIN_SYNC_SCHEMAS)
+                .withPluginClasspath();
+
+        // Then: Validate task was a success and file exists in build directory's mainSchemas folder.
+        String mainSchemasDir = testProjectDir.getRoot() + File.separator + "build" + File.separator + "mainSchemas" + File.separator;
+        BuildResult result = runner.build();
+        File buildSchema = new File(mainSchemasDir + schemaFilename);
+        assertTrue(result.task(MAIN_SYNC_SCHEMAS).getOutcome() == SUCCESS);
+        assertTrue(buildSchema.exists());
+
+        // When: Rerun the task.
+        result = runner.build();
+
+        // Then: Validate task was up-to-date and file exists in the build directory's mainSchemas folder.
+        assertTrue(result.task(MAIN_SYNC_SCHEMAS).getOutcome() == UP_TO_DATE);
+        assertTrue(buildSchema.exists());
+    }
+
+    @Test
+    public void testMainSyncSchemas_whenFileBecomesStale() throws IOException {
+        // Given: Default project with PegasusPlugin and two schema files.
+        setupProject(testProjectDir);
+        File schemasDir = createSchemaDirectory(testProjectDir);
+        String schemaFilename1 = "A.pdsc";
+        new File(schemasDir, schemaFilename1).createNewFile();
+        String schemaFilename2 = "B.pdsc";
+        File schemaFile2 = new File(schemasDir, schemaFilename2);
+        schemaFile2.createNewFile();
+
+        // When: Run the mainSyncSchemas task.
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments(MAIN_SYNC_SCHEMAS)
+                .withPluginClasspath();
+
+        // Then: Validate task was a success and both files were moved to the build directory's mainSchemas folder.
+        String mainSchemasDir = testProjectDir.getRoot() + File.separator + "build" + File.separator + "mainSchemas" + File.separator;
+        BuildResult result = runner.build();
+        File buildSchema1 = new File(mainSchemasDir + schemaFilename1);
+        File buildSchema2 = new File(mainSchemasDir + schemaFilename2);
+        assertTrue(result.task(MAIN_SYNC_SCHEMAS).getOutcome() == SUCCESS);
+        assertTrue(buildSchema1.exists());
+        assertTrue(buildSchema2.exists());
+
+        // When: Delete one of the schemas and rerun the task.
+        assertTrue(schemaFile2.delete());
+        result = runner.build();
+
+        // Then: Validate task was a success and stale file gets removed from build directory's mainSchemas folder.
+        assertTrue(result.task(MAIN_SYNC_SCHEMAS).getOutcome() == SUCCESS);
+        assertTrue(buildSchema1.exists());
+        assertFalse(buildSchema2.exists());
+    }
+
+    /**
+     * Write file to disk with specified content.
+     */
+    private void writeFile(File destination, String content) throws IOException {
+        try (BufferedWriter output = new BufferedWriter(new FileWriter(destination))) {
+            output.write(content);
+        }
+    }
+
+    /**
+     * Set up project that applies the pegasus plugin.
+     */
+    private void setupProject(TemporaryFolder temporaryFolder) throws IOException {
+        File buildFile = temporaryFolder.newFile("build.gradle");
+        String buildFileContent = "plugins { id 'pegasus' }\n";
+        writeFile(buildFile, buildFileContent);
+    }
+
+    /**
+     * Create pegasus schema src directory.
+     */
+    private File createSchemaDirectory(TemporaryFolder temporaryFolder) {
+        File schemasDir = new File(temporaryFolder.getRoot() + File.separator + "src" + File.separator + "main" + File.separator + "pegasus");
+        schemasDir.mkdirs();
+        return schemasDir;
+    }
+}

--- a/gradle-plugins/src/test/java/com/linkedin/pegasus/gradle/TestPegasusPlugin.java
+++ b/gradle-plugins/src/test/java/com/linkedin/pegasus/gradle/TestPegasusPlugin.java
@@ -15,12 +15,16 @@
 */
 package com.linkedin.pegasus.gradle;
 
-import java.util.Map;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.Sync;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 import static org.testng.Assert.*;
 
@@ -55,5 +59,17 @@ public final class TestPegasusPlugin
 
     assertFalse(pegasusOptions.get("main").hasGenerationMode(PegasusOptions.GenerationMode.AVRO));
     assertTrue(pegasusOptions.get("main").hasGenerationMode(PegasusOptions.GenerationMode.PEGASUS));
+  }
+
+  @Test
+  public void testPluginCreatesCorrectTasks() {
+    // Given/When: Pegasus Plugin is applied to a project.
+    Project project = ProjectBuilder.builder().build();
+    project.getPlugins().apply(PegasusPlugin.class);
+
+    // Then: Validate the Copy/Sync Schema tasks are of the correct type.
+    assertTrue(project.getTasks().getByName("mainCopyPdscSchemas") instanceof DefaultTask);
+    assertTrue(project.getTasks().getByName("mainCopySchemas") instanceof Copy);
+    assertTrue(project.getTasks().getByName("mainSyncSchemas") instanceof Sync);
   }
 }


### PR DESCRIPTION
This fixes a bug when building the data template jar without doing a gradle clean task, pdsc's that were moved or deleted will still be present in the jar. 

The actual issue is that the pegasus plugin uses the Gradle Copy type task instead of a Sync type.

Things in this PR:
* Created new junitTest and testngTest tasks -> previously the test task did only testng tests
* Added ability to run functional tests in the gradle-plugin module
* Updated the PegasusPlugin to use the sync task to copy the schemas instead of the copy task
* Created functional tests to validate PegasusPlugin copies schemas properly  