### PR TITLE
Fix a bug when check with entry prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-- Fix a bug in FileFormatDataSchemaParser, where jar entry match failed because of case
+- Fix a bug in `FileFormatDataSchemaParser` and remove `isExtensionEntry` method call to simplify the logic.
 
 ## [29.6.3] - 2020-09-03
 - Updated HTTP/2 parent channel idle timeout logging level to info from error 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Fix a bug in FileFormatDataSchemaParser, where jar entry match failed because of case
 
 ## [29.6.3] - 2020-09-03
 - Updated HTTP/2 parent channel idle timeout logging level to info from error 

--- a/data/src/main/java/com/linkedin/data/schema/resolver/ExtensionsDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/ExtensionsDataSchemaResolver.java
@@ -18,8 +18,6 @@ package com.linkedin.data.schema.resolver;
 
 import com.linkedin.data.schema.DataSchemaParserFactory;
 import com.linkedin.data.schema.DataSchemaResolver;
-import com.linkedin.data.schema.grammar.PdlSchemaParser;
-import com.linkedin.data.schema.grammar.PdlSchemaParserFactory;
 
 
 /**

--- a/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
@@ -94,7 +94,7 @@ public class FileFormatDataSchemaParser {
                 final JarEntry entry = entries.nextElement();
                 if (!entry.isDirectory() &&
                     entry.getName().endsWith(_schemaParserFactory.getLanguageExtension()) &&
-                    (entry.getName().toLowerCase().startsWith(_schemaResolver.getSchemasDirectoryName().name().toLowerCase())))
+                    (entry.getName().toLowerCase().startsWith(_schemaResolver.getSchemasDirectoryName().name().toLowerCase() + "/")))
                 {
                   parseJarEntry(jarFile, entry, result);
                   result.getSourceFiles().add(sourceFile);

--- a/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
@@ -148,21 +148,6 @@ public class FileFormatDataSchemaParser {
   }
 
   /**
-   * Schema files when archived in a jar can start with pegasus/... or extensions/
-   * For the resolver that is supporting extensions as directory name, we like it to be included in the parsing
-   * @param entry an entry in the jar file, e.g. "pegasus/..." or "extensions/...."
-   * @return true if this entry starts with "extensions"
-   */
-  private boolean isExtensionEntry(JarEntry entry)
-  {
-    if (_schemaResolver.getSchemasDirectoryName() == SchemaDirectoryName.EXTENSIONS)
-    {
-      return entry.getName().startsWith(EXTENSION_PATH_ENTRY);
-    }
-    return false;
-  }
-
-  /**
    * Parse a source that specifies a file (not a fully qualified schema name).
    *
    * @param schemaSourceFile provides the source file.

--- a/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
@@ -94,7 +94,7 @@ public class FileFormatDataSchemaParser {
                 final JarEntry entry = entries.nextElement();
                 if (!entry.isDirectory() &&
                     entry.getName().endsWith(_schemaParserFactory.getLanguageExtension()) &&
-                    (entry.getName().toLowerCase().startsWith(_schemaResolver.getSchemasDirectoryName().name().toLowerCase() + "/")))
+                    (entry.getName().startsWith(_schemaResolver.getSchemasDirectoryName().getName() + "/")))
                 {
                   parseJarEntry(jarFile, entry, result);
                   result.getSourceFiles().add(sourceFile);

--- a/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
@@ -92,8 +92,9 @@ public class FileFormatDataSchemaParser {
               while (entries.hasMoreElements())
               {
                 final JarEntry entry = entries.nextElement();
-                if (!entry.isDirectory() && entry.getName().endsWith(_schemaParserFactory.getLanguageExtension()) &&
-                    (entry.getName().startsWith(_schemaResolver.getSchemasDirectoryName().getName()) || isExtensionEntry(entry)))
+                if (!entry.isDirectory() &&
+                    entry.getName().endsWith(_schemaParserFactory.getLanguageExtension()) &&
+                    (entry.getName().toLowerCase().startsWith(_schemaResolver.getSchemasDirectoryName().name().toLowerCase())))
                 {
                   parseJarEntry(jarFile, entry, result);
                   result.getSourceFiles().add(sourceFile);

--- a/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
+++ b/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
@@ -172,6 +172,54 @@ public class TestDataSchemaParser
     }
   }
 
+  @DataProvider(name = "PegasusSchemasWithExtensionResolver")
+  private Object[][] createPegasusSchemasWithExtensionResolver()
+  {
+    return new Object[][]
+        {
+            {
+                new String[]{
+                    "pegasus/Foo.pdl",
+                    "pegasus/Bar.pdl",
+                    "pegasus/Fuzz.pdsc"
+                },
+                new String[]{}
+            },
+        };
+  }
+
+  @Test(dataProvider = "PegasusSchemasWithExtensionResolver")
+  public void testBaseSchemaFilesInExtensionResolverInJar(String[] files, String[] expected) throws Exception
+  {
+    String tempDirectoryPath = _tempDir.getAbsolutePath();
+    String jarFile = tempDirectoryPath + FS + "test.jar";
+    String schemaDir = pegasusDir + FS + "extensionSchemas";
+    Map<String, String> entryToFileMap = Arrays.stream(files).collect(Collectors.toMap(
+        filename -> schemaDir + FS + filename,
+        filename -> filename));
+    createTempJarFile(entryToFileMap, jarFile);
+
+    ExtensionsDataSchemaResolver resolver = new ExtensionsDataSchemaResolver(jarFile);
+    try
+    {
+      DataSchemaParser parser = new DataSchemaParser(jarFile, resolver);
+      DataSchemaParser.ParseResult parseResult = parser.parseSources(new String[]{jarFile});
+      Map<DataSchema, DataSchemaLocation> schemas = parseResult.getSchemaAndLocations();
+      assertEquals(schemas.size(), expected.length);
+      Set<String> actualNames = schemas
+          .keySet()
+          .stream()
+          .map(dataSchema -> (NamedDataSchema) dataSchema)
+          .map(NamedDataSchema::getName)
+          .collect(Collectors.toSet());
+      assertEquals(actualNames, Arrays.stream(expected).collect(Collectors.toSet()));
+    }
+    catch (Exception e)
+    {
+      Assert.fail("Test failed");
+    }
+  }
+
   @Test(dataProvider = "entityRelationshipInputFiles")
   public void testSchemaFilesInExtensionPathInFolder(String[] files, String[] expectedExtensions) throws Exception
   {

--- a/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
+++ b/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
@@ -137,6 +137,14 @@ public class TestDataSchemaParser
                     "BarExtension"
                 }
             },
+            {
+                new String[]{
+                    "pegasus/Foo.pdl",
+                    "pegasus/Bar.pdl",
+                    "pegasus/Fuzz.pdsc"
+                },
+                new String[]{}
+            },
         };
   }
 
@@ -157,7 +165,7 @@ public class TestDataSchemaParser
       DataSchemaParser parser = new DataSchemaParser(jarFile, resolver);
       DataSchemaParser.ParseResult parseResult = parser.parseSources(new String[]{jarFile});
       Map<DataSchema, DataSchemaLocation> extensions = parseResult.getExtensionDataSchemaAndLocations();
-      assertEquals(extensions.size(), 3);
+      assertEquals(extensions.size(), expectedExtensions.length);
       Set<String> actualNames = extensions
           .keySet()
           .stream()
@@ -172,53 +180,6 @@ public class TestDataSchemaParser
     }
   }
 
-  @DataProvider(name = "PegasusSchemasWithExtensionResolver")
-  private Object[][] createPegasusSchemasWithExtensionResolver()
-  {
-    return new Object[][]
-        {
-            {
-                new String[]{
-                    "pegasus/Foo.pdl",
-                    "pegasus/Bar.pdl",
-                    "pegasus/Fuzz.pdsc"
-                },
-                new String[]{}
-            },
-        };
-  }
-
-  @Test(dataProvider = "PegasusSchemasWithExtensionResolver")
-  public void testBaseSchemaFilesInExtensionResolverInJar(String[] files, String[] expected) throws Exception
-  {
-    String tempDirectoryPath = _tempDir.getAbsolutePath();
-    String jarFile = tempDirectoryPath + FS + "test.jar";
-    String schemaDir = pegasusDir + FS + "extensionSchemas";
-    Map<String, String> entryToFileMap = Arrays.stream(files).collect(Collectors.toMap(
-        filename -> schemaDir + FS + filename,
-        filename -> filename));
-    createTempJarFile(entryToFileMap, jarFile);
-
-    ExtensionsDataSchemaResolver resolver = new ExtensionsDataSchemaResolver(jarFile);
-    try
-    {
-      DataSchemaParser parser = new DataSchemaParser(jarFile, resolver);
-      DataSchemaParser.ParseResult parseResult = parser.parseSources(new String[]{jarFile});
-      Map<DataSchema, DataSchemaLocation> schemas = parseResult.getSchemaAndLocations();
-      assertEquals(schemas.size(), expected.length);
-      Set<String> actualNames = schemas
-          .keySet()
-          .stream()
-          .map(dataSchema -> (NamedDataSchema) dataSchema)
-          .map(NamedDataSchema::getName)
-          .collect(Collectors.toSet());
-      assertEquals(actualNames, Arrays.stream(expected).collect(Collectors.toSet()));
-    }
-    catch (Exception e)
-    {
-      Assert.fail("Test failed");
-    }
-  }
 
   @Test(dataProvider = "entityRelationshipInputFiles")
   public void testSchemaFilesInExtensionPathInFolder(String[] files, String[] expectedExtensions) throws Exception
@@ -234,7 +195,7 @@ public class TestDataSchemaParser
       String[] schemaFiles = Arrays.stream(files).map(casename -> pegasusDir + FS + "extensionSchemas" + FS + casename).toArray(String[]::new);
       DataSchemaParser.ParseResult parseResult = parser.parseSources(schemaFiles);
       Map<DataSchema, DataSchemaLocation> extensions = parseResult.getExtensionDataSchemaAndLocations();
-      assertEquals(extensions.size(), 3);
+      assertEquals(extensions.size(), expectedExtensions.length);
       Set<String> actualNames = extensions
           .keySet()
           .stream()


### PR DESCRIPTION
When we are parsing schemas from a jar, the entry from both "pegasus" and "extension" should be considered. But in the code when we check if it is "pegasus" , I use
```
entry.getName().startsWith(_schemaResolver.getSchemasDirectoryName().getName()) || isExtensionEntry(entry)
```
where the resolver will return "extension" when getSchemasDirectoryName is called. Which is an error while it should be 
```
entry.getName().startsWith("pegasus") || isExtensionEntry(entry)
```

The semantic is to say: if the entry is either started with "pegasus" or started with "extension", I will parse this entry