### PR TITLE
Make addFields on AbstractRequestBuilder public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Provide public method in the AbstractRequestBuilder for adding field projections (#353)
 
 ## [29.4.5] - 2020-07-21
 - Update ExtensionSchemaValidation task to check extension schema annotation (#254)

--- a/restli-client/src/main/java/com/linkedin/restli/client/AbstractRequestBuilder.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/AbstractRequestBuilder.java
@@ -271,6 +271,17 @@ public abstract class AbstractRequestBuilder<K, V, R extends Request<?>> extends
     return this;
   }
 
+  public void addFields(PathSpec... fieldPaths)
+  {
+    if (_queryParams.containsKey(RestConstants.FIELDS_PARAM))
+    {
+      throw new IllegalStateException("Entity projection fields already set on this request: "
+                                          + _queryParams.get(RestConstants.FIELDS_PARAM));
+    }
+    setParam(RestConstants.FIELDS_PARAM, fieldPaths == null ? null : new HashSet<>(Arrays.asList(fieldPaths)));
+  }
+
+
   public AbstractRequestBuilder<K, V, R> pathKey(String name, Object value)
   {
     _pathKeys.put(name, value);
@@ -357,16 +368,6 @@ public abstract class AbstractRequestBuilder<K, V, R extends Request<?>> extends
   protected void addAssocKey(String key, Object value)
   {
     _assocKey.append(key, value);
-  }
-
-  protected void addFields(PathSpec... fieldPaths)
-  {
-    if (_queryParams.containsKey(RestConstants.FIELDS_PARAM))
-    {
-      throw new IllegalStateException("Entity projection fields already set on this request: "
-                                          + _queryParams.get(RestConstants.FIELDS_PARAM));
-    }
-    setParam(RestConstants.FIELDS_PARAM, fieldPaths == null ? null : new HashSet<>(Arrays.asList(fieldPaths)));
   }
 
   protected void addMetadataFields(PathSpec... fieldPaths)


### PR DESCRIPTION
We have a use case where we want a method to be able to take any type of
request builder (e.g. BatchGetRequestBuilder or FindRequestBuilder) and
we want to be able to add fields to the request.

Currently, we can accomplish this by using
setParam(RestConstants.FIELDS_PARAM, newHashSet(fields)), but it would
be simpler to just expose the addFields method instead.