### PR TITLE
Add PathSpecSet: a set of PathSpecSet with support for full projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add PathSpecSet, an immutable set of PathSpecs that is convenient to use when building logic based on Rest.li projection
 
 ## [29.14.2] - 2021-02-03
 - Exclude conflicting velocity engine dependency.

--- a/data-transform/src/main/java/com/linkedin/data/transform/filter/request/MaskCreator.java
+++ b/data-transform/src/main/java/com/linkedin/data/transform/filter/request/MaskCreator.java
@@ -21,7 +21,7 @@
 package com.linkedin.data.transform.filter.request;
 
 import com.linkedin.data.schema.PathSpec;
-
+import com.linkedin.data.schema.PathSpecSet;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -53,6 +53,26 @@ public class MaskCreator
   public static MaskTree createPositiveMask(Collection<PathSpec> paths)
   {
     return createMaskTree(paths, MaskOperation.POSITIVE_MASK_OP);
+  }
+
+  /**
+   * Create a positive mask for the given set.
+   *
+   * @param pathSpecSet the set that should be in the mask
+   * @return a {@link MaskTree}
+   */
+  public static MaskTree createPositiveMask(PathSpecSet pathSpecSet)
+  {
+    if (pathSpecSet.isAllInclusive())
+    {
+      MaskTree maskTree = new MaskTree();
+      maskTree.addOperation(new PathSpec(PathSpec.WILDCARD), MaskOperation.POSITIVE_MASK_OP);
+      return maskTree;
+    }
+    else
+    {
+      return createMaskTree(pathSpecSet.getPathSpecs(), MaskOperation.POSITIVE_MASK_OP);
+    }
   }
 
   /**

--- a/data-transform/src/test/java/com/linkedin/data/transform/filter/TestMaskCreation.java
+++ b/data-transform/src/test/java/com/linkedin/data/transform/filter/TestMaskCreation.java
@@ -23,15 +23,16 @@ package com.linkedin.data.transform.filter;
 
 import com.linkedin.data.DataMap;
 import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.schema.PathSpecSet;
 import com.linkedin.data.transform.filter.request.MaskCreator;
 import com.linkedin.data.transform.filter.request.MaskOperation;
 import com.linkedin.data.transform.filter.request.MaskTree;
 
 import java.io.IOException;
 
-import java.nio.file.Path;
 import java.util.Map;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static com.linkedin.data.TestUtil.dataMapFromString;
@@ -372,4 +373,36 @@ public class TestMaskCreation
     mask.addOperation(new PathSpec("a"), MaskOperation.NEGATIVE_MASK_OP);
     Assert.assertEquals(mask.toString(), "{a=0}");
   }
+
+  @Test(dataProvider = "pathSpecSetProvider")
+  public void testPositiveMaskWithPathSpecSet(PathSpecSet input, MaskTree expected)
+  {
+    Assert.assertEquals(MaskCreator.createPositiveMask(input).getOperations(), expected.getOperations());
+  }
+
+  @DataProvider
+  public static Object[][] pathSpecSetProvider()
+  {
+    MaskTree simpleMaskTree = new MaskTree();
+    simpleMaskTree.addOperation(new PathSpec("myField"), MaskOperation.POSITIVE_MASK_OP);
+    MaskTree fullMaskTree = new MaskTree();
+    fullMaskTree.addOperation(new PathSpec(PathSpec.WILDCARD), MaskOperation.POSITIVE_MASK_OP);
+
+    return new Object[][] {
+        {
+            PathSpecSet.of(new PathSpec("myField")),
+            simpleMaskTree
+        },
+        {
+            PathSpecSet.empty(),
+            new MaskTree()
+        },
+        {
+            PathSpecSet.allInclusive(),
+            fullMaskTree
+        }
+    };
+  }
+
+
 }

--- a/data/src/main/java/com/linkedin/data/schema/PathSpec.java
+++ b/data/src/main/java/com/linkedin/data/schema/PathSpec.java
@@ -124,9 +124,34 @@ public class PathSpec
     return Collections.unmodifiableList(_path);
   }
 
+  /**
+   * Specifies whether this PathSpec has no segment
+   * @return <code>true</code> if this pathSpec has no segment, <code>false</code> otherwise
+   */
+  public boolean isEmptyPath()
+  {
+    return _path.isEmpty();
+  }
+
   public Map<String, Object> getPathAttributes()
   {
     return Collections.unmodifiableMap(_attributes);
+  }
+
+  /**
+   * Returns a new PathSpec using the same path as this PathSpec but truncated of its last element.
+   * The parent of an empty PathSpec is itself.
+   */
+  public PathSpec getParent()
+  {
+    if (_path.size() <= 1)
+    {
+      return emptyPath();
+    }
+    else
+    {
+      return new PathSpec(_path.subList(0, _path.size() - 1));
+    }
   }
 
   @Override

--- a/data/src/main/java/com/linkedin/data/schema/PathSpecSet.java
+++ b/data/src/main/java/com/linkedin/data/schema/PathSpecSet.java
@@ -1,0 +1,426 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.data.schema;
+
+import com.linkedin.data.template.RecordTemplate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+
+/**
+ * Represents an immutable set of {@link PathSpec}s.
+ *
+ * <p>Path spec set is a convenient wrapper for a collection of {@link PathSpec}. A few advantages of using this class
+ * over manually passing around {@code Set<PathSpec>} is:
+ *
+ * <ul>
+ *   <li>guaranteed immutable representation</li>
+ *   <li>
+ *     explicitly supports "all inclusive" which translates into fetching everything (default for Rest.li resources),
+ *     as well as "empty" which translates into fetching no fields
+ *   </li>
+ *   <li>mutable builder for incrementally assembling an immutable {@link PathSpecSet}</li>
+ *   <li>built-in utility to mask a {@link RecordTemplate} with the stored path specs</li>
+ * </ul>
+ *
+ * @author Joseph Florencio
+ */
+final public class PathSpecSet
+{
+  private final static PathSpecSet EMPTY = new PathSpecSet(Collections.emptySet(), false);
+  private final static PathSpecSet ALL_INCLUSIVE = new PathSpecSet(Collections.emptySet(), true);
+
+  private final Set<PathSpec> _pathSpecs;
+  private final boolean _allInclusive;
+
+  private PathSpecSet(Builder builder)
+  {
+    this(new HashSet<>(builder._pathSpecs), builder._allInclusive);
+  }
+
+  private PathSpecSet(Set<PathSpec> pathSpecs, boolean allInclusive)
+  {
+    _pathSpecs = Collections.unmodifiableSet(pathSpecs);
+    _allInclusive = allInclusive;
+  }
+
+  /**
+   * Creates a new PathSpecSet by copying the input {@code pathSpecs}.
+   *
+   * @param pathSpecs input path specs
+   * @return immutable path spec set
+   */
+  public static PathSpecSet of(Collection<PathSpec> pathSpecs)
+  {
+    if (pathSpecs.isEmpty())
+    {
+      return empty();
+    }
+    else
+    {
+      return new PathSpecSet(new HashSet<>(pathSpecs), false);
+    }
+  }
+
+  /**
+   * Creates a new path spec set from the input {@code pathSpecs}.
+   *
+   * @param pathSpecs input path specs
+   * @return immutable path spec set
+   */
+  public static PathSpecSet of(PathSpec... pathSpecs)
+  {
+    return of(Arrays.asList(pathSpecs));
+  }
+
+  /**
+   * @return mutable builder to incrementally construct a {@link PathSpecSet}
+   */
+  public static Builder newBuilder()
+  {
+    return new Builder();
+  }
+
+  /**
+   * @return immutable path spec set that represents an empty projection (no fields requested)
+   */
+  public static PathSpecSet empty()
+  {
+    return EMPTY;
+  }
+
+  /**
+   * @return immutable path spec set that represents that the user wants all fields (all fields requested)
+   */
+  public static PathSpecSet allInclusive()
+  {
+    return ALL_INCLUSIVE;
+  }
+
+  /**
+   * @return null if a {@link #allInclusive()}, elsewise a new {@link PathSpec} array for the projection. Intended to
+   *         be used passed into Rest.li builder's {@code fields} method.
+   */
+  public PathSpec[] toArray()
+  {
+    if (_allInclusive)
+    {
+      return null;
+    }
+    return _pathSpecs.toArray(new PathSpec[0]);
+  }
+
+  /**
+   * Creates a new mutable builder using this path spec set as a starting state
+   *
+   * @return a mutable builder
+   */
+  public Builder toBuilder()
+  {
+    return newBuilder().add(this);
+  }
+
+  /**
+   * @return underlying {@link PathSpec}s represented by this path spec set. Note that if this is a
+   *         {@link #allInclusive()} this will be an empty set even though all fields are desired.
+   */
+  public Set<PathSpec> getPathSpecs()
+  {
+    return _pathSpecs;
+  }
+
+  /**
+   * @return if this is an {@link #empty()} path spec set (no fields requested)
+   */
+  public boolean isEmpty()
+  {
+    return _pathSpecs.isEmpty() && !_allInclusive;
+  }
+
+  /**
+   * @return if this is a PathSpecSet representing the intent to retrieve all fields
+   */
+  public boolean isAllInclusive()
+  {
+    return _allInclusive;
+  }
+
+  /**
+   * Returns true if this {@link PathSpecSet} contains the input {@link PathSpec}.
+   *
+   * A {@link PathSpec} is always in a {@link PathSpecSet} if {@link PathSpecSet#isAllInclusive()}.
+   *
+   * A {@link PathSpec} is in a {@link PathSpecSet} if {@link PathSpecSet#getPathSpecs()} contains the {@link PathSpec} or
+   * any parent {@link PathSpec}.
+   *
+   * <pre>
+   * PathSpecSet.allInclusive().contains(/a); // true
+   * PathSpecSet.of(/a).contains(/a); // true
+   * PathSpecSet.of(/a).contains(/a/b); // true
+   * </pre>
+   *
+   * @param pathSpec the input {@link PathSpec} to look for in the {@link PathSpecSet}
+   * @return true if the input {@link PathSpec} is in this {@link PathSpecSet}
+   */
+  public boolean contains(PathSpec pathSpec)
+  {
+    if (_allInclusive)
+    {
+      return true;
+    }
+
+    return IntStream.range(0, pathSpec.getPathComponents().size() + 1)
+        .mapToObj(i -> new PathSpec(pathSpec.getPathComponents().subList(0, i).toArray(new String[0])))
+        .anyMatch(_pathSpecs::contains);
+  }
+
+  /**
+   * Return a copy of this {@link PathSpecSet} where the contained {@link PathSpec}s are scoped to the input parent
+   * {@link PathSpec}.
+   *
+   * For example, suppose you have these models:
+   * <pre>
+   * record Foo {
+   *   bar: int
+   *   baz: int
+   * }
+   *
+   * record Zing {
+   *   foo: Foo
+   * }
+   * </pre>
+   *
+   * <p>If you want to only fetch the "bar" field from a "Zing" record you might make a {@link PathSpecSet} like this:
+   * {@code PathSpecSet.of(/foo/bar)}.</p>
+   *
+   * <p>However, suppose you already have a {@link PathSpecSet} from the perspective of "Foo" but need a
+   * {@link PathSpecSet} for your "Zing" downstream.  This method make this easy:
+   * <pre>
+   * PathSpecSet fooPathSpecSet = PathSpecSet.of(/bar);
+   * PathSpecSet zingPathSpecSet = fooPathSpecSet.copyWithScope(/foo);
+   *
+   * zingPathSpecSet.equals(PathSpecSet.of(/foo/bar); // true
+   * </pre>
+   * </p>
+   * If you scope an empty {@link PathSpecSet} it remains empty.
+   *
+   * @param parent the parent {@link PathSpec} to use when scoping the contained {@link PathSpec}s
+   * @return a new {@link PathSpecSet} that is scoped to the new parent
+   */
+  public PathSpecSet copyWithScope(PathSpec parent)
+  {
+    if (this.isAllInclusive())
+    {
+      return PathSpecSet.of(parent);
+    }
+
+    if (this.isEmpty())
+    {
+      return PathSpecSet.empty();
+    }
+
+    Builder builder = newBuilder();
+
+    this.getPathSpecs().stream()
+        .map(childPathSpec -> {
+          List<String> parentPathComponents = parent.getPathComponents();
+          List<String> childPathComponents = childPathSpec.getPathComponents();
+          ArrayList<String> list = new ArrayList<>(parentPathComponents.size() + childPathComponents.size());
+          list.addAll(parentPathComponents);
+          list.addAll(childPathComponents);
+          return list;
+        })
+        .map(PathSpec::new)
+        .forEach(builder::add);
+
+    return builder.build();
+  }
+
+  /**
+   * Return a copy of this {@link PathSpecSet} where only {@link PathSpec}s that are prefixed with the input
+   * {@link PathSpec} are retained.
+   *
+   * Additionally, the prefix is removed for the retained {@link PathSpec}s.
+   *
+   * Here are some examples showing the functionality:
+   *
+   * <pre>
+   * // This PathSpecSet is empty because no PathSpecs originally contained start with "abc"
+   * PathSpecSet emptyPathSpecSet = PathSpecSet.of(/bar/baz).copyAndRemovePrefix(/abc);
+   *
+   * // This PathSpecSet is allInclusive because it contains the entire prefix PathSpec
+   * PathSpecSet allInclusivePathSpecSet = PathSpecSet.of(/bar).copyAndRemovePrefix(/bar)
+   *
+   * // The following "equals" evaluates to true
+   * PathSpecSet prefixRemovedPathSpecSet = PathSpecSet.of(/bar/baz, /bar/abc).copyAndRemovePrefix(/bar);
+   * prefixRemovedPathSpecSet.equals(PathSpecSet.of(/baz, /abc));
+   * </pre>
+   *
+   * @param prefix the {@link PathSpec} prefix to use when retaining {@link PathSpec}s.
+   * @return a {@link PathSpecSet} with elements starting with the input {@link PathSpec} prefix
+   */
+  public PathSpecSet copyAndRemovePrefix(PathSpec prefix)
+  {
+    if (isAllInclusive() || isEmpty())
+    {
+      // allInclusive or empty projections stay the same
+      return this;
+    }
+
+    // if we contain the exact prefix or any sub prefix, it should be an all inclusive set
+    PathSpec partialPrefix = prefix;
+    do
+    {
+      if (getPathSpecs().contains(partialPrefix))
+      {
+        return allInclusive();
+      }
+      partialPrefix = partialPrefix.getParent();
+    } while (!partialPrefix.isEmptyPath());
+
+    List<String> prefixPathComponents = prefix.getPathComponents();
+    int prefixPathLength = prefixPathComponents.size();
+
+    return PathSpecSet.of(
+        getPathSpecs().stream()
+            .filter(pathSpec -> {
+              List<String> pathComponents = pathSpec.getPathComponents();
+              return pathComponents.size() > prefixPathLength && prefixPathComponents.equals(pathComponents.subList(0, prefixPathLength));
+            })
+            .map(pathSpec -> new PathSpec(pathSpec.getPathComponents().subList(prefixPathLength, pathSpec.getPathComponents().size()).toArray(new String[0])))
+            .collect(Collectors.toSet()));
+  }
+
+  /**
+   * Mutable builder for {@link PathSpecSet}.
+   */
+  public static final class Builder
+  {
+    private final Set<PathSpec> _pathSpecs = new HashSet<>();
+    private boolean _allInclusive;
+
+    /**
+     * Add all of the fields stored inside of {@code ps} to this builder.
+     *
+     * <p>Note that if {@code ps} {@link #isAllInclusive()}, this builder converts into "allInclusive" mode and
+     * all subsequent add operations are ignored.
+     *
+     * @param ps path specs to add
+     * @return this builder
+     */
+    public Builder add(PathSpecSet ps)
+    {
+      if (ps._allInclusive || _allInclusive)
+      {
+        _pathSpecs.clear();
+        _allInclusive = true;
+        return this;
+      }
+      _pathSpecs.addAll(ps._pathSpecs);
+      return this;
+    }
+
+    /**
+     * Add all {@code pathSpecs} to this builder.
+     *
+     * @param pathSpecs path specs to add
+     * @return this builder
+     */
+    public Builder add(PathSpec... pathSpecs)
+    {
+      if (_allInclusive)
+      {
+        return this;
+      }
+      Collections.addAll(_pathSpecs, pathSpecs);
+      return this;
+    }
+
+    /**
+     * Add a single {@link PathSpec} specified by the components in {@code paths}.
+     *
+     * @param paths path components to form into a single {@link PathSpec} and add
+     * @return this builder
+     */
+    public Builder add(Collection<String> paths)
+    {
+      return add(new PathSpec(paths.toArray(new String[paths.size()])));
+    }
+
+    /**
+     * Add all {@link PathSpec} in another Builder to this Builder.
+     *
+     * @param builder add all the instances of {@link PathSpec} in this builder to the current builder
+     * @return this builder
+     */
+    public Builder addAll(Builder builder)
+    {
+      return add(builder.build());
+    }
+
+    /**
+     * @return if this builder will build into an empty {@link PathSpecSet}.
+     */
+    public boolean isEmpty()
+    {
+      return !_allInclusive && _pathSpecs.isEmpty();
+    }
+
+    /**
+     * @return immutable path spec set
+     */
+    public PathSpecSet build()
+    {
+      if (_allInclusive)
+      {
+        return PathSpecSet.allInclusive();
+      }
+      else
+      {
+        return new PathSpecSet(this);
+      }
+    }
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    return EqualsBuilder.reflectionEquals(this, o);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return HashCodeBuilder.reflectionHashCode(this);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PathSpecSet{" + (_allInclusive ? "all inclusive" : StringUtils.join(_pathSpecs, ',')) + "}";
+  }
+}

--- a/data/src/test/java/com/linkedin/data/schema/TestPathSpec.java
+++ b/data/src/test/java/com/linkedin/data/schema/TestPathSpec.java
@@ -1,0 +1,85 @@
+package com.linkedin.data.schema;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static java.lang.Boolean.*;
+
+
+public class TestPathSpec
+{
+
+  @Test(dataProvider = "pathSpecsWithEmptyFlag")
+  public void testIsEmptyPath(PathSpec testPathSpec, boolean expectedResponse)
+  {
+    Assert.assertEquals(testPathSpec.isEmptyPath(), expectedResponse);
+  }
+
+  @DataProvider
+  public static Object[][] pathSpecsWithEmptyFlag()
+  {
+    PathSpec emptyPathSpecWithAttributes = new PathSpec();
+    emptyPathSpecWithAttributes.setAttribute(PathSpec.ATTR_ARRAY_START, 0);
+    emptyPathSpecWithAttributes.setAttribute(PathSpec.ATTR_ARRAY_COUNT, 5);
+
+    PathSpec pathSpecWithAttributes = new PathSpec("field1", "field2");
+    pathSpecWithAttributes.setAttribute(PathSpec.ATTR_ARRAY_START, 0);
+    pathSpecWithAttributes.setAttribute(PathSpec.ATTR_ARRAY_COUNT, 5);
+
+    return new Object[][]{
+        {
+            new PathSpec(), TRUE
+        },
+        {
+            emptyPathSpecWithAttributes, TRUE
+        },
+        {
+            new PathSpec("field"), FALSE
+        },
+        {
+            new PathSpec("field1", "field2"), FALSE
+        },
+        {
+            pathSpecWithAttributes, FALSE
+        },
+
+    };
+  }
+
+  @Test(dataProvider = "pathSpecsWithParent")
+  public void testGetParent(PathSpec testPathSpec, PathSpec expectedParent)
+  {
+    Assert.assertEquals(testPathSpec.getParent(), expectedParent);
+  }
+
+  @DataProvider
+  public static Object[][] pathSpecsWithParent()
+  {
+    PathSpec pathSpecWithAttributes = new PathSpec("field1", "field2");
+    pathSpecWithAttributes.setAttribute(PathSpec.ATTR_ARRAY_START, 0);
+    pathSpecWithAttributes.setAttribute(PathSpec.ATTR_ARRAY_COUNT, 5);
+
+    return new Object[][]{
+        {
+          new PathSpec(), new PathSpec()
+        },
+        {
+          PathSpec.emptyPath(), new PathSpec()
+        },
+        {
+          new PathSpec("field"), new PathSpec()
+        },
+        {
+            new PathSpec("field1", "field2"), new PathSpec("field1")
+        },
+        {
+            new PathSpec("field1", "field2", "field3"), new PathSpec("field1", "field2")
+        },
+        {
+            pathSpecWithAttributes, new PathSpec("field1")
+        },
+
+    };
+  }
+}

--- a/data/src/test/java/com/linkedin/data/schema/TestPathSpecSet.java
+++ b/data/src/test/java/com/linkedin/data/schema/TestPathSpecSet.java
@@ -1,0 +1,313 @@
+package com.linkedin.data.schema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+
+/**
+ * Unit tests for {@link PathSpecSet}.
+ */
+public class TestPathSpecSet {
+
+  private static final PathSpec THREE_FIELD_MODEL_ALL_FIELDS = new PathSpec();
+  private static final PathSpec THREE_FIELD_MODEL_FIELD1 = new PathSpec("field1");
+  private static final PathSpec THREE_FIELD_MODEL_FIELD2 = new PathSpec("field2");
+  private static final PathSpec THREE_FIELD_MODEL_FIELD3 = new PathSpec("record1");
+  private static final PathSpec THREE_FIELD_MODEL_EMBEDDED_FIELD1 =
+      new PathSpec(THREE_FIELD_MODEL_FIELD3.getPathComponents(), "embedded1");
+
+  private static final PathSpec NESTED_MODELS_SIMPLE_RECORD = new PathSpec("simpleRecord");
+  private static final PathSpec NESTED_MODELS_SIMPLE_RECORD_FIELD1 =
+      new PathSpec(NESTED_MODELS_SIMPLE_RECORD.getPathComponents(), "intField");
+  private static final PathSpec NESTED_MODELS_SIMPLE_RECORD_FIELD2 =
+      new PathSpec(NESTED_MODELS_SIMPLE_RECORD.getPathComponents(), "byteField");
+  private static final PathSpec NESTED_MODELS_ARRAY_ITEMS = new PathSpec("arrayOfRecords", "items");
+  private static final PathSpec NESTED_MODELS_MAP_VALUES = new PathSpec("mapOfRecords", "values");
+
+  @Test
+  public void testEmpty() {
+    PathSpecSet pathSpecSet = PathSpecSet.empty();
+    Assert.assertEquals(pathSpecSet.getPathSpecs(), Collections.emptySet());
+    Assert.assertFalse(pathSpecSet.isAllInclusive());
+    Assert.assertTrue(pathSpecSet.isEmpty());
+    Assert.assertEquals(pathSpecSet.toArray(), new PathSpec[0]);
+  }
+
+  @Test
+  public void testAllInclusiveSet() {
+    PathSpecSet pathSpecSet = PathSpecSet.allInclusive();
+    Assert.assertEquals(pathSpecSet.getPathSpecs(), Collections.emptySet());
+    Assert.assertTrue(pathSpecSet.isAllInclusive());
+    Assert.assertFalse(pathSpecSet.isEmpty());
+    Assert.assertNull(pathSpecSet.toArray());
+  }
+
+  @Test(dataProvider = "pathSpecCollections")
+  public void testCreateFromPathSpecCollection(List<PathSpec> pathSpecs) {
+    PathSpecSet pathSpecSet = PathSpecSet.of(pathSpecs);
+    Assert.assertEquals(pathSpecSet.getPathSpecs(), new HashSet<>(pathSpecs));
+    Assert.assertFalse(pathSpecSet.isEmpty());
+    Assert.assertFalse(pathSpecSet.isAllInclusive());
+  }
+
+  @Test(dataProvider = "pathSpecCollections")
+  public void testCreateFromPathSpecCollectionIsImmutable(List<PathSpec> pathSpecs) {
+    List<PathSpec> pathSpecToMutate = new ArrayList<>(pathSpecs);
+    PathSpecSet pathSpecSet = PathSpecSet.of(pathSpecToMutate);
+    pathSpecToMutate.add(THREE_FIELD_MODEL_FIELD3);
+    Assert.assertEquals(pathSpecSet.getPathSpecs(), new HashSet<>(pathSpecs));
+  }
+
+  @Test
+  public void testCreateFromPathSpecVarArgs() {
+    PathSpecSet pathSpecSet = PathSpecSet.of(THREE_FIELD_MODEL_FIELD1, THREE_FIELD_MODEL_FIELD2);
+    Assert.assertEquals(pathSpecSet.getPathSpecs(),
+        new HashSet<>(Arrays.asList(THREE_FIELD_MODEL_FIELD1, THREE_FIELD_MODEL_FIELD2)));
+  }
+
+  @Test
+  public void testAssembleFromBuilder() {
+    PathSpecSet pathSpecSet = PathSpecSet.newBuilder()
+        .add(Lists.newArrayList("record1"))
+        .add(THREE_FIELD_MODEL_FIELD1)
+        .add(PathSpecSet.of(THREE_FIELD_MODEL_FIELD2))
+        .build();
+
+    Assert.assertEquals(pathSpecSet.getPathSpecs(),
+        new HashSet<>(Arrays.asList(THREE_FIELD_MODEL_FIELD1, THREE_FIELD_MODEL_FIELD2, THREE_FIELD_MODEL_FIELD3)));
+  }
+
+  @Test(dataProvider = "buildersWithAllInclusive")
+  public void testAssembleFromBuilderWithAllInclusiveSetOverridingAllValues(PathSpecSet.Builder builder) {
+    Assert.assertFalse(builder.isEmpty());
+    PathSpecSet pathSpecSet = builder.build();
+    Assert.assertEquals(pathSpecSet, PathSpecSet.allInclusive());
+    Assert.assertTrue(pathSpecSet.isAllInclusive());
+    Assert.assertEquals(pathSpecSet.getPathSpecs(), new HashSet<>());
+  }
+
+  @Test
+  public void testEmptyBuilder() {
+    Assert.assertTrue(PathSpecSet.newBuilder().isEmpty());
+    Assert.assertTrue(PathSpecSet.newBuilder().add().isEmpty());
+  }
+
+  @Test
+  public void testBuilderNotEmpty() {
+    Assert.assertFalse(PathSpecSet.newBuilder().add(THREE_FIELD_MODEL_FIELD1).isEmpty());
+  }
+
+  @Test(dataProvider = "copyWithScopeProvider")
+  public void testCopyWithScope(PathSpecSet input, PathSpec parent, PathSpecSet expected) {
+    Assert.assertEquals(input.copyWithScope(parent), expected);
+  }
+
+  @Test(dataProvider = "copyAndRemovePrefixProvider")
+  public void testCopyAndRemovePrefix(PathSpecSet input, PathSpec prefix, PathSpecSet expected) {
+    Assert.assertEquals(input.copyAndRemovePrefix(prefix), expected);
+  }
+
+  @Test
+  public void testToString() {
+    Assert.assertEquals(PathSpecSet.of(THREE_FIELD_MODEL_FIELD1).toString(), "PathSpecSet{/field1}");
+    Assert.assertEquals(PathSpecSet.allInclusive().toString(), "PathSpecSet{all inclusive}");
+  }
+
+  @Test
+  public void testHashCode() {
+    PathSpecSet pss1 = PathSpecSet.of(THREE_FIELD_MODEL_FIELD1, THREE_FIELD_MODEL_FIELD2);
+    PathSpecSet pss2 = PathSpecSet.of(THREE_FIELD_MODEL_FIELD1, THREE_FIELD_MODEL_FIELD2);
+    Assert.assertEquals(pss1.hashCode(), pss2.hashCode());
+  }
+
+  @Test
+  public void testContainsAllInclusiveSet() {
+    PathSpecSet allIncliveSet = PathSpecSet.allInclusive();
+
+    Assert.assertTrue(allIncliveSet.contains(THREE_FIELD_MODEL_ALL_FIELDS));
+    Assert.assertTrue(allIncliveSet.contains(THREE_FIELD_MODEL_FIELD3));
+    Assert.assertTrue(allIncliveSet.contains(THREE_FIELD_MODEL_EMBEDDED_FIELD1));
+  }
+
+  @Test
+  public void testContainsEmptyProjection() {
+    PathSpecSet empty = PathSpecSet.empty();
+
+    Assert.assertFalse(empty.contains(THREE_FIELD_MODEL_ALL_FIELDS));
+    Assert.assertFalse(empty.contains(THREE_FIELD_MODEL_FIELD3));
+    Assert.assertFalse(empty.contains(THREE_FIELD_MODEL_EMBEDDED_FIELD1));
+  }
+
+  @Test
+  public void testContainsExactAndChild() {
+    PathSpecSet pss1 = PathSpecSet.of(THREE_FIELD_MODEL_FIELD3);
+    Assert.assertFalse(pss1.contains(THREE_FIELD_MODEL_ALL_FIELDS));
+    Assert.assertTrue(pss1.contains(THREE_FIELD_MODEL_FIELD3));
+    Assert.assertTrue(pss1.contains(THREE_FIELD_MODEL_EMBEDDED_FIELD1));
+    Assert.assertFalse(pss1.contains(THREE_FIELD_MODEL_FIELD2));
+
+    PathSpecSet pss2 = PathSpecSet.of(THREE_FIELD_MODEL_EMBEDDED_FIELD1);
+    Assert.assertFalse(pss1.contains(THREE_FIELD_MODEL_ALL_FIELDS));
+    Assert.assertFalse(pss2.contains(THREE_FIELD_MODEL_FIELD3));
+    Assert.assertTrue(pss2.contains(THREE_FIELD_MODEL_EMBEDDED_FIELD1));
+    Assert.assertTrue(pss2.contains(new PathSpec(THREE_FIELD_MODEL_EMBEDDED_FIELD1.getPathComponents(), "foo")));
+    Assert.assertFalse(pss1.contains(THREE_FIELD_MODEL_FIELD2));
+
+    PathSpecSet pss3 = PathSpecSet.of(THREE_FIELD_MODEL_ALL_FIELDS);
+    Assert.assertTrue(pss3.contains(THREE_FIELD_MODEL_ALL_FIELDS));
+    Assert.assertTrue(pss3.contains(THREE_FIELD_MODEL_FIELD3));
+    Assert.assertTrue(pss3.contains(THREE_FIELD_MODEL_EMBEDDED_FIELD1));
+  }
+
+  @DataProvider
+  public static Object[][] buildersWithAllInclusive() {
+    return new Object[][]{
+        {
+            PathSpecSet.newBuilder()
+                .add(PathSpecSet.allInclusive())
+                .add(Lists.newArrayList("field1"))
+                .add(THREE_FIELD_MODEL_FIELD2)
+                .add(PathSpecSet.of(THREE_FIELD_MODEL_FIELD3))
+        },
+        {
+            PathSpecSet.newBuilder()
+                .add(Lists.newArrayList("field1"))
+                .add(THREE_FIELD_MODEL_FIELD2)
+                .add(PathSpecSet.of(THREE_FIELD_MODEL_FIELD3))
+                .add(PathSpecSet.allInclusive())
+        },
+        {
+            PathSpecSet.newBuilder()
+                .add(Lists.newArrayList("field1"))
+                .add(THREE_FIELD_MODEL_FIELD2)
+                .add(PathSpecSet.allInclusive())
+                .add(PathSpecSet.of(THREE_FIELD_MODEL_FIELD3))
+        }
+    };
+  }
+
+  @DataProvider
+  public static Object[][] pathSpecCollections() {
+    return new Object[][] {
+        {
+          Collections.singletonList(THREE_FIELD_MODEL_FIELD1),
+        },
+        {
+
+          Arrays.asList(THREE_FIELD_MODEL_FIELD1, THREE_FIELD_MODEL_FIELD2),
+        }
+    };
+  }
+
+  @DataProvider
+  public static Object[][] copyWithScopeProvider() {
+    return new Object[][] {
+        {
+            PathSpecSet.of(THREE_FIELD_MODEL_FIELD1),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.of(new PathSpec("simpleRecord", "field1"))
+        },
+        {
+            PathSpecSet.newBuilder()
+                .add(THREE_FIELD_MODEL_FIELD1)
+                .add(THREE_FIELD_MODEL_FIELD2)
+                .build(),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.newBuilder()
+                .add(new PathSpec("simpleRecord", "field1"))
+                .add(new PathSpec("simpleRecord", "field2"))
+                .build()
+        },
+        {
+            PathSpecSet.of(THREE_FIELD_MODEL_FIELD1),
+            NESTED_MODELS_ARRAY_ITEMS,
+            PathSpecSet.of(new PathSpec("arrayOfRecords", "items", "field1"))
+        },
+        {
+            PathSpecSet.of(THREE_FIELD_MODEL_FIELD1),
+            NESTED_MODELS_MAP_VALUES,
+            PathSpecSet.of(new PathSpec("mapOfRecords", "values", "field1"))
+        },
+        {
+            PathSpecSet.empty(),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.empty()
+        },
+        {
+            PathSpecSet.allInclusive(),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.of(NESTED_MODELS_SIMPLE_RECORD)
+        }
+    };
+  }
+
+  @DataProvider
+  public static Object[][] copyAndRemovePrefixProvider() {
+    return new Object[][] {
+        {
+            PathSpecSet.empty(),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.empty()
+        },
+        {
+            PathSpecSet.allInclusive(),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.allInclusive()
+        },
+        {
+            PathSpecSet.of(NESTED_MODELS_SIMPLE_RECORD),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.allInclusive()
+        },
+        {
+            PathSpecSet.of(NESTED_MODELS_SIMPLE_RECORD, NESTED_MODELS_SIMPLE_RECORD_FIELD1),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.allInclusive()
+        },
+        {
+            PathSpecSet.of(
+                new PathSpec("recordField"),
+                new PathSpec("recordField", "nestedRecord", "nestedField2"),
+                new PathSpec("intField")
+            ),
+            new PathSpec("recordField", "nestedRecord"),
+            PathSpecSet.allInclusive()
+        },
+        {
+            PathSpecSet.of(
+                new PathSpec("recordField", "nestedRecord", "nestedField1"),
+                new PathSpec("recordField", "nestedRecord", "nestedField2"),
+                new PathSpec("intField")
+            ),
+            new PathSpec("recordField", "nestedRecord"),
+            PathSpecSet.of(
+                new PathSpec("nestedField1"),
+                new PathSpec("nestedField2")
+            )
+        },
+        {
+            PathSpecSet.of(NESTED_MODELS_ARRAY_ITEMS),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.empty()
+        },
+        {
+            PathSpecSet.of(NESTED_MODELS_SIMPLE_RECORD_FIELD1, NESTED_MODELS_SIMPLE_RECORD_FIELD2,
+                NESTED_MODELS_ARRAY_ITEMS),
+            NESTED_MODELS_SIMPLE_RECORD,
+            PathSpecSet.of(new PathSpec("intField"), new PathSpec("byteField"))
+        },
+        {
+            PathSpecSet.of(),
+            NESTED_MODELS_ARRAY_ITEMS,
+            PathSpecSet.empty()
+        }
+    };
+  }
+}


### PR DESCRIPTION
The PathSpecSet provides functionalities to more easily build or edit a set of PathSpec. In addition, it offers the support for a full projection so that methods like "contains" always return true making it easier for the client code to write logic with the set.