### PR TITLE
D2 relative strategy integration test

### DIFF
--- a/d2-int-test/build.gradle
+++ b/d2-int-test/build.gradle
@@ -18,5 +18,6 @@ dependencies {
   testCompile project(path: ':d2', configuration: 'testArtifacts')
   testCompile project(':d2-test-api')
   testRuntime project(':r2-jetty')
+  testCompile project(':test-util')
 }
 

--- a/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerStrategy.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerStrategy.java
@@ -1,0 +1,776 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.loadbalancer.strategies;
+
+import com.linkedin.d2.D2QuarantineProperties;
+import com.linkedin.d2.D2RelativeStrategyProperties;
+import com.linkedin.d2.HttpStatusCodeRange;
+import com.linkedin.d2.HttpStatusCodeRangeArray;
+import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.PropertyKeys;
+import com.linkedin.d2.balancer.strategies.framework.ErrorCountCorrelation;
+import com.linkedin.d2.balancer.strategies.framework.LatencyCorrelation;
+import com.linkedin.d2.balancer.strategies.framework.LoadBalancerStrategyTestRunner;
+import com.linkedin.d2.balancer.strategies.framework.LoadBalancerStrategyTestRunnerBuilder;
+import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategyFactory;
+import com.linkedin.d2.loadBalancerStrategyType;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Integration tests for the load balancer strategies
+ */
+public class TestLoadBalancerStrategy
+{
+  // Some default values to build default test scenarios
+  private static final String DEFAULT_SERVICE_NAME = "dummyService";
+  private static final int DEFAULT_NUM_HOSTS = 5;
+  private static final int DEFAULT_REQUESTS_PER_INTERVAL = 1000;
+  private static final String DEFAULT_HIGH_ERROR_RATE = "0.2";
+  private static final String DEFAULT_LOW_ERROR_RATE = "0.05";
+  private static final double DEFAULT_QUARANTINE_PERCENTAGE = 0.5;
+  private static final double DEFAULT_WEIGHT = 1;
+  private static final int HEALTHY_ERROR_COUNT = 0;
+  private static final int UNHEALTHY_ERROR_COUNT = 100;
+  private static final long UNHEALTHY_HOST_CONSTANT_LATENCY = 1000L;
+  private static final long HEALTHY_HOST_CONSTANT_LATENCY = 50L;
+  private static final LatencyCorrelation HEALTHY_HOST_LATENCY_CORRELATION =
+      (callCount, intervalIndex) -> HEALTHY_HOST_CONSTANT_LATENCY;
+  private static final ErrorCountCorrelation HEALTHY_HOST_ERROR_COUNT_CORRELATION =
+      (callCount, intervalIndex) -> HEALTHY_ERROR_COUNT;
+  // As time goes, the host latency becomes longer and longer
+  private static final LatencyCorrelation HOST_BECOMING_UNHEALTHY_LATENCY =
+      (callCount, intervalIndex) -> Long.min(HEALTHY_HOST_CONSTANT_LATENCY + intervalIndex * 500L, UNHEALTHY_HOST_CONSTANT_LATENCY);
+  // As time goes, the host latency becomes shorter and shorter and recovers to healthy state
+  private static final LatencyCorrelation HOST_RECOVERING_TO_HEALTHY_LATENCY =
+      (callCount, intervalIndex) -> Long.max(UNHEALTHY_HOST_CONSTANT_LATENCY - intervalIndex * 100L, HEALTHY_HOST_CONSTANT_LATENCY);
+  // As time goes, the host latency becomes bigger and bigger
+  private static final ErrorCountCorrelation HOST_BECOMING_UNHEALTHY_ERROR =
+      (callCount, intervalIndex) -> Integer.min(HEALTHY_ERROR_COUNT + intervalIndex * 10, UNHEALTHY_ERROR_COUNT);
+  // As time goes, the host error count comes to 0
+  private static final ErrorCountCorrelation HOST_RECOVERING_TO_HEALTHY_ERROR =
+      (callCount, intervalIndex) -> Integer.max(UNHEALTHY_ERROR_COUNT - intervalIndex * 10, HEALTHY_ERROR_COUNT);
+
+  @SuppressWarnings("serial")
+  private static final Map<String, String> DEGRADER_PROPERTIES_WITH_HIGH_LOW_ERROR = new HashMap<String, String>()
+  {{
+    put(PropertyKeys.DEGRADER_HIGH_ERROR_RATE, DEFAULT_HIGH_ERROR_RATE);
+    put(PropertyKeys.DEGRADER_LOW_ERROR_RATE, DEFAULT_LOW_ERROR_RATE);
+  }};
+  private static final int HEALTHY_POINTS = 100;
+  private static final int QUARANTINED_POINTS = 0;
+  private static final int INITIAL_RECOVERY_POINTS = 0;
+  // Sometimes the points change between 1 and 2 for Degrader strategy
+  private static final int FULLY_DROPPED_POINTS = 2;
+
+  @Test(dataProvider = "constantBadHost")
+  public void testConstantBadHost(LoadBalancerStrategyTestRunner constantBadHostRunner)
+  {
+    constantBadHostRunner.runWait();
+    Map<URI, Integer> pointsMap = constantBadHostRunner.getPoints();
+
+    assertEquals(pointsMap.get(constantBadHostRunner.getUri(0)).intValue(),
+        (int) (HEALTHY_POINTS - RelativeLoadBalancerStrategyFactory.DEFAULT_DOWN_STEP * HEALTHY_POINTS * 2),
+        "The bad host points should drop to 60");
+    assertEquals(pointsMap.get(constantBadHostRunner.getUri(1)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(constantBadHostRunner.getUri(2)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(constantBadHostRunner.getUri(3)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(constantBadHostRunner.getUri(4)).intValue(), HEALTHY_POINTS);
+  }
+
+  @DataProvider(name = "constantBadHost")
+  public Object[][] getConstantBadHost()
+  {
+    int numIntervals = 3;
+    return new Object[][]
+        {
+            {create1Unhealthy4HealthyHostWithLatency(loadBalancerStrategyType.DEGRADER, numIntervals)},
+            {create1Unhealthy4HealthyHostWithLatency(loadBalancerStrategyType.RELATIVE, numIntervals)},
+            {create1Unhealthy4HealthyHostWithError(loadBalancerStrategyType.DEGRADER, numIntervals)},
+            {create1Unhealthy4HealthyHostWithError(loadBalancerStrategyType.RELATIVE, numIntervals)},
+        };
+  }
+
+  @Test(dataProvider = "goingBadHost")
+  public void testPointsDropToZero(LoadBalancerStrategyTestRunner goingBadHostRunner)
+  {
+    goingBadHostRunner.runWait();
+    List<Integer> pointHistory = goingBadHostRunner.getPointHistory().get(goingBadHostRunner.getUri(0));
+
+    assertEquals(pointHistory.get(0).intValue(), HEALTHY_POINTS);
+    assertTrue(pointHistory.get(19).intValue() <= FULLY_DROPPED_POINTS, "The points should be below 2");
+  }
+
+  @DataProvider(name = "goingBadHost")
+  public Object[][] getGoingBadHost()
+  {
+    int numIntervals = 20;
+    return new Object[][]
+        {
+            {create1GoingBad4HealthyHostWithLatency(loadBalancerStrategyType.DEGRADER, numIntervals)},
+            {create1GoingBad4HealthyHostWithLatency(loadBalancerStrategyType.RELATIVE, numIntervals)},
+            {create1GoingBad4HealthyHostWithError(loadBalancerStrategyType.DEGRADER, numIntervals)},
+            {create1GoingBad4HealthyHostWithError(loadBalancerStrategyType.RELATIVE, numIntervals)},
+        };
+  }
+
+  @Test(dataProvider = "recoveringHost")
+  public void testPointsRecoverToNormal(LoadBalancerStrategyTestRunner recoveringHostRunner)
+  {
+    recoveringHostRunner.runWait();
+
+    // Get the point history for the unhealthy host
+    List<Integer> pointHistory = recoveringHostRunner.getPointHistory().get(recoveringHostRunner.getUri(0));
+
+    assertTrue(getLowestPoints(pointHistory) <= FULLY_DROPPED_POINTS, "Points should be fully dropped in the middle");
+    assertEquals(pointHistory.get(34).intValue(), HEALTHY_POINTS, "Points should recover to 100");
+  }
+
+  @DataProvider(name = "recoveringHost")
+  public Object[][] getRecoveringHost()
+  {
+    int numIntervals = 35;
+    return new Object[][]
+        {
+            {create1Receovering4HealthyHostWithLatency(loadBalancerStrategyType.DEGRADER, numIntervals)},
+            {create1Receovering4HealthyHostWithLatency(loadBalancerStrategyType.RELATIVE, numIntervals)},
+            {create1Receovering4HealthyHostWithError(loadBalancerStrategyType.DEGRADER, numIntervals)},
+            {create1Receovering4HealthyHostWithError(loadBalancerStrategyType.RELATIVE, numIntervals)},
+        };
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testLowQps(loadBalancerStrategyType type)
+  {
+    Map<String, String> degraderPropertiesWithMinCallCount = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithMinCallCount = new D2RelativeStrategyProperties();
+    // Set minCallCount to be 20
+    degraderPropertiesWithMinCallCount.put(PropertyKeys.DEGRADER_MIN_CALL_COUNT, "20");
+    relativePropertiesWithMinCallCount.setMinCallCount(20);
+
+    LoadBalancerStrategyTestRunnerBuilder
+        builder = new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+        // Only send 10 requests per interval
+        .setConstantRequestCount(10)
+        .setNumIntervals(10)
+        // One host with unhealthy latency
+        .setConstantLatency(Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(new HashMap<>(), degraderPropertiesWithMinCallCount).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithMinCallCount).build();
+
+    testRunner.runWait();
+    Map<URI, Integer> pointsMap = testRunner.getPoints();
+
+    assertEquals(pointsMap.get(testRunner.getUri(0)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(1)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(2)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(3)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(4)).intValue(), HEALTHY_POINTS);
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testGrowingQps(loadBalancerStrategyType type)
+  {
+    Map<String, String> degraderPropertiesWithMinCallCount = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithMinCallCount = new D2RelativeStrategyProperties();
+
+    // Set minCallCount to be 100
+    degraderPropertiesWithMinCallCount.put(PropertyKeys.DEGRADER_MIN_CALL_COUNT, "100");
+    relativePropertiesWithMinCallCount.setMinCallCount(100);
+
+    LoadBalancerStrategyTestRunnerBuilder builder =
+        new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+            // send growing traffic: 10, 60, 110, 160...
+            .setDynamicRequestCount((intervalIndex) -> 10 + 50 * intervalIndex)
+            .setNumIntervals(50)
+            // One host with unhealthy latency
+            .setConstantLatency(Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY,
+                HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+                HEALTHY_HOST_CONSTANT_LATENCY));
+     LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+         ? builder.setDegraderStrategies(new HashMap<>(), degraderPropertiesWithMinCallCount).build()
+         : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithMinCallCount).build();
+
+    testRunner.runWait();
+    List<Integer> pointHistory = testRunner.getPointHistory().get(testRunner.getUri(0));
+    int lowestPoints = getLowestPoints(pointHistory);
+
+    assertEquals(pointHistory.get(3).intValue(), HEALTHY_POINTS,
+        "The unhealthy host still has 100 points on 4th iteration because QPS was small");
+    assertTrue(lowestPoints <= FULLY_DROPPED_POINTS, "The points will eventually drop");
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testDifferentUpDownStep(loadBalancerStrategyType type) {
+    Map<String, String> degraderPropertiesWithUpDownStep = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithUpDownStep = new D2RelativeStrategyProperties();
+
+    // Set up/downStep to be 0.3
+    double step = 0.3;
+    degraderPropertiesWithUpDownStep.put(PropertyKeys.DEGRADER_UP_STEP, String.valueOf(step));
+    degraderPropertiesWithUpDownStep.put(PropertyKeys.DEGRADER_DOWN_STEP, String.valueOf(step));
+    relativePropertiesWithUpDownStep.setUpStep(step);
+    relativePropertiesWithUpDownStep.setDownStep(step);
+
+    LoadBalancerStrategyTestRunnerBuilder builder =
+        new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+            .setConstantRequestCount(1000)
+            .setNumIntervals(3)
+            // One host with unhealthy latency
+            .setConstantLatency(Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY,
+                HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+                HEALTHY_HOST_CONSTANT_LATENCY));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(new HashMap<>(), degraderPropertiesWithUpDownStep).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithUpDownStep).build();
+
+    testRunner.runWait();
+    Map<URI, Integer> pointsMap = testRunner.getPoints();
+
+    assertEquals(pointsMap.get(testRunner.getUri(0)).intValue(), (int) (HEALTHY_POINTS - 2 * step * HEALTHY_POINTS));
+    assertEquals(pointsMap.get(testRunner.getUri(1)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(2)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(3)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(4)).intValue(), HEALTHY_POINTS);
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testOneHost(loadBalancerStrategyType type) {
+    LoadBalancerStrategyTestRunner testRunner =
+        new LoadBalancerStrategyTestRunnerBuilder(type,
+            // Set to corner case - only 1 host
+            DEFAULT_SERVICE_NAME, 1)
+            .setConstantRequestCount(100)
+            .setNumIntervals(3)
+            .setConstantLatency(Arrays.asList(HEALTHY_HOST_CONSTANT_LATENCY))
+            .build();
+    testRunner.runWait();
+    List<Integer> pointHistory = testRunner.getPointHistory().get(testRunner.getUri(0));
+
+    assertEquals(pointHistory.get(2).intValue(), HEALTHY_POINTS);
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testStayQuarantined(loadBalancerStrategyType type) {
+    Map<String, Object> strategyPropertiesWithQuarantineEnabled = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithQuarantineEnabled = new D2RelativeStrategyProperties();
+    D2QuarantineProperties quarantineProperties = new D2QuarantineProperties().setQuarantineMaxPercent(DEFAULT_QUARANTINE_PERCENTAGE);
+
+    strategyPropertiesWithQuarantineEnabled.put(PropertyKeys.HTTP_LB_QUARANTINE_MAX_PERCENT, String.valueOf(DEFAULT_QUARANTINE_PERCENTAGE));
+    relativePropertiesWithQuarantineEnabled.setQuarantineProperties(quarantineProperties);
+
+    LoadBalancerStrategyTestRunnerBuilder builder =
+        new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+            .setConstantRequestCount(1000)
+            .setNumIntervals(10)
+            .setConstantLatency(Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY,
+                HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+                HEALTHY_HOST_CONSTANT_LATENCY));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(strategyPropertiesWithQuarantineEnabled, new HashMap<>()).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithQuarantineEnabled).build();
+
+    testRunner.runWait();
+    List<Integer> pointHistory = testRunner.getPointHistory().get(testRunner.getUri(0));
+
+    assertEquals(pointHistory.get(9).intValue(), QUARANTINED_POINTS);
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testQuarantineRecovery(loadBalancerStrategyType type) {
+    Map<String, Object> strategyPropertiesWithQuarantineEnabled = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithQuarantineEnabled = new D2RelativeStrategyProperties();
+    D2QuarantineProperties quarantineProperties = new D2QuarantineProperties().setQuarantineMaxPercent(DEFAULT_QUARANTINE_PERCENTAGE);
+
+    strategyPropertiesWithQuarantineEnabled.put(PropertyKeys.HTTP_LB_QUARANTINE_MAX_PERCENT, String.valueOf(DEFAULT_QUARANTINE_PERCENTAGE));
+    relativePropertiesWithQuarantineEnabled.setQuarantineProperties(quarantineProperties);
+
+    LoadBalancerStrategyTestRunnerBuilder builder =
+        new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+            .setConstantRequestCount(1000)
+            .setNumIntervals(40)
+            .setDynamicLatency(Arrays.asList(HOST_RECOVERING_TO_HEALTHY_LATENCY,
+                HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION,
+                HEALTHY_HOST_LATENCY_CORRELATION));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(strategyPropertiesWithQuarantineEnabled, new HashMap<>()).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithQuarantineEnabled).build();
+    testRunner.runWait();
+    List<Integer> pointHistory = testRunner.getPointHistory().get(testRunner.getUri(0));
+
+    assertEquals(getLowestPoints(pointHistory), QUARANTINED_POINTS);
+    assertEquals(pointHistory.get(39).intValue(), HEALTHY_POINTS);
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testQuarantineHittingMaxPercentage(loadBalancerStrategyType type) {
+    Map<String, Object> strategyPropertiesWithQuarantineEnabled = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithQuarantineEnabled = new D2RelativeStrategyProperties();
+
+    // Only 1/5 of the hosts can be quarantined
+    double quarantinePercentage = 0.2;
+    strategyPropertiesWithQuarantineEnabled.put(PropertyKeys.HTTP_LB_QUARANTINE_MAX_PERCENT, String.valueOf(quarantinePercentage));
+    D2QuarantineProperties quarantineProperties = new D2QuarantineProperties().setQuarantineMaxPercent(quarantinePercentage);
+    relativePropertiesWithQuarantineEnabled.setQuarantineProperties(quarantineProperties);
+
+    LoadBalancerStrategyTestRunnerBuilder builder =
+        new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+            .setConstantRequestCount(1000)
+            .setNumIntervals(10)
+            // 2 unhealthy hosts and 3 healthy host
+            .setConstantLatency(Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY, UNHEALTHY_HOST_CONSTANT_LATENCY,
+                HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(strategyPropertiesWithQuarantineEnabled, new HashMap<>()).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithQuarantineEnabled).build();
+
+    testRunner.runWait();
+    Map<URI, Integer> pointsMap = testRunner.getPoints();
+
+    Assert.assertTrue(pointsMap.values().contains(QUARANTINED_POINTS));
+    Assert.assertTrue(pointsMap.values().contains(INITIAL_RECOVERY_POINTS), "There should be host that is not quarantined but fully dropped");
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testFastRecovery(loadBalancerStrategyType type) {
+    Map<String, Object> strategyPropertiesWithQuarantineEnabled = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithQuarantineEnabled = new D2RelativeStrategyProperties();
+
+    strategyPropertiesWithQuarantineEnabled.put(PropertyKeys.HTTP_LB_QUARANTINE_MAX_PERCENT, String.valueOf(DEFAULT_QUARANTINE_PERCENTAGE));
+    strategyPropertiesWithQuarantineEnabled.put(PropertyKeys.HTTP_LB_RING_RAMP_FACTOR, "2.0");
+    relativePropertiesWithQuarantineEnabled.setQuarantineProperties(new D2QuarantineProperties().setQuarantineMaxPercent(DEFAULT_QUARANTINE_PERCENTAGE));
+    relativePropertiesWithQuarantineEnabled.setEnableFastRecovery(true);
+
+    LoadBalancerStrategyTestRunnerBuilder builder =
+        new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+            .setConstantRequestCount(100)
+            .setNumIntervals(30)
+            .setDegraderStrategies(strategyPropertiesWithQuarantineEnabled, new HashMap<>())
+            // All hosts with unhealthy latency
+            .setDynamicLatency(Arrays.asList(HOST_RECOVERING_TO_HEALTHY_LATENCY,
+                HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION,
+                HEALTHY_HOST_LATENCY_CORRELATION));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(strategyPropertiesWithQuarantineEnabled, new HashMap<>()).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithQuarantineEnabled).build();
+
+    testRunner.runWait();
+    List<Integer> pointHistory = testRunner.getPointHistory().get(testRunner.getUri(0));
+
+    assertTrue(hasPointsInHistory(pointHistory, Arrays.asList(2)), "Fast recovery should recover the points from 1 to 2 initially");
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testSlowStart(loadBalancerStrategyType type) {
+    Map<String, String> degraderPropertiesWithSlowStart = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithSlowStart = new D2RelativeStrategyProperties();
+    degraderPropertiesWithSlowStart.put(PropertyKeys.DEGRADER_SLOW_START_THRESHOLD, "0.2");
+    relativePropertiesWithSlowStart.setSlowStartThreshold(0.2);
+
+    LoadBalancerStrategyTestRunnerBuilder builder =
+        new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+            .setConstantRequestCount(60)
+            .setNumIntervals(30)
+            .setDegraderStrategies(new HashMap<>(), degraderPropertiesWithSlowStart)
+            // All hosts with unhealthy latency
+            .setDynamicLatency(Arrays.asList(HOST_RECOVERING_TO_HEALTHY_LATENCY,
+                HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION,
+                HEALTHY_HOST_LATENCY_CORRELATION));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(new HashMap<>(), degraderPropertiesWithSlowStart).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithSlowStart).build();
+
+    testRunner.runWait();
+    List<Integer> pointHistory = testRunner.getPointHistory().get(testRunner.getUri(0));
+
+    assertTrue(hasPointsInHistory(pointHistory, Arrays.asList(2, 4, 8, 16)), "Slow start should double the health score when it is below threshold");
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testSlowStartWithInitialHealthScore(loadBalancerStrategyType type)
+  {
+    Map<String, String> degraderPropertiesWithSlowStart = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithSlowStart = new D2RelativeStrategyProperties();
+    degraderPropertiesWithSlowStart.put(PropertyKeys.DEGRADER_INITIAL_DROP_RATE, "0.99");
+    degraderPropertiesWithSlowStart.put(PropertyKeys.DEGRADER_SLOW_START_THRESHOLD, "0.5");
+    relativePropertiesWithSlowStart.setInitialHealthScore(0.01);
+    relativePropertiesWithSlowStart.setSlowStartThreshold(0.5);
+
+    LoadBalancerStrategyTestRunnerBuilder builder =
+        new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, 5)
+            .setConstantRequestCount(60)
+            .setNumIntervals(30)
+            .setDegraderStrategies(new HashMap<>(), degraderPropertiesWithSlowStart)
+            // All hosts with healthy latency
+            .setConstantLatency(Arrays.asList(HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+                HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(new HashMap<>(), degraderPropertiesWithSlowStart).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithSlowStart).build();
+
+    testRunner.runWait();
+    List<Integer> pointHistory = testRunner.getPointHistory().get(testRunner.getUri(0));
+
+    assertTrue(hasPointsInHistory(pointHistory, Arrays.asList(1, 4, 16)));
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testErrorStatusMatch(loadBalancerStrategyType type)
+  {
+    Map<String, Object> strategyPropertiesWithErrorFilter = new HashMap<>();
+    D2RelativeStrategyProperties relativePropertiesWithErrorFilter = new D2RelativeStrategyProperties();
+    // Only 503 is counted as error
+    strategyPropertiesWithErrorFilter.put(PropertyKeys.HTTP_LB_ERROR_STATUS_REGEX, "(503)");
+    relativePropertiesWithErrorFilter.setErrorStatusFilter(
+        new HttpStatusCodeRangeArray(Arrays.asList(new HttpStatusCodeRange().setLowerBound(503).setUpperBound(503))));
+
+    LoadBalancerStrategyTestRunnerBuilder
+        builder = new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(6)
+        .setConstantLatency(Arrays.asList(HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY))
+        .setConstantErrorCount(Arrays.asList(UNHEALTHY_ERROR_COUNT, HEALTHY_ERROR_COUNT, HEALTHY_ERROR_COUNT,
+            HEALTHY_ERROR_COUNT, HEALTHY_ERROR_COUNT));
+    LoadBalancerStrategyTestRunner testRunner = type == loadBalancerStrategyType.DEGRADER
+        ? builder.setDegraderStrategies(strategyPropertiesWithErrorFilter, new HashMap<>()).build()
+        : builder.setRelativeLoadBalancerStrategies(relativePropertiesWithErrorFilter).build();
+
+    testRunner.runWait();
+    Map<URI, Integer> pointsMap = testRunner.getPoints();
+
+    // Event with the error 500, the host is not marked as unhealthy
+    assertEquals(pointsMap.get(testRunner.getUri(0)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(1)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(2)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(3)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(4)).intValue(), HEALTHY_POINTS);
+  }
+
+  @Test(dataProvider = "strategy")
+  public void testPartitionWeightChange(loadBalancerStrategyType type)
+  {
+    double weight = 0.5;
+    Map<Integer, PartitionData> partitionDataMap = new HashMap<>();
+    partitionDataMap.put(LoadBalancerStrategyTestRunner.DEFAULT_PARTITION_ID, new PartitionData(weight));
+
+    LoadBalancerStrategyTestRunner testRunner = new LoadBalancerStrategyTestRunnerBuilder(type,
+        DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .addPartitionDataMap(0, partitionDataMap)
+        .setNumIntervals(3)
+        .setConstantLatency(Arrays.asList(HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY))
+        .build();
+
+    testRunner.runWait();
+    Map<URI, Integer> pointsMap = testRunner.getPoints();
+
+    assertEquals(pointsMap.get(testRunner.getUri(0)).intValue(), (int) (weight * HEALTHY_POINTS));
+    assertEquals(pointsMap.get(testRunner.getUri(1)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(2)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(3)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(4)).intValue(), HEALTHY_POINTS);
+  }
+
+  @DataProvider(name = "strategy")
+  public Object[][] getStrategy()
+  {
+    return new Object[][]
+        {
+            {loadBalancerStrategyType.DEGRADER},
+            {loadBalancerStrategyType.RELATIVE}
+        };
+  }
+
+  @Test
+  public void testMostHostWithHighLatency()
+  {
+    LoadBalancerStrategyTestRunner testRunner = new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.RELATIVE,
+        DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(6)
+        // 4/5 hosts have high latency, the average will be higher
+        .setConstantLatency(Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY,
+            UNHEALTHY_HOST_CONSTANT_LATENCY, UNHEALTHY_HOST_CONSTANT_LATENCY, UNHEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY))
+        .build();
+
+    testRunner.runWait();
+    Map<URI, Integer> pointsMap = testRunner.getPoints();
+
+    assertEquals(pointsMap.get(testRunner.getUri(0)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(1)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(2)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(3)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMap.get(testRunner.getUri(4)).intValue(), HEALTHY_POINTS);
+  }
+
+  @Test(dataProvider = "highFactor")
+  public void testDifferentHighLatencyFactors(double highFactor)
+  {
+    long unhealthyLatency = 800L;
+    long healthyLatency = 400L;
+    long avgLatency = (unhealthyLatency + 4 * healthyLatency) / 5;
+
+    D2RelativeStrategyProperties relativeStrategyProperties = new D2RelativeStrategyProperties()
+        .setRelativeLatencyHighThresholdFactor(highFactor);
+
+    LoadBalancerStrategyTestRunner testRunner = new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.RELATIVE,
+        DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(3)
+        .setConstantLatency(
+            Arrays.asList(unhealthyLatency, healthyLatency, healthyLatency, healthyLatency, healthyLatency))
+        .setRelativeLoadBalancerStrategies(relativeStrategyProperties)
+        .build();
+
+    testRunner.runWait();
+    Map<URI, Integer> pointsMap = testRunner.getPoints();
+
+    if (highFactor < (double) unhealthyLatency / avgLatency)
+    {
+      assertEquals(pointsMap.get(testRunner.getUri(0)).intValue(),
+          (int) (HEALTHY_POINTS - RelativeLoadBalancerStrategyFactory.DEFAULT_DOWN_STEP * HEALTHY_POINTS * 2));
+    }
+    else
+    {
+      assertEquals(pointsMap.get(testRunner.getUri(0)).intValue(), HEALTHY_POINTS);
+    }
+  }
+
+  @DataProvider(name = "highFactor")
+  public Object[][] getHighFactor()
+  {
+    return new Object[][]
+        {
+            {1.2},
+            {1.3},
+            {1.4},
+            {1.5},
+            {1.6},
+            {1.7},
+            {1.8}
+        };
+  }
+
+  @Test
+  public void testOneHostBelongToMultiplePartitions()
+  {
+    Map<Integer, PartitionData> partitionDataMapForBothPartitions = new HashMap<>();
+    partitionDataMapForBothPartitions.put(0, new PartitionData(DEFAULT_WEIGHT));
+    partitionDataMapForBothPartitions.put(1, new PartitionData(DEFAULT_WEIGHT));
+    Map<Integer, PartitionData> partitionDataMapPartition0 = new HashMap<>();
+    partitionDataMapPartition0.put(0, new PartitionData(DEFAULT_WEIGHT));
+    Map<Integer, PartitionData> partitionDataMapPartition1 = new HashMap<>();
+    partitionDataMapPartition1.put(1, new PartitionData(DEFAULT_WEIGHT));
+
+    LoadBalancerStrategyTestRunner testRunner = new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.RELATIVE,
+        DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        // There are 2 partitions
+        .addPartitionUriMap(0, Arrays.asList(0, 1, 2))
+        .addPartitionUriMap(1, Arrays.asList(0, 3, 4))
+        .addPartitionDataMap(0, partitionDataMapForBothPartitions)
+        .addPartitionDataMap(1, partitionDataMapPartition0)
+        .addPartitionDataMap(2, partitionDataMapPartition0)
+        .addPartitionDataMap(3, partitionDataMapPartition1)
+        .addPartitionDataMap(4, partitionDataMapPartition1)
+        .setNumIntervals(3)
+        // Host 0, 3, 4 have high latency, host 1 & 2 have healthy latency
+        .setConstantLatency(
+            Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+            UNHEALTHY_HOST_CONSTANT_LATENCY, UNHEALTHY_HOST_CONSTANT_LATENCY))
+        .build();
+
+    // Send traffic to partition 0 and 1
+    testRunner.runWait(Arrays.asList(0, 1));
+
+    Map<URI, Integer> pointsMapPartition0 = testRunner.getPoints(0);
+    Map<URI, Integer> pointsMapPartition1 = testRunner.getPoints(1);
+
+    assertEquals(pointsMapPartition0.get(testRunner.getUri(0)).intValue(),
+        (int) (HEALTHY_POINTS - RelativeLoadBalancerStrategyFactory.DEFAULT_DOWN_STEP * HEALTHY_POINTS * 2));
+    assertEquals(pointsMapPartition1.get(testRunner.getUri(0)).intValue(), HEALTHY_POINTS);
+  }
+
+  @Test
+  public void testAllHostsBelongToMultiplePartitions()
+  {
+    Map<Integer, PartitionData> partitionDataMapForBothPartitions = new HashMap<>();
+    partitionDataMapForBothPartitions.put(0, new PartitionData(DEFAULT_WEIGHT));
+    partitionDataMapForBothPartitions.put(1, new PartitionData(DEFAULT_WEIGHT));
+
+    LoadBalancerStrategyTestRunner testRunner = new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.RELATIVE,
+        DEFAULT_SERVICE_NAME, 3)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        // There are 2 partitions
+        .addPartitionUriMap(0, Arrays.asList(0, 1, 2))
+        .addPartitionUriMap(1, Arrays.asList(0, 1, 2))
+        .addPartitionDataMap(0, partitionDataMapForBothPartitions)
+        .addPartitionDataMap(1, partitionDataMapForBothPartitions)
+        .addPartitionDataMap(2, partitionDataMapForBothPartitions)
+        .setNumIntervals(3)
+        .setConstantLatency(
+            Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY))
+        .build();
+
+    // Send traffic to partition 0 and 1
+    testRunner.runWait(Arrays.asList(0, 1));
+
+    Map<URI, Integer> pointsMapPartition0 = testRunner.getPoints(0);
+    Map<URI, Integer> pointsMapPartition1 = testRunner.getPoints(1);
+
+    assertEquals(pointsMapPartition0.get(testRunner.getUri(0)).intValue(),
+        (int) (HEALTHY_POINTS - RelativeLoadBalancerStrategyFactory.DEFAULT_DOWN_STEP * HEALTHY_POINTS * 2));
+    assertEquals(pointsMapPartition0.get(testRunner.getUri(1)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMapPartition0.get(testRunner.getUri(2)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMapPartition1.get(testRunner.getUri(0)).intValue(),
+        (int) (HEALTHY_POINTS - RelativeLoadBalancerStrategyFactory.DEFAULT_DOWN_STEP * HEALTHY_POINTS * 2));
+    assertEquals(pointsMapPartition1.get(testRunner.getUri(1)).intValue(), HEALTHY_POINTS);
+    assertEquals(pointsMapPartition1.get(testRunner.getUri(2)).intValue(), HEALTHY_POINTS);
+  }
+
+  private static int getLowestPoints(List<Integer> pointHistory)
+  {
+    return pointHistory.stream().min(Integer::compareTo)
+        .orElse(HEALTHY_POINTS);
+  }
+
+  /**
+   * Verify a certain sequence occurred in the point history
+   */
+  private static boolean hasPointsInHistory(List<Integer> pointHistory, List<Integer> expectedPointsSequence) {
+    int expectedPointsIndex = 0;
+    int pointHistoryIndex = 0;
+    while (pointHistoryIndex < pointHistory.size() && expectedPointsIndex < expectedPointsSequence.size()) {
+      if (expectedPointsSequence.get(expectedPointsIndex) != pointHistory.get(pointHistoryIndex)) {
+        pointHistoryIndex ++;
+        continue;
+      }
+      pointHistoryIndex ++;
+      expectedPointsIndex ++;
+    }
+
+    return expectedPointsIndex == expectedPointsSequence.size();
+  }
+
+  /**
+   * The following methods create some default test scenarios
+   */
+  private static LoadBalancerStrategyTestRunner create1Unhealthy4HealthyHostWithLatency(loadBalancerStrategyType type, int numIntervals)
+  {
+    return new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(numIntervals)
+        .setConstantLatency(Arrays.asList(UNHEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY))
+        .build();
+  }
+
+  private static LoadBalancerStrategyTestRunner create1Receovering4HealthyHostWithLatency(loadBalancerStrategyType type, int numIntervals)
+  {
+    return new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(numIntervals)
+        .setDynamicLatency(Arrays.asList(HOST_RECOVERING_TO_HEALTHY_LATENCY,
+            HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION,
+            HEALTHY_HOST_LATENCY_CORRELATION))
+        .build();
+  }
+
+  private static LoadBalancerStrategyTestRunner create1GoingBad4HealthyHostWithLatency(loadBalancerStrategyType type, int numIntervals)
+  {
+    return new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(numIntervals)
+        .setDynamicLatency(Arrays.asList(HOST_BECOMING_UNHEALTHY_LATENCY,
+            HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION, HEALTHY_HOST_LATENCY_CORRELATION,
+            HEALTHY_HOST_LATENCY_CORRELATION))
+        .build();
+  }
+
+  private static LoadBalancerStrategyTestRunner create1Unhealthy4HealthyHostWithError(loadBalancerStrategyType type, int numIntervals)
+  {
+    LoadBalancerStrategyTestRunnerBuilder
+        builder = new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(numIntervals)
+        .setConstantLatency(Arrays.asList(HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY))
+        .setConstantErrorCount(Arrays.asList(UNHEALTHY_ERROR_COUNT, HEALTHY_ERROR_COUNT, HEALTHY_ERROR_COUNT,
+            HEALTHY_ERROR_COUNT, HEALTHY_ERROR_COUNT));
+    return setDefaultErrorRate(builder, type).build();
+  }
+
+  private static LoadBalancerStrategyTestRunner create1Receovering4HealthyHostWithError(loadBalancerStrategyType type, int numIntervals)
+  {
+    LoadBalancerStrategyTestRunnerBuilder
+        builder = new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(numIntervals)
+        .setConstantLatency(Arrays.asList(HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY))
+        .setDynamicErrorCount(Arrays.asList(HOST_RECOVERING_TO_HEALTHY_ERROR, HEALTHY_HOST_ERROR_COUNT_CORRELATION,
+            HEALTHY_HOST_ERROR_COUNT_CORRELATION, HEALTHY_HOST_ERROR_COUNT_CORRELATION, HEALTHY_HOST_ERROR_COUNT_CORRELATION));
+    return setDefaultErrorRate(builder, type).build();
+  }
+
+  private static LoadBalancerStrategyTestRunner create1GoingBad4HealthyHostWithError(loadBalancerStrategyType type, int numIntervals)
+  {
+    LoadBalancerStrategyTestRunnerBuilder
+        builder = new LoadBalancerStrategyTestRunnerBuilder(type, DEFAULT_SERVICE_NAME, DEFAULT_NUM_HOSTS)
+        .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
+        .setNumIntervals(numIntervals)
+        .setConstantLatency(Arrays.asList(HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY, HEALTHY_HOST_CONSTANT_LATENCY,
+            HEALTHY_HOST_CONSTANT_LATENCY))
+        .setDynamicErrorCount(Arrays.asList(HOST_BECOMING_UNHEALTHY_ERROR, HEALTHY_HOST_ERROR_COUNT_CORRELATION,
+            HEALTHY_HOST_ERROR_COUNT_CORRELATION, HEALTHY_HOST_ERROR_COUNT_CORRELATION, HEALTHY_HOST_ERROR_COUNT_CORRELATION));
+    return setDefaultErrorRate(builder, type).build();
+  }
+
+  private static LoadBalancerStrategyTestRunnerBuilder setDefaultErrorRate(LoadBalancerStrategyTestRunnerBuilder builder, loadBalancerStrategyType type)
+  {
+    switch (type)
+    {
+      case RELATIVE:
+        return builder.setRelativeLoadBalancerStrategies(new D2RelativeStrategyProperties()
+            .setLowErrorRate(Double.valueOf(DEFAULT_LOW_ERROR_RATE))
+            .setHighErrorRate(Double.valueOf(DEFAULT_HIGH_ERROR_RATE)));
+      case DEGRADER:
+      default:
+        return builder.setDegraderStrategies(new HashMap<>(), DEGRADER_PROPERTIES_WITH_HIGH_LOW_ERROR);
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerTestHelper.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerTestHelper.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.balancer.strategies.relative;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Map;
 
 
@@ -34,6 +35,6 @@ public class RelativeLoadBalancerTestHelper {
    */
   public static Map<URI, Integer> getPointsMap(RelativeLoadBalancerStrategy strategy, int partitionId)
   {
-    return strategy.getPointsMap(partitionId);
+    return Collections.unmodifiableMap(strategy.getPointsMap(partitionId));
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerTestHelper.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerTestHelper.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2012 LinkedIn Corp.
+   Copyright (c) 2020 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -20,7 +20,18 @@ import java.net.URI;
 import java.util.Map;
 
 
+/**
+ * The helper class for {@link RelativeLoadBalancerStrategy} related tests
+ */
 public class RelativeLoadBalancerTestHelper {
+
+  /**
+   * Get points map for a given partition
+   *
+   * @param strategy The object of the strategy
+   * @param partitionId The id of the partition
+   * @return The points map
+   */
   public static Map<URI, Integer> getPointsMap(RelativeLoadBalancerStrategy strategy, int partitionId)
   {
     return strategy.getPointsMap(partitionId);

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerTestHelper.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerTestHelper.java
@@ -1,0 +1,28 @@
+/*
+   Copyright (c) 2012 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.relative;
+
+import java.net.URI;
+import java.util.Map;
+
+
+public class RelativeLoadBalancerTestHelper {
+  public static Map<URI, Integer> getPointsMap(RelativeLoadBalancerStrategy strategy, int partitionId)
+  {
+    return strategy.getPointsMap(partitionId);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ConstantErrorCountManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ConstantErrorCountManager.java
@@ -1,0 +1,40 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+import java.net.URI;
+import java.util.Map;
+
+
+/**
+ * Create server errors at constant rate
+ */
+public class ConstantErrorCountManager implements ErrorCountManager
+{
+  private Map<URI, Integer> _constantErrorCountMap;
+
+  public ConstantErrorCountManager(Map<URI, Integer> constantErrorCountMap)
+  {
+    _constantErrorCountMap = constantErrorCountMap;
+  }
+
+  @Override
+  public int getErrorCount(URI uri, int hostRequestCount, int intervalIndex)
+  {
+    return _constantErrorCountMap.get(uri);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ConstantLatencyManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ConstantLatencyManager.java
@@ -1,0 +1,39 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+import java.net.URI;
+import java.util.Map;
+
+
+/**
+ * Return constant latency for each host
+ */
+class ConstantLatencyManager implements LatencyManager
+{
+  private Map<URI, Long> _constantLatencyMap;
+
+  public ConstantLatencyManager(Map<URI, Long> constantLatencyMap)
+  {
+    _constantLatencyMap = constantLatencyMap;
+  }
+  @Override
+  public long getLatency(URI uri, int hostRequestCount, int intervalIndex)
+  {
+    return _constantLatencyMap.get(uri);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ConstantRequestCountManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ConstantRequestCountManager.java
@@ -1,0 +1,36 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+/**
+ * Create constant request count in each interval
+ */
+class ConstantRequestCountManager implements RequestCountManager
+{
+  private final int _requestsPerInterval;
+
+  ConstantRequestCountManager(int requestsPerInterval)
+  {
+    _requestsPerInterval = requestsPerInterval;
+  }
+
+  @Override
+  public int getRequestCount(int intervalIndex)
+  {
+    return _requestsPerInterval;
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/DynamicErrorCountManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/DynamicErrorCountManager.java
@@ -1,0 +1,40 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+import java.net.URI;
+import java.util.Map;
+
+
+/**
+ * Create dynamic error count using the correlation with call count and the interval index
+ */
+class DynamicErrorCountManager implements ErrorCountManager
+{
+  private final Map<URI, ErrorCountCorrelation> _errorCountCalculationMap;
+
+  DynamicErrorCountManager(Map<URI, ErrorCountCorrelation> errorCountCalculationMap)
+  {
+    _errorCountCalculationMap = errorCountCalculationMap;
+  }
+
+  @Override
+  public int getErrorCount(URI uri, int hostRequestCount, int intervalIndex)
+  {
+    return _errorCountCalculationMap.get(uri).getErrorCount(hostRequestCount, intervalIndex);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/DynamicLatencyManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/DynamicLatencyManager.java
@@ -1,0 +1,40 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+import java.net.URI;
+import java.util.Map;
+
+
+/**
+ * Create dynamic latency using the QPS and current interval correlation
+ */
+class DynamicLatencyManager implements LatencyManager
+{
+  private final Map<URI, LatencyCorrelation> _latencyCalculationMap;
+
+  DynamicLatencyManager(Map<URI, LatencyCorrelation> latencyCalculationMap)
+  {
+    _latencyCalculationMap = latencyCalculationMap;
+  }
+
+  @Override
+  public long getLatency(URI uri, int hostRequestCount, int intervalIndex)
+  {
+    return _latencyCalculationMap.get(uri).getLatency(hostRequestCount, intervalIndex);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/DynamicRequestCountManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/DynamicRequestCountManager.java
@@ -1,0 +1,36 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+/**
+ * Create different number of requests in each interval based on user defined correlation formula
+ */
+class DynamicRequestCountManager implements RequestCountManager
+{
+  private final RequestCountCorrelation _requestCountCorrelation;
+
+  DynamicRequestCountManager(RequestCountCorrelation requestCountCorrelation)
+  {
+    _requestCountCorrelation = requestCountCorrelation;
+  }
+
+  @Override
+  public int getRequestCount(int intervalIndex)
+  {
+    return _requestCountCorrelation.getRequestCount(intervalIndex);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ErrorCountCorrelation.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ErrorCountCorrelation.java
@@ -1,0 +1,33 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+/**
+ * Define the correlation between latency, call count and time
+ */
+public interface ErrorCountCorrelation
+{
+
+  /**
+   * Given the requests per interval and the current interval, calculate the error count
+   *
+   * @param requestsPerInterval the number of requests received in the interval
+   * @param intervalIndex the index of the current interval since the test initialization
+   * @return Expected error count
+   */
+  int getErrorCount(int requestsPerInterval, int intervalIndex);
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ErrorCountManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/ErrorCountManager.java
@@ -1,0 +1,35 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+import java.net.URI;
+
+
+/**
+ * The helper class that creates different error count patterns based on user definition
+ */
+interface ErrorCountManager {
+  /**
+   * Provide the total error count for a given interval
+   *
+   * @param uri The uri of the server host
+   * @param hostRequestCount The request count the host received in the last interval
+   * @param intervalIndex The index of the current interval
+   * @return The total call count that the test will send in the interval
+   */
+  int getErrorCount(URI uri, int hostRequestCount, int intervalIndex);
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/LatencyCorrelation.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/LatencyCorrelation.java
@@ -1,0 +1,32 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+/**
+ * Define the correlation between latency, call count and time
+ */
+public interface LatencyCorrelation
+{
+
+  /**
+   * Given the requests per interval, calculate the latency
+   * @param requestsPerInterval the number of requests received in the interval
+   * @param intervalIndex the index of the current interval since the test initialization
+   * @return Expected latency
+   */
+  long getLatency(int requestsPerInterval, int intervalIndex);
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/LatencyManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/LatencyManager.java
@@ -1,0 +1,38 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+import java.net.URI;
+
+
+/**
+ * Defines the latency for a particular host in an interval based on user definition
+ */
+interface LatencyManager
+{
+
+  /**
+   * Given an interval, calculate the latency for a host
+   * The latency may be correlated to the QPS
+   *
+   * @param uri The uri of the server host
+   * @param hostRequestCount The request count the host received in the last interval
+   * @param intervalIndex The index of the current interval
+   * @return The expected latency
+   */
+  long getLatency(URI uri, int hostRequestCount, int intervalIndex);
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/LoadBalancerStrategyTestRunner.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/LoadBalancerStrategyTestRunner.java
@@ -1,0 +1,259 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
+import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategyV3;
+import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
+import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerTestHelper;
+import com.linkedin.d2.balancer.util.URIRequest;
+import com.linkedin.r2.message.Request;
+import com.linkedin.r2.message.RequestContext;
+import com.linkedin.r2.message.rest.RestRequest;
+import com.linkedin.r2.message.rest.RestRequestBuilder;
+import com.linkedin.r2.message.rest.RestResponse;
+import com.linkedin.r2.transport.common.bridge.common.TransportCallback;
+import com.linkedin.test.util.ClockedExecutor;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Create the load balancer tests with flexible settings
+ * The class creates an instance of the given strategy, run {@link LoadBalancerStrategy#getTrackerClient(Request, RequestContext, long, int, Map)}
+ * with the settings such as hosts, number of intervals, QPS and latency.
+ * Please use {@link LoadBalancerStrategyTestRunnerBuilder} to create the test runner
+ *
+ * To run the test, use {@link LoadBalancerStrategyTestRunner#runWait()}
+ *
+ * Internally we run the test in the following steps:
+ * 1. Identify the number of intervals, run iterations
+ * 2. In each iteration, send requests based on call count for this interval.
+ *    Each iteration is executed at the beginning of an interval
+ */
+public class LoadBalancerStrategyTestRunner
+{
+  private static final Logger _log = LoggerFactory.getLogger(LoadBalancerStrategyTestRunner.class);
+  private static final long DEFAULT_GENERATION_ID = 0L;
+  public static final int DEFAULT_PARTITION_ID = 0;
+
+  private final LoadBalancerStrategy _strategy;
+  private final String _serviceName;
+  private final List<URI> _uris;
+  private final Map<Integer, Map<URI, TrackerClient>> _partitionTrackerClientsMap;
+  private final int _numIntervals;
+  private final RequestCountManager _requestsManager;
+  private final ClockedExecutor _clockedExecutor;
+
+  // Performance stats
+  private Map<URI, Integer> _currentErrorMap;
+  private Map<URI, Integer> _lastRequestCountMap;
+  private Map<URI, Integer> _currentRequestCountMap;
+  private Map<URI, Integer> _callCountMap;
+  private Map<URI, Long> _latencySumMap;
+  private Map<URI, List<Integer>> _pointHistoryMap = new HashMap<>();
+
+  public LoadBalancerStrategyTestRunner(LoadBalancerStrategy strategy, String serviceName,
+      List<URI> uris, Map<Integer, Map<URI, TrackerClient>> partitionTrackerClientsMap,
+      int numIntervals, RequestCountManager requestsManager, ClockedExecutor clockedExecutor, Map<URI, Integer> currentErrorMap,
+      Map<URI, Integer> lastRequestCountMap, Map<URI, Integer> currentRequestCountMap, Map<URI, Integer> callCountMap, Map<URI, Long> latencySumMap)
+  {
+    _strategy = strategy;
+    _serviceName = serviceName;
+    _numIntervals = numIntervals;
+    _requestsManager = requestsManager;
+    _uris = uris;
+    _partitionTrackerClientsMap = partitionTrackerClientsMap;
+    _clockedExecutor = clockedExecutor;
+
+    _currentErrorMap = currentErrorMap;
+    _lastRequestCountMap = lastRequestCountMap;
+    _currentRequestCountMap = currentRequestCountMap;
+    _callCountMap = callCountMap;
+    _latencySumMap = latencySumMap;
+  }
+
+  /**
+   * Get the uri of the Nth host in the list
+   *
+   * @param index The index of the host
+   * @return The URI of the host
+   */
+  public URI getUri(int index)
+  {
+    return _uris.get(index);
+  }
+
+  /**
+   * Get points of each URI
+   *
+   * @return The URI to points map
+   */
+  public Map<URI, Integer> getPoints()
+  {
+    return getPoints(DEFAULT_PARTITION_ID);
+  }
+
+  /**
+   * Get points for the given partition
+   *
+   * @param partitionId The id of the partition
+   * @return The URI to points map
+   */
+  public Map<URI, Integer> getPoints(int partitionId)
+  {
+    if (_strategy instanceof DegraderLoadBalancerStrategyV3)
+    {
+      return ((DegraderLoadBalancerStrategyV3) _strategy).getState().getPartitionState(partitionId).getPointsMap();
+    } else if (_strategy instanceof RelativeLoadBalancerStrategy)
+    {
+      return RelativeLoadBalancerTestHelper.getPointsMap((RelativeLoadBalancerStrategy) _strategy, partitionId);
+    }
+    return new HashMap<>();
+  }
+
+  /**
+   * Get the points history for past intervals
+   */
+  public Map<URI, List<Integer>> getPointHistory()
+  {
+    return _pointHistoryMap;
+  }
+
+  /**
+   * Get the average latency for all the hosts during the test
+   *
+   * @return the average latency for all the hosts during the test
+   */
+  public double getAvgLatency()
+  {
+    long latencySum = 0;
+    int callCountTotal = 0;
+
+    for (URI uri : _callCountMap.keySet())
+    {
+      callCountTotal += _callCountMap.getOrDefault(uri, 0);
+      latencySum += _latencySumMap.getOrDefault(uri, 0L);
+    }
+
+    return latencySum / callCountTotal;
+  }
+
+  public void runWait()
+  {
+    runWait(Arrays.asList(DEFAULT_PARTITION_ID));
+  }
+
+  public void runWait(List<Integer> partitionIds)
+  {
+    Future<Void> running = run(partitionIds);
+    if (running != null)
+    {
+      try
+      {
+        running.get();
+      }
+      catch (InterruptedException | ExecutionException e)
+      {
+        _log.error("Test running interrupted", e);
+      }
+    }
+  }
+
+  /**
+   * Run the mocked test for the given intervals, each interval is scheduled to be run at the fixed interval time
+   * If there are mutiple partitions, we will send traffic evenly to these partitions
+   */
+  private Future<Void> run(List<Integer> partitionIds)
+  {
+    _clockedExecutor.scheduleWithFixedDelay(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        runInterval(partitionIds);
+      }
+    }, 0, LoadBalancerStrategyTestRunnerBuilder.INTERVAL_IN_MILLIS, TimeUnit.MILLISECONDS);
+    return _clockedExecutor.runFor(LoadBalancerStrategyTestRunnerBuilder.INTERVAL_IN_MILLIS * _numIntervals);
+  }
+
+  /**
+   * Execute one interval with the given request count
+   */
+  private void runInterval(List<Integer> partitionIds)
+  {
+    int currentIntervalIndex = (int) (_clockedExecutor.currentTimeMillis() / LoadBalancerStrategyTestRunnerBuilder.INTERVAL_IN_MILLIS);
+    int requestCount = _requestsManager.getRequestCount(currentIntervalIndex);
+    int partitionIndex = 0;
+
+    for (int i = 0; i < requestCount; i++)
+    {
+      // construct the requests
+      URIRequest uriRequest = new URIRequest("d2://" + _serviceName + "/" + i);
+      RestRequest restRequest = new RestRequestBuilder(uriRequest.getURI()).build();
+      RequestContext requestContext = new RequestContext();
+      int partitionId = partitionIds.get(partitionIndex);
+      Map<URI, TrackerClient> trackerClientMap = _partitionTrackerClientsMap.get(partitionId);
+
+      // Get client with default generation id and cluster id
+      TrackerClient trackerClient =
+          _strategy.getTrackerClient(restRequest, requestContext, DEFAULT_GENERATION_ID, partitionId, trackerClientMap);
+      partitionIndex = partitionIndex >= partitionIds.size() - 1 ? 0 : partitionIndex + 1;
+
+      TransportCallback<RestResponse> restCallback = (response) ->
+      {
+      };
+      if (trackerClient != null)
+      {
+        // Send the request to the picked host if the decision is not DROP
+        trackerClient.restRequest(restRequest, requestContext, Collections.emptyMap(), restCallback);
+
+        // Increase the count in the current request count map
+        URI uri = trackerClient.getUri();
+        if (_currentRequestCountMap.containsKey(trackerClient.getUri()))
+        {
+          _currentRequestCountMap.put(uri, _currentRequestCountMap.get(uri) + 1);
+        } else {
+          _currentRequestCountMap.put(uri, 1);
+        }
+      }
+    }
+    _currentErrorMap.clear();
+    _lastRequestCountMap.clear();
+    _lastRequestCountMap.putAll(_currentRequestCountMap);
+    _currentRequestCountMap = new HashMap<>();
+
+    // Collect health points stats in this iteration
+    Map<URI, Integer> currentPointsMap = getPoints();
+    for (URI uri : currentPointsMap.keySet())
+    {
+      _pointHistoryMap.putIfAbsent(uri,  new ArrayList<>());
+      _pointHistoryMap.get(uri).add(currentPointsMap.getOrDefault(uri, 0));
+    }
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/LoadBalancerStrategyTestRunnerBuilder.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/LoadBalancerStrategyTestRunnerBuilder.java
@@ -1,0 +1,449 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+import com.linkedin.common.callback.Callback;
+import com.linkedin.common.util.None;
+import com.linkedin.d2.D2RelativeStrategyProperties;
+import com.linkedin.d2.balancer.clients.DegraderTrackerClientImpl;
+import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.clients.TrackerClientImpl;
+import com.linkedin.d2.balancer.config.RelativeStrategyPropertiesConverter;
+import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.PropertyKeys;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
+import com.linkedin.d2.balancer.strategies.degrader.DegraderConfigFactory;
+import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategyFactoryV3;
+import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategyFactory;
+import com.linkedin.d2.loadBalancerStrategyType;
+import com.linkedin.r2.message.RequestContext;
+import com.linkedin.r2.message.rest.RestException;
+import com.linkedin.r2.message.rest.RestRequest;
+import com.linkedin.r2.message.rest.RestResponse;
+import com.linkedin.r2.message.rest.RestResponseBuilder;
+import com.linkedin.r2.transport.common.bridge.client.TransportClient;
+import com.linkedin.r2.transport.common.bridge.common.TransportCallback;
+import com.linkedin.r2.transport.common.bridge.common.TransportResponseImpl;
+import com.linkedin.test.util.ClockedExecutor;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.eclipse.jetty.http.HttpStatus;
+
+
+/**
+ * Builder class to build a {@link LoadBalancerStrategyTestRunner}
+ */
+public class LoadBalancerStrategyTestRunnerBuilder
+{
+  public static final long INTERVAL_IN_MILLIS = 5000L;
+  private static final String URI_PREFIX = "http://test.qa";
+  private static final String URI_SUFFIX = ".com:5555";
+  public static final String DEFAULT_CLUSTER_NAME = "dummyCluster";
+  public static final String DEFAULT_PATH = "/path";
+  // This strategy list is not in use, please use the loadBalancerType to indicate the type of strategy
+  public static final List<String> DEFAULT_STRATEGY_LIST = Arrays.asList("DEGRADER", "RANDOM", "RELATIVE");
+  public static final int HEALTHY_ERROR_COUNT = 0;
+  @SuppressWarnings("serial")
+  private static final Map<Integer, PartitionData> DEFAULT_PARTITION_DATA_MAP = new HashMap<Integer, PartitionData>()
+  {{
+    put(LoadBalancerStrategyTestRunner.DEFAULT_PARTITION_ID, new PartitionData(1.0));
+  }};
+
+  private LoadBalancerStrategy _strategy;
+  private ServiceProperties _serviceProperties;
+  private Map<URI, Map<Integer, PartitionData>> _partitionDataMap = new HashMap<>();
+  private Map<Integer, Set<URI>> _partitionUrisMap = new HashMap<>();
+  private String _serviceName;
+  private List<URI> _uris;
+  private List<MockTransportClient> _transportClients;
+  private int _numIntervals;
+  private LatencyManager _latencyManager;
+  private ErrorCountManager _errorCountManager;
+  private RequestCountManager _requestCountManager;
+  private final loadBalancerStrategyType _type;
+  private final ClockedExecutor _clockedExecutor = new ClockedExecutor();
+
+  // Performance stats
+  private Map<URI, Integer> _currentErrorCountMap = new HashMap<>();
+  private Map<URI, Integer> _lastRequestCountMap = new HashMap<>();
+  private Map<URI, Integer> _currentRequestCountMap = new HashMap<>();
+  private Map<URI, Integer> _callCountMap = new HashMap<>();
+  private Map<URI, Long> _latencySumMap = new HashMap<>();
+
+  public LoadBalancerStrategyTestRunnerBuilder(final loadBalancerStrategyType type, final String serviceName, final int numHosts)
+  {
+    _type = type;
+    _serviceName = serviceName;
+    _numIntervals = 1;
+
+    // Create server hosts
+    _uris = new ArrayList<>();
+    Map<URI, Integer> errorCounMap = new HashMap<>();
+    for (int i = 0; i < numHosts; i++)
+    {
+      URI uri = URI.create(URI_PREFIX + i + URI_SUFFIX);
+      _uris.add(uri);
+      errorCounMap.put(uri, HEALTHY_ERROR_COUNT);
+    }
+    _errorCountManager = new ConstantErrorCountManager(errorCounMap);
+  }
+
+  /**
+   * Set the partition map for trackerClients
+   * @param partitionDataMap Specifies partition id to weight map for each server host
+   */
+  public LoadBalancerStrategyTestRunnerBuilder addPartitionDataMap(int uriIndex, Map<Integer, PartitionData> partitionDataMap)
+  {
+    _partitionDataMap.put(_uris.get(uriIndex), partitionDataMap);
+    return this;
+  }
+
+  public LoadBalancerStrategyTestRunnerBuilder addPartitionUriMap(int partitionId, List<Integer> uriIndexes)
+  {
+    Set<URI> uriSet = uriIndexes.stream()
+        .map(uriIndex -> _uris.get(uriIndex))
+        .collect(Collectors.toSet());
+    _partitionUrisMap.put(partitionId, uriSet);
+    return this;
+  }
+
+  /**
+   * Set the number of intervals that the test is going to execute.
+   * The calculation updates the new state of the balancer on each interval, within one interval the point of each host should stay the same
+   * @param numIntervals Number of intervals to execute
+   */
+  public LoadBalancerStrategyTestRunnerBuilder setNumIntervals(int numIntervals)
+  {
+    _numIntervals = numIntervals;
+    return this;
+  }
+
+  /**
+   * Set a constant call count for all the intervals
+   * @param requestCountPerInterval The number of calls sent for each interval
+   */
+  public LoadBalancerStrategyTestRunnerBuilder setConstantRequestCount(int requestCountPerInterval)
+  {
+    _requestCountManager = new ConstantRequestCountManager(requestCountPerInterval);
+    return this;
+  }
+
+  /**
+   * Set the call count for each interval with a free-formed formula
+   * @param requestCountCorrelation The correlation between call count and the interval index
+   */
+  public LoadBalancerStrategyTestRunnerBuilder setDynamicRequestCount(RequestCountCorrelation requestCountCorrelation)
+  {
+    _requestCountManager = new DynamicRequestCountManager(requestCountCorrelation);
+    return this;
+  }
+
+  /**
+   * Set a constant latency for different hosts in all intervals
+   * @param latencyForHosts The constant latency to set for each host
+   */
+  public LoadBalancerStrategyTestRunnerBuilder setConstantLatency(List<Long> latencyForHosts)
+  {
+    if (latencyForHosts.size() != _uris.size())
+    {
+      throw new IllegalArgumentException("The latency list size has to match with the host size");
+    }
+    Map<URI, Long> latencyMap = new HashMap<>();
+    for (int i = 0; i < latencyForHosts.size(); i++)
+    {
+      latencyMap.put(_uris.get(i), latencyForHosts.get(i));
+    }
+    _latencyManager = new ConstantLatencyManager(latencyMap);
+    return this;
+  }
+
+  /**
+   * Set the latency to be a relationship of the call count that each host gets
+   * @param latencyCalculationList A correlation formula list for each host, the size of the map should equal the number of uris.
+   */
+  public LoadBalancerStrategyTestRunnerBuilder setDynamicLatency(List<LatencyCorrelation> latencyCalculationList)
+  {
+    if (latencyCalculationList.size() != _uris.size())
+    {
+      throw new IllegalArgumentException("The dynamic latency list size has to match with the host size");
+    }
+
+    Map<URI, LatencyCorrelation> latencyCalculationMap = new HashMap<>();
+    for (int i = 0; i < latencyCalculationList.size(); i++)
+    {
+      latencyCalculationMap.put(_uris.get(i), latencyCalculationList.get(i));
+    }
+
+    _latencyManager = new DynamicLatencyManager(latencyCalculationMap);
+    return this;
+  }
+
+  /**
+   * Set a constant error count for different hosts in all intervals
+   * @param errorCountForHosts The constant error count to set for each host
+   */
+  public LoadBalancerStrategyTestRunnerBuilder setConstantErrorCount(List<Integer> errorCountForHosts)
+  {
+    if (errorCountForHosts.size() != _uris.size())
+    {
+      throw new IllegalArgumentException("The error count list size has to match with the host size");
+    }
+    Map<URI, Integer> errorCountMap = new HashMap<>();
+    for (int i = 0; i < errorCountForHosts.size(); i++)
+    {
+      errorCountMap.put(_uris.get(i), errorCountForHosts.get(i));
+    }
+    _errorCountManager = new ConstantErrorCountManager(errorCountMap);
+    return this;
+  }
+
+  /**
+   * Set the error count to be a relationship of the call count and intervals
+   * @param errorCountCalculationList A correlation formula list for each host, the size of the map should equal the number of uris.
+   */
+  public LoadBalancerStrategyTestRunnerBuilder setDynamicErrorCount(
+      List<ErrorCountCorrelation> errorCountCalculationList)
+  {
+    if (errorCountCalculationList.size() != _uris.size())
+    {
+      throw new IllegalArgumentException("The dynamic error count list size has to match with the host size");
+    }
+
+    Map<URI, ErrorCountCorrelation> errorCountCalculationMap = new HashMap<>();
+    for (int i = 0; i < errorCountCalculationList.size(); i++)
+    {
+      errorCountCalculationMap.put(_uris.get(i), errorCountCalculationList.get(i));
+    }
+
+    _errorCountManager = new DynamicErrorCountManager(errorCountCalculationMap);
+    return this;
+  }
+
+  public LoadBalancerStrategyTestRunnerBuilder setDegraderStrategies(Map<String, Object> strategyProperties,
+      Map<String, String> degraderProperties)
+  {
+    // Copy a new map in case the original map is immutable
+    Map<String, Object> strategyPropertiesCopy = new HashMap<>();
+    if (strategyProperties != null)
+    {
+      strategyPropertiesCopy.putAll(strategyProperties);
+    }
+    strategyPropertiesCopy.put(PropertyKeys.CLOCK, _clockedExecutor);
+    strategyPropertiesCopy.put(PropertyKeys.HTTP_LB_QUARANTINE_EXECUTOR_SERVICE, _clockedExecutor);
+
+    Map<String, String> degraderPropertiesCopy = new HashMap<>();
+    if (degraderPropertiesCopy != null)
+    {
+      degraderPropertiesCopy.putAll(degraderProperties);
+    }
+
+    _serviceProperties = new ServiceProperties(_serviceName, DEFAULT_CLUSTER_NAME, DEFAULT_PATH, DEFAULT_STRATEGY_LIST,
+        strategyPropertiesCopy, null, degraderPropertiesCopy, null, null);
+    return this;
+  }
+
+  public LoadBalancerStrategyTestRunnerBuilder setRelativeLoadBalancerStrategies(D2RelativeStrategyProperties relativeLoadBalancerStrategies)
+  {
+    _serviceProperties = new ServiceProperties(_serviceName, DEFAULT_CLUSTER_NAME, DEFAULT_PATH, DEFAULT_STRATEGY_LIST,
+        null, null, null, null, null,
+        null, null, RelativeStrategyPropertiesConverter.toMap(relativeLoadBalancerStrategies));
+    return this;
+  }
+
+  /**
+   * Build the test runner
+   */
+  public LoadBalancerStrategyTestRunner build()
+  {
+    switch (_type)
+    {
+      case DEGRADER:
+        return buildDegraderStrategy();
+      case RELATIVE:
+      default:
+        return buildRelativeStrategy();
+    }
+  }
+
+  private LoadBalancerStrategyTestRunner buildDegraderStrategy()
+  {
+    if (_serviceProperties == null)
+    {
+      setDegraderStrategies(new HashMap<>(), new HashMap<>());
+    }
+    _strategy = new DegraderLoadBalancerStrategyFactoryV3().newLoadBalancer(_serviceProperties);
+
+    _transportClients = _uris.stream()
+        .map(uri -> new MockTransportClient(_clockedExecutor, _latencyManager, _errorCountManager, uri, INTERVAL_IN_MILLIS,
+            _currentErrorCountMap, _lastRequestCountMap, _callCountMap, _latencySumMap))
+        .collect(Collectors.toList());
+    Map<URI, TrackerClient> trackerClientMap = _transportClients.stream()
+        .map(transportClient -> {
+          // If partition map is not specified, by default we only support one partition
+          Map<Integer, PartitionData> partitionDataMap = _partitionDataMap.getOrDefault(transportClient.getUri(),
+              DEFAULT_PARTITION_DATA_MAP);
+
+          return new DegraderTrackerClientImpl(transportClient.getUri(), partitionDataMap, transportClient, _clockedExecutor,
+              DegraderConfigFactory.toDegraderConfig(_serviceProperties.getDegraderProperties()));
+        })
+        .collect(Collectors.toMap(TrackerClient::getUri, trackerClient -> trackerClient));
+
+    return buildInternal(trackerClientMap);
+  }
+
+  private LoadBalancerStrategyTestRunner buildRelativeStrategy()
+  {
+    if (_serviceProperties == null)
+    {
+      setRelativeLoadBalancerStrategies(new D2RelativeStrategyProperties());
+    }
+    _strategy = new RelativeLoadBalancerStrategyFactory(_clockedExecutor, null, new ArrayList<>(), null, _clockedExecutor)
+        .newLoadBalancer(_serviceProperties);
+
+    _transportClients = _uris.stream()
+        .map(uri -> new MockTransportClient(_clockedExecutor, _latencyManager, _errorCountManager, uri, INTERVAL_IN_MILLIS,
+            _currentErrorCountMap, _lastRequestCountMap, _callCountMap, _latencySumMap))
+        .collect(Collectors.toList());
+    Map<URI, TrackerClient> trackerClientMap = _transportClients.stream()
+        .map(transportClient -> {
+          // If partition map is not specified, by default we only support one partition
+          Map<Integer, PartitionData> partitionDataMap = _partitionDataMap.getOrDefault(transportClient.getUri(),
+              DEFAULT_PARTITION_DATA_MAP);
+
+          return new TrackerClientImpl(transportClient.getUri(), partitionDataMap, transportClient, _clockedExecutor,
+              INTERVAL_IN_MILLIS, (status) -> status >= 500 && status <= 599);
+        })
+        .collect(Collectors.toMap(TrackerClient::getUri, trackerClient -> trackerClient));
+
+    return buildInternal(trackerClientMap);
+  }
+
+  private LoadBalancerStrategyTestRunner buildInternal(Map<URI, TrackerClient> trackerClientMap)
+  {
+    Map<Integer, Map<URI, TrackerClient>> partitionTrackerClientsMap = new HashMap<>();
+    if (_partitionUrisMap.size() != 0)
+    {
+      for (Integer partitionId : _partitionUrisMap.keySet())
+      {
+        Map<URI, TrackerClient> trackerClientsByPartition = _partitionUrisMap.get(partitionId).stream()
+            .map(trackerClientMap::get)
+            .collect(Collectors.toMap(TrackerClient::getUri, trackerClient -> trackerClient));
+        partitionTrackerClientsMap.put(partitionId, trackerClientsByPartition);
+      }
+    }
+    else
+    {
+      partitionTrackerClientsMap.put(LoadBalancerStrategyTestRunner.DEFAULT_PARTITION_ID, trackerClientMap);
+    }
+    return new LoadBalancerStrategyTestRunner(_strategy, _serviceName, _uris, partitionTrackerClientsMap, _numIntervals,
+        _requestCountManager, _clockedExecutor, _currentErrorCountMap, _lastRequestCountMap, _currentRequestCountMap,
+        _callCountMap, _latencySumMap);
+  }
+
+  /**
+   * Mock a transport client, the transport client leverages the clockedExecutor to control the latency
+   */
+  class MockTransportClient implements TransportClient
+  {
+    private final ClockedExecutor _clockedExecutor;
+    private final LatencyManager _latencyManager;
+    private final ErrorCountManager _errorCountManager;
+    private final URI _uri;
+    private final long _intervalMillis;
+
+    private Map<URI, Integer> _currentErrorCountMap;
+    private Map<URI, Integer> _lastRequestCountMap;
+    private Map<URI, Integer> _callCountMap;
+    private Map<URI, Long> _latencySumMap;
+
+    MockTransportClient(
+        ClockedExecutor executor, LatencyManager latencyManager, ErrorCountManager errorCountManager, URI uri,
+        long intervalMillis, Map<URI, Integer> currentErrorCountMap, Map<URI, Integer> lastRequestCountMap,
+        Map<URI, Integer> callCountMap, Map<URI, Long> latencySumMap)
+    {
+      _clockedExecutor = executor;
+      _latencyManager = latencyManager;
+      _errorCountManager = errorCountManager;
+      _uri = uri;
+      _intervalMillis = intervalMillis;
+
+      _currentErrorCountMap = currentErrorCountMap;
+      _lastRequestCountMap = lastRequestCountMap;
+      _callCountMap = callCountMap;
+      _latencySumMap = latencySumMap;
+    }
+
+    @Override
+    public void restRequest(RestRequest request, RequestContext requestContext, Map<String, String> wireAttrs,
+        TransportCallback<RestResponse> callback)
+    {
+      int currentIntervalIndex = (int) (_clockedExecutor.currentTimeMillis() / _intervalMillis);
+      int requestCount = _lastRequestCountMap.getOrDefault(_uri, 0);
+      long latency = _latencyManager.getLatency(_uri, requestCount, currentIntervalIndex);
+      boolean hasError = _errorCountManager.getErrorCount(_uri, requestCount, currentIntervalIndex) -
+          _currentErrorCountMap.getOrDefault(_uri, 0) > 0;
+
+      _clockedExecutor.schedule(new Runnable()
+      {
+        @Override
+        public void run()
+        {
+          RestResponseBuilder restResponseBuilder = new RestResponseBuilder().setEntity(request.getURI().getRawPath().getBytes());
+          if (hasError)
+          {
+            restResponseBuilder.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+            RestException restException = new RestException(restResponseBuilder.build(), new Throwable("internal error"));
+            callback.onResponse(TransportResponseImpl.error(restException));
+            return;
+          }
+          callback.onResponse(TransportResponseImpl.success(restResponseBuilder.build()));
+        }
+      }, latency, TimeUnit.MILLISECONDS);
+
+      // Collect basic stats
+      if (hasError)
+      {
+        _currentErrorCountMap.putIfAbsent(_uri, 0);
+        _currentErrorCountMap.put(_uri, _currentErrorCountMap.get(_uri) + 1);
+      }
+      _callCountMap.putIfAbsent(_uri, 0);
+      _callCountMap.put(_uri, _callCountMap.get(_uri) + 1);
+      _latencySumMap.putIfAbsent(_uri, 0L);
+      _latencySumMap.put(_uri, _latencySumMap.get(_uri) + latency);
+
+    }
+
+    @Override
+    public void shutdown(Callback<None> callback)
+    {
+      callback.onSuccess(None.none());
+    }
+
+    public URI getUri()
+    {
+      return _uri;
+    }
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/RequestCountCorrelation.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/RequestCountCorrelation.java
@@ -1,0 +1,31 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+/**
+ * Define the correlation between request count and time
+ */
+public interface RequestCountCorrelation
+{
+
+  /**
+   * Given the interval index, calculate the request count to send
+   * @param intervalIndex the index of the current interval since the test initialization
+   * @return Expected requestCount
+   */
+  int getRequestCount(int intervalIndex);
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/RequestCountManager.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/framework/RequestCountManager.java
@@ -1,0 +1,31 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.framework;
+
+/**
+ * The interface to manage the number of requests sent in each interval
+ */
+interface RequestCountManager
+{
+
+  /**
+   * Provide the total request count for a given interval
+   * @param intervalIndex The index of the current interval
+   * @return The total call count that the test will send in the interval
+   */
+  int getRequestCount(int intervalIndex);
+}


### PR DESCRIPTION
Changes include:
1. A test framework to provide different call count, latency, error rate in multiple intervals to test load balancer strategies. Users can plugin different behaviors to perform all the scenario tests.
2. The actual integration test for RelativeLoadBalancer. Some of the tests run against both relative strategy and the old degrader strategy, and verify the expected behaviors are the same.