### PR TITLE
update DarkClusterConfigMap before registering ClusterListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.4.12] - 2020-08-10
+- directly fetch DarkClusterConfigMap during startup, before registering ClusterListener.
+
 ## [29.4.11] - 2020-08-06
 - Relax validation of read-only fields for upsert usecase: UPDATE used for create or update. Fields marked as ReadOnly will be treated as optional for UPDATE methods.
 
@@ -4575,7 +4578,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.12...master
+[29.4.12]: https://github.com/linkedin/rest.li/compare/v29.4.11...v29.4.12
 [29.4.11]: https://github.com/linkedin/rest.li/compare/v29.4.10...v29.4.11
 [29.4.10]: https://github.com/linkedin/rest.li/compare/v29.4.9...v29.4.10
 [29.4.9]: https://github.com/linkedin/rest.li/compare/v29.4.8...v29.4.9

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
@@ -84,10 +84,15 @@ public class DarkClusterStrategyFactoryImpl implements DarkClusterStrategyFactor
   @Override
   public void start()
   {
-    _facilities.getClusterInfoProvider().registerClusterListener(_clusterListener);
     // make sure we're listening to the source cluster and have strategies for any
-    // associated dark clusters.
+    // associated dark clusters. The order matters here: we directly invoke onClusterAdded to
+    // directly query zookeeper for the DarkClusterConfigMap, and then we add the listener.
+    // Doing it in reverse causes a timeout. Ideally, registerClusterListener would have some
+    // functionality similar to SimpleLoadBalancer.listenToCluster that both adds a listener and
+    // requests the data through the eventbus, which will trigger ClusterSubscriber::handlePut and
+    // and iterate through the ClusterListeners.
     _clusterListener.onClusterAdded(_sourceClusterName);
+    _facilities.getClusterInfoProvider().registerClusterListener(_clusterListener);
     LOG.info("listening to dark clusters on " + _sourceClusterName);
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.4.11
+version=29.4.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
We need to update the DarkClusterConfigMap before registering the ClusterListener in DarkClusterStrategyFactoryImpl::start. Otherwise, we get a timeout trying to update the DarkClusterConfigMap (reasons unknown). While we will investigate the timeout further, we have verified that directly calling the onClusterAdded first and then registering the ClusterListener fixes the problem. 

The ideal solution is to have registerClusterListener() function similarly to SimpleLoadBalancer.listenToCluster(), which will request the data from the eventbus, and trigger ClusterSubscriber.handlePut(), which will iterate through the ClusterListeners. Another issue will be opened to track that solution.