### PR TITLE
Only include the underlying exception message in BufferedReaderInputStream

### DIFF
--- a/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/streaming/BufferedReaderInputStream.java
+++ b/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/streaming/BufferedReaderInputStream.java
@@ -54,7 +54,9 @@ class BufferedReaderInputStream extends InputStream implements Reader
 
     if (_throwable != null)
     {
-      throw new IOException(_throwable);
+      // Underlying network layer might throw an exception here and in certain frameworks, the exception class might not be classloaded (e.g. J2EE servlet containers separate server classes from application classes)
+      // however logging framework might try to load the class when logging this exception, creating performance problems.
+      throw new IOException(_throwable.getMessage());
     }
     else if (done())
     {


### PR DESCRIPTION
only propagate the exception message instead of the entire exception here