### PR TITLE
Add an option (enabled by default) to gracefully degrade on encountering invalid surrogate pairs during protobuf string serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.4.3] - 2020-07-01
+- Add an option (enabled by default) to gracefully degrade on encountering invalid surrogate pairs during protobuf string serialization (#334)
+
 ## [29.4.2] - 2020-06-25
 - Update Pegasus Plugin's CopySchema tasks to delete stale schemas (#337)
 
@@ -4546,8 +4549,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.3...master
+[29.4.3]: https://github.com/linkedin/rest.li/compare/v29.4.2...v29.4.3
 [29.4.2]: https://github.com/linkedin/rest.li/compare/v29.4.1...v29.4.2
 [29.4.1]: https://github.com/linkedin/rest.li/compare/v29.4.0...v29.4.1
 [29.4.0]: https://github.com/linkedin/rest.li/compare/v29.3.2...v29.4.0

--- a/data/src/main/java/com/linkedin/data/codec/ProtobufCodecOptions.java
+++ b/data/src/main/java/com/linkedin/data/codec/ProtobufCodecOptions.java
@@ -56,13 +56,24 @@ public class ProtobufCodecOptions
    */
   private final boolean _enableFixedLengthFloatDoubles;
 
+  /**
+   * If true, then tolerates invalid surrogate pairs when serializing strings to UTF-8 bytes. Invalid characters are
+   * replaced with the default replacement character. If false, then an exception is thrown when encountering such
+   * sequences.
+   *
+   * <p>Enabled by default.</p>
+   */
+  private final boolean _shouldTolerateInvalidSurrogatePairs;
+
   private ProtobufCodecOptions(SymbolTable symbolTable,
                                boolean enableASCIIOnlyStrings,
-                               boolean enableFixedLengthFloatDoubles)
+                               boolean enableFixedLengthFloatDoubles,
+                               boolean tolerateInvalidSurrogatePairs)
   {
     _symbolTable = symbolTable == null ? EmptySymbolTable.SHARED : symbolTable;
     _enableASCIIOnlyStrings = enableASCIIOnlyStrings;
     _enableFixedLengthFloatDoubles = enableFixedLengthFloatDoubles;
+    _shouldTolerateInvalidSurrogatePairs = tolerateInvalidSurrogatePairs;
   }
 
   /**
@@ -88,6 +99,15 @@ public class ProtobufCodecOptions
   public boolean shouldEnableFixedLengthFloatDoubles()
   {
     return _enableFixedLengthFloatDoubles;
+  }
+
+  /**
+   * @return True if invalid surrogate pairs should be tolerated when serializing strings to UTF-8, with all invalid
+   * occurences replaced with the default replacement character. If false, then an exception will be thrown when
+   * encountering such data.
+   */
+  public boolean shouldTolerateInvalidSurrogatePairs() {
+    return _shouldTolerateInvalidSurrogatePairs;
   }
 
   /**
@@ -125,11 +145,21 @@ public class ProtobufCodecOptions
      */
     private boolean _enableFixedLengthFloatDoubles;
 
+    /**
+     * If true, then tolerates invalid surrogate pairs when serializing strings to UTF-8 bytes. Invalid characters are
+     * replaced with the default replacement character. If false, then an exception is thrown when encountering such
+     * sequences.
+     *
+     * <p>Enabled by default.</p>
+     */
+    private boolean _shouldTolerateInvalidSurrogatePairs;
+
     public Builder()
     {
       _symbolTable = null;
       _enableASCIIOnlyStrings = false;
       _enableFixedLengthFloatDoubles = false;
+      _shouldTolerateInvalidSurrogatePairs = true;
     }
 
     /**
@@ -168,11 +198,25 @@ public class ProtobufCodecOptions
     }
 
     /**
+     * If true, then tolerates invalid surrogate pairs when serializing strings to UTF-8 bytes. Invalid characters are
+     * replaced with the default replacement character. If false, then an exception is thrown when encountering such
+     * sequences.
+     */
+    public Builder setShouldTolerateInvalidSurrogatePairs(boolean tolerateInvalidSurrogatePairs)
+    {
+      this._shouldTolerateInvalidSurrogatePairs = tolerateInvalidSurrogatePairs;
+      return this;
+    }
+
+    /**
      * Build an options instance.
      */
     public ProtobufCodecOptions build()
     {
-      return new ProtobufCodecOptions(_symbolTable, _enableASCIIOnlyStrings, _enableFixedLengthFloatDoubles);
+      return new ProtobufCodecOptions(_symbolTable,
+          _enableASCIIOnlyStrings,
+          _enableFixedLengthFloatDoubles,
+          _shouldTolerateInvalidSurrogatePairs);
     }
   }
 }

--- a/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
@@ -466,7 +466,8 @@ public class ProtobufDataCodec implements DataCodec
         // If the byte length is the same as the string length, then this is an ASCII-only string.
         _protoWriter.writeString(value, byteLength ->
             (_options.shouldEnableASCIIOnlyStrings() && value.length() == byteLength) ?
-                ASCII_STRING_LITERAL_ORDINAL : STRING_LITERAL_ORDINAL);
+                ASCII_STRING_LITERAL_ORDINAL : STRING_LITERAL_ORDINAL,
+            _options.shouldTolerateInvalidSurrogatePairs());
       }
     }
 

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/ProtobufDataEncoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/ProtobufDataEncoder.java
@@ -43,7 +43,6 @@ import java.io.OutputStream;
 public class ProtobufDataEncoder extends AbstractDataEncoder
 {
   private final ProtobufCodecOptions _options;
-  private ProtoWriter _writer;
 
   public ProtobufDataEncoder(DataMap dataMap, int bufferSize)
   {

--- a/data/src/test/java/com/linkedin/data/codec/CodecDataProviders.java
+++ b/data/src/test/java/com/linkedin/data/codec/CodecDataProviders.java
@@ -68,6 +68,26 @@ public class CodecDataProviders
   }
 
   @DataProvider
+  public static Object[][] surrogatePairData()
+  {
+    List<Object[]> list = new ArrayList<>();
+    list.add(new Object[] {"a\uD800", "a?", 2, false, false});
+    list.add(new Object[] {"\uD800a", "?a", 2, false, false});
+    list.add(new Object[] {"\uD800\uD800", "??", 2, false, false});
+    list.add(new Object[] {"abc\uD800\uD800abc", "abc??abc", 8, false, false});
+    list.add(new Object[] {"\uDBFF\uDFFF", "\uDBFF\uDFFF", 4, true, false});
+    list.add(new Object[] {"\uD83D\uDE00\uD83D\uDE00", "\uD83D\uDE00\uD83D\uDE00", 8, true, false});
+    list.add(new Object[] {"a\uD800", "a?", 2, false, true});
+    list.add(new Object[] {"\uD800a", "?a", 2, false, true});
+    list.add(new Object[] {"\uD800\uD800", "??", 2, false, true});
+    list.add(new Object[] {"abc\uD800\uD800abc", "abc??abc", 8, false, true});
+    list.add(new Object[] {"\uDBFF\uDFFF", "\uDBFF\uDFFF", 4, true, true});
+    list.add(new Object[] {"\uD83D\uDE00\uD83D\uDE00", "\uD83D\uDE00\uD83D\uDE00", 8, true, true});
+
+    return list.toArray(new Object[][] {});
+  }
+
+  @DataProvider
   public static Object[][] streamCodecData()
   {
     List<Object[]> list = new ArrayList<>();

--- a/data/src/test/java/com/linkedin/data/codec/TestProtobufCodec.java
+++ b/data/src/test/java/com/linkedin/data/codec/TestProtobufCodec.java
@@ -17,7 +17,10 @@
 package com.linkedin.data.codec;
 
 import com.linkedin.data.DataComplex;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.protobuf.Utf8Utils;
 import java.io.IOException;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class TestProtobufCodec extends TestCodec
@@ -35,5 +38,43 @@ public class TestProtobufCodec extends TestCodec
           .setEnableFixedLengthFloatDoubles(enableFixedLengthFloatDoubles)
           .build());
     testDataCodec(codec, dataComplex);
+  }
+
+  @Test(dataProvider = "surrogatePairData", dataProviderClass = CodecDataProviders.class)
+  public void testSurrogatePairs(String value, String expectedString, int expectedLength,
+      boolean isValidSurrogatePair, boolean tolerateInvalidSurrogatePairs) throws Exception
+  {
+    DataCodec codec =
+        new ProtobufDataCodec(new ProtobufCodecOptions.Builder()
+            .setShouldTolerateInvalidSurrogatePairs(tolerateInvalidSurrogatePairs)
+            .build());
+
+    if (isValidSurrogatePair) {
+      Assert.assertEquals(Utf8Utils.encodedLength(value, true), expectedLength);
+      Assert.assertEquals(Utf8Utils.encodedLength(value, false), expectedLength);
+    } else {
+      Assert.assertEquals(Utf8Utils.encodedLength(value, true), expectedLength);
+      try {
+        Utf8Utils.encodedLength(value, false);
+        Assert.fail("Exception not thrown for invalid surrogate pair");
+      } catch (IllegalArgumentException e) {
+        // Success.
+      }
+    }
+
+    DataMap dataMap = new DataMap();
+    dataMap.put("key", value);
+
+    if (isValidSurrogatePair || tolerateInvalidSurrogatePairs) {
+      DataMap roundtrip = codec.bytesToMap(codec.mapToBytes(dataMap));
+      Assert.assertEquals(roundtrip.get("key"), expectedString);
+    } else {
+      try {
+        codec.bytesToMap(codec.mapToBytes(dataMap));
+        Assert.fail("Exception not thrown for invalid surrogate pair");
+      } catch (IOException e) {
+        // Success.
+      }
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.4.2
+version=29.4.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/li-protobuf/src/main/java/com/linkedin/data/protobuf/Utf8Utils.java
+++ b/li-protobuf/src/main/java/com/linkedin/data/protobuf/Utf8Utils.java
@@ -56,6 +56,12 @@ import java.io.IOException;
 public class Utf8Utils
 {
   /**
+   * Default replacement character emitted when encountering invalid surrogate pairs and when tolerating such
+   * behavior is enabled.
+   */
+  private static final char DEFAULT_REPLACEMENT_CHAR = '?';
+
+  /**
    * UTF-8 lookup table.
    *
    * Bytes representing ASCII characters return 0.
@@ -96,8 +102,6 @@ public class Utf8Utils
     UTF8_LOOKUP_TABLE = table;
   }
 
-  private static final IllegalArgumentException INVALID_UTF8_EXCEPTION = new IllegalArgumentException("Invalid UTF-8");
-
   public static int lookupUtfTable(int initialByte)
   {
     return UTF8_LOOKUP_TABLE[initialByte];
@@ -113,8 +117,7 @@ public class Utf8Utils
    * return offset + a.length;
    * }</pre>
    * <p>
-   * but is more efficient in both time and space. One key difference is that this method requires
-   * paired surrogates, and therefore does not support chunking. While {@code
+   * but is more efficient in both time and space. While {@code
    * String.getBytes(UTF_8)} replaces unpaired surrogates with the default replacement character,
    * this method throws {@link IllegalArgumentException}.
    *
@@ -134,6 +137,43 @@ public class Utf8Utils
    *                                        {@code bytes.length - offset}
    */
   public static int encode(CharSequence in, byte[] out, int offset, int length)
+  {
+    return encode(in, out, offset, length, false);
+  }
+
+  /**
+   * Encodes an input character sequence ({@code in}) to UTF-8 in the target array ({@code out}).
+   * For a string, this method is similar to
+   *
+   * <pre>{@code
+   * byte[] a = string.getBytes(UTF_8);
+   * System.arraycopy(a, 0, bytes, offset, a.length);
+   * return offset + a.length;
+   * }</pre>
+   * <p>
+   * but is more efficient in both time and space. If tolerateInvalidSurrogatePairs is set to true, then
+   * this method replaces unpaired surrogates with the default replacement character, else
+   * this method throws {@link IllegalArgumentException}.
+   *
+   * <p>To ensure sufficient space in the output buffer, either call {@link #encodedLength} to
+   * compute the exact amount needed, or leave room for {@code Utf8.MAX_BYTES_PER_CHAR *
+   * sequence.length()}, which is the largest possible number of bytes that any input can be
+   * encoded to.
+   *
+   * @param in                            the input character sequence to be encoded
+   * @param out                           the target array
+   * @param offset                        the starting offset in {@code bytes} to start writing at
+   * @param length                        the length of the {@code bytes}, starting from {@code offset}
+   * @param tolerateInvalidSurrogatePairs True if invalid surrogate pairs should be tolerated, emitting the standard
+   *                                      replacement character when encountering them; false if an exception should
+   *                                      be thrown when encountering them.
+   * @return the new offset, equivalent to {@code offset + Utf8.encodedLength(sequence)}
+   * @throws IllegalArgumentException       if {@code sequence} contains ill-formed UTF-16 (unpaired
+   *                                        surrogates) and tolerateInvalidSurrogatePairs is true.
+   * @throws ArrayIndexOutOfBoundsException if {@code sequence} encoded in UTF-8 is longer than
+   *                                        {@code bytes.length - offset}
+   */
+  public static int encode(CharSequence in, byte[] out, int offset, int length, boolean tolerateInvalidSurrogatePairs)
   {
     int utf16Length = in.length();
     int j = offset;
@@ -178,26 +218,46 @@ public class Utf8Utils
         // Minimum code point represented by a surrogate pair is 0x10000, 17 bits,
         // four UTF-8 bytes
         final char low;
-        if (i + 1 == in.length() || !Character.isSurrogatePair(c, (low = in.charAt(++i))))
+        if (i + 1 == in.length() || !Character.isSurrogatePair(c, (low = in.charAt(i + 1))))
         {
-          throw new IllegalArgumentException("Unpaired surrogate at index " + (i - 1) + " of " + utf16Length);
+          if (tolerateInvalidSurrogatePairs)
+          {
+            out[j++] = DEFAULT_REPLACEMENT_CHAR;
+          }
+          else
+          {
+            throw new IllegalArgumentException("Unpaired surrogate at index " + (i - 1) + " of " + utf16Length);
+          }
         }
-        int codePoint = Character.toCodePoint(c, low);
-        out[j++] = (byte) ((0xF << 4) | (codePoint >>> 18));
-        out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
-        out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
-        out[j++] = (byte) (0x80 | (0x3F & codePoint));
+        else
+        {
+          i++;
+          int codePoint = Character.toCodePoint(c, low);
+          out[j++] = (byte) ((0xF << 4) | (codePoint >>> 18));
+          out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
+          out[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
+          out[j++] = (byte) (0x80 | (0x3F & codePoint));
+        }
       }
       else
       {
-        // If we are surrogates and we're not a surrogate pair, always throw an
-        // UnpairedSurrogateException instead of an ArrayOutOfBoundsException.
-        if ((Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE)
-            && (i + 1 == in.length() || !Character.isSurrogatePair(c, in.charAt(i + 1))))
+        // If we are surrogates and we're not a surrogate pair, then throw an Illegal argument exception if
+        // we are not a surrogate pair, else throw an ArrayIndexOutOfBoundsException
+        if ((Character.isSurrogate(c)) && (i + 1 == in.length() || !Character.isSurrogatePair(c, in.charAt(i + 1))))
         {
-          throw new IllegalArgumentException("Unpaired surrogate at index " + i + " of " + utf16Length);
+          if (tolerateInvalidSurrogatePairs)
+          {
+            out[j++] = DEFAULT_REPLACEMENT_CHAR;
+          }
+          else
+          {
+            throw new IllegalArgumentException("Unpaired surrogate at index " + i + " of " + utf16Length);
+          }
         }
-        throw new ArrayIndexOutOfBoundsException("Failed writing " + c + " at index " + j);
+        else
+        {
+          throw new ArrayIndexOutOfBoundsException("Failed writing " + c + " at index " + j);
+        }
       }
     }
     return j;
@@ -212,6 +272,19 @@ public class Utf8Utils
    *                                  surrogates)
    */
   public static int encodedLength(CharSequence sequence)
+  {
+    return encodedLength(sequence, false);
+  }
+
+  /**
+   * Returns the number of bytes in the UTF-8-encoded form of {@code sequence}. For a string, this
+   * method is equivalent to {@code string.getBytes(UTF_8).length}, but is more efficient in both
+   * time and space.
+   *
+   * @throws IllegalArgumentException if {@code sequence} contains ill-formed UTF-16 (unpaired
+   *                                  surrogates) and tolerateInvalidSurrogatePairs is true.
+   */
+  public static int encodedLength(CharSequence sequence, boolean tolerateInvalidSurrogatePairs)
   {
     // Warning to maintainers: this implementation is highly optimized.
     int utf16Length = sequence.length();
@@ -234,7 +307,7 @@ public class Utf8Utils
       }
       else
       {
-        utf8Length += encodedLengthGeneral(sequence, i);
+        utf8Length += encodedLengthGeneral(sequence, i, tolerateInvalidSurrogatePairs);
         break;
       }
     }
@@ -248,7 +321,7 @@ public class Utf8Utils
     return utf8Length;
   }
 
-  private static int encodedLengthGeneral(CharSequence sequence, int start)
+  private static int encodedLengthGeneral(CharSequence sequence, int start, boolean tolerateInvalidSurrogatePairs)
   {
     int utf16Length = sequence.length();
     int utf8Length = 0;
@@ -262,14 +335,22 @@ public class Utf8Utils
       else
       {
         utf8Length += 2;
-        // jdk7+: if (Character.isSurrogate(c)) {
-        if (Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE)
+        if (Character.isSurrogate(c))
         {
           // Check that we have a well-formed surrogate pair.
           int cp = Character.codePointAt(sequence, i);
           if (cp < Character.MIN_SUPPLEMENTARY_CODE_POINT)
           {
-            throw new IllegalArgumentException("Unpaired surrogate at index " + i + " of " + utf16Length);
+            if (tolerateInvalidSurrogatePairs)
+            {
+              // Subtract 2 since the standard replacement character '?' will not consume the already
+              // accounted for 2 bytes.
+              utf8Length -= 2;
+            }
+            else
+            {
+              throw new IllegalArgumentException("Unpaired surrogate at index " + i + " of " + utf16Length);
+            }
           }
           i++;
         }


### PR DESCRIPTION
The graceful degradation is similar to jackson, in the sense that every invalid surrogate is replaced by ?