### PR TITLE
Disable string interning in Jackson JSON since it causes GC issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.4.4] - 2020-07-02
+- Disable string interning in Jackson JSON since it causes GC issues (#346)
+
 ## [29.4.3] - 2020-07-01
 - Add an option (enabled by default) to gracefully degrade on encountering invalid surrogate pairs during protobuf string serialization (#334)
 
@@ -4549,7 +4552,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.4...master
+[29.4.4]: https://github.com/linkedin/rest.li/compare/v29.4.3...v29.4.4
 [29.4.3]: https://github.com/linkedin/rest.li/compare/v29.4.2...v29.4.3
 [29.4.2]: https://github.com/linkedin/rest.li/compare/v29.4.1...v29.4.2
 [29.4.1]: https://github.com/linkedin/rest.li/compare/v29.4.0...v29.4.1

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -51,6 +51,18 @@ import java.util.TreeMap;
  */
 public abstract class AbstractJacksonDataCodec implements DataCodec
 {
+  /**
+   * Default factory to be shared between all jackson JSON codec instances. This is done to maximize factory reuse for
+   * performance reasons as recommended by Jackson authors.
+   *
+   * <a href="https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance">Jackson Performance</a>
+   */
+  public static final JsonFactory JSON_FACTORY = new JsonFactory();
+  static {
+    // Disable string interning by default since it causes GC issues.
+    JSON_FACTORY.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+  }
+
   protected static final int DEFAULT_BUFFER_SIZE = 4096;
 
   protected final JsonFactory _factory;

--- a/data/src/main/java/com/linkedin/data/codec/JacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/JacksonDataCodec.java
@@ -48,7 +48,7 @@ public class JacksonDataCodec extends AbstractJacksonDataCodec implements TextDa
 
   public JacksonDataCodec()
   {
-    this(new JsonFactory());
+    this(JSON_FACTORY);
   }
 
   public JacksonDataCodec(JsonFactory jsonFactory)

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/AbstractJacksonDataDecoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/AbstractJacksonDataDecoder.java
@@ -65,7 +65,7 @@ class AbstractJacksonDataDecoder<T extends DataComplex> extends AbstractDataDeco
     }
   }
 
-  private final JsonFactory _jsonFactory;
+  protected final JsonFactory _jsonFactory;
   private DataMapBuilder _currDataMapBuilder;
 
   /**

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonJsonDataDecoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonJsonDataDecoder.java
@@ -16,8 +16,10 @@
 
 package com.linkedin.data.codec.entitystream;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.json.async.NonBlockingJsonParser;
 import com.linkedin.data.DataComplex;
+import com.linkedin.data.codec.AbstractJacksonDataCodec;
 import com.linkedin.data.parser.NonBlockingDataParser;
 import java.util.EnumSet;
 
@@ -36,16 +38,21 @@ public class JacksonJsonDataDecoder<T extends DataComplex> extends AbstractJacks
   @Deprecated
   protected JacksonJsonDataDecoder(byte expectedFirstToken)
   {
-    super(JacksonStreamDataCodec.JSON_FACTORY, expectedFirstToken);
+    super(AbstractJacksonDataCodec.JSON_FACTORY, expectedFirstToken);
   }
 
   protected JacksonJsonDataDecoder(EnumSet<NonBlockingDataParser.Token> expectedFirstToken)
   {
-    super(JacksonStreamDataCodec.JSON_FACTORY, expectedFirstToken);
+    super(AbstractJacksonDataCodec.JSON_FACTORY, expectedFirstToken);
+  }
+
+  protected JacksonJsonDataDecoder(JsonFactory jsonFactory, EnumSet<NonBlockingDataParser.Token> expectedFirstToken)
+  {
+    super(jsonFactory, expectedFirstToken);
   }
 
   public JacksonJsonDataDecoder()
   {
-    super(JacksonStreamDataCodec.JSON_FACTORY);
+    super(AbstractJacksonDataCodec.JSON_FACTORY);
   }
 }

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonJsonDataEncoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonJsonDataEncoder.java
@@ -16,10 +16,12 @@
 
 package com.linkedin.data.codec.entitystream;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.linkedin.data.ByteString;
 import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
+import com.linkedin.data.codec.AbstractJacksonDataCodec;
 
 
 /**
@@ -35,11 +37,21 @@ public class JacksonJsonDataEncoder extends AbstractJacksonDataEncoder implement
 {
   public JacksonJsonDataEncoder(DataMap dataMap, int bufferSize)
   {
-    super(JacksonStreamDataCodec.JSON_FACTORY, dataMap, bufferSize);
+    super(AbstractJacksonDataCodec.JSON_FACTORY, dataMap, bufferSize);
   }
 
   public JacksonJsonDataEncoder(DataList dataList, int bufferSize)
   {
-    super(JacksonStreamDataCodec.JSON_FACTORY, dataList, bufferSize);
+    super(AbstractJacksonDataCodec.JSON_FACTORY, dataList, bufferSize);
+  }
+
+  public JacksonJsonDataEncoder(JsonFactory jsonFactory, DataMap dataMap, int bufferSize)
+  {
+    super(jsonFactory, dataMap, bufferSize);
+  }
+
+  public JacksonJsonDataEncoder(JsonFactory jsonFactory, DataList dataList, int bufferSize)
+  {
+    super(jsonFactory, dataList, bufferSize);
   }
 }

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonJsonDataListDecoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonJsonDataListDecoder.java
@@ -16,13 +16,20 @@
 
 package com.linkedin.data.codec.entitystream;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.linkedin.data.DataList;
+import com.linkedin.data.codec.AbstractJacksonDataCodec;
 
 
 public class JacksonJsonDataListDecoder extends JacksonJsonDataDecoder<DataList>
 {
   public JacksonJsonDataListDecoder()
   {
-    super(START_ARRAY_TOKEN);
+    this(AbstractJacksonDataCodec.JSON_FACTORY);
+  }
+
+  public JacksonJsonDataListDecoder(JsonFactory jsonFactory)
+  {
+    super(jsonFactory, START_ARRAY_TOKEN);
   }
 }

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonJsonDataMapDecoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonJsonDataMapDecoder.java
@@ -16,13 +16,20 @@
 
 package com.linkedin.data.codec.entitystream;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.linkedin.data.DataMap;
+import com.linkedin.data.codec.AbstractJacksonDataCodec;
 
 
 public class JacksonJsonDataMapDecoder extends JacksonJsonDataDecoder<DataMap>
 {
   public JacksonJsonDataMapDecoder()
   {
-    super(START_OBJECT_TOKEN);
+    this(AbstractJacksonDataCodec.JSON_FACTORY);
+  }
+
+  public JacksonJsonDataMapDecoder(JsonFactory jsonFactory)
+  {
+    super(jsonFactory, START_OBJECT_TOKEN);
   }
 }

--- a/data/src/test/java/com/linkedin/data/codec/TestJacksonCodec.java
+++ b/data/src/test/java/com/linkedin/data/codec/TestJacksonCodec.java
@@ -33,10 +33,8 @@ import java.util.Map;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
+
 
 /**
  * Tests specific to {@link JacksonDataCodec}
@@ -151,25 +149,22 @@ public class TestJacksonCodec extends TestCodec
   }
 
   /**
-   * Test to make sure that field names are interned.
-   *
-   * @throws IOException
+   * Test to make sure that field names are not interned by default.
    */
   @Test
-  public void testStringIntern() throws IOException
+  public void testStringInternDisabledByDefault() throws IOException
   {
     final String keyName = "testKey";
     final String json = "{ \"" + keyName + "\" : 1 }";
     final byte[] jsonAsBytes = json.getBytes(Data.UTF_8_CHARSET);
 
-    final JsonFactory jsonFactory = new JsonFactory();
-    final JacksonDataCodec codec = new JacksonDataCodec(jsonFactory);
-    // make sure intern field names is enabled
-    assertTrue(jsonFactory.isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES));
-    assertTrue(jsonFactory.isEnabled(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES));
+    final JacksonDataCodec codec = new JacksonDataCodec();
+    // make sure intern field names is disabled by default
+    assertFalse(codec._factory.isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES));
     final DataMap map = codec.bytesToMap(jsonAsBytes);
     final String key = map.keySet().iterator().next();
-    assertSame(key, keyName);
+    assertEquals(key, keyName);
+    assertNotSame(key, keyName);
   }
 
   @Test(dataProvider = "longKeyFromByteSource", dataProviderClass = CodecDataProviders.class)

--- a/data/src/test/java/com/linkedin/data/codec/entitystream/TestJacksonJsonDataEncoder.java
+++ b/data/src/test/java/com/linkedin/data/codec/entitystream/TestJacksonJsonDataEncoder.java
@@ -17,20 +17,26 @@
 
 package com.linkedin.data.codec.entitystream;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.linkedin.data.ChunkedByteStringCollector;
 import com.linkedin.data.ByteString;
+import com.linkedin.data.ChunkedByteStringWriter;
+import com.linkedin.data.Data;
 import com.linkedin.data.DataComplex;
 import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.TestUtil;
 import com.linkedin.data.codec.CodecDataProviders;
+import com.linkedin.data.codec.JacksonDataCodec;
 import com.linkedin.entitystream.CollectingReader;
 import com.linkedin.entitystream.EntityStream;
 import com.linkedin.entitystream.EntityStreams;
 
+import com.linkedin.entitystream.Writer;
+import java.io.IOException;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 
 public class TestJacksonJsonDataEncoder
@@ -43,6 +49,42 @@ public class TestJacksonJsonDataEncoder
     byte[] actual = encode(dataComplex);
 
     assertEquals(actual, expected);
+  }
+
+  /**
+   * Test to make sure that field names are not interned by default.
+   */
+  @Test
+  public void testStringInternDisabledByDefault() throws Exception
+  {
+    final String keyName = "testKey";
+    DataMap dataMap = new DataMap();
+    dataMap.put(keyName, 1);
+
+    JacksonJsonDataEncoder encoder = new JacksonJsonDataEncoder(dataMap, 3);
+    // make sure intern field names is disabled by default
+    assertFalse(encoder._jsonFactory.isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES));
+
+    EntityStream<ByteString> entityStream = EntityStreams.newEntityStream(encoder);
+    CollectingReader<ByteString, ?, ChunkedByteStringCollector.Result> reader =
+        new CollectingReader<>(new ChunkedByteStringCollector());
+    entityStream.setReader(reader);
+
+    byte[] encoded = reader.getResult().toCompletableFuture().get().data;
+
+    JacksonJsonDataMapDecoder decoder = new JacksonJsonDataMapDecoder();
+    // make sure intern field names is disabled
+    assertFalse(decoder._jsonFactory.isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES));
+
+    Writer<ByteString> writer = new ChunkedByteStringWriter(encoded, 3);
+    entityStream = EntityStreams.newEntityStream(writer);
+    entityStream.setReader(decoder);
+
+    DataMap map = decoder.getResult().toCompletableFuture().get();
+
+    final String key = map.keySet().iterator().next();
+    assertEquals(key, keyName);
+    assertNotSame(key, keyName);
   }
 
   private byte[] encode(DataComplex data)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.4.3
+version=29.4.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
1. Make JsonFactory parameterized so that multiple codec instances can share the same factory if necessary
2. Make the default factory a static singleton for factory reuse to minimize garbage

Interning seems to be messing with batch_get where the keys are not schema but are values, resulting in a large number of strings being interned.