### PR TITLE
Remove "Fruits" from test suite compatibility matrix as it appear to be added by mistake

### DIFF
--- a/src/testsuite_compatibility_matrix.md
+++ b/src/testsuite_compatibility_matrix.md
@@ -47,7 +47,6 @@ Based on these test suites, we've made the following compatibility matrices:
 | Enum&nbsp;with&nbsp;Properties | x | x | |
 | Fixed | x | | Python does not support Fixed in the same way as Java|
 | Fixed5 | x | | Python does not support Fixed in the same way as Java|
-| Fruits | x | x | |
 | Includes | x | x | |
 | Large&nbsp;Record | x | x | |
 | Map&nbsp;of&nbsp;Ints| x | x | |


### PR DESCRIPTION
The "Fruits" entry seems to be wrongly added, thus removing