### PR TITLE
Fixed build trackerClient bug when scheme does not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.6.0-rc.2] - 2020-08-20
+- Fixed uri scheme reading bug
+
 ## [29.6.0-rc.1] - 2020-08-17
 - Provide new load balancer option that uses average cluster latency as the latency baseline and calculates host latency relatively to the average cluster latency.
 
@@ -4599,7 +4602,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.0-rc.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.0-rc.2...master
+[29.6.0-rc.2]: https://github.com/linkedin/rest.li/compare/v29.6.0-rc.1...v29.6.0-rc.2
 [29.6.0-rc.1]: https://github.com/linkedin/rest.li/compare/v29.5.2...v29.6.0-rc.1
 [29.5.2]: https://github.com/linkedin/rest.li/compare/v29.5.1...v29.5.2
 [29.5.1]: https://github.com/linkedin/rest.li/compare/v29.4.14...v29.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.6.0-rc.2] - 2020-08-20
-- Fixed uri scheme reading bug
+- Fixed uri scheme reading bug when creating TrackerClient objects.
 
 ## [29.6.0-rc.1] - 2020-08-17
 - Provide new load balancer option that uses average cluster latency as the latency baseline and calculates host latency relatively to the average cluster latency.

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -782,7 +782,7 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
   }
 
   @Nullable
-  TrackerClient buildTrackerClient(URI uri, UriProperties uriProperties, String serviceName,
+  private TrackerClient buildTrackerClient(URI uri, UriProperties uriProperties, String serviceName,
       ServiceProperties serviceProperties)
   {
     TransportClient transportClient = getTransportClient(serviceName, uri);
@@ -797,10 +797,10 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
     }
 
     return serviceProperties == null ? null : TrackerClientFactory.createTrackerClient(uri,
-        uriProperties,
-        serviceProperties,
-        loadBalancerStrategy.getName(),
-        transportClient);
+                                                                                       uriProperties,
+                                                                                       serviceProperties,
+                                                                                       loadBalancerStrategy.getName(),
+                                                                                       transportClient);
   }
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -778,18 +778,29 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
   {
     LoadBalancerStateItem<ServiceProperties> servicePropertiesItem = _serviceProperties.get(serviceName);
     ServiceProperties serviceProperties = servicePropertiesItem == null ? null : servicePropertiesItem.getProperty();
+    return buildTrackerClient(uri, uriProperties, serviceName, serviceProperties);
+  }
 
+  @Nullable
+  TrackerClient buildTrackerClient(URI uri, UriProperties uriProperties, String serviceName,
+      ServiceProperties serviceProperties)
+  {
     TransportClient transportClient = getTransportClient(serviceName, uri);
+    LoadBalancerStrategy loadBalancerStrategy = _serviceStrategies.get(serviceName).get(uri.getScheme().toLowerCase());
     if (transportClient == null)
+    {
+      return null;
+    }
+    if (loadBalancerStrategy == null)
     {
       return null;
     }
 
     return serviceProperties == null ? null : TrackerClientFactory.createTrackerClient(uri,
-                                                                                       uriProperties,
-                                                                                       serviceProperties,
-                                                                                       _serviceStrategies.get(serviceName).get(uri.getScheme()).getName(),
-                                                                                       transportClient);
+        uriProperties,
+        serviceProperties,
+        loadBalancerStrategy.getName(),
+        transportClient);
   }
 
   /**
@@ -841,12 +852,7 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
 
       for (URI uri : uris)
       {
-
-        TrackerClient trackerClient = TrackerClientFactory.createTrackerClient(uri,
-                                                                               uriProperties,
-                                                                               serviceProperties,
-                                                                               _serviceStrategies.get(serviceName).get(uri.getScheme()).getName(),
-                                                                               _serviceClients.get(serviceName).get(uri.getScheme()));
+        TrackerClient trackerClient = buildTrackerClient(uri, uriProperties, serviceName, serviceProperties);
         if (trackerClient != null)
         {
           newTrackerClients.put(uri, trackerClient);

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerStateTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerStateTest.java
@@ -19,11 +19,9 @@ package com.linkedin.d2.balancer.simple;
 import com.linkedin.common.callback.Callbacks;
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
-import com.linkedin.d2.balancer.LoadBalancer;
 import com.linkedin.d2.balancer.LoadBalancerState;
 import com.linkedin.d2.balancer.LoadBalancerState.LoadBalancerStateListenerCallback;
 import com.linkedin.d2.balancer.LoadBalancerState.NullStateListenerCallback;
-import com.linkedin.d2.balancer.clients.DegraderTrackerClient;
 import com.linkedin.d2.balancer.clients.DegraderTrackerClientImpl;
 import com.linkedin.d2.balancer.clients.TrackerClient;
 import com.linkedin.d2.balancer.event.NoopEventEmitter;
@@ -86,8 +84,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import javax.xml.ws.Service;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerStateTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerStateTest.java
@@ -86,6 +86,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
+import javax.xml.ws.Service;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -1830,6 +1832,34 @@ public class SimpleLoadBalancerStateTest
 
     assertEquals(clusterListener1.getClusterRemovedCount(CLUSTER1_CLUSTER_NAME), 1, "expected 1 call indicating removal on shutdown");
     assertEquals(clusterListener1.getClusterRemovedCount(CLUSTER2_CLUSTER_NAME), 1, "expected 1 call indicating removal on shutdown");
+  }
+
+  @Test
+  public void testSchemeNotSupported()
+  {
+    reset();
+
+    // Create https uri and scheme only supports http
+    URI uri = URI.create("https://cluster-1/test1");
+    List<String> schemes = new ArrayList<>();
+    Map<Integer, PartitionData> partitionData = new HashMap<>(1);
+    partitionData.put(DefaultPartitionAccessor.DEFAULT_PARTITION_ID, new PartitionData(1d));
+    Map<URI, Map<Integer, PartitionData>> uriData = new HashMap<>();
+    uriData.put(uri, partitionData);
+
+    schemes.add("http");
+    // set up state
+    _state.listenToCluster("cluster-1", new NullStateListenerCallback());
+    _state.listenToService("service-1", new NullStateListenerCallback());
+    _serviceRegistry.put("service-1", new ServiceProperties("service-1", "cluster-1",
+        "/test", Arrays.asList("random"), Collections.emptyMap(),
+        null, null, schemes, null));
+    assertNull(_state.getClient("service-1", uri));
+
+    _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
+
+    TrackerClient client = _state.getClient("service-1", uri);
+    assertNull(client);
   }
 
   private static class TestShutdownCallback implements PropertyEventShutdownCallback

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.6.0-rc.1
+version=29.6.0-rc.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
When we applied version 29.6.0-rc.1 we found an issue at LinkedIn internal testing. The issue is that the previous code assumes each uri will create a TrackerClient object, it did not check which scheme the uri supports. In reality, when client only supports one scheme, and server host can announce to both http and https. When that happens, we should explicitly check if the uri scheme is supported by client side, if not, we should return null when getting the TrackerClient.

Testing:
1. Added unit test
2. Generated snapshot and tested in identity-mt's pcl, it passed now