### PR TITLE
Provide an option to set an overridden SSL socket factory for the default symbol table provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.4.14] - 2020-08-11
+- Provide an option to set an overridden SSL socket factory for the default symbol table provider 
+
 ## [29.4.13] - 2020-08-11
 - Undeprecate some Rest.li client methods since we do want the ability to set default content/accept types at the client level
 
@@ -4581,7 +4584,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.13...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.14...master
+[29.4.14]: https://github.com/linkedin/rest.li/compare/v29.4.13...v29.4.14
 [29.4.13]: https://github.com/linkedin/rest.li/compare/v29.4.12...v29.4.13
 [29.4.12]: https://github.com/linkedin/rest.li/compare/v29.4.11...v29.4.12
 [29.4.11]: https://github.com/linkedin/rest.li/compare/v29.4.10...v29.4.11

--- a/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
+++ b/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,9 +64,21 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
   public static final String SYMBOL_TABLE_URI_PATH = "symbolTable";
 
   /**
+   * Overridden SSL socket factory if any.
+   */
+  private static SSLSocketFactory SSL_SOCKET_FACTORY;
+
+  /**
    * Cache storing mapping from symbol table name to symbol table.
    */
   private final Cache<String, SymbolTable> _cache;
+
+  /**
+   * Set the overridden SSL socket factory.
+   */
+  public static void setSSLSocketFactory(SSLSocketFactory socketFactory) {
+    SSL_SOCKET_FACTORY = socketFactory;
+  }
 
   /**
    * Constructor
@@ -156,6 +170,12 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
 
   HttpURLConnection openConnection(String url) throws IOException
   {
-    return (HttpURLConnection) new URL(url).openConnection();
+    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    if (SSL_SOCKET_FACTORY != null && connection instanceof HttpsURLConnection)
+    {
+      ((HttpsURLConnection) connection).setSSLSocketFactory(SSL_SOCKET_FACTORY);
+    }
+
+    return connection;
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.4.13
+version=29.4.14
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Services may want to use a custom SSL socket factory for connecting to the symbol table provider on other services.