### PR TITLE
Update ExtensionSchemaValidationCmdLineApp with more validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 - Fix a bug in `FileFormatDataSchemaParser` and remove `isExtensionEntry` method call to simplify the logic.
+- Update ExtensionSchemaValidationCmdLineApp with more validations.
 
 ## [29.6.3] - 2020-09-03
 - Updated HTTP/2 parent channel idle timeout logging level to info from error 

--- a/restli-tools/src/test/extensions/invalidExtensionAnnotation/FooExtensions.pdl
+++ b/restli-tools/src/test/extensions/invalidExtensionAnnotation/FooExtensions.pdl
@@ -1,0 +1,8 @@
+/**
+ * Invalid extension schema:
+ * @extension.bar is not a valid @extension annotation.
+ */
+record FooExtensions includes Foo {
+  @extension.bar = "finder: test"
+  injectedField: DummyKey
+}

--- a/restli-tools/src/test/extensions/invalidExtensionSchemaName/FooExtend.pdl
+++ b/restli-tools/src/test/extensions/invalidExtensionSchemaName/FooExtend.pdl
@@ -1,0 +1,9 @@
+/**
+ * Invalid extension schema:
+ * The name of the extension schema is not end with "Extensions".
+ */
+record FooExtend includes Foo {
+  @extension.versionSuffix = "V2"
+  @extension.using = "finder: test"
+  injectedField: DummyKey
+}

--- a/restli-tools/src/test/extensions/invalidFieldAnnotation/FooExtensions.pdl
+++ b/restli-tools/src/test/extensions/invalidFieldAnnotation/FooExtensions.pdl
@@ -1,0 +1,9 @@
+/**
+ * Invalid extension schema:
+ * The field type : DummyKeyWithoutAnnotation is not annotated with "resourceKey".
+ */
+record FooExtensions includes Foo {
+  @extension.versionSuffix = "V2"
+  @extension.using = "finder: test"
+  injectedField: DummyKeyWithoutAnnotation
+}

--- a/restli-tools/src/test/extensions/invalidFieldName/BazExtensions.pdl
+++ b/restli-tools/src/test/extensions/invalidFieldName/BazExtensions.pdl
@@ -1,0 +1,8 @@
+/**
+ * Invalid extension schema:
+ * The field name - "injectedField" has already defined in the included schema - Baz.
+ */
+record BazExtensions includes Baz {
+  @extension.using = "finder: test"
+  injectedField: array[DummyKey]
+}

--- a/restli-tools/src/test/extensions/invalidFieldType/FooExtensions.pdl
+++ b/restli-tools/src/test/extensions/invalidFieldType/FooExtensions.pdl
@@ -1,0 +1,9 @@
+/**
+ * Invalid extension schema:
+ * The field type of extension schema is neither a Typeref nor any array of Typeref
+ */
+record FooExtensions includes Foo {
+  @extension.versionSuffix = "V2"
+  @extension.using = "finder: test"
+  injectedField: DummyKeyWithWrongType
+}

--- a/restli-tools/src/test/extensions/invalidVersionSuffix/BarExtensions.pdl
+++ b/restli-tools/src/test/extensions/invalidVersionSuffix/BarExtensions.pdl
@@ -1,0 +1,9 @@
+/**
+ * Invalid extension schema:
+ * The value of @extension.versionSuffix does not match the value of @resourceKey.versionSuffix on DummyKey
+ */
+record BarExtensions includes Bar {
+  @extension.versionSuffix = "V3"
+  @extension.using = "finder: test"
+  injectedField: DummyKey
+}

--- a/restli-tools/src/test/extensions/validCase/BarExtensions.pdl
+++ b/restli-tools/src/test/extensions/validCase/BarExtensions.pdl
@@ -1,0 +1,4 @@
+record BarExtensions includes Bar {
+  @extension.using = "finder: test"
+  injectedField: array[DummyKey]
+}

--- a/restli-tools/src/test/extensions/validCase/FooExtensions.pdl
+++ b/restli-tools/src/test/extensions/validCase/FooExtensions.pdl
@@ -1,0 +1,5 @@
+record FooExtensions includes Foo {
+  @extension.versionSuffix = "V2"
+  @extension.using = "finder: test"
+  injectedField: DummyKey
+}

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -1,0 +1,100 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.linkedin.restli.tools.data;
+
+import java.io.File;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TestExtensionSchemaValidationCmdLineApp
+{
+  private String testDir = System.getProperty("testDir", new File("src/test").getAbsolutePath());
+  private String testPegasusDir = testDir + File.separator + "pegasus";
+  private String testExtensionDir = testDir + File.separator + "extensions";
+
+  @DataProvider
+  private Object[][] extensionSchemaInputFiles()
+  {
+    return new Object[][]
+        {
+            // In the array, first element is input directory of extension schema.
+            //               second element is whether the input extension schema is valid.
+            //               third element is the expected error message if the input extension schema is not valid.
+            {
+                "validCase",
+                true,
+                null
+            },
+            {
+                "invalidVersionSuffix",
+                false,
+                "versionSuffix value: 'V3' does not match the versionSuffix value which was defined in resourceKey annotation"
+            },
+            {
+                "invalidExtensionSchemaName",
+                false,
+                "Invalid extension schema name: 'FooExtend'. The name of the extension schema must be <baseSchemaName> + 'Extensions'"
+            },
+            {
+                "invalidExtensionAnnotation",
+                false,
+                "Extension schema annotation is not valid: ERROR :: /bar :: unrecognized field found but not allowed\n"
+            },
+            {
+                "invalidFieldAnnotation",
+                false,
+                "Field schema: { \"type\" : \"typeref\", \"name\" : \"DummyKeyWithoutAnnotation\", "
+                    + "\"doc\" : \"A test schema which is used as a field type in extension schema.\", \"ref\" : \"string\" } is not annotated with 'resourceKey'"
+            },
+            {
+                "invalidFieldType",
+                false,
+                "Field schema: '{ \"type\" : \"record\", \"name\" : \"DummyKeyWithWrongType\", "
+                    + "\"doc\" : \"A test schema which is used as a field type in extension schema.\", \"fields\" : [  ] }' is not a TypeRef type."
+            },
+            {
+                "invalidFieldName",
+                false,
+                "Field \"injectedField\" defined more than once, with \"int\" defined in \"Baz\" and { \"type\" : \"array\", \"items\" : { \"type\" : "
+                    + "\"typeref\", \"name\" : \"DummyKey\", \"doc\" : \"A test schema which is used as a field type in extension schema.\","
+                    + " \"ref\" : \"string\", \"resourceKey\" : [ { \"entity\" : \"Profile\", \"keyConfig\" : { \"keys\" : { \"profilesId\" : "
+                    + "{ \"assocKey\" : { \"authorId\" : \"fabricName\", \"objectId\" : \"sessionId\" } } } }, \"resourcePath\" : \"/profiles/{profilesId}\" }, "
+                    + "{ \"entity\" : \"ProfileV2\", \"keyConfig\" : { \"keys\" : { \"profilesId\" : { \"assocKey\" : { \"authorId\" : \"fabricName\", \"objectId\" : "
+                    + "\"sessionId\" } } } }, \"resourcePath\" : \"/profilesV2/{profilesId}\", \"versionSuffix\" : \"V2\" } ] } } defined in \"BazExtensions\".\n"
+            }
+        };
+  }
+
+  @Test(dataProvider = "extensionSchemaInputFiles")
+  public void testExtensionSchemaValidation(String inputDir, boolean isValid, String errorMessage)
+  {
+      String resolverPath = testPegasusDir;
+      String inputPath = testExtensionDir + File.separator + inputDir;
+      try
+      {
+        ExtensionSchemaValidationCmdLineApp.parseAndValidateExtensionSchemas(resolverPath, new File(inputPath));
+        Assert.assertTrue(isValid);
+      }
+      catch (Exception e)
+      {
+        Assert.assertTrue(!isValid);
+        Assert.assertEquals(e.getMessage(), errorMessage);
+      }
+  }
+}

--- a/restli-tools/src/test/pegasus/Bar.pdl
+++ b/restli-tools/src/test/pegasus/Bar.pdl
@@ -1,0 +1,6 @@
+/**
+ * A test schema which is used as a base schema in extension schema.
+ */
+record Bar {
+  testField: int
+}

--- a/restli-tools/src/test/pegasus/Baz.pdl
+++ b/restli-tools/src/test/pegasus/Baz.pdl
@@ -1,0 +1,6 @@
+/**
+ * A test schema which is used as a base schema in extension schema.
+ */
+record Baz {
+  injectedField: int
+}

--- a/restli-tools/src/test/pegasus/DummyKey.pdl
+++ b/restli-tools/src/test/pegasus/DummyKey.pdl
@@ -1,0 +1,32 @@
+/**
+ * A test schema which is used as a field type in extension schema.
+ */
+@resourceKey = [ {
+  "keyConfig" : {
+    "keys" : {
+      "profilesId" : {
+        "assocKey" : {
+          "authorId" : "fabricName",
+          "objectId" : "sessionId"
+        }
+      }
+    }
+  },
+  "entity" : "Profile",
+  "resourcePath" : "/profiles/{profilesId}"
+}, {
+  "keyConfig" : {
+    "keys" : {
+      "profilesId" : {
+        "assocKey" : {
+          "authorId" : "fabricName",
+          "objectId" : "sessionId"
+        }
+      }
+    }
+  },
+  "entity" : "ProfileV2",
+  "resourcePath" : "/profilesV2/{profilesId}",
+  "versionSuffix" : "V2"
+} ]
+typeref DummyKey = string

--- a/restli-tools/src/test/pegasus/DummyKeyWithWrongType.pdl
+++ b/restli-tools/src/test/pegasus/DummyKeyWithWrongType.pdl
@@ -1,0 +1,4 @@
+/**
+ * A test schema which is used as a field type in extension schema.
+ */
+record DummyKeyWithWrongType {}

--- a/restli-tools/src/test/pegasus/DummyKeyWithoutAnnotation.pdl
+++ b/restli-tools/src/test/pegasus/DummyKeyWithoutAnnotation.pdl
@@ -1,0 +1,4 @@
+/**
+ * A test schema which is used as a field type in extension schema.
+ */
+typeref DummyKeyWithoutAnnotation = string

--- a/restli-tools/src/test/pegasus/Foo.pdl
+++ b/restli-tools/src/test/pegasus/Foo.pdl
@@ -1,0 +1,7 @@
+/**
+ * A test schema which is used as a base schema in extension schema.
+ */
+record Foo {
+  foo: int
+  bar: string
+}


### PR DESCRIPTION
Add following validations for extension schemas
1. The extension schema name has to follow the naming convention - 'baseSchemaName' + "Extensions"
2. The extension schema can only include base schema
3. The extension schema's fields can only be Typeref or array of Typeref
4. The extension schema's field's annotation - versionSuffix value has to match the versionSuffix value in "resourceKey" annotation.

And tests