### PR TITLE
Treat ReadOnly fields as optional in PU patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.5.3] - 2020-08-17
+- Treat `ReadOnly` required fields as optional in `PARTIAL_UPDATE`/`BATCH_PARTIAL_UPDATE` patches.
+  This will allow such patches to set fields containing descendent `ReadOnly` required fields, which wasn't possible before.
+
 ## [29.5.2] - 2020-08-17
 - Allow publishing unstable release candidate versions of Rest.li (e.g. `1.2.3-rc.1`) from non-master branches.
     - It's _strongly_ suggested to only use a release candidate version if you have a specific reason to do so.
-- Put extension schemas into the dataTemplate jar under /extensions path instead of putting them into the extensionSchema jar.
-- Remove stacktrace when convert between RestException and Stream Exception
+- Put extension schemas into the `dataTemplate` jar under `/extensions` path instead of putting them into the `extensionSchema` jar.
+- Remove stacktrace when convert between `RestException` and `StreamException`.
 
 ## [29.5.1] - 2020-08-14
 - Provide an option in `SmoothRateLimiter` to not drop tasks if going above the max buffered. Dropping tasks might be more diruptive to workflows compared to just not ratelimit.
@@ -4596,7 +4600,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.5.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.5.3...master
+[29.5.3]: https://github.com/linkedin/rest.li/compare/v29.5.2...v29.5.3
 [29.5.2]: https://github.com/linkedin/rest.li/compare/v29.5.1...v29.5.2
 [29.5.1]: https://github.com/linkedin/rest.li/compare/v29.4.14...v29.5.1
 [29.4.14]: https://github.com/linkedin/rest.li/compare/v29.4.13...v29.4.14

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.5.2
+version=29.5.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRestLiValidation.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRestLiValidation.java
@@ -64,17 +64,16 @@ import com.linkedin.restli.examples.greetings.client.ValidationDemosRequestBuild
 import com.linkedin.restli.server.validation.RestLiValidationFilter;
 import com.linkedin.restli.test.util.PatchBuilder;
 import com.linkedin.restli.test.util.RootBuilderWrapper;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 
 /**
@@ -558,6 +557,8 @@ public class TestRestLiValidation extends RestLiIntegrationTest
             "{\"patch\": {\"validationDemoNext\": {\"$set\": {\"stringA\": \"some value\"}}}}",
             // A field (MapWithTyperefs/key1) containing a CreateOnly field (MapWithTyperefs/key1/id) has to be partially set
             "{\"patch\": {\"MapWithTyperefs\": {\"key1\": {\"$set\": {\"message\": \"some message\", \"tone\": \"SINCERE\"}}}}}",
+            // Okay to set a field containing a ReadOnly field by omitting the ReadOnly field
+            "{\"patch\": {\"$set\": {\"ArrayWithInlineRecord\": [{\"bar2\": \"missing bar1\"}]}}}",
             // Okay to delete a field containing a ReadOnly field
             "{\"patch\": {\"$delete\": [\"ArrayWithInlineRecord\"]}}",
             // Okay to delete a field containing a CreateOnly field


### PR DESCRIPTION
This fix treats `ReadOnly` required fields as optional when validating
`(BATCH)PARTIAL_UPDATE` patch inputs. Without this fix, users were unable
to perform patch set operations on record fields where the record
contains a `ReadOnly` field. Were the field included, it would fail
`ReadOnly` validation; were it omitted, it would fail since it's required.
With this fix, users can omit the field from the patch input.

**NOTE:** This PR is incomplete, as I still need to add integration tests.