### PR TITLE
Add test for low qps simulation

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/QuarantineManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/QuarantineManager.java
@@ -363,7 +363,7 @@ public class QuarantineManager {
       TrackerClientState trackerClientState, double serverWeight, Set<TrackerClient> recoverySet,
       PartitionState oldPartitionState)
   {
-    if (trackerClientState.getHealthScore() <= StateUpdater.MIN_HEALTH_SCORE
+    if (trackerClientState.getHealthScore() <= StateUpdater.MIN_HEALTH_SCORE + DOUBLE_COMPARISON_THRESHOLD
         && serverWeight > MIN_ZOOKEEPER_SERVER_WEIGHT)
     {
       // Enroll the client to recovery set if the health score dropped to 0, but zookeeper does not set the client weight to be 0


### PR DESCRIPTION
Added a test to simulate the situation when the qps is super low

Test condition:
A cluster of 20 hosts
In each interval, only send 20 requests in total
The latency range is from 100 to 500 ms, randomly generated

Test result:
When fast recovery is enabled, some hosts will drop but they will recover soon
When fast recovery is not enabled, there are several hosts that will stay at point 1 for a long time. I only ran 100 intervals, there are 4-5 hosts that stayed at point 1 for half of the intervals till the end.