### PR TITLE
Fix the non-deterministic issue

### DIFF
--- a/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
@@ -27,12 +27,14 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import org.apache.commons.io.FilenameUtils;
 
 
@@ -179,7 +181,8 @@ public class DataSchemaParser
    */
   public static class ParseResult
   {
-    private final Map<DataSchema, DataSchemaLocation> _schemaAndLocations = new LinkedHashMap<>();
+    // The purpose of the sorting is to keep generated java meta classes consistent accross different input file orders
+    private final Map<DataSchema, DataSchemaLocation> _schemaAndLocations = new TreeMap<>(Comparator.comparing(DataSchema::toString));
     private final Set<File> _sourceFiles = new HashSet<>();
     protected final StringBuilder _messageBuilder = new StringBuilder();
 

--- a/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
@@ -602,7 +602,6 @@ public class TemplateSpecGenerator
 
     final MapTemplateSpec mapClass = (MapTemplateSpec) classInfo.definedClass;
     registerClassTemplateSpec(schema, mapClass);
-
     mapClass.setValueClass(processSchema(valueSchema, enclosingClass, memberName));
     mapClass.setValueDataClass(determineDataClass(valueSchema, enclosingClass, memberName));
 
@@ -706,7 +705,6 @@ public class TemplateSpecGenerator
     fixedClass.setClassName(schema.getName());
     fixedClass.setModifiers(ModifierSpec.PUBLIC);
     registerClassTemplateSpec(schema, fixedClass);
-
     return fixedClass;
   }
 

--- a/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
@@ -602,6 +602,7 @@ public class TemplateSpecGenerator
 
     final MapTemplateSpec mapClass = (MapTemplateSpec) classInfo.definedClass;
     registerClassTemplateSpec(schema, mapClass);
+
     mapClass.setValueClass(processSchema(valueSchema, enclosingClass, memberName));
     mapClass.setValueDataClass(determineDataClass(valueSchema, enclosingClass, memberName));
 
@@ -705,6 +706,7 @@ public class TemplateSpecGenerator
     fixedClass.setClassName(schema.getName());
     fixedClass.setModifiers(ModifierSpec.PUBLIC);
     registerClassTemplateSpec(schema, fixedClass);
+
     return fixedClass;
   }
 

--- a/generator/src/test/java/com/linkedin/pegasus/generator/TestPegasusDataTemplateGenerator.java
+++ b/generator/src/test/java/com/linkedin/pegasus/generator/TestPegasusDataTemplateGenerator.java
@@ -227,6 +227,8 @@ public class TestPegasusDataTemplateGenerator
             {new String[]{"ATypeRef.pdsc", "Service.pdsc"}, new String[]{"Service.pdsc", "ATypeRef.pdsc"}},
             {new String[]{"AField.pdl", "ARecord.pdl"}, new String[]{"ARecord.pdl", "AField.pdl"}},
             {new String[]{"BRecord.pdl", "BField.pdl"}, new String[]{"BField.pdl", "BRecord.pdl"}},
+            {new String[]{"FooArray1.pdl", "FooArray2.pdl"}, new String[]{"FooArray2.pdl", "FooArray1.pdl"}},
+            {new String[]{"FooMap1.pdl", "FooMap2.pdl"}, new String[]{"FooMap2.pdl", "FooMap1.pdl"}},
         };
   }
 

--- a/generator/src/test/resources/generator/Bar.pdl
+++ b/generator/src/test/resources/generator/Bar.pdl
@@ -1,0 +1,4 @@
+record Bar {
+  field1: int,
+  field2: string
+}

--- a/generator/src/test/resources/generator/FooArray1.pdl
+++ b/generator/src/test/resources/generator/FooArray1.pdl
@@ -1,0 +1,3 @@
+record FooArray1 {
+  field1: array[Bar] = []
+}

--- a/generator/src/test/resources/generator/FooArray2.pdl
+++ b/generator/src/test/resources/generator/FooArray2.pdl
@@ -1,0 +1,3 @@
+record FooArray2 {
+  field: array[Bar]
+}

--- a/generator/src/test/resources/generator/FooMap1.pdl
+++ b/generator/src/test/resources/generator/FooMap1.pdl
@@ -1,0 +1,3 @@
+record FooMap1 {
+  fieldIsMap: map[string, Bar]
+}

--- a/generator/src/test/resources/generator/FooMap2.pdl
+++ b/generator/src/test/resources/generator/FooMap2.pdl
@@ -1,0 +1,3 @@
+record FooMap2 {
+  fieldIsMap: map[string, Bar]
+}


### PR DESCRIPTION
Previous fix didn't take care the schema type of Map and Array etc. The non-consistency problem happens in the following scenario:
Suppose there are 3 PDL files, 
Foo1.pdl which has a field of array with type Bar
Foo2.pdl which also has a field of array with type Bar
This 3 schema file will generate Foo1.java Foo2.java and Bar.java and also BarArray.java

It is the annotation in the BarArray.java appeared to have non-consistency in terms appearing to have 2 different generated-by files. Sometimes it is Foo1.pdl, sometimes it is Foo2.pdl.

The solution can be multiple:
1. Just add "pushSchemaLocation" calls to put Bar.pdl location in the BarArray generated class. But this is wrong since the BarArray class should be generated by Foo1 or Foo2

2nd solution is to have the input always sorted. This is way we take little hit on build-time performance, but we gain consistency where once we build, the following many times we can rely on build cache.

