### PR TITLE
Improve performance of uri mask encoding and decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.4.5] - 2020-07-21
 - Update ExtensionSchemaValidation task to check extension schema annotation (#254)
+- Improve performance of uri mask encoding and decoding (#350)
 
 ## [29.4.4] - 2020-07-02
 - Disable string interning in Jackson JSON since it causes GC issues (#346)
@@ -4553,7 +4556,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.5...master
+[29.4.5]: https://github.com/linkedin/rest.li/compare/v29.4.4...v29.4.5
 [29.4.4]: https://github.com/linkedin/rest.li/compare/v29.4.3...v29.4.4
 [29.4.3]: https://github.com/linkedin/rest.li/compare/v29.4.2...v29.4.3
 [29.4.2]: https://github.com/linkedin/rest.li/compare/v29.4.1...v29.4.2

--- a/data-transform/src/main/java/com/linkedin/data/transform/filter/FilterConstants.java
+++ b/data-transform/src/main/java/com/linkedin/data/transform/filter/FilterConstants.java
@@ -14,9 +14,6 @@
    limitations under the License.
 */
 
-/**
- * $id$
- */
 package com.linkedin.data.transform.filter;
 
 public class FilterConstants

--- a/data-transform/src/main/java/com/linkedin/data/transform/filter/MaskComposition.java
+++ b/data-transform/src/main/java/com/linkedin/data/transform/filter/MaskComposition.java
@@ -90,6 +90,11 @@ public class MaskComposition implements Interpreter
                          instrCtx);
           }
         }
+        // This can happen if the mask is for an array field and the merged start/count resulted in default values.
+        // Setting the wildcard mask to represent all items are included.
+        if (data.isEmpty()) {
+          data.put(FilterConstants.WILDCARD, FilterConstants.POSITIVE);
+        }
       }
     }
   }

--- a/data-transform/src/main/java/com/linkedin/data/transform/filter/MaskComposition.java
+++ b/data-transform/src/main/java/com/linkedin/data/transform/filter/MaskComposition.java
@@ -92,7 +92,8 @@ public class MaskComposition implements Interpreter
         }
         // This can happen if the mask is for an array field and the merged start/count resulted in default values.
         // Setting the wildcard mask to represent all items are included.
-        if (data.isEmpty()) {
+        if (data.isEmpty())
+        {
           data.put(FilterConstants.WILDCARD, FilterConstants.POSITIVE);
         }
       }

--- a/data-transform/src/main/java/com/linkedin/data/transform/filter/request/MaskCreator.java
+++ b/data-transform/src/main/java/com/linkedin/data/transform/filter/request/MaskCreator.java
@@ -20,12 +20,10 @@
 
 package com.linkedin.data.transform.filter.request;
 
-import com.linkedin.data.DataMap;
 import com.linkedin.data.schema.PathSpec;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 
 
 /**
@@ -86,33 +84,6 @@ public class MaskCreator
     {
       maskTree.addOperation(path, op);
     }
-
-    // Clean up empty masks. This usually happens for array masks whose $start and $count are removed if they have the
-    // default values of 0 and Integer.MAX_INT, respectively.
-    cleanUpEmptyMasks(maskTree.getDataMap());
-
     return maskTree;
-  }
-
-  /**
-   * Helper method to clean up empty masks with positive integer mask
-   */
-  private static void cleanUpEmptyMasks(DataMap mask)
-  {
-    for (Map.Entry<String, Object> entry: mask.entrySet())
-    {
-      if (entry.getValue() instanceof DataMap)
-      {
-        if (((DataMap) entry.getValue()).isEmpty())
-        {
-          // Replace the empty mask with positive integer mask
-          mask.put(entry.getKey(), MaskOperation.POSITIVE_MASK_OP.getRepresentation());
-        }
-        else
-        {
-          cleanUpEmptyMasks((DataMap) entry.getValue());
-        }
-      }
-    }
   }
 }

--- a/data-transform/src/test/java/com/linkedin/data/transform/filter/TestFilterOnData.java
+++ b/data-transform/src/test/java/com/linkedin/data/transform/filter/TestFilterOnData.java
@@ -255,6 +255,12 @@ public class TestFilterOnData
       /*expected*/    "{'b': [{'a': 'aaa'}, {'b': 'bbb'}, {'c': 'ccc'}, {'d': 'ddd'}, {'e': 'eee'}]}"
     },
     {
+        /*description:*/"Filter contains simple positive mask on array field. Array contains objects.",
+        /*data:*/       "{'a': 10, 'b': [{'a': 'aaa'}, {'b': 'bbb'}, {'c': 'ccc'}, {'d': 'ddd'}, {'e': 'eee'}]}",
+        /*filter:*/     "{'b' : 1}",
+        /*expected*/    "{'b': [{'a': 'aaa'}, {'b': 'bbb'}, {'c': 'ccc'}, {'d': 'ddd'}, {'e': 'eee'}]}"
+    },
+    {
       /*description:*/"Filter contains only negative wildcard.",
       /*data:*/       "{'a': 10, 'b': [1, 2, 3, 4, 5, 6]}",
       /*filter:*/     "{'b' : { '$*': 0}}",

--- a/data-transform/src/test/java/com/linkedin/data/transform/filter/TestMaskCompositionOnData.java
+++ b/data-transform/src/test/java/com/linkedin/data/transform/filter/TestMaskCompositionOnData.java
@@ -264,7 +264,7 @@ public class TestMaskCompositionOnData
       /*description:*/"Compose disjoint array ranges with a default for start and count. The result is smallest range containing both ranges.",
       /*data1:*/      "{'a': { '$count': 10 }}",
       /*data2:*/      "{'a': { '$start': 20 }}",
-      /*expected*/    "{'a': {}}"
+      /*expected*/    "{'a': { '$*': 1}}"
     },
     {
       /*description:*/"Compose array ranges when one range contain other. The result is larger range.",
@@ -282,19 +282,19 @@ public class TestMaskCompositionOnData
       /*description:*/"Compose array ranges with one of them having the default values specified explicitly.",
       /*data1:*/      "{'a': { '$start': 0, '$count': 2147483647 }}",
       /*data2:*/      "{'a': { '$start': 20, '$count': 50 }}",
-      /*expected*/    "{'a': {}}"
+      /*expected*/    "{'a': {'$*': 1}}"
     },
     {
       /*description:*/"Compose array ranges with one of them having the count default value specified explicitly.",
       /*data1:*/      "{'a': { '$count': 2147483647 }}",
       /*data2:*/      "{'a': { '$start': 20, '$count': 50 }}",
-      /*expected*/    "{'a': {}}"
+      /*expected*/    "{'a': {'$*': 1}}"
     },
     {
       /*description:*/"Compose array ranges with one of them having the start default value specified explicitly.",
       /*data1:*/      "{'a': { '$start': 0 }}",
       /*data2:*/      "{'a': { '$start': 20, '$count': 50 }}",
-      /*expected*/    "{'a': {}}"
+      /*expected*/    "{'a': {'$*': 1}}"
     },
     {
       /*description:*/"Compose array ranges with one of them having range values that overflows the integer range.",

--- a/data-transform/src/test/java/com/linkedin/data/transform/filter/TestMaskCreation.java
+++ b/data-transform/src/test/java/com/linkedin/data/transform/filter/TestMaskCreation.java
@@ -211,9 +211,11 @@ public class TestMaskCreation
     MaskTree mask = MaskCreator.createPositiveMask(arrayFirstHalfPath, arraySecondHalfPath);
 
     // Build the expected map with both start and count filtered out
-    // {parent={arrayField=1}}
+    // {parent={arrayField={$*=1}}}
     DataMap parentMap = new DataMap();
-    parentMap.put("arrayField", MaskOperation.POSITIVE_MASK_OP.getRepresentation());
+    DataMap arrayFieldMap = new DataMap();
+    arrayFieldMap.put(FilterConstants.WILDCARD, MaskOperation.POSITIVE_MASK_OP.getRepresentation());
+    parentMap.put("arrayField", arrayFieldMap);
     DataMap expectedMaskMap = new DataMap();
     expectedMaskMap.put("parent", parentMap);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.4.4
+version=29.4.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/java/com/linkedin/restli/internal/common/URIMaskUtil.java
+++ b/restli-common/src/main/java/com/linkedin/restli/internal/common/URIMaskUtil.java
@@ -149,7 +149,7 @@ public class URIMaskUtil
         state = ParseState.PARSE_FIELDS;
         break;
       case DESCEND:
-        if (toparse.charAt(index) != ':' || toparse.charAt(index + 1) != '(')
+        if (toparse.charAt(index) != ':' || index + 1 == toparse.length() || toparse.charAt(index + 1) != '(')
         {
           throw new IllegalStateException("Internal Error parsing mask: unexpected parse buffer '"
               + toparse.substring(index) + "' while descending");

--- a/restli-common/src/main/java/com/linkedin/restli/internal/common/URIParamUtils.java
+++ b/restli-common/src/main/java/com/linkedin/restli/internal/common/URIParamUtils.java
@@ -58,53 +58,40 @@ public class URIParamUtils
    * For projection parameters stored in dataMap, this function handles both cases when the value is a original string
    * or a structured {@link DataMap}
    *
-   * @param dataMap the {@link DataMap} which contains projection parameters as keys
+   * @param dataMap the {@link DataMap} which represents the query parameters
    * @return a {@link Map} from query param key to value in encoded string
    */
   private static Map<String, String> dataMapToQueryParams(DataMap dataMap)
   {
-    final Map<String, String> result = encodeDataMapParameters(dataMap);
-
-    // Serialize the projection MaskTree values
-    for (final String parameterName : RestConstants.PROJECTION_PARAMETERS)
+    Map<String, String> flattenedMap = new HashMap<>();
+    for (Map.Entry<String, Object> entry : dataMap.entrySet())
     {
-      if (dataMap.containsKey(parameterName))
+      // Serialize the projection MaskTree values
+      if (RestConstants.PROJECTION_PARAMETERS.contains(entry.getKey()))
       {
-        Object projectionParameters = dataMap.get(parameterName);
+        Object projectionParameters = entry.getValue();
         if (projectionParameters instanceof String)
         {
-          result.put(parameterName, (String) projectionParameters);
+          flattenedMap.put(entry.getKey(), (String) projectionParameters);
         }
         else if (projectionParameters instanceof DataMap)
         {
-          result.put(parameterName, URIMaskUtil.encodeMaskForURI((DataMap) projectionParameters));
+          flattenedMap.put(entry.getKey(), URIMaskUtil.encodeMaskForURI((DataMap) projectionParameters));
         }
         else
         {
           throw new IllegalArgumentException("Invalid projection field data type");
         }
       }
-    }
+      else
+      {
 
-    return result;
-  }
-
-  /**
-   * Encode the given {@link DataMap} as a map from query param to value
-   *
-   * @param dataMap the {@link com.linkedin.data.DataMap} to be encoded
-   * @return a {@link Map} from query param key to value
-   */
-  private static Map<String, String> encodeDataMapParameters(DataMap dataMap)
-  {
-    Map<String, String> flattenedMap = new HashMap<String, String>();
-    for (Map.Entry<String, Object> entry : dataMap.entrySet())
-    {
-      String flattenedValue = encodeElement(entry.getValue(),
-                                            URLEscaper.Escaping.URL_ESCAPING,
-                                            UriComponent.Type.QUERY_PARAM);
-      String encodedKey = encodeString(entry.getKey(), URLEscaper.Escaping.URL_ESCAPING, UriComponent.Type.QUERY_PARAM);
-      flattenedMap.put(encodedKey, flattenedValue);
+        String flattenedValue = encodeElement(entry.getValue(),
+                                              URLEscaper.Escaping.URL_ESCAPING,
+                                              UriComponent.Type.QUERY_PARAM);
+        String encodedKey = encodeString(entry.getKey(), URLEscaper.Escaping.URL_ESCAPING, UriComponent.Type.QUERY_PARAM);
+        flattenedMap.put(encodedKey, flattenedValue);
+      }
     }
     return flattenedMap;
   }

--- a/restli-common/src/test/java/com/linkedin/restli/internal/common/TestURIMaskUtil.java
+++ b/restli-common/src/test/java/com/linkedin/restli/internal/common/TestURIMaskUtil.java
@@ -42,66 +42,70 @@ import com.linkedin.data.transform.filter.request.MaskTree;
  */
 public class TestURIMaskUtil
 {
+  @DataProvider(parallel = true)
+  private Object[][] uriMaskTests()
+  {
+    return new String[][] {
+        {
+            /*description:*/    "Simple positve mask.",
+            /*mask in JSON:*/   "{'aaa': 1, 'bbb': 1, 'ccc': 1}",
+            /*mask in URI:*/    "aaa,bbb,ccc",
+        },
+        {
+            /*description:*/    "Simple negative mask.",
+            /*mask in JSON:*/   "{'aaa': 0, 'bbb': 0, 'ccc': 0}",
+            /*mask in URI:*/    "-aaa,-bbb,-ccc",
+        },
+        {
+            /*description:*/    "Nested positve mask.",
+            /*mask in JSON:*/   "{'aaa': 1, 'bbb': { 'ccc': 1}}",
+            /*mask in URI:*/    "aaa,bbb:(ccc)",
+        },
+        {
+            /*description:*/    "Nested negative mask.",
+            /*mask in JSON:*/   "{'aaa': 1, 'bbb': { 'ccc': 0}}",
+            /*mask in URI:*/    "aaa,bbb:(-ccc)",
+        },
+        {
+            /*description:*/    "Simple positive wildcard mask.",
+            /*mask in JSON:*/   "{'$*': 1 }",
+            /*mask in URI:*/    "$*",
+        },
+        {
+            /*description:*/    "Simple negative wildcard mask.",
+            /*mask in JSON:*/   "{'$*': 0 }",
+            /*mask in URI:*/    "-$*",
+        },
+        {
+            /*description:*/    "Test mixed positive and negative mask.",
+            /*mask in JSON:*/   "{'a': 1, 'b': { '$*': 1, 'c': 0 } }",
+            /*mask in URI:*/    "a,b:($*,-c)",
+        },
+        {
+            /*description:*/    "Test deeply nested mixed positive and negative mask.",
+            /*mask in JSON:*/   "{'a': { '$*': { '$*': 1, 'e': 0 }, 'b': { 'c': { 'd': 0 }}}, 'e': { 'f': { 'g': 0 }}}",
+            /*mask in URI:*/    "a:($*:($*,-e),b:(c:(-d))),e:(f:(-g))",
+        },
+        {
+            /*description:*/    "Test array range with a start value specified.",
+            /*mask in JSON:*/   "{'a': 1, 'b': { '$*': 1, '$start': 2 } }",
+            /*mask in URI:*/    "a,b:($*,$start:2)",
+        },
+        {
+            /*description:*/    "Test array range with a start and count value specified.",
+            /*mask in JSON:*/   "{'a': 1, 'b': { '$*': { 'c': 1 }, '$start': 2, '$count': 4 } }",
+            /*mask in URI:*/    "a,b:($*:(c),$start:2,$count:4)",
+        },
+        {
+            /*description:*/    "Test array range with a start and count value specified as 0 and 1 (same as negative and positive mask).",
+            /*mask in JSON:*/   "{'a': 1, 'b': { '$*': 1, '$start': 0, '$count': 1 } }",
+            /*mask in URI:*/    "a,b:($*,$start:0,$count:1)",
+        }
+    };
+  }
 
-  public static final String[][] TESTS = new String[][] {
-    {
-      /*description:*/    "Simple positve mask.",
-      /*mask in JSON:*/   "{'aaa': 1, 'bbb': 1, 'ccc': 1}",
-      /*mask in URI:*/    "aaa,bbb,ccc",
-    },
-    {
-      /*description:*/    "Simple negative mask.",
-      /*mask in JSON:*/   "{'aaa': 0, 'bbb': 0, 'ccc': 0}",
-      /*mask in URI:*/    "-aaa,-bbb,-ccc",
-    },
-    {
-      /*description:*/    "Nested positve mask.",
-      /*mask in JSON:*/   "{'aaa': 1, 'bbb': { 'ccc': 1}}",
-      /*mask in URI:*/    "aaa,bbb:(ccc)",
-    },
-    {
-      /*description:*/    "Nested negative mask.",
-      /*mask in JSON:*/   "{'aaa': 1, 'bbb': { 'ccc': 0}}",
-      /*mask in URI:*/    "aaa,bbb:(-ccc)",
-    },
-    {
-      /*description:*/    "Simple positive wildcard mask.",
-      /*mask in JSON:*/   "{'$*': 1 }",
-      /*mask in URI:*/    "$*",
-    },
-    {
-      /*description:*/    "Simple negative wildcard mask.",
-      /*mask in JSON:*/   "{'$*': 0 }",
-      /*mask in URI:*/    "-$*",
-    },
-    {
-      /*description:*/    "Test mixed positive and negative mask.",
-      /*mask in JSON:*/   "{'a': 1, 'b': { '$*': 1, 'c': 0 } }",
-      /*mask in URI:*/    "a,b:($*,-c)",
-    },
-    {
-      /*description:*/    "Test deeply nested mixed positive and negative mask.",
-      /*mask in JSON:*/   "{'a': { '$*': { '$*': 1, 'e': 0 }, 'b': { 'c': { 'd': 0 }}}, 'e': { 'f': { 'g': 0 }}}",
-      /*mask in URI:*/    "a:($*:($*,-e),b:(c:(-d))),e:(f:(-g))",
-    },
-    {
-      /*description:*/    "Test array range with a start value specified.",
-      /*mask in JSON:*/   "{'a': 1, 'b': { '$*': 1, '$start': 2 } }",
-      /*mask in URI:*/    "a,b:($*,$start:2)",
-    },
-    {
-      /*description:*/    "Test array range with a start and count value specified.",
-      /*mask in JSON:*/   "{'a': 1, 'b': { '$*': { 'c': 1 }, '$start': 2, '$count': 4 } }",
-      /*mask in URI:*/    "a,b:($*:(c),$start:2,$count:4)",
-    },
-    {
-      /*description:*/    "Test array range with a start and count value specified as 0 and 1 (same as negative and positive mask).",
-      /*mask in JSON:*/   "{'a': 1, 'b': { '$*': 1, '$start': 0, '$count': 1 } }",
-      /*mask in URI:*/    "a,b:($*,$start:0,$count:1)",
-    }
-  };
-
-  private void executeSingleTestCase(String jsonMask, String uriMask, String description) throws IllegalMaskException,
+  @Test(dataProvider = "uriMaskTests")
+  public void testUriMaskEncodingDecoding(String description, String jsonMask, String uriMask) throws IllegalMaskException,
       IOException
   {
     testEncodingToURI(jsonMask, uriMask, description);
@@ -111,7 +115,7 @@ public class TestURIMaskUtil
   private void testDecodingFromURI(String jsonMask, String uriMask, String description) throws IllegalMaskException,
       IOException
   {
-    MaskTree decoded = URIMaskUtil.decodeMaskUriFormat(new StringBuilder(uriMask));
+    MaskTree decoded = URIMaskUtil.decodeMaskUriFormat(uriMask);
     DataMap expectedMask = dataMapFromString(jsonMask.replace('\'', '"'));
     assertEquals(decoded.getDataMap(),
                  expectedMask,
@@ -198,14 +202,7 @@ public class TestURIMaskUtil
                      + encoded);
   }
 
-  @Test
-  public void test() throws Exception
-  {
-    for (String[] testCase : TESTS)
-      executeSingleTestCase(testCase[1], testCase[2], testCase[0]);
-  }
-
-  @DataProvider(name = "invalidArrayRangeProvider")
+  @DataProvider(name = "invalidArrayRangeProvider", parallel = true)
   private Object[][] invalidArrayRangeProvider()
   {
     return new Object[][] {
@@ -222,12 +219,20 @@ public class TestURIMaskUtil
   {
     try
     {
-      URIMaskUtil.decodeMaskUriFormat(new StringBuilder(uriMask));
+      URIMaskUtil.decodeMaskUriFormat(uriMask);
       fail("Excepted to throw an exception with a message: " + errorMessage);
     }
     catch (IllegalMaskException e)
     {
       assertTrue(e.getMessage().contains(errorMessage));
     }
+  }
+
+  @Test
+  public void uriDecodeWithWhitespaces() throws IllegalMaskException, IOException {
+     MaskTree tree = URIMaskUtil.decodeMaskUriFormat("a ,\tb:($*:(c), $start:2,$count :4)");
+     DataMap dataMap = tree.getDataMap();
+     assertEquals(dataMap, dataMapFromString(
+         "{'a': 1, 'b': { '$*': { 'c': 1 }, '$start': 2, '$count': 4 } }".replace('\'', '"')));
   }
 }

--- a/restli-int-test-client/src/test/java/com/linkedin/restli/examples/groups/TestPatchGeneration.java
+++ b/restli-int-test-client/src/test/java/com/linkedin/restli/examples/groups/TestPatchGeneration.java
@@ -116,7 +116,7 @@ public class TestPatchGeneration
     //"id,location:(longitude,latitude),name";
     final String actualEncodedMaskURI = URIMaskUtil.encodeMaskForURI(mask);
     //We convert back into a MaskTree so we can compare DataMaps because the URI could be in any order
-    final MaskTree generatedMaskTree = URIMaskUtil.decodeMaskUriFormat(new StringBuilder(actualEncodedMaskURI));
+    final MaskTree generatedMaskTree = URIMaskUtil.decodeMaskUriFormat(actualEncodedMaskURI);
     Assert.assertEquals(generatedMaskTree.getDataMap(), idLocationNameMap, "The actual encoded Mask URI should be correct");
   }
 

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/util/ArgumentUtils.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/util/ArgumentUtils.java
@@ -155,7 +155,7 @@ public class ArgumentUtils
   {
     try
     {
-      return URIMaskUtil.decodeMaskUriFormat(new StringBuilder(uriParam));
+      return URIMaskUtil.decodeMaskUriFormat(uriParam);
     }
     catch (IllegalMaskException e)
     {


### PR DESCRIPTION
Fixes the following issues:
Encoding:
 - Projection parameters were first encoded using default logic and then overwritten using the encoded value from URIMask encoding. Avoiding the unnecessary double encoding for projection parameters.
 - During mask creation, we iterate through the entire datamap to cleanup empty masks. Since {'a': 1 } and { 'a' : { '$*': 1} } are functionally equivalent, we can avoid the extra iteration by setting $*:1.
   This might increase the URI size slightly, but the chance of someone using array start/count with default values for both is going to be very low, so doing this optimization makes sense.
 - During encoding a string is created for each sub datamap and then appended to the parent string builder. This is avoided by passing in the string builder to encode into.
Decoding:
 - The decoding logic was poorly designed. It was deleting characters from the front of string builder. This is avoided by passing in the string param directly and checking chars using charAt.