### PR TITLE
Fix ChangedFileReportTask.java for gradle 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.5.8] - 2020-08-27
+- Make `ChangedFileReportTask` gradle task compatible with Gradle 6.0
+
 ## [29.5.7] - 2020-08-26
 - Add pdsc support for ExtensionsDataSchemaResolver for support legacy files in pdsc
 - Add/patch default values in restli response, controlled by $sendDefault flag in URL or server configs
@@ -4614,7 +4617,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.5.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.5.8...master
+[29.5.8]: https://github.com/linkedin/rest.li/compare/v29.5.7...v29.5.8
 [29.5.7]: https://github.com/linkedin/rest.li/compare/v29.5.6...v29.5.7
 [29.5.6]: https://github.com/linkedin/rest.li/compare/v29.5.5...v29.5.6
 [29.5.5]: https://github.com/linkedin/rest.li/compare/v29.5.4...v29.5.5

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ChangedFileReportTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ChangedFileReportTask.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -20,6 +21,12 @@ public class ChangedFileReportTask extends DefaultTask
 
   private FileCollection _idlFiles = getProject().files();
   private FileCollection _snapshotFiles = getProject().files();
+
+  public ChangedFileReportTask()
+  {
+    //with Gradle 6.0, Declaring an incremental task without outputs is not allowed.
+    getOutputs().upToDateWhen(Specs.satisfyNone());
+  }
 
   @TaskAction
   public void checkFilesForChanges(IncrementalTaskInputs inputs)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.5.7
+version=29.5.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Declaring an incremental task without declaring outputs is now deprecated. Declare file outputs or use TaskOutputs.upToDateWhen() instead. resolves #354

REF: https://docs.gradle.org/current/userguide/upgrading_version_5.html#declaring_an_incremental_task_without_outputs