### PR TITLE
Relax validation for upsert usecase: UPDATE used for create or update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.4.11] - 2020-08-06
 - Relax validation of read-only fields for upsert usecase: UPDATE used for create or update. Fields marked as ReadOnly will be treated as optional for UPDATE methods.
 
 ## [29.4.10] - 2020-08-05
@@ -4573,7 +4575,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.11...master
+[29.4.11]: https://github.com/linkedin/rest.li/compare/v29.4.10...v29.4.11
 [29.4.10]: https://github.com/linkedin/rest.li/compare/v29.4.9...v29.4.10
 [29.4.9]: https://github.com/linkedin/rest.li/compare/v29.4.8...v29.4.9
 [29.4.8]: https://github.com/linkedin/rest.li/compare/v29.4.7...v29.4.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Relax validation of read-only fields for upsert usecase: UPDATE used for create or update. Fields marked as ReadOnly will be treated as optional for UPDATE methods.
 
 ## [29.4.7] - 2020-07-30
 - Add support for configuring fields that are always projected on the server. Configs can be applied for the entire service, resource or method level.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.4.10
+version=29.4.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/AutomaticValidationDemoResource.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/AutomaticValidationDemoResource.java
@@ -17,7 +17,6 @@
 package com.linkedin.restli.examples.greetings.server;
 
 
-import com.linkedin.restli.common.EmptyRecord;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.common.PatchRequest;
 import com.linkedin.restli.common.validation.CreateOnly;

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRestLiValidation.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRestLiValidation.java
@@ -663,6 +663,9 @@ public class TestRestLiValidation extends RestLiIntegrationTest
     greetingMap.put("key1", new Greeting());
     return new Object[][]
         {
+            // Required fields even if marked createOnly should be present
+            {new ValidationDemo(),
+                 "/stringB :: field is required but not found and has no default value"},
             // Required fields should be present in an update request
             {new ValidationDemo().setArrayWithInlineRecord(myItems),
                 "/ArrayWithInlineRecord/0/bar2 :: field is required but not found and has no default value"},
@@ -703,6 +706,9 @@ public class TestRestLiValidation extends RestLiIntegrationTest
     }
   }
 
+  /**
+   * Required but read-only fields are optional. Required create-only fields must be present.
+   */
   public static Object[] updateSuccesses()
   {
     ValidationDemo.UnionFieldWithInlineRecord unionField = new ValidationDemo.UnionFieldWithInlineRecord();
@@ -717,8 +723,11 @@ public class TestRestLiValidation extends RestLiIntegrationTest
     map.put("key1", new Greeting().setId(1).setMessage("msg").setTone(Tone.FRIENDLY));
     return new Object[]
         {
-            // All required fields have to be present, regardless of ReadOnly or CreateOnly annotations
+            // All fields present.
             validationDemo1,
+            // ReadOnly fields stringA, intA not present
+            new ValidationDemo().setStringB("BBB").setUnionFieldWithInlineRecord(unionField2)
+                    .setIntB(5432).setArrayWithInlineRecord(array).setMapWithTyperefs(map).setValidationDemoNext(validationDemo1),
             new ValidationDemo().setStringA("aaa").setStringB("bbb").setUnionFieldWithInlineRecord(unionField2)
                 .setIntA(1234).setIntB(5678).setArrayWithInlineRecord(array).setMapWithTyperefs(map).setValidationDemoNext(validationDemo1)
         };


### PR DESCRIPTION
Fields marked as ReadOnly will be optional for UPDATE methods.