### PR TITLE
Update default values in d2 client based on global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.6.2] - 2020-08-31
+- Updated d2 client default config values
+
 ## [29.6.1] - 2020-08-31
 - Update R2's HTTP client API to support other Netty EventLoopGroup in addition to NioEventLoopGroup
 - Fix a RetryClient bug where NullPointerException is raised when excluded hosts hint is not set at retry
@@ -4625,7 +4628,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.2...master
+[29.6.2]: https://github.com/linkedin/rest.li/compare/v29.6.1...v29.6.2
 [29.6.1]: https://github.com/linkedin/rest.li/compare/v29.6.0...v29.6.1
 [29.6.0]: https://github.com/linkedin/rest.li/compare/v29.5.8...v29.6.0
 [29.5.8]: https://github.com/linkedin/rest.li/compare/v29.5.7...v29.5.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.6.2] - 2020-08-31
-- Updated d2 client default config values
+- Updated d2 client default config values.
 
 ## [29.6.1] - 2020-08-31
 - Update R2's HTTP client API to support other Netty EventLoopGroup in addition to NioEventLoopGroup

--- a/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerPerformanceSimulation.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerPerformanceSimulation.java
@@ -371,7 +371,7 @@ public class TestLoadBalancerPerformanceSimulation {
 
     return new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.RELATIVE, DEFAULT_SERVICE_NAME, numHosts)
         .setConstantRequestCount(DEFAULT_REQUESTS_PER_INTERVAL)
-        .setNumIntervals(100)
+        .setNumIntervals(200)
         .setDynamicLatency(latencyCorrelationList)
         .setRelativeLoadBalancerStrategies(relativeStrategyProperties)
         .build();
@@ -396,7 +396,7 @@ public class TestLoadBalancerPerformanceSimulation {
 
     return new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.RELATIVE, DEFAULT_SERVICE_NAME, numHosts)
         .setConstantRequestCount(requestCountPerInterval)
-        .setNumIntervals(30)
+        .setNumIntervals(100)
         .setDynamicLatency(latencyCorrelationList)
         .setRelativeLoadBalancerStrategies(relativeStrategyProperties)
         .build();
@@ -416,7 +416,7 @@ public class TestLoadBalancerPerformanceSimulation {
 
     return new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.DEGRADER, DEFAULT_SERVICE_NAME, numHosts)
         .setConstantRequestCount(requestCountPerInterval)
-        .setNumIntervals(30)
+        .setNumIntervals(100)
         .setDynamicLatency(latencyCorrelationList)
         .build();
   }
@@ -441,7 +441,7 @@ public class TestLoadBalancerPerformanceSimulation {
 
     return new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.RELATIVE, DEFAULT_SERVICE_NAME, numHosts)
         .setConstantRequestCount(10000)
-        .setNumIntervals(30)
+        .setNumIntervals(100)
         .setDynamicLatency(latencyCorrelationList)
         .setRelativeLoadBalancerStrategies(relativeStrategyProperties)
         .build();
@@ -469,7 +469,7 @@ public class TestLoadBalancerPerformanceSimulation {
 
     return new LoadBalancerStrategyTestRunnerBuilder(loadBalancerStrategyType.RELATIVE, DEFAULT_SERVICE_NAME, numHosts)
         .setConstantRequestCount(numRequestsPerInterval)
-        .setNumIntervals(100)
+        .setNumIntervals(200)
         .setDynamicLatency(latencyCorrelationList)
         .setRelativeLoadBalancerStrategies(relativeStrategyProperties)
         .build();

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -60,7 +60,7 @@ public class D2ClientConfig
   boolean shutdownAsynchronously = false;
   boolean isSymlinkAware = true;
   Map<String, Map<String, Object>> clientServicesConfig = Collections.<String, Map<String, Object>>emptyMap();
-  boolean useNewEphemeralStoreWatcher = false;
+  boolean useNewEphemeralStoreWatcher = true;
   HealthCheckOperations healthCheckOperations = null;
   boolean enableSaveUriDataOnDisk = false;
   /**
@@ -70,7 +70,7 @@ public class D2ClientConfig
   ScheduledExecutorService _backupRequestsExecutorService = null;
   boolean retry = false;
   int retryLimit = DEAULT_RETRY_LIMIT;
-  boolean warmUp = false;
+  boolean warmUp = true;
   int warmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
   int zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   int warmUpConcurrentRequests = WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS;
@@ -83,7 +83,7 @@ public class D2ClientConfig
   PartitionAccessorRegistry partitionAccessorRegistry = null;
   Function<ZooKeeper, ZooKeeper> zooKeeperDecorator = null;
   Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories = Collections.emptyMap();
-  boolean requestTimeoutHandlerEnabled = false;
+  boolean requestTimeoutHandlerEnabled = true;
   SslSessionValidatorFactory sslSessionValidatorFactory = null;
   ZKPersistentConnection zkConnectionToUseForLB = null;
   ScheduledExecutorService startUpExecutorService = null;

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
@@ -57,8 +57,8 @@ public class WarmUpLoadBalancer extends LoadBalancerWithFacilitiesDelegator
   /**
    * Default max of concurrent outstanding warm up requests
    */
-  public static final int DEFAULT_CONCURRENT_REQUESTS = 20;
-  public static final int DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS = 30;
+  public static final int DEFAULT_CONCURRENT_REQUESTS = 1;
+  public static final int DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS = 60;
 
   private final ConcurrentLinkedDeque<Future<?>> _outstandingRequests;
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
@@ -219,9 +219,9 @@ public class WarmUpLoadBalancerTest
   }
 
   @Test(timeOut = 10000)
-  public void testThrottling() throws URISyntaxException, InterruptedException, ExecutionException, TimeoutException
+  public void testThrottling() throws InterruptedException
   {
-    int NRequests = 500;
+    int NRequests = 100;
     createNServicesIniFiles(NRequests);
 
     TestLoadBalancer balancer = new TestLoadBalancer(50);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.6.1
+version=29.6.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
In D2ClientConfig, there are several configurations that are using a completely new config from LinkedIn global config. In order to make the configuration in sync, especially for those who are not using default d2client from container, we are made this change.

All the configs I changed in this PR are based on global-config/globals/si-pegasus.src
 <property name="__r2d2DefaultClient__.r2d2Client.warmUp" value="true" /> 
 <property name="__r2d2DefaultClient__.r2d2Client.warmUpConcurrentRequests" value="1" /> 
 <property name="__r2d2DefaultClient__.r2d2Client.warmUpTimeoutSeconds" value="60" /> 
 <property name="__r2d2DefaultClient__.r2d2Client.enableRequestTimeoutPerRequest" value="true"/> 
 <w:wildcard name="^.*.useNewEphemeralStoreWatcher" type="^.*/com.linkedin.d2.client.factory.D2ClientFactory$" value="true"/>