### PR TITLE
Start adding support for multiple input dirs to pegasus (multiple da…

### DIFF
--- a/gradle-plugins/build.gradle
+++ b/gradle-plugins/build.gradle
@@ -46,5 +46,8 @@ integTest {
   dependsOn configurations.dataTemplateForTesting, configurations.pegasusPluginForTesting
   systemProperty 'integTest.dataTemplateCompileDependencies', "'${configurations.dataTemplateForTesting.join("', '")}'"
   systemProperty 'integTest.pegasusPluginDependencies', "'${configurations.pegasusPluginForTesting.join("', '")}'"
+  doFirst {
+    systemProperty 'debug-jvm', debug
+  }
 }
 

--- a/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginCacheabilityTest.groovy
+++ b/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginCacheabilityTest.groovy
@@ -17,6 +17,7 @@ class PegasusPluginCacheabilityTest extends Specification {
     def runner = GradleRunner.create()
         .withProjectDir(tempDir.root)
         .withPluginClasspath()
+        .withDebug(Boolean.parseBoolean(System.getProperty("debug-jvm")))
         .withArguments('mainDataTemplateJar')
 
     def settingsFile = tempDir.newFile('settings.gradle')

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusOptions.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusOptions.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,10 +33,19 @@ import org.slf4j.LoggerFactory;
 
 public class PegasusOptions
 {
+  private PegasusOptions(ConfigurableFileCollection dataSchemaDirs) {
+    this.dataSchemaDirs = dataSchemaDirs;
+  }
+
+  public static PegasusOptions create(ConfigurableFileCollection dataSchemaDirs) {
+    return new PegasusOptions(dataSchemaDirs);
+  }
+
   public Set<GenerationMode> generationModes = new HashSet<GenerationMode>(Arrays.asList(GenerationMode.PEGASUS));
   public IdlOptions idlOptions = new IdlOptions();
   public ClientOptions clientOptions = new ClientOptions();
   public RestModelOptions restModelOptions = new RestModelOptions();
+  private final ConfigurableFileCollection dataSchemaDirs;
 
   private static final Logger _log = LoggerFactory.getLogger(PegasusOptions.class);
 
@@ -166,5 +176,12 @@ public class PegasusOptions
     {
       return _restResourcesRootPath != null ? _restResourcesRootPath : "src/main/java";
     }
+  }
+
+  /**
+   * Locations to search for data schemas.
+   */
+  public ConfigurableFileCollection getDataSchemaDirs() {
+    return dataSchemaDirs;
   }
 }

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/TranslateSchemasTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/TranslateSchemasTask.java
@@ -13,6 +13,7 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
@@ -26,7 +27,7 @@ import org.gradle.api.tasks.TaskAction;
  */
 @CacheableTask
 public class TranslateSchemasTask extends DefaultTask {
-  private File _inputDir;
+  private FileCollection _inputDirs = getProject().files();
   private FileCollection _resolverPath;
   private FileCollection _codegenClasspath;
   private File _destinationDir;
@@ -42,14 +43,16 @@ public class TranslateSchemasTask extends DefaultTask {
   public void translate()
   {
     getProject().getLogger().info("Translating data schemas ...");
-    _destinationDir.mkdirs();
+    if (_destinationDir != null) {
+      _destinationDir.mkdirs();
+    }
 
-    String resolverPathStr = _resolverPath.plus(getProject().files(_inputDir)).getAsPath();
+    String resolverPathStr = _resolverPath.plus(_inputDirs).getAsPath();
 
-    FileCollection _pathedCodegenClasspath;
+    FileCollection pathedCodegenClasspath;
     try
     {
-      _pathedCodegenClasspath = PathingJarUtil.generatePathingJar(getProject(), getName(),
+      pathedCodegenClasspath = PathingJarUtil.generatePathingJar(getProject(), getName(),
           _codegenClasspath, false);
     }
     catch (IOException e)
@@ -57,6 +60,14 @@ public class TranslateSchemasTask extends DefaultTask {
       throw new GradleException("Error occurred generating pathing JAR.", e);
     }
 
+    for (File dir : _inputDirs.getFiles()) {
+      if (dir.exists() && (!dir.isDirectory() || dir.list().length > 0)) {
+        javaExec(resolverPathStr, pathedCodegenClasspath, dir);
+      }
+    }
+  }
+
+  private void javaExec(String resolverPathStr, FileCollection pathedCodegenClasspath, File inputDir) {
     getProject().javaexec(javaExecSpec ->
     {
       String resolverPathArg = resolverPathStr;
@@ -66,7 +77,7 @@ public class TranslateSchemasTask extends DefaultTask {
             "translateSchemas_resolverPath", Collections.singletonList(resolverPathArg), getTemporaryDir()));
       }
       javaExecSpec.setMain("com.linkedin.restli.tools.data.SchemaFormatTranslator");
-      javaExecSpec.setClasspath(_pathedCodegenClasspath);
+      javaExecSpec.setClasspath(pathedCodegenClasspath);
       javaExecSpec.args("--source-format");
       javaExecSpec.args(_sourceFormat.getFileExtension());
       javaExecSpec.args("--destination-format");
@@ -89,25 +100,39 @@ public class TranslateSchemasTask extends DefaultTask {
         javaExecSpec.args("--force-pdsc-fully-qualified-names");
       }
       javaExecSpec.args(resolverPathArg);
-      javaExecSpec.args(_inputDir.getAbsolutePath());
-      javaExecSpec.args(_destinationDir.getAbsolutePath());
+      javaExecSpec.args(inputDir.getAbsolutePath());
+      if (_destinationDir == null) {
+        javaExecSpec.args(inputDir.getAbsolutePath());
+      } else {
+        javaExecSpec.args(_destinationDir.getAbsolutePath());
+      }
     });
   }
 
   /**
-   * Directory containing the data schema files to translate.
+   * Directories containing the data schema files to translate.
    */
-  @InputDirectory
+  @InputFiles
   @SkipWhenEmpty
-  @PathSensitive(PathSensitivity.RELATIVE)
-  public File getInputDir()
+  public FileCollection getInputDirs()
   {
-    return _inputDir;
+    return _inputDirs;
   }
 
+  public void setInputDirs(FileCollection fileCollection) {
+    _inputDirs = fileCollection;
+  }
+
+  @Deprecated
+  public File getInputDir()
+  {
+    return _inputDirs.getSingleFile();
+  }
+
+  @Deprecated
   public void setInputDir(File inputDir)
   {
-    _inputDir = inputDir;
+    _inputDirs = getProject().files(inputDir);
   }
 
   /**


### PR DESCRIPTION
…ta schema dirs).

This is useful for generating schemas. Our use case is for metadata (DataHub), we want to annotate metadata models with an annotation, and then auto generate event schemas based on those annotations (and then from there avro + java, etc). We want all models (hand written metadata models + auto generated events) in the same module.

Note that there seems to be a lack of tests in this area, I was able to add one but let me know if there are some other kind of tests or procedures I'm missing...


Change details:
- Add a file collection to the `PegasusOptions` object  for the data schema dirs. This defaults to the existing data schema dir the plugin would look for.
- Adjust tasks that used the one data schema dir to accept file collections instead.
  - Tasks that executed some jars may be called one per data schema dir. This could be made more optimal by changing those applications to accept multiple inputs as well, but for now this works.
- Added a test that shows off what I sort of want: have a task that generates a pegasus file, and then wire that up to the rest of the pegasus plugin.