### PR TITLE
fix dark cluster startup problem

### DIFF
--- a/darkcluster-test-api/src/main/java/com/linkedin/darkcluster/MockClusterInfoProvider.java
+++ b/darkcluster-test-api/src/main/java/com/linkedin/darkcluster/MockClusterInfoProvider.java
@@ -29,6 +29,7 @@ import com.linkedin.d2.balancer.util.ClusterInfoProvider;
 
 public class MockClusterInfoProvider implements ClusterInfoProvider
 {
+  DarkClusterConfigMap EMPTY_DARK_CLUSTER_CONFIG_MAP = new DarkClusterConfigMap();
   Map<String, DarkClusterConfigMap> lookupMap = new HashMap<>();
   List<LoadBalancerClusterListener> clusterListeners = new ArrayList<>();
   Map<String, Integer> clusterHttpsCount = new HashMap<>();
@@ -51,7 +52,7 @@ public class MockClusterInfoProvider implements ClusterInfoProvider
   public DarkClusterConfigMap getDarkClusterConfigMap(String clusterName)
     throws ServiceUnavailableException
   {
-    return lookupMap.get(clusterName);
+    return lookupMap.getOrDefault(clusterName, EMPTY_DARK_CLUSTER_CONFIG_MAP);
   }
 
   @Override

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
@@ -55,6 +55,7 @@ public class TestDarkClusterStrategyFactory
   static final String SOURCE_CLUSTER_NAME = "FooCluster";
   static final String DARK_CLUSTER_NAME = "FooCluster-dark";
   static final String DARK_CLUSTER_NAME2 = "FooCluster-dark2";
+  static final String PREEXISTING_DARK_CLUSTER_NAME = "FooCluster-darkOld";
   private static final int SEED = 2;
   private DarkClusterStrategyFactory _strategyFactory;
   private MockClusterInfoProvider _clusterInfoProvider;
@@ -64,6 +65,8 @@ public class TestDarkClusterStrategyFactory
   {
     _clusterInfoProvider = new MockClusterInfoProvider();
     Facilities facilities = new MockFacilities(_clusterInfoProvider);
+    DarkClusterConfig darkClusterConfigOld = createRelativeTrafficMultiplierConfig(0.5f);
+    _clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, PREEXISTING_DARK_CLUSTER_NAME, darkClusterConfigOld);
     DarkClusterDispatcher darkClusterDispatcher = new DefaultDarkClusterDispatcher(new MockClient(false));
     _strategyFactory = new DarkClusterStrategyFactoryImpl(facilities,
                                                           SOURCE_CLUSTER_NAME,
@@ -104,6 +107,14 @@ public class TestDarkClusterStrategyFactory
     DarkClusterStrategy strategy2 = _strategyFactory.get(DARK_CLUSTER_NAME);
     Assert.assertTrue(strategy2 instanceof RelativeTrafficMultiplierDarkClusterStrategy);
     Assert.assertEquals(((RelativeTrafficMultiplierDarkClusterStrategy) strategy2).getMultiplier(), 0.5f, "expected 0.5f multiplier");
+  }
+
+  @Test
+  public void testStrategyPopulatedWithoutExplicitUpdate()
+  {
+    DarkClusterStrategy strategy = _strategyFactory.get(PREEXISTING_DARK_CLUSTER_NAME);
+    Assert.assertTrue(strategy instanceof RelativeTrafficMultiplierDarkClusterStrategy);
+    Assert.assertEquals(((RelativeTrafficMultiplierDarkClusterStrategy) strategy).getMultiplier(), 0.5f, "expected 0.5f multiplier");
   }
 
   @Test


### PR DESCRIPTION
The Dark Cluster ClusterListener is registered after we have already started listening to the cluster, so we need to explicitly trigger a refresh of the dark cluster strategies. The previous change introduced this bug by moving all strategy changes into the ClusterListener (instead of creating the strategy on demand), but forgetting to make sure we have an updated state after we start listening. 

I added a unit test and logging to make sure we don't regress and can tell the order in production logs.