### PR TITLE
add callback based ClusterInfoProvider.getDarkClusterConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.5.0] - 2020-08-12
+add Callback method for ClusterInfoProvider.getDarkClusterConfigMap
+
 ## [29.4.14] - 2020-08-11
 - Provide an option to set an overridden SSL socket factory for the default symbol table provider 
 
@@ -4584,7 +4587,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.4.14...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.5.0...master
+[29.5.0]: https://github.com/linkedin/rest.li/compare/v29.4.14...v29.5.0
 [29.4.14]: https://github.com/linkedin/rest.li/compare/v29.4.13...v29.4.14
 [29.4.13]: https://github.com/linkedin/rest.li/compare/v29.4.12...v29.4.13
 [29.4.12]: https://github.com/linkedin/rest.li/compare/v29.4.11...v29.4.12

--- a/d2/src/main/java/com/linkedin/d2/balancer/Facilities.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/Facilities.java
@@ -68,8 +68,5 @@ public interface Facilities
    * Obtain a ClusterInfoProvider
    * @return ClusterInfoProvider
    */
-  default ClusterInfoProvider getClusterInfoProvider()
-  {
-    return (clusterName, scheme, partitionId) -> 0;
-  };
+  ClusterInfoProvider getClusterInfoProvider();
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/AbstractLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/AbstractLoadBalancerSubscriber.java
@@ -32,7 +32,7 @@ import static com.linkedin.d2.discovery.util.LogUtil.trace;
 public abstract class AbstractLoadBalancerSubscriber<T> implements
   PropertyEventSubscriber<T>
 {
-  private static final Logger _log = LoggerFactory.getLogger(SimpleLoadBalancerState.class);
+  private static final Logger _log = LoggerFactory.getLogger(AbstractLoadBalancerSubscriber.class);
 
   private final String                                                                  _name;
   private final int                                                                     _type;

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/ClusterInfoProvider.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.balancer.util;
 
+import com.linkedin.common.callback.Callback;
 import com.linkedin.d2.DarkClusterConfigMap;
 import com.linkedin.d2.balancer.ServiceUnavailableException;
 import com.linkedin.d2.balancer.properties.PropertyKeys;
@@ -53,6 +54,10 @@ public interface ClusterInfoProvider
    * Get the DarkClusterConfigMap for a particular d2 cluster. This is needed to to find the dark clusters that correspond
    * to a regular d2 cluster.
    *
+   * use the callback version instead to avoid blocking threads. Unfortunately, we can't put @Deprecated on
+   * the method or in this javadoc because there's a bug in the jdk that won't suppress warnings on implementations.
+   * This was supposedly fixed in https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6480588 but the problem is still
+   * in 8u172.
    * @param clusterName
    * @return
    * @throws ServiceUnavailableException
@@ -61,6 +66,15 @@ public interface ClusterInfoProvider
   {
     return new DarkClusterConfigMap();
   }
+
+  /**
+   * Get the DarkClusterConfigMap for a particular d2 cluster. This is needed to to find the dark clusters that correspond
+   * to a regular d2 cluster.
+   *
+   * @param clusterName name of the source cluster
+   * @param callback callback to invoke when the DarkClusterConfigMap is retrieved
+   */
+  void getDarkClusterConfigMap(String clusterName, Callback<DarkClusterConfigMap> callback);
 
   /**
    * Register a listener for Cluster changes. Listeners can refresh any internal state/cache after getting triggered.

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/DelegatingFacilities.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/DelegatingFacilities.java
@@ -20,6 +20,8 @@
 
 package com.linkedin.d2.balancer.util;
 
+import com.linkedin.common.callback.Callback;
+import com.linkedin.d2.DarkClusterConfigMap;
 import com.linkedin.d2.balancer.Directory;
 import com.linkedin.d2.balancer.Facilities;
 import com.linkedin.d2.balancer.KeyMapper;
@@ -101,8 +103,21 @@ public class DelegatingFacilities implements Facilities
                               HashRingProvider hashRingProvider)
   {
     this(directoryProvider, keyMapperProvider, clientFactoryProvider, partitionInfoProvider, hashRingProvider,
-        (clusterName, scheme, partitionId) -> 0);
+      new ClusterInfoProvider()
+      {
+        @Override
+        public int getClusterCount(String clusterName, String scheme, int partitionId)
+        {
+          return 0;
+        }
+
+        @Override
+        public void getDarkClusterConfigMap(String clusterName, Callback<DarkClusterConfigMap> callback)
+        {
+        }
+      });
   }
+
   public DelegatingFacilities(DirectoryProvider directoryProvider,
       KeyMapperProvider keyMapperProvider,
       ClientFactoryProvider clientFactoryProvider,

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/TogglingLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/TogglingLoadBalancer.java
@@ -208,6 +208,12 @@ public class TogglingLoadBalancer implements LoadBalancer, HashRingProvider, Cli
   }
 
   @Override
+  public void getDarkClusterConfigMap(String clusterName, Callback<DarkClusterConfigMap> callback)
+  {
+    _clusterInfoProvider.getDarkClusterConfigMap(clusterName, callback);
+  }
+
+  @Override
   public void registerClusterListener(LoadBalancerClusterListener clusterListener)
   {
     _clusterInfoProvider.registerClusterListener(clusterListener);

--- a/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSLoadBalancer.java
@@ -119,6 +119,12 @@ public class ZKFSLoadBalancer
   }
 
   @Override
+  public void getDarkClusterConfigMap(String clusterName, Callback<DarkClusterConfigMap> callback)
+  {
+    _currentLoadBalancer.getDarkClusterConfigMap(clusterName, callback);
+  }
+
+  @Override
   public void registerClusterListener(LoadBalancerClusterListener clusterListener)
   {
     _currentLoadBalancer.registerClusterListener(clusterListener);

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -273,9 +273,22 @@ public class SimpleLoadBalancerTest
 
     populateUriRegistry(numHttp, numHttps, partitionIdForAdd, uriRegistry);
 
-    DarkClusterConfigMap returnedDarkClusterConfigMap = loadBalancer.getDarkClusterConfigMap(CLUSTER1_NAME);
-    Assert.assertEquals(returnedDarkClusterConfigMap, darkClusterConfigMap, "dark cluster configs should be equal");
-    Assert.assertEquals(returnedDarkClusterConfigMap.get(DARK_CLUSTER1_NAME).getMultiplier(), 1.0f, "multiplier should match");
+    loadBalancer.getDarkClusterConfigMap(CLUSTER1_NAME,
+      new Callback<DarkClusterConfigMap>()
+      {
+        @Override
+        public void onError(Throwable e)
+        {
+          Assert.fail("getDarkClusterConfigMap threw exception", e);
+        }
+
+        @Override
+        public void onSuccess(DarkClusterConfigMap returnedDarkClusterConfigMap)
+        {
+          Assert.assertEquals(returnedDarkClusterConfigMap, darkClusterConfigMap, "dark cluster configs should be equal");
+          Assert.assertEquals(returnedDarkClusterConfigMap.get(DARK_CLUSTER1_NAME).getMultiplier(), 1.0f, "multiplier should match");
+        }
+      });
   }
 
   @Test
@@ -295,9 +308,21 @@ public class SimpleLoadBalancerTest
         Collections.emptySet(), NullPartitionProperties.getInstance(), Collections.emptyList(),
                                                              DarkClustersConverter.toProperties(darkClusterConfigMap), false));
 
-    DarkClusterConfigMap returnedDarkClusterConfigMap = loadBalancer.getDarkClusterConfigMap(CLUSTER1_NAME);
-    Assert.assertEquals(returnedDarkClusterConfigMap, darkClusterConfigMap, "dark cluster configs should be equal");
-    Assert.assertEquals(returnedDarkClusterConfigMap.get(DARK_CLUSTER1_NAME).getMultiplier(), 1.0f, "multiplier should match");
+    loadBalancer.getDarkClusterConfigMap(CLUSTER1_NAME, new Callback<DarkClusterConfigMap>()
+    {
+      @Override
+      public void onError(Throwable e)
+      {
+        Assert.fail("getDarkClusterConfigMap threw exception", e);
+      }
+
+      @Override
+      public void onSuccess(DarkClusterConfigMap returnedDarkClusterConfigMap)
+      {
+        Assert.assertEquals(returnedDarkClusterConfigMap, darkClusterConfigMap, "dark cluster configs should be equal");
+        Assert.assertEquals(returnedDarkClusterConfigMap.get(DARK_CLUSTER1_NAME).getMultiplier(), 1.0f, "multiplier should match");
+      }
+    });
   }
 
   @Test
@@ -309,8 +334,20 @@ public class SimpleLoadBalancerTest
     MockStore<UriProperties> uriRegistry = new MockStore<>();
     SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
 
-    DarkClusterConfigMap returnedDarkClusterConfigMap = loadBalancer.getDarkClusterConfigMap(NONEXISTENT_CLUSTER);
-    Assert.assertEquals(returnedDarkClusterConfigMap.size(), 0, "expected empty map");
+    loadBalancer.getDarkClusterConfigMap(NONEXISTENT_CLUSTER, new Callback<DarkClusterConfigMap>()
+    {
+      @Override
+      public void onError(Throwable e)
+      {
+        Assert.fail("getDarkClusterConfigMap threw exception", e);
+      }
+
+      @Override
+      public void onSuccess(DarkClusterConfigMap returnedDarkClusterConfigMap)
+      {
+        Assert.assertEquals(returnedDarkClusterConfigMap.size(), 0, "expected empty map");
+      }
+    });
   }
 
   /**

--- a/darkcluster-test-api/src/main/java/com/linkedin/darkcluster/MockClusterInfoProvider.java
+++ b/darkcluster-test-api/src/main/java/com/linkedin/darkcluster/MockClusterInfoProvider.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.darkcluster;
 
+import com.linkedin.common.callback.Callback;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -53,6 +54,11 @@ public class MockClusterInfoProvider implements ClusterInfoProvider
     throws ServiceUnavailableException
   {
     return lookupMap.getOrDefault(clusterName, EMPTY_DARK_CLUSTER_CONFIG_MAP);
+  }
+
+  @Override
+  public void getDarkClusterConfigMap(String clusterName, Callback<DarkClusterConfigMap> callback) {
+    callback.onSuccess(lookupMap.getOrDefault(clusterName, EMPTY_DARK_CLUSTER_CONFIG_MAP));
   }
 
   @Override

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterStrategyFactoryImpl.java
@@ -87,7 +87,7 @@ public class DarkClusterStrategyFactoryImpl implements DarkClusterStrategyFactor
     // make sure we're listening to the source cluster and have strategies for any
     // associated dark clusters. While registering the cluster listener is enough,
     // we also "warm up" the strategies directly by triggering the clusterListener so that
-    // we retrieve the dark clusters before any inbound request. This is a
+    // we retrieve the dark clusters before any inbound request.
     _facilities.getClusterInfoProvider().registerClusterListener(_clusterListener);
     _clusterListener.onClusterAdded(_sourceClusterName);
     LOG.info("listening to dark clusters on " + _sourceClusterName);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.4.14
+version=29.5.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Add a callback method for ClusterInfoProvider.getDarkClusterConfigMap.

bumping the minor version because I technically made backwards incompatible changes to the Facilities interface (by not provide a default implementation of ClusterInfoProvider) and to ClusterInfoProvider (by adding a new interface method).

Also note that I did not deprecate the old interface method; there's a bug in the jdk that is preventing me from doing that. I suspect that the deprecation suppress works across modules but not within the same module, because I didn't get the warning for the MockClusterInfoProvider, but I did get it for ZKFSLoadBalancer and TogglingLoadBalancer.

Using this callback in DarkClusterStrategyFactoryImpl solves the timeout issue in startup, verified through pulling these changes into an app. I tried various ways to reproduce this in unit tests, but was unable to, even though we know the startup thread was blocked until timeout.