### PR TITLE
add missing ClusterInfoProvider implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.4.9] - 2020-08-04
-- Add missing ClusterInfoProvider implementations in ZKFSLoadBalancer and TogglingLoadBalancer
+- Add missing ClusterInfoProvider implementations in ZKFSLoadBalancer and TogglingLoadBalancer.
 
 ## [29.4.8] - 2020-08-04
 - Add identical traffic multiplier strategy for dark clusters to enable identical traffic across all dark clusters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.4.9] - 2020-08-04
+- Add missing ClusterInfoProvider implementations in ZKFSLoadBalancer and TogglingLoadBalancer
+
 ## [29.4.8] - 2020-08-04
 - Add identical traffic multiplier strategy for dark clusters to enable identical traffic across all dark clusters
 
@@ -4566,7 +4569,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.9...master
+[29.4.9]: https://github.com/linkedin/rest.li/compare/v29.4.8...v29.4.9
 [29.4.8]: https://github.com/linkedin/rest.li/compare/v29.4.7...v29.4.8
 [29.4.7]: https://github.com/linkedin/rest.li/compare/v29.4.6...v29.4.7
 [29.4.6]: https://github.com/linkedin/rest.li/compare/v29.4.5...v29.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.4.9] - 2020-08-04
-- Add missing ClusterInfoProvider implementations in ZKFSLoadBalancer and TogglingLoadBalancer.
+- Add missing ClusterInfoProvider implementations in ZKFSLoadBalancer and TogglingLoadBalancer
 
 ## [29.4.8] - 2020-08-04
 - Add identical traffic multiplier strategy for dark clusters to enable identical traffic across all dark clusters

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
@@ -25,6 +25,9 @@ import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
 
 /**
  * ClusterInfoProvider provides a mechanism to access detailed cluster information from the D2 infrastructure.
+ * Implementations should implement at least getClusterCount, getDarkClusterConfigMap, registerClusterListener,
+ * and unregisterClusterListener. Some have a default implementation for backwards compatibility reasons, but
+ * should be regarded as required.
  *
  * @author David Hoa
  * @version $Revision: $

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/TogglingLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/TogglingLoadBalancer.java
@@ -25,6 +25,7 @@ import com.linkedin.common.callback.Callbacks;
 import com.linkedin.common.util.None;
 import com.linkedin.d2.DarkClusterConfigMap;
 import com.linkedin.d2.balancer.LoadBalancer;
+import com.linkedin.d2.balancer.LoadBalancerClusterListener;
 import com.linkedin.d2.balancer.ServiceUnavailableException;
 import com.linkedin.d2.balancer.WarmUpService;
 import com.linkedin.d2.balancer.properties.ServiceProperties;
@@ -204,5 +205,17 @@ public class TogglingLoadBalancer implements LoadBalancer, HashRingProvider, Cli
     throws ServiceUnavailableException
   {
     return _clusterInfoProvider.getDarkClusterConfigMap(clusterName);
+  }
+
+  @Override
+  public void registerClusterListener(LoadBalancerClusterListener clusterListener)
+  {
+    _clusterInfoProvider.registerClusterListener(clusterListener);
+  }
+
+  @Override
+  public void unregisterClusterListener(LoadBalancerClusterListener clusterListener)
+  {
+    _clusterInfoProvider.unregisterClusterListener(clusterListener);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSLoadBalancer.java
@@ -22,10 +22,12 @@ package com.linkedin.d2.balancer.zkfs;
 
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.util.None;
+import com.linkedin.d2.DarkClusterConfigMap;
 import com.linkedin.d2.balancer.Directory;
 import com.linkedin.d2.balancer.Facilities;
 import com.linkedin.d2.balancer.KeyMapper;
 import com.linkedin.d2.balancer.LoadBalancer;
+import com.linkedin.d2.balancer.LoadBalancerClusterListener;
 import com.linkedin.d2.balancer.LoadBalancerWithFacilities;
 import com.linkedin.d2.balancer.ServiceUnavailableException;
 import com.linkedin.d2.balancer.WarmUpService;
@@ -108,6 +110,24 @@ public class ZKFSLoadBalancer
   public int getClusterCount(String clusterName, String scheme, int partitionId) throws ServiceUnavailableException
   {
     return _currentLoadBalancer.getClusterCount(clusterName, scheme, partitionId);
+  }
+
+  @Override
+  public DarkClusterConfigMap getDarkClusterConfigMap(String clusterName) throws ServiceUnavailableException
+  {
+    return _currentLoadBalancer.getDarkClusterConfigMap(clusterName);
+  }
+
+  @Override
+  public void registerClusterListener(LoadBalancerClusterListener clusterListener)
+  {
+    _currentLoadBalancer.registerClusterListener(clusterListener);
+  }
+
+  @Override
+  public void unregisterClusterListener(LoadBalancerClusterListener clusterListener)
+  {
+    _currentLoadBalancer.unregisterClusterListener(clusterListener);
   }
 
   public interface TogglingLoadBalancerFactory

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.4.8
+version=29.4.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
ZKFSLoadBalancer and TogglingLoadBalancer were missing implementations of registerClusterListener and unregisterClusterListener, so services were never getting updates after startup.  There's a default implementation in ClusterInfoProvider for backwards compatibility reasons, but these are really required, because of how classes can be wrapped.

Unfortunately, there's no easy way to simulate a state refresh to do an end-to-end test outside of really bringing up a service. Verified fix through debugger after stack was fully constructed.