### PR TITLE
Update Pegasus Plugin's CopySchema tasks to delete stale schemas 

### DIFF
--- a/gradle-plugins/build.gradle
+++ b/gradle-plugins/build.gradle
@@ -1,12 +1,50 @@
 // Setup integTests
 apply from: "${buildScriptDirPath}/integTest.gradle"
 
+configurations {
+  dataTemplateForTesting
+  pegasusPluginForTesting
+}
+
 dependencies {
   testImplementation externalDependency.testng
   testImplementation externalDependency.junit
+
+  dataTemplateForTesting project(':data')
+  pegasusPluginForTesting project(':data')
+  pegasusPluginForTesting project(':data-avro-generator')
+  pegasusPluginForTesting project(':generator')
+  pegasusPluginForTesting project(':restli-tools')
 }
 
 // This is done so that the plugin can know which version of restli should be used when creating the pegasus configuration.
 processResources {
   filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: ['version': project.version as String])
 }
+
+task resourcesDirWithoutPegasusVersionProperties(type: Sync) {
+  dependsOn processResources
+  description 'Creates a backup of the build/gradle-plugins/resources/main/ folder, ' +
+          'but excluding pegasus-version.properties. ' +
+          'This allows testing the version of pegasus jars in the current build.'
+
+  from(sourceSets.main.output.resourcesDir) {
+    exclude 'pegasus-version.properties'
+  }
+  into "$buildDir/$name"
+}
+
+tasks.pluginUnderTestMetadata {
+  dependsOn tasks.resourcesDirWithoutPegasusVersionProperties
+
+  // allows us to test plugin application without the unpublished version set in pegasus-version.properties
+  // also we add the localLibsForTesting to avoid leaking dependencies in published metadata
+  pluginClasspath.setFrom(files(sourceSets.main.java.outputDir, sourceSets.main.groovy.outputDir, tasks.resourcesDirWithoutPegasusVersionProperties))
+}
+
+integTest {
+  dependsOn configurations.dataTemplateForTesting, configurations.pegasusPluginForTesting
+  systemProperty 'integTest.dataTemplateCompileDependencies', "'${configurations.dataTemplateForTesting.join("', '")}'"
+  systemProperty 'integTest.pegasusPluginDependencies', "'${configurations.pegasusPluginForTesting.join("', '")}'"
+}
+

--- a/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginCacheabilityTest.groovy
+++ b/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginCacheabilityTest.groovy
@@ -1,0 +1,95 @@
+package com.linkedin.pegasus.gradle
+
+import groovy.json.JsonOutput
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.*
+
+class PegasusPluginCacheabilityTest extends Specification {
+  @Rule
+  TemporaryFolder tempDir = new TemporaryFolder()
+
+  def 'mainDataTemplateJar tasks are up-to-date'() {
+    setup:
+    def runner = GradleRunner.create()
+        .withProjectDir(tempDir.root)
+        .withPluginClasspath()
+        .withArguments('mainDataTemplateJar')
+
+    def settingsFile = tempDir.newFile('settings.gradle')
+    settingsFile << "rootProject.name = 'test-project'"
+
+    def buildFile = tempDir.newFile('build.gradle')
+    buildFile << """
+    |plugins { 
+    |  id 'pegasus' 
+    |}
+    |
+    |repositories { 
+    |  jcenter()
+    |}
+    |
+    |dependencies {
+    |  dataTemplateCompile files(${System.getProperty('integTest.dataTemplateCompileDependencies')})
+    |  pegasusPlugin files(${System.getProperty('integTest.pegasusPluginDependencies')})
+    |}
+    """.stripMargin()
+
+    // Create a simple pdsc schema
+    def schemaFilename = 'ATypeRef.pdsc'
+    def pegasusDir = tempDir.newFolder('src', 'main', 'pegasus')
+    def pdscFile = new File("$pegasusDir.path$File.separator$schemaFilename")
+    def pdscData = [
+            type: 'typeref',
+            name: 'ATypeRef',
+            ref:  'string',
+            doc:  'A type ref data.'
+    ]
+    pdscFile << JsonOutput.prettyPrint(JsonOutput.toJson(pdscData))
+
+    // Expected schema files in the build directory
+    def compiledSchema = new File([tempDir.root, 'build', 'classes', 'java', 'mainGeneratedDataTemplate', 'ATypeRef.class'].join(File.separator))
+    def preparedSchema = new File([tempDir.root, 'build', 'mainSchemas', schemaFilename].join(File.separator))
+
+    when:
+    def result = runner.build()
+
+    then:
+    // Validate task output are expected
+    result.task(':generateDataTemplate').outcome == SUCCESS
+    result.task(':compileMainGeneratedDataTemplateJava').outcome == SUCCESS
+    result.task(':mainDestroyStaleFiles').outcome == SKIPPED
+    result.task(':mainCopyPdscSchemas').outcome == SKIPPED
+    result.task(':mainCopySchemas').outcome == SUCCESS
+    result.task(':processMainGeneratedDataTemplateResources').outcome == NO_SOURCE
+    result.task(':mainGeneratedDataTemplateClasses').outcome ==  SUCCESS
+    result.task(':mainTranslateSchemas').outcome == SUCCESS
+    result.task(':mainDataTemplateJar').outcome == SUCCESS
+
+    // Validate compiled and prepared schemas exist
+    compiledSchema.exists()
+    preparedSchema.exists()
+
+    when:
+    result = runner.build()
+
+    then:
+    // Validate task output are expected
+    result.task(':generateDataTemplate').outcome == UP_TO_DATE
+    result.task(':compileMainGeneratedDataTemplateJava').outcome == UP_TO_DATE
+    result.task(':mainDestroyStaleFiles').outcome == SKIPPED
+    result.task(':mainCopyPdscSchemas').outcome == SKIPPED
+    result.task(':mainCopySchemas').outcome == UP_TO_DATE
+    result.task(':processMainGeneratedDataTemplateResources').outcome == NO_SOURCE
+    result.task(':mainGeneratedDataTemplateClasses').outcome == UP_TO_DATE
+    result.task(':mainTranslateSchemas').outcome == UP_TO_DATE
+    result.task(':mainDataTemplateJar').outcome == UP_TO_DATE
+
+    // Validate compiled and prepared schemas exist
+    compiledSchema.exists()
+    preparedSchema.exists()
+  }
+}

--- a/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginIntegrationTest.groovy
+++ b/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginIntegrationTest.groovy
@@ -1,10 +1,12 @@
 package com.linkedin.pegasus.gradle
 
+import groovy.json.JsonOutput
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class PegasusPluginIntegrationTest extends Specification {
   @Rule
@@ -19,11 +21,78 @@ class PegasusPluginIntegrationTest extends Specification {
     def result = GradleRunner.create()
         .withProjectDir(tempDir.root)
         .withPluginClasspath()
-        .withArguments("mainDataTemplateJar")
+        .withArguments('mainDataTemplateJar')
         .forwardOutput()
         .build()
 
     then:
-    result.task(':mainDataTemplateJar').outcome == TaskOutcome.SUCCESS
+    result.task(':mainDataTemplateJar').outcome == SUCCESS
+  }
+
+  def 'mainCopySchema task will remove stale pdsc'() {
+    setup:
+    def runner = GradleRunner.create()
+        .withProjectDir(tempDir.root)
+        .withPluginClasspath()
+        .withArguments('mainDataTemplateJar')
+
+    def settingsFile = tempDir.newFile('settings.gradle')
+    settingsFile << "rootProject.name = 'test-project'"
+
+    def buildFile = tempDir.newFile('build.gradle')
+    buildFile << """
+    |plugins {
+    |  id 'pegasus'
+    |}
+    |
+    |repositories {
+    |  jcenter()
+    |}
+    |
+    |dependencies {
+    |  dataTemplateCompile files(${System.getProperty('integTest.dataTemplateCompileDependencies')})
+    |  pegasusPlugin files(${System.getProperty('integTest.pegasusPluginDependencies')})
+    |}
+    """.stripMargin()
+
+    def pegasusDir = tempDir.newFolder('src', 'main', 'pegasus')
+    def pdscFilename1 = 'ATypeRef.pdsc'
+    def pdscFile1 = new File("$pegasusDir.path$File.separator$pdscFilename1")
+    def pdscData1 = [
+        type: 'typeref',
+        name: 'ATypeRef',
+        ref : 'string',
+        doc : 'A type ref data.'
+    ]
+    pdscFile1 << JsonOutput.prettyPrint(JsonOutput.toJson(pdscData1))
+    def pdscFilename2 = 'BTypeRef.pdsc'
+    def pdscFile2 = new File("$pegasusDir.path$File.separator$pdscFilename2")
+    def pdscData2 = [
+        type: 'typeref',
+        name: 'BTypeRef',
+        ref : 'string',
+        doc : 'B type ref data.'
+    ]
+    pdscFile2 << JsonOutput.prettyPrint(JsonOutput.toJson(pdscData2))
+    def mainSchemasDir = [tempDir.root, 'build', 'mainSchemas'].join(File.separator)
+    def preparedPdscFile1 = new File("$mainSchemasDir$File.separator$pdscFilename1")
+    def preparedPdscFile2 = new File("$mainSchemasDir$File.separator$pdscFilename2")
+
+    when:
+    def result = runner.build()
+
+    then:
+    result.task(':mainCopySchemas').getOutcome() == SUCCESS
+    preparedPdscFile1.exists()
+    preparedPdscFile2.exists()
+
+    when:
+    pdscFile1.delete()
+    result = runner.build()
+
+    then:
+    result.task(':mainCopySchemas').getOutcome() == SUCCESS
+    !preparedPdscFile1.exists()
+    preparedPdscFile2.exists()
   }
 }

--- a/gradle-plugins/src/test/java/com/linkedin/pegasus/gradle/TestPegasusPlugin.java
+++ b/gradle-plugins/src/test/java/com/linkedin/pegasus/gradle/TestPegasusPlugin.java
@@ -15,12 +15,16 @@
 */
 package com.linkedin.pegasus.gradle;
 
-import java.util.Map;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.Delete;
+import org.gradle.api.tasks.Sync;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 import static org.testng.Assert.*;
 
@@ -55,5 +59,17 @@ public final class TestPegasusPlugin
 
     assertFalse(pegasusOptions.get("main").hasGenerationMode(PegasusOptions.GenerationMode.AVRO));
     assertTrue(pegasusOptions.get("main").hasGenerationMode(PegasusOptions.GenerationMode.PEGASUS));
+  }
+
+  @Test
+  public void testTaskTypes() {
+    // Given/When: Pegasus Plugin is applied to a project.
+    Project project = ProjectBuilder.builder().build();
+    project.getPlugins().apply(PegasusPlugin.class);
+
+    // Then: Validate the Copy/Sync Schema tasks are of the correct type.
+    assertTrue(project.getTasks().getByName("mainDestroyStaleFiles") instanceof Delete);
+    assertTrue(project.getTasks().getByName("mainCopyPdscSchemas") instanceof Copy);
+    assertTrue(project.getTasks().getByName("mainCopySchemas") instanceof Sync);
   }
 }


### PR DESCRIPTION
This PR needs to go into master after https://github.com/linkedin/rest.li/pull/328/

The Issue:
The issue is that the pegasus plugin, when preparing the schemas for
publication, will copy the schemas to the build directory without
removing stale schemas. Without the fix, these stale schemas will be
packaged into the data template jar -> which is a problem.

The current workaround, which is implemented, is that we have a delete
task and a copy task. The delete task is triggered by a gradle project
flag. The copy moves the files as intended. This workaround is not
viable since it breaks the UP-TO-DATE checks between builds. In
particular, it breaks the UP-TO-DATE checks during a HOT RELOAD
(runPlay task of the Play Framework).

The Fix:
Instead of the workaround as above, we "skip" the delete task and make
the copy task become a sync task. The task name stays the same but the
class type will be a sync task which will "Synchronizes the contents of
a destination directory with some source directories and files
[https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Sync.html]".
This task will now delete stale files in the destination and will pass
the 'up-to-date' between builds.

Testing:
Integ test:
1) Validate cacheability/up-to-date of tasks between builds when running the mainDataTemplateJar task. 
2) Validate the mainCopySchemas task will delete stale schemas (this is the issue that was specified above). This was tested using the mainDataTemplateJar task which has a dependency on the mainCopySchemas task.

Unit test:
1) Validate the mainCopySchemas task is a Sync task

In addition, I worked with @DPUkyle to create multiple configurations
to allow the integ test to work. (Kyle's original PR: https://github.com/Astro03/rest.li/pull/2)
 - Pass necessary configurations using sysprops and custom configurations
 - Custom task to keep pegasus-version.properties out of the integTest classpath
 - Override TemporaryFolder to prevent cleanup
 - Use settings.gradle to prevent randomly-generated values in project under test