### PR TITLE
Allow publishing release candidate versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script: ./scripts/travis/build.sh
 branches:
   only:
     - master
-    - /^v\d+\.\d+\.\d+$/
+    - /^v\d+\.\d+\.\d+(-rc\.\d+)?$/
 
 # Set environment variables (includes Bintray credentials)
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,43 +13,45 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Allow publishing unstable release candidate versions of Rest.li (e.g. `1.2.3-rc.1`) from non-master branches.
+    - It's _strongly_ suggested to only use a release candidate version if you have a specific reason to do so.
 
 ## [29.5.1] - 2020-08-14
-- Provide an option in SmoothRateLimiter to not drop tasks if going above the max buffered. Dropping tasks might be more diruptive to workflows compared to just not ratelimit.
+- Provide an option in `SmoothRateLimiter` to not drop tasks if going above the max buffered. Dropping tasks might be more diruptive to workflows compared to just not ratelimit.
 
 ## [29.5.0] - 2020-08-12
-add Callback method for ClusterInfoProvider.getDarkClusterConfigMap
+- Add Callback method for `ClusterInfoProvider.getDarkClusterConfigMap`.
 
 ## [29.4.14] - 2020-08-11
-- Provide an option to set an overridden SSL socket factory for the default symbol table provider 
+- Provide an option to set an overridden SSL socket factory for the default symbol table provider.
 
 ## [29.4.13] - 2020-08-11
-- Undeprecate some Rest.li client methods since we do want the ability to set default content/accept types at the client level
+- Undeprecate some Rest.li client methods since we do want the ability to set default content/accept types at the client level.
 
 ## [29.4.12] - 2020-08-10
-- directly fetch DarkClusterConfigMap during startup, before registering ClusterListener.
+- Directly fetch `DarkClusterConfigMap` during startup, before registering `ClusterListener`.
 
 ## [29.4.11] - 2020-08-06
 - Relax validation of read-only fields for upsert usecase: UPDATE used for create or update. Fields marked as ReadOnly will be treated as optional for UPDATE methods.
 
 ## [29.4.10] - 2020-08-05
-- Allow RestRestliServer and StreamRestliServer throw RestException & StreamException with no stacktrace
+- Allow `RestRestliServer` and `StreamRestliServer` to throw `RestException` & `StreamException` with no stacktrace.
 
 ## [29.4.9] - 2020-08-04
-- Add missing ClusterInfoProvider implementations in ZKFSLoadBalancer and TogglingLoadBalancer
+- Add missing `ClusterInfoProvider` implementations in `ZKFSLoadBalancer` and `TogglingLoadBalancer`.
 
 ## [29.4.8] - 2020-08-04
-- Add identical traffic multiplier strategy for dark clusters to enable identical traffic across all dark clusters
+- Add identical traffic multiplier strategy for dark clusters to enable identical traffic across all dark clusters.
 
 ## [29.4.7] - 2020-07-30
 - Add support for configuring fields that are always projected on the server. Configs can be applied for the entire service, resource or method level.
 
 ## [29.4.6] - 2020-07-29
 - Provide a default symbol table provider implementation that doesn't use symbol tables for requests/responses of its own, but is able to retrieve remote symbol tables to decode responses from other services (#357)
-- Provide public method in the AbstractRequestBuilder for adding field projections (#353)
+- Provide public method in the `AbstractRequestBuilder` for adding field projections (#353)
 
 ## [29.4.5] - 2020-07-21
-- Update ExtensionSchemaValidation task to check extension schema annotation (#254)
+- Update `ExtensionSchemaValidation` task to check extension schema annotation (#254)
 - Improve performance of uri mask encoding and decoding (#350)
 
 ## [29.4.4] - 2020-07-02
@@ -59,7 +61,7 @@ add Callback method for ClusterInfoProvider.getDarkClusterConfigMap
 - Add an option (enabled by default) to gracefully degrade on encountering invalid surrogate pairs during protobuf string serialization (#334)
 
 ## [29.4.2] - 2020-06-25
-- Update Pegasus Plugin's CopySchema tasks to delete stale schemas (#337)
+- Update Pegasus Plugin's `CopySchema` tasks to delete stale schemas (#337)
 
 ## [29.4.1] - 2020-06-24
 - Relax visibility of some methods in PDL schema parser to allow extending it.

--- a/scripts/help-text/release.txt
+++ b/scripts/help-text/release.txt
@@ -1,9 +1,13 @@
 Usage: ./scripts/release [OPTION]... [TARGET_COMMIT]
-Releases a new version of Rest.li by creating and pushing a tag at TARGET_COMMIT (defaults to HEAD).
-This script must be run from the root project directory.
+Releases a new version of Rest.li by creating and pushing a tag at TARGET_COMMIT (defaults to HEAD). This script must be
+run from the root project directory. TARGET_COMMIT must be an ancestor of master, unless the version being released is a
+release candidate version.
+
+Please note that the version used to create the tag will be the project version defined at HEAD, not at TARGET_COMMIT,
+though this should be fixed in the future.
 
 Options:
-  -h, --help                    print this help text and exit
+  -h, --help                    print this help text and exit.
 
 Examples:
   ./scripts/release             create and push a release tag at HEAD

--- a/scripts/release
+++ b/scripts/release
@@ -17,7 +17,7 @@ for ARG in "$@"; do
     cat ./scripts/help-text/release.txt
     exit 0
   else
-    TARGET="$1"
+    TARGET="$ARG"
   fi
 done
 
@@ -30,11 +30,9 @@ if [ $? != 0 ]; then
   exit 2
 fi
 
-# Ensure that the target commit is an ancestor of master
-git merge-base --is-ancestor $TARGET_COMMIT master
-if [ $? != 0 ]; then
-  echo "Invalid target: $TARGET"
-  echo 'Please select a target commit which is an ancestor of master.'
+# Abort if there are uncommitted changes in the properties file
+if [ "$(git diff -- $PROPERTIES_FILE)" ]; then
+  echo "There are uncommitted changes in $PROPERTIES_FILE, please try again once all your changes are committed."
   exit 1
 fi
 
@@ -45,9 +43,64 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
+# Determine if the version is a release candidate version
+RELEASE_CANDIDATE=false
+if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+  RELEASE_CANDIDATE=true
+fi
+
+# Ensure that the target commit is an ancestor of master
+git merge-base --is-ancestor $TARGET_COMMIT master
+if [ $? != 0 ]; then
+  if $RELEASE_CANDIDATE; then
+    # Since this is a release candidate, allow it with a warning and confirmation
+    echo -n "You're attempting to publish a release candidate from a non-master branch. Are you sure you want to do this? (y/N) "
+    read ANSWER
+    if [[ ! "$ANSWER" =~ ^[yY]+$ ]]; then
+      echo 'Aborting...'
+      exit 1
+    fi
+  else
+    # In the general case, don't allow it
+    echo "Invalid target: $TARGET"
+    echo 'Please select a target commit which is an ancestor of master.'
+    exit 1
+  fi
+fi
+
+# Update local tags
+echo -n 'Updating local tags via remote fetch... '
+git fetch origin > /dev/null 2>&1
+echo 'done'
+
+# Perform some release candidate assertions, if applicable
+if $RELEASE_CANDIDATE; then
+  SUFFIXLESS_VERSION=${VERSION%-*}
+  # Assert that this release candidate precedes the associated release
+  if [ "$(git tag --list v$SUFFIXLESS_VERSION)" ]; then
+    echo "Cannot create release candidate $VERSION, as a release for $SUFFIXLESS_VERSION already exists."
+    echo "Release candidates must come before proper releases, so please bump the project version in $PROPERTIES_FILE and try again."
+    exit 1
+  fi
+  # Assert that there exists no available lower RC number (e.g. don't allow 1.2.3-rc.2 if 1.2.3-rc.1 is available)
+  RC_NUMBER=1
+  while true; do
+    RC_VERSION="$SUFFIXLESS_VERSION-rc.$RC_NUMBER"
+    # Break once we've reached the current RC number
+    if [ "$VERSION" = "$RC_VERSION" ]; then break; fi
+    # If this lower RC number is available, fail and suggest the user to use this RC number instead
+    if [ -z "$(git tag --list "v$RC_VERSION")" ]; then
+      echo "Cannot create release candidate $VERSION, as $RC_VERSION doesn't exist."
+      echo "Please try again using $RC_VERSION as the project version in $PROPERTIES_FILE."
+      exit 1
+    fi
+    let 'RC_NUMBER++'
+  done
+fi
+
 # Ensure that release tag name wouldn't conflict with a local branch
 TAG_NAME="v$VERSION"
-git show-ref --verify refs/heads/$TAG_NAME >/dev/null 2>&1
+git show-ref --verify refs/heads/$TAG_NAME > /dev/null 2>&1
 if [ $? = 0 ]; then
   echo "Cannot create tag $TAG_NAME, as it would conflict with a local branch of the same name."
   echo 'Please delete this branch and avoid naming branches like this in the future.'

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -21,8 +21,15 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
+# Determine if the version is a release candidate version
+RELEASE_CANDIDATE=false
+if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+  RELEASE_CANDIDATE=true
+fi
+
 # If the project version is being bumped in this PR, assert that the changelog contains an entry for it
-if (git diff ${TRAVIS_BRANCH}...HEAD -- gradle.properties | grep -F "+version=$VERSION" > /dev/null) &&
+if (! $RELEASE_CANDIDATE) &&
+    (git diff ${TRAVIS_BRANCH}...HEAD -- gradle.properties | grep -F "+version=$VERSION" > /dev/null) &&
     ! ( (cat CHANGELOG.md | grep -F "## [$VERSION] -" > /dev/null) &&
         (cat CHANGELOG.md | grep -F "[$VERSION]: https" > /dev/null) ); then
   echo "This change bumps the project version to $VERSION, but no changelog entry could be found for this version!"


### PR DESCRIPTION
This change will allow the maintainers of Rest.li to publish release
candidate versions (e.g. `1.2.3-rc.1`) from non-master branches in order
to test experimental features in a safe way as dictated by industry
convention as per the [SemVer](https://semver.org/) spec. Also cleans up the changelog a bit.

Notes:
- Changes to `scripts/release` add support and assertions for the local CLI.
- Changes to `scripts/travis/publish-tag.sh` add support on the Travis CI side.
- The change to `.travis.yml` enables deployment (i.e. bintray publishing) for RC tags.