### PR TITLE
Add JMX monitors for RelativeLoadBalancerStrategy

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/LoadBalancerQuarantine.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/LoadBalancerQuarantine.java
@@ -304,6 +304,11 @@ public class LoadBalancerQuarantine
     return _timeTilNextCheck;
   }
 
+  public boolean isInQuarantine()
+  {
+    return _quarantineState == QuarantineStates.FAILURE || _quarantineState == QuarantineStates.WAIT;
+  }
+
   // For testing only
   public HealthCheck getHealthCheckClient()
   {

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
@@ -106,7 +106,7 @@ public class PartitionState
     return _clusterGenerationId;
   }
 
-  Map<TrackerClient, TrackerClientState> getTrackerClientStateMap()
+  public Map<TrackerClient, TrackerClientState> getTrackerClientStateMap()
   {
     return _trackerClientStateMap;
   }
@@ -116,7 +116,7 @@ public class PartitionState
     return _trackerClientStateMap.keySet();
   }
 
-  Map<TrackerClient, LoadBalancerQuarantine> getQuarantineMap()
+  public Map<TrackerClient, LoadBalancerQuarantine> getQuarantineMap()
   {
     return _quarantineMap;
   }
@@ -151,7 +151,7 @@ public class PartitionState
     _clusterGenerationId = clusterGenerationId;
   }
 
-  Map<URI, Integer> getPointsMap()
+  public Map<URI, Integer> getPointsMap()
   {
     return _pointsMap;
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
@@ -91,6 +91,11 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
     return _stateUpdater.getRing(partitionId);
   }
 
+  public PartitionState getPartitionState(int partitionId)
+  {
+    return _stateUpdater.getPartitionState(partitionId);
+  }
+
   /**
    * Exposed for testings
    */

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -330,7 +330,7 @@ public class StateUpdater
 
     return callCountSum + outstandingCallCountSum == 0
         ? 0
-        : (latencySum + outstandingLatencySum) / (callCountSum + outstandingCallCountSum);
+        : Math.round((latencySum + outstandingLatencySum) / (double) (callCountSum + outstandingCallCountSum));
   }
 
   public static long getAvgHostLatency(CallTracker.CallStats callStats)

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -333,7 +333,7 @@ public class StateUpdater
         : (latencySum + outstandingLatencySum) / (callCountSum + outstandingCallCountSum);
   }
 
-  private static long getAvgHostLatency(CallTracker.CallStats callStats)
+  public static long getAvgHostLatency(CallTracker.CallStats callStats)
   {
     double avgLatency = callStats.getCallTimeStats().getAverage();
     long avgOutstandingLatency = callStats.getOutstandingStartTimeAvg();

--- a/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
@@ -22,6 +22,7 @@ import com.linkedin.d2.balancer.simple.SimpleLoadBalancer;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategyV3;
+import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.discovery.stores.file.FileStore;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperEphemeralStore;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperPermanentStore;
@@ -105,6 +106,11 @@ public class JmxManager
     {
       checkReg(new DegraderLoadBalancerStrategyV3Jmx((DegraderLoadBalancerStrategyV3) strategy), name);
     }
+    else if (strategy instanceof RelativeLoadBalancerStrategy)
+    {
+      checkReg(new RelativeLoadBalancerStrategyJmx((RelativeLoadBalancerStrategy) strategy), name);
+
+    }
     else
     {
       warn(_log, "unable to register a jmx bean for unknown strategy: ", strategy);
@@ -117,6 +123,12 @@ public class JmxManager
    * Register the jmx bean passed in with the jmx manager.
    */
   public synchronized JmxManager registerLoadBalancerStrategyV3JmxBean(String name, DegraderLoadBalancerStrategyV3JmxMBean strategyJmx)
+  {
+    checkReg(strategyJmx, name);
+    return this;
+  }
+
+  public synchronized JmxManager registerRelativeLoadBalancerStrategyJmxBean(String name, RelativeLoadBalancerStrategyJmxMBean strategyJmx)
   {
     checkReg(strategyJmx, name);
     return this;

--- a/d2/src/main/java/com/linkedin/d2/jmx/NoOpJmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/NoOpJmxManager.java
@@ -95,6 +95,11 @@ public class NoOpJmxManager extends JmxManager
     return this;
   }
 
+  public synchronized NoOpJmxManager registerRelativeLoadBalancerStrategyJmxBean(String name, RelativeLoadBalancerStrategyJmxMBean strategyJmx)
+  {
+    return this;
+  }
+
   public synchronized NoOpJmxManager registerZooKeeperAnnouncer(String name, ZooKeeperAnnouncer announcer)
   {
     return this;

--- a/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
@@ -1,0 +1,168 @@
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.strategies.LoadBalancerQuarantine;
+import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
+import com.linkedin.d2.balancer.strategies.relative.TrackerClientState;
+import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
+import com.linkedin.util.degrader.CallTracker;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStrategyJmxMBean
+{
+  private final RelativeLoadBalancerStrategy _strategy;
+
+  public RelativeLoadBalancerStrategyJmx(RelativeLoadBalancerStrategy strategy)
+  {
+    _strategy = strategy;
+  }
+
+  @Override
+  public double getLatencyStandardDeviation()
+  {
+    Map<TrackerClient, TrackerClientState> stateMap =
+        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+
+    List<Double> weightedLatencies = stateMap.keySet().stream()
+        .map(trackerClient -> getWeightedLatency(trackerClient.getLatestCallStats()))
+        .collect(Collectors.toList());
+
+    double avgLatency = weightedLatencies.stream()
+        .mapToDouble(Double::doubleValue)
+        .average()
+        .orElse(0);
+
+    double variance = weightedLatencies.stream()
+        .map(latency -> Math.pow(latency - avgLatency, 2))
+        .mapToDouble(Double::doubleValue)
+        .average()
+        .orElse(0);
+
+    return Math.sqrt(variance);
+  }
+
+  @Override
+  public double getLatencyAverageAbsoluteDeviation()
+  {
+    Map<TrackerClient, TrackerClientState> stateMap =
+        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+
+    List<Double> weightedLatencies = stateMap.keySet().stream()
+        .map(trackerClient -> getWeightedLatency(trackerClient.getLatestCallStats()))
+        .collect(Collectors.toList());
+
+    double avgLatency = weightedLatencies.stream()
+        .mapToDouble(Double::doubleValue)
+        .average()
+        .orElse(0);
+
+    return weightedLatencies.stream()
+        .map(latency -> Math.abs(latency - avgLatency))
+        .mapToDouble(Double::doubleValue)
+        .average()
+        .orElse(0);
+  }
+
+  @Override
+  public double getLatencyMedianAbsoluteDeviation()
+  {
+    Map<TrackerClient, TrackerClientState> stateMap =
+        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+
+    List<Double> weightedLatencies = stateMap.keySet().stream()
+        .map(trackerClient -> getWeightedLatency(trackerClient.getLatestCallStats()))
+        .collect(Collectors.toList());
+
+    double medianLatency = getMedian(weightedLatencies);
+
+    List<Double> medianAbsolutes = weightedLatencies.stream()
+        .map(latency -> Math.abs(latency - medianLatency))
+        .collect(Collectors.toList());
+
+    return getMedian(medianAbsolutes);
+  }
+
+  @Override
+  public double getLatencyMaxAbsoluteDeviation()
+  {
+    Map<TrackerClient, TrackerClientState> stateMap =
+        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+
+    List<Double> weightedLatencies = stateMap.keySet().stream()
+        .map(trackerClient -> getWeightedLatency(trackerClient.getLatestCallStats()))
+        .collect(Collectors.toList());
+
+    double avgLatency = weightedLatencies.stream()
+        .mapToDouble(Double::doubleValue)
+        .average()
+        .orElse(0);
+
+    return weightedLatencies.stream()
+        .map(latency -> Math.abs(latency - avgLatency))
+        .mapToDouble(Double::doubleValue)
+        .max()
+        .orElse(0);
+  }
+
+  @Override
+  public int getUnhealthyHostsCount()
+  {
+    Map<TrackerClient, TrackerClientState> stateMap =
+        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+
+    return (int) stateMap.values().stream()
+        .filter(TrackerClientState::isUnhealthy)
+        .count();
+  }
+
+  @Override
+  public int getQuarantineHostsCount() {
+    Map<TrackerClient, LoadBalancerQuarantine> quarantineMap =
+        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getQuarantineMap();
+
+    return (int) quarantineMap.values().stream()
+        .filter(LoadBalancerQuarantine::isInQuarantine)
+        .count();
+  }
+
+  @Override
+  public int getTotalPointsInHashRing() {
+    Map<URI, Integer> uris = _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getPointsMap();
+
+    return uris.values().stream()
+        .mapToInt(Integer::intValue)
+        .sum();
+  }
+
+  private static double getWeightedLatency(CallTracker.CallStats callStats)
+  {
+    int callCount = callStats.getCallCount();
+    int outstandingCallCount = callStats.getOutstandingCount();
+
+    return (callStats.getCallTimeStats().getAverage() * callCount +
+        callStats.getOutstandingStartTimeAvg() * outstandingCallCount) / (callCount + outstandingCallCount);
+  }
+
+  private static double getMedian(List<Double> values)
+  {
+    Collections.sort(values);
+
+    if (values.size() == 0)
+    {
+      return 0;
+    }
+    else if (values.size() % 2 == 0)
+    {
+      return (values.get(values.size() / 2) + values.get(values.size() / 2 - 1)) / 2;
+    }
+    else
+    {
+      return values.get(values.size() / 2);
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxMBean.java
@@ -1,0 +1,47 @@
+package com.linkedin.d2.jmx;
+
+public interface RelativeLoadBalancerStrategyJmxMBean
+{
+
+  /**
+   *
+   * @return the standard deviation of cluster latency
+   */
+  double getLatencyStandardDeviation();
+
+  /**
+   *
+   * @return the average absolute deviation around average of cluster latency
+   */
+  double getLatencyAverageAbsoluteDeviation();
+
+  /**
+   *
+   * @return the median absolute deviation around median of cluster latency
+   */
+  double getLatencyMedianAbsoluteDeviation();
+
+  /**
+   *
+   * @return the maximum absolute deviation around average of cluster latency
+   */
+  double getLatencyMaxAbsoluteDeviation();
+
+  /**
+   *
+   * @return the number of unhealthy hosts
+   */
+  int getUnhealthyHostsCount();
+
+  /**
+   *
+   * @return the number of hosts in quarantine
+   */
+  int getQuarantineHostsCount();
+
+  /**
+   *
+   * @return number of total points in hash ring
+   */
+  int getTotalPointsInHashRing();
+}

--- a/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxMBean.java
@@ -1,3 +1,20 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
 package com.linkedin.d2.jmx;
 
 public interface RelativeLoadBalancerStrategyJmxMBean
@@ -5,27 +22,33 @@ public interface RelativeLoadBalancerStrategyJmxMBean
 
   /**
    *
-   * @return the standard deviation of cluster latency
+   * @return the standard deviation of cluster latencies
    */
   double getLatencyStandardDeviation();
 
   /**
    *
-   * @return the average absolute deviation around average of cluster latency
+   * @return the mean absolute deviation of cluster latencies
    */
-  double getLatencyAverageAbsoluteDeviation();
+  double getLatencyMeanAbsoluteDeviation();
 
   /**
    *
-   * @return the median absolute deviation around median of cluster latency
+   * @return the standard deviation of cluster latencies that are above average
    */
-  double getLatencyMedianAbsoluteDeviation();
+  double getAboveAverageLatencyStandardDeviation();
 
   /**
    *
-   * @return the maximum absolute deviation around average of cluster latency
+   * @return the relative ratio between max latency and average cluster latency
    */
-  double getLatencyMaxAbsoluteDeviation();
+  double getMaxLatencyRelativeFactor();
+
+  /**
+   *
+   * @return the relative ratio between nth percentile latency and average cluster latency
+   */
+  double getNthPercentileLatencyRelativeFactor(double pct);
 
   /**
    *

--- a/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
@@ -76,6 +76,15 @@ public class RelativeLoadBalancerStrategyJmxTest {
     assertTrue(jmx2.getLatencyStandardDeviation() > jmx1.getLatencyStandardDeviation());
     assertTrue(jmx2.getLatencyMeanAbsoluteDeviation() > jmx1.getLatencyMeanAbsoluteDeviation());
     assertTrue(jmx2.getAboveAverageLatencyStandardDeviation() > jmx1.getAboveAverageLatencyStandardDeviation());
+
+    List<TrackerClient> trackerClientsDiverse3 = TrackerClientMockHelper.mockTrackerClients(4,
+        Arrays.asList(20, 20, 20, 0), Arrays.asList(10, 10, 10, 0),
+        Arrays.asList(100L, 150L, 200L, 0L), Arrays.asList(50L, 75L, 100L, 0L), Arrays.asList(0, 0, 0, 0));
+
+    RelativeLoadBalancerStrategyJmx jmx3 = mockRelativeLoadBalancerStrategyJmx(trackerClientsDiverse3);
+    assertEquals(jmx3.getLatencyStandardDeviation(), jmx1.getLatencyStandardDeviation());
+    assertEquals(jmx3.getLatencyMeanAbsoluteDeviation(), jmx1.getLatencyMeanAbsoluteDeviation());
+    assertEquals(jmx3.getAboveAverageLatencyStandardDeviation(), jmx1.getAboveAverageLatencyStandardDeviation());
   }
 
   @Test

--- a/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
@@ -77,6 +77,8 @@ public class RelativeLoadBalancerStrategyJmxTest {
     assertTrue(jmx2.getLatencyMeanAbsoluteDeviation() > jmx1.getLatencyMeanAbsoluteDeviation());
     assertTrue(jmx2.getAboveAverageLatencyStandardDeviation() > jmx1.getAboveAverageLatencyStandardDeviation());
 
+
+    // hosts not receiving any traffic should not affect deviation calculation
     List<TrackerClient> trackerClientsDiverse3 = TrackerClientMockHelper.mockTrackerClients(4,
         Arrays.asList(20, 20, 20, 0), Arrays.asList(10, 10, 10, 0),
         Arrays.asList(100L, 150L, 200L, 0L), Arrays.asList(50L, 75L, 100L, 0L), Arrays.asList(0, 0, 0, 0));

--- a/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
@@ -1,0 +1,133 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.strategies.relative.PartitionState;
+import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
+import com.linkedin.d2.balancer.strategies.relative.TrackerClientMockHelper;
+import com.linkedin.d2.balancer.strategies.relative.TrackerClientState;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.easymock.EasyMock.anyInt;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class RelativeLoadBalancerStrategyJmxTest {
+  private RelativeLoadBalancerStrategyJmx mockRelativeLoadBalancerStrategyJmx(List<TrackerClient> trackerClients)
+  {
+    Map<TrackerClient, TrackerClientState> trackerClientsMap = new HashMap<>();
+    for (TrackerClient trackerClient : trackerClients)
+    {
+      trackerClientsMap.put(trackerClient, new TrackerClientState(1, 1));
+    }
+
+    RelativeLoadBalancerStrategy strategy = Mockito.mock(RelativeLoadBalancerStrategy.class);
+    PartitionState state = Mockito.mock(PartitionState.class);
+    Mockito.when(state.getTrackerClientStateMap()).thenReturn(trackerClientsMap);
+    Mockito.when(strategy.getPartitionState(anyInt())).thenReturn(state);
+
+    return new RelativeLoadBalancerStrategyJmx(strategy);
+  }
+
+  @Test
+  public void testLatencyDeviation()
+  {
+    List<TrackerClient> trackerClientsEqual = TrackerClientMockHelper.mockTrackerClients(2,
+        Arrays.asList(20, 20), Arrays.asList(10, 10), Arrays.asList(200L, 200L), Arrays.asList(100L, 100L), Arrays.asList(0, 0));
+
+    RelativeLoadBalancerStrategyJmx jmx = mockRelativeLoadBalancerStrategyJmx(trackerClientsEqual);
+    assertEquals(jmx.getLatencyStandardDeviation(), 0.0);
+    assertEquals(jmx.getLatencyMeanAbsoluteDeviation(), 0.0);
+    assertEquals(jmx.getAboveAverageLatencyStandardDeviation(), 0.0);
+
+    List<TrackerClient> trackerClientsDiverse1 = TrackerClientMockHelper.mockTrackerClients(3,
+        Arrays.asList(20, 20, 20), Arrays.asList(10, 10, 10),
+        Arrays.asList(100L, 150L, 200L), Arrays.asList(50L, 75L, 100L), Arrays.asList(0, 0, 0));
+
+    List<TrackerClient> trackerClientsDiverse2 = TrackerClientMockHelper.mockTrackerClients(4,
+        Arrays.asList(20, 20, 20, 20), Arrays.asList(10, 10, 10, 10),
+        Arrays.asList(100L, 200L, 400L, 600L), Arrays.asList(50L, 100L, 200L, 300L), Arrays.asList(0, 0, 0, 0));
+
+    RelativeLoadBalancerStrategyJmx jmx1 = mockRelativeLoadBalancerStrategyJmx(trackerClientsDiverse1);
+    RelativeLoadBalancerStrategyJmx jmx2 = mockRelativeLoadBalancerStrategyJmx(trackerClientsDiverse2);
+
+    assertTrue(jmx2.getLatencyStandardDeviation() > jmx1.getLatencyStandardDeviation());
+    assertTrue(jmx2.getLatencyMeanAbsoluteDeviation() > jmx1.getLatencyMeanAbsoluteDeviation());
+    assertTrue(jmx2.getAboveAverageLatencyStandardDeviation() > jmx1.getAboveAverageLatencyStandardDeviation());
+  }
+
+  @Test
+  public void testLatencyRelativeFactor()
+  {
+    List<TrackerClient> trackerClientsEqual = TrackerClientMockHelper.mockTrackerClients(2,
+        Arrays.asList(20, 20), Arrays.asList(10, 10), Arrays.asList(200L, 200L), Arrays.asList(100L, 100L), Arrays.asList(0, 0));
+
+    RelativeLoadBalancerStrategyJmx jmx = mockRelativeLoadBalancerStrategyJmx(trackerClientsEqual);
+    assertEquals(jmx.getMaxLatencyRelativeFactor(), 1.0);
+    assertEquals(jmx.getNthPercentileLatencyRelativeFactor(0.95), 1.0);
+
+    List<TrackerClient> trackerClientsDiverse = TrackerClientMockHelper.mockTrackerClients(4,
+        Arrays.asList(20, 20, 20, 20), Arrays.asList(10, 10, 10, 10),
+        Arrays.asList(100L, 200L, 300L, 400L), Arrays.asList(50L, 100L, 150L, 200L), Arrays.asList(0, 0, 0, 0));
+
+    jmx = mockRelativeLoadBalancerStrategyJmx(trackerClientsDiverse);
+    double maxLatencyRelativeFactor = jmx.getMaxLatencyRelativeFactor();
+    double p95LatencyRelativeFactor = jmx.getNthPercentileLatencyRelativeFactor(0.95);
+    assertTrue(maxLatencyRelativeFactor > 1 && maxLatencyRelativeFactor < 2);
+    assertTrue(p95LatencyRelativeFactor > 1 && p95LatencyRelativeFactor < 2);
+    assertTrue(p95LatencyRelativeFactor < maxLatencyRelativeFactor);
+  }
+
+  @Test
+  public void testEmptyList()
+  {
+    RelativeLoadBalancerStrategyJmx jmx = mockRelativeLoadBalancerStrategyJmx(new ArrayList<>());
+    assertEquals(jmx.getLatencyStandardDeviation(), 0.0);
+    assertEquals(jmx.getLatencyMeanAbsoluteDeviation(), 0.0);
+    assertEquals(jmx.getAboveAverageLatencyStandardDeviation(), 0.0);
+    assertEquals(jmx.getMaxLatencyRelativeFactor(), 0.0);
+    assertEquals(jmx.getNthPercentileLatencyRelativeFactor(0.95), 0.0);
+    assertEquals(jmx.getTotalPointsInHashRing(), 0);
+    assertEquals(jmx.getUnhealthyHostsCount(), 0);
+    assertEquals(jmx.getQuarantineHostsCount(), 0);
+  }
+
+  @Test
+  public void testZeroLatency()
+  {
+    List<TrackerClient> trackerClients = TrackerClientMockHelper.mockTrackerClients(3,
+        Arrays.asList(0, 0, 0), Arrays.asList(0, 0, 0), Arrays.asList(0L, 0L, 0L), Arrays.asList(0L, 0L, 0L), Arrays.asList(0, 0, 0));
+
+    RelativeLoadBalancerStrategyJmx jmx = mockRelativeLoadBalancerStrategyJmx(trackerClients);
+    assertEquals(jmx.getLatencyStandardDeviation(), 0.0);
+    assertEquals(jmx.getLatencyMeanAbsoluteDeviation(), 0.0);
+    assertEquals(jmx.getAboveAverageLatencyStandardDeviation(), 0.0);
+    assertEquals(jmx.getMaxLatencyRelativeFactor(), 0.0);
+    assertEquals(jmx.getNthPercentileLatencyRelativeFactor(0.95), 0.0);
+    assertEquals(jmx.getTotalPointsInHashRing(), 0);
+    assertEquals(jmx.getUnhealthyHostsCount(), 0);
+    assertEquals(jmx.getQuarantineHostsCount(), 0);
+  }
+}


### PR DESCRIPTION
Adding a couple of JMX monitors for relative load balancer strategy, including
1. Standard Deviation, average absolute deviation, median absolute deviation and max absolute deviation of cluster latency.
2. Number of unhealthy hosts
3. Number of hosts in quarantine
4. Total points in the hash ring