### PR TITLE
[TESTING] Trigger Travis changelog check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-
-## [29.3.3] - 2020-06-22
 - Add new changelog (`CHANGELOG.md`) and changelog helper script (`./scripts/update-changelog`).
 
 ## [29.3.2] - 2020-06-19
@@ -4540,8 +4538,7 @@ patch operations can re-use these classes for generating patch messages.
 ## [0.14.1]
 
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.3.3...master
-[29.3.3]: https://github.com/linkedin/rest.li/compare/v29.3.2...v29.3.3
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.3.2...master
 [29.3.2]: https://github.com/linkedin/rest.li/compare/v29.3.1...v29.3.2
 [29.3.1]: https://github.com/linkedin/rest.li/compare/v29.3.0...v29.3.1
 [29.3.0]: https://github.com/linkedin/rest.li/compare/v29.2.5...v29.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 - Add new changelog (`CHANGELOG.md`) and changelog helper script (`./scripts/update-changelog`).
 
+## [29.3.3] - 2020-06-22
+
 ## [29.3.2] - 2020-06-19
 - Fix dark cluster startup problem (#330)
 - Only include the underlying exception message in BufferedReaderInputStream instead of rethrowing the original exception (#329)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-- Add new changelog (`CHANGELOG.md`) and changelog helper script (`./scripts/update-changelog`).
 
 ## [29.3.3] - 2020-06-22
+- Add new changelog (`CHANGELOG.md`) and changelog helper script (`./scripts/update-changelog`).
 
 ## [29.3.2] - 2020-06-19
 - Fix dark cluster startup problem (#330)
@@ -4540,7 +4540,8 @@ patch operations can re-use these classes for generating patch messages.
 ## [0.14.1]
 
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.3.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.3.3...master
+[29.3.3]: https://github.com/linkedin/rest.li/compare/v29.3.2...v29.3.3
 [29.3.2]: https://github.com/linkedin/rest.li/compare/v29.3.1...v29.3.2
 [29.3.1]: https://github.com/linkedin/rest.li/compare/v29.3.0...v29.3.1
 [29.3.0]: https://github.com/linkedin/rest.li/compare/v29.2.5...v29.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-version=29.3.3
+version=29.3.2
+# Don't bump version, don't bump changelog
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.3.2
+version=29.3.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Bump to `29.3.3` without updating the changelog to ensure that Travis will quickly reject the PR.