### PR TITLE
Create client side config to enable relative load balancer from client library

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -166,7 +166,8 @@ public class D2ClientBuilder
                   _config.startUpExecutorService,
                   _config.jmxManager,
                   _config.d2JmxManagerPrefix,
-                  _config.zookeeperReadWindowMs);
+                  _config.zookeeperReadWindowMs,
+                  _config.enableRelativeLoadBalancer);
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() :
@@ -479,6 +480,12 @@ public class D2ClientBuilder
     return this;
   }
 
+  public D2ClientBuilder setEnableRelativeLoadBalancer(boolean enableRelativeLoadBalancer)
+  {
+    _config.enableRelativeLoadBalancer = enableRelativeLoadBalancer;
+    return this;
+  }
+
   private Map<String, TransportClientFactory> createDefaultTransportClientFactories()
   {
     final Map<String, TransportClientFactory> clientFactories = new HashMap<String, TransportClientFactory>();
@@ -509,11 +516,14 @@ public class D2ClientBuilder
     loadBalancerStrategyFactories.putIfAbsent("degraderV3", degraderStrategyFactoryV3);
     loadBalancerStrategyFactories.putIfAbsent("degraderV2_1", degraderStrategyFactoryV3);
 
-    final RelativeLoadBalancerStrategyFactory relativeLoadBalancerStrategyFactory = new RelativeLoadBalancerStrategyFactory(
-        _config._executorService, _config.healthCheckOperations, Collections.emptyList(), _config.eventEmitter,
-        SystemClock.instance());
-    loadBalancerStrategyFactories.putIfAbsent(RelativeLoadBalancerStrategy.RELATIVE_LOAD_BALANCER_STRATEGY_NAME,
-        relativeLoadBalancerStrategyFactory);
+    if (_config.enableRelativeLoadBalancer)
+    {
+      final RelativeLoadBalancerStrategyFactory relativeLoadBalancerStrategyFactory = new RelativeLoadBalancerStrategyFactory(
+          _config._executorService, _config.healthCheckOperations, Collections.emptyList(), _config.eventEmitter,
+          SystemClock.instance());
+      loadBalancerStrategyFactories.putIfAbsent(RelativeLoadBalancerStrategy.RELATIVE_LOAD_BALANCER_STRATEGY_NAME,
+          relativeLoadBalancerStrategyFactory);
+    }
 
     return loadBalancerStrategyFactories;
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -89,6 +89,7 @@ public class D2ClientConfig
   ScheduledExecutorService startUpExecutorService = null;
   JmxManager jmxManager = new NoOpJmxManager();
   String d2JmxManagerPrefix = "UnknownPrefix";
+  boolean enableRelativeLoadBalancer = false;
 
   private static final int DEAULT_RETRY_LIMIT = 3;
 
@@ -139,7 +140,8 @@ public class D2ClientConfig
                  ScheduledExecutorService startUpExecutorService,
                  JmxManager jmxManager,
                  String d2JmxManagerPrefix,
-                 int zookeeperReadWindowMs)
+                 int zookeeperReadWindowMs,
+                 boolean enableRelativeLoadBalancer)
   {
     this.zkHosts = zkHosts;
     this.zkSessionTimeoutInMs = zkSessionTimeoutInMs;
@@ -185,5 +187,6 @@ public class D2ClientConfig
     this.jmxManager = jmxManager;
     this.d2JmxManagerPrefix = d2JmxManagerPrefix;
     this.zookeeperReadWindowMs = zookeeperReadWindowMs;
+    this.enableRelativeLoadBalancer = enableRelativeLoadBalancer;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientFactory.java
@@ -152,7 +152,9 @@ public class TrackerClientFactory
                 RelativeLoadBalancerStrategyFactory.DEFAULT_UPDATE_INTERVAL_MS,
                 Long.class);
           }
+          break;
         case (DegraderLoadBalancerStrategyV3.DEGRADER_STRATEGY_NAME):
+        default:
           Map<String, Object> loadBalancerStrategyProperties = serviceProperties.getLoadBalancerStrategyProperties();
           if (loadBalancerStrategyProperties != null)
           {

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientFactory.java
@@ -143,6 +143,15 @@ public class TrackerClientFactory
     {
       switch (loadBalancerStrategyName)
       {
+        case (RelativeLoadBalancerStrategy.RELATIVE_LOAD_BALANCER_STRATEGY_NAME):
+          Map<String, Object> relativeLoadBalancerProperties = serviceProperties.getRelativeStrategyProperties();
+          if (relativeLoadBalancerProperties != null)
+          {
+            interval = MapUtil.getWithDefault(serviceProperties.getRelativeStrategyProperties(),
+                PropertyKeys.UPDATE_INTERVAL_MS,
+                RelativeLoadBalancerStrategyFactory.DEFAULT_UPDATE_INTERVAL_MS,
+                Long.class);
+          }
         case (DegraderLoadBalancerStrategyV3.DEGRADER_STRATEGY_NAME):
           Map<String, Object> loadBalancerStrategyProperties = serviceProperties.getLoadBalancerStrategyProperties();
           if (loadBalancerStrategyProperties != null)

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/RelativeStrategyPropertiesConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/RelativeStrategyPropertiesConverter.java
@@ -48,10 +48,6 @@ import static com.linkedin.d2.balancer.properties.util.PropertyUtil.coerce;
  */
 public class RelativeStrategyPropertiesConverter
 {
-  private static final JacksonDataCodec CODEC = new JacksonDataCodec();
-  private static final ValidationOptions VALIDATION_OPTIONS =
-    new ValidationOptions(RequiredMode.FIXUP_ABSENT_WITH_DEFAULT, CoercionMode.STRING_TO_PRIMITIVE);
-
   /**
    * Convert {@link D2RelativeStrategyProperties} to Map
    *

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -30,6 +30,8 @@ import com.linkedin.d2.balancer.properties.ServiceProperties;
 import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategyV3;
+import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.balancer.util.ClientFactoryProvider;
 import com.linkedin.d2.balancer.util.LoadBalancerUtil;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
@@ -1054,6 +1056,14 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
     }
 
     Map<String, LoadBalancerStrategy> newStrategies = new ConcurrentHashMap<>();
+
+    if (factory == null && strategyList != null && strategyList.size() == 1
+        && strategyList.contains(RelativeLoadBalancerStrategy.RELATIVE_LOAD_BALANCER_STRATEGY_NAME)
+        && !_loadBalancerStrategyFactories.containsKey(RelativeLoadBalancerStrategy.RELATIVE_LOAD_BALANCER_STRATEGY_NAME))
+    {
+      factory = _loadBalancerStrategyFactories.get(DegraderLoadBalancerStrategyV3.DEGRADER_STRATEGY_NAME);
+      warn(_log, "unable to find cluster or factory for ", serviceProperties, ", defaulting to ", factory);
+    }
 
     if (factory == null || serviceProperties.getPrioritizedSchemes() == null || serviceProperties.getPrioritizedSchemes().isEmpty())
     {


### PR DESCRIPTION
Exposed a configuration in d2 client library to enable the relative load balancer. To have the relative load balancer work, client and server need to meet the following criteria:
1. Server configured the relative strategy in d2 lps file and updated to Zookeeper
2. Client upgrades the pegasus dependency version
3. Client turn on the enableRelativeLoadBalancer to true

To understand the pilot onboarding process, please see https://docs.google.com/document/d/19DpiTNuzXpdSaK-kYPRYg9RJenxJfuIy5zYX_l_1gtA/edit#heading=h.dpqigh1gl2z0