### PR TITLE
Update RestLiValidatorFilter and RestLiDataValidator to expose creation of restli validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.6.3] - 2020-09-09
+- Update RestLiValidatorFilter and RestLiDataValidator to expose creation of restli validators
+
 ## [29.6.2] - 2020-08-31
 - Updated d2 client default config values.
 
@@ -4629,7 +4632,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.3...master
+[29.6.3]: https://github.com/linkedin/rest.li/compare/v29.6.2...v29.6.3
 [29.6.2]: https://github.com/linkedin/rest.li/compare/v29.6.1...v29.6.2
 [29.6.1]: https://github.com/linkedin/rest.li/compare/v29.6.0...v29.6.1
 [29.6.0]: https://github.com/linkedin/rest.li/compare/v29.5.8...v29.6.0

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -1013,6 +1013,34 @@ public class TestSchemaTranslator
               null
           },
           {
+              // required array of record field with default.
+              "{ " +
+                  "  \"type\" : \"record\", " +
+                  "  \"name\" : \"foo\", " +
+                  "  \"fields\" : [ " +
+                  "    { " +
+                  "      \"name\" : \"f1\", " +
+                  "      \"type\" : { " +
+                  "         \"type\": \"array\", " +
+                  "         \"items\": { " +
+                  "           \"type\" : \"record\", " +
+                  "           \"name\" : \"bar\", " +
+                  "           \"fields\" : [ " +
+                  "             { \"name\" : \"b1\", \"type\" : \"int\" } " +
+                  "            ] " +
+                  "          } " +
+                  "       }, " +
+                  "       \"default\": [] " +
+                  "    } "+
+                  "  ] " +
+                  "}",
+              allModes,
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"f1\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" } ] } }, \"default\" : [  ] } ] }",
+              null,
+              null,
+              null
+          },
+          {
               // include
               "{ " +
                   "  \"type\" : \"record\", " +

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.6.2
+version=29.6.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
@@ -16,8 +16,10 @@
 
 package com.linkedin.restli.common.validation;
 
+import com.linkedin.common.callback.Function;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.validation.ValidationResult;
+import com.linkedin.data.schema.validator.DataSchemaAnnotationValidator;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.transform.filter.request.MaskTree;
 import com.linkedin.restli.common.ResourceMethod;
@@ -32,6 +34,7 @@ import java.util.Collections;
  */
 public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
   private final DataSchema _validatingSchema;
+  private final Function<DataSchema, DataSchemaAnnotationValidator> _validatorInitFunc;
 
   /**
    * Constructor.
@@ -53,6 +56,7 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
     }
 
     _validatingSchema = validatingSchema;
+    _validatorInitFunc = DataSchemaAnnotationValidator::new;
   }
 
   /**
@@ -63,7 +67,7 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
   @Override
   public ValidationResult validateOutput(RecordTemplate dataTemplate)
   {
-    return super.validateOutputAgainstSchema(dataTemplate, _validatingSchema);
+    return super.validateOutputAgainstSchema(dataTemplate, _validatingSchema, _validatorInitFunc);
   }
 
   /**

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
@@ -34,7 +34,6 @@ import java.util.Collections;
  */
 public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
   private final DataSchema _validatingSchema;
-  private final DataValidator _inputDataValidator;
   private final DataSchemaAnnotationValidator _outputSchemaValidator;
 
   /**
@@ -57,7 +56,6 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
     }
 
     _validatingSchema = validatingSchema;
-    _inputDataValidator = new DataValidator(_validatingSchema);
     _outputSchemaValidator = new DataSchemaAnnotationValidator(_validatingSchema);
   }
 
@@ -87,18 +85,6 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
     else
     {
       return super.getValidatorForOutput(validatingSchema);
-    }
-  }
-
-  @Override
-  protected Validator getValidatorForInput(DataSchema validatingSchema) {
-    if (_validatingSchema.equals(validatingSchema))
-    {
-      return _inputDataValidator;
-    }
-    else
-    {
-      return super.getValidatorForInput(validatingSchema);
     }
   }
 

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 
 /**
  * Extension of {@link RestLiDataValidator} to allow for validation against a provided data schema.
+ * This validator is only used for output validation.
  *
  * @author Evan Williams
  */

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.restli.common.validation;
 
-import com.linkedin.common.callback.Function;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.validation.ValidationResult;
 import com.linkedin.data.schema.validator.DataSchemaAnnotationValidator;
@@ -34,7 +33,7 @@ import java.util.Collections;
  */
 public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
   private final DataSchema _validatingSchema;
-  private final Function<DataSchema, DataSchemaAnnotationValidator> _validatorInitFunc;
+  private final DataSchemaAnnotationValidator _schemaValidator;
 
   /**
    * Constructor.
@@ -56,7 +55,7 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
     }
 
     _validatingSchema = validatingSchema;
-    _validatorInitFunc = DataSchemaAnnotationValidator::new;
+    _schemaValidator = new DataSchemaAnnotationValidator(_validatingSchema);
   }
 
   /**
@@ -67,7 +66,7 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
   @Override
   public ValidationResult validateOutput(RecordTemplate dataTemplate)
   {
-    return super.validateOutputAgainstSchema(dataTemplate, _validatingSchema, _validatorInitFunc);
+    return super.validateOutputAgainstSchema(dataTemplate, _validatingSchema, _schemaValidator);
   }
 
   /**

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
@@ -78,14 +78,14 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
    * @return validator
    */
   @Override
-  protected Validator getValidatorForOutput(DataSchema validatingSchema) {
+  protected Validator getValidatorForOutputEntityValidation(DataSchema validatingSchema) {
     if (_validatingSchema.equals(validatingSchema))
     {
       return _outputSchemaValidator;
     }
     else
     {
-      return super.getValidatorForOutput(validatingSchema);
+      return super.getValidatorForOutputEntityValidation(validatingSchema);
     }
   }
 

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
@@ -17,6 +17,8 @@
 package com.linkedin.restli.common.validation;
 
 import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.validation.ValidateDataAgainstSchema;
+import com.linkedin.data.schema.validation.ValidationOptions;
 import com.linkedin.data.schema.validation.ValidationResult;
 import com.linkedin.data.schema.validator.DataSchemaAnnotationValidator;
 import com.linkedin.data.template.RecordTemplate;
@@ -66,7 +68,9 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
   @Override
   public ValidationResult validateOutput(RecordTemplate dataTemplate)
   {
-    return super.validateOutputAgainstSchema(dataTemplate, _validatingSchema, _schemaValidator);
+    return super.validateOutputAgainstSchema(dataTemplate,
+        () -> ValidateDataAgainstSchema.validate(dataTemplate.data(), _validatingSchema, new ValidationOptions(),
+            _schemaValidator));
   }
 
   /**

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
@@ -78,7 +78,11 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
    * @return validator
    */
   @Override
-  protected Validator getValidatorForOutputEntityValidation(DataSchema validatingSchema) {
+  protected Validator getValidatorForOutputEntityValidation(DataSchema validatingSchema)
+  {
+    // Validates that the schema passed in is the same as the schema used in the constructor
+    // Intentionally does an == check to avoid a more computational heavy .equals for larger schemas
+    // Only if this is true, return the validator created in the constructor
     if (_validatingSchema == validatingSchema)
     {
       return _outputSchemaValidator;

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataSchemaDataValidator.java
@@ -79,7 +79,7 @@ public class RestLiDataSchemaDataValidator extends RestLiDataValidator {
    */
   @Override
   protected Validator getValidatorForOutputEntityValidation(DataSchema validatingSchema) {
-    if (_validatingSchema.equals(validatingSchema))
+    if (_validatingSchema == validatingSchema)
     {
       return _outputSchemaValidator;
     }

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
@@ -528,7 +528,7 @@ public class RestLiDataValidator
     // Custom validation rules and Rest.li annotations for set operations are checked here.
     // It's okay if required fields are absent in a partial update request, so use ignore mode.
     return ValidateDataAgainstSchema.validate(new SimpleDataElement(entity.data(), entity.schema()),
-        new ValidationOptions(RequiredMode.IGNORE), getValidatorForInput(entity.schema()));
+        new ValidationOptions(RequiredMode.IGNORE), getValidatorForInputEntityValidation(entity.schema()));
   }
 
   /**
@@ -608,20 +608,20 @@ public class RestLiDataValidator
     //  the client cannot supply them in a create request, so they should be treated as optional.
     //  similarly for update requests used as upsert (update to create), they are treated as optional.
     validationOptions.setTreatOptional(_readOnlyOptionalPredicate);
-    return ValidateDataAgainstSchema.validate(entity, validationOptions, getValidatorForInput(entity.schema()));
+    return ValidateDataAgainstSchema.validate(entity, validationOptions, getValidatorForInputEntityValidation(entity.schema()));
   }
 
   private ValidationResult validateOutputEntity(RecordTemplate entity, DataSchema validatingSchema)
   {
     return ValidateDataAgainstSchema.validate(entity.data(), validatingSchema, new ValidationOptions(),
-        getValidatorForOutput(validatingSchema));
+        getValidatorForOutputEntityValidation(validatingSchema));
   }
 
-  protected Validator getValidatorForOutput(DataSchema validatingSchema) {
+  protected Validator getValidatorForOutputEntityValidation(DataSchema validatingSchema) {
     return new DataSchemaAnnotationValidator(validatingSchema);
   }
 
-  protected Validator getValidatorForInput(DataSchema validatingSchema) {
+  protected Validator getValidatorForInputEntityValidation(DataSchema validatingSchema) {
     return new DataValidator(validatingSchema);
   }
 

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
@@ -168,12 +168,12 @@ public class RestLiDataValidator
         if (annotation.annotationType() == ReadOnly.class)
         {
           annotationMap.put(ReadOnly.class.getAnnotation(RestSpecAnnotation.class).name(),
-                            Arrays.asList(((ReadOnly) annotation).value()));
+              Arrays.asList(((ReadOnly) annotation).value()));
         }
         else if (annotation.annotationType() == CreateOnly.class)
         {
           annotationMap.put(CreateOnly.class.getAnnotation(RestSpecAnnotation.class).name(),
-                            Arrays.asList(((CreateOnly) annotation).value()));
+              Arrays.asList(((CreateOnly) annotation).value()));
         }
       }
     }
@@ -201,9 +201,9 @@ public class RestLiDataValidator
    * @param validatorClassMap custom validator class map (see {@link #RestLiDataValidator(Map, Class, ResourceMethod, Map)} for explanation)
    */
   public RestLiDataValidator(Annotation[] annotations,
-                             Class<? extends RecordTemplate> valueClass,
-                             ResourceMethod resourceMethod,
-                             Map<String, Class<? extends Validator>> validatorClassMap)
+      Class<? extends RecordTemplate> valueClass,
+      ResourceMethod resourceMethod,
+      Map<String, Class<? extends Validator>> validatorClassMap)
   {
     this(annotationsToMap(annotations), valueClass, resourceMethod, validatorClassMap);
   }
@@ -216,8 +216,8 @@ public class RestLiDataValidator
    * @param resourceMethod resource method type
    */
   public RestLiDataValidator(Map<String, List<String>> annotations,
-                             Class<? extends RecordTemplate> valueClass,
-                             ResourceMethod resourceMethod)
+      Class<? extends RecordTemplate> valueClass,
+      ResourceMethod resourceMethod)
   {
     this(annotations, valueClass, resourceMethod, Collections.emptyMap());
   }
@@ -233,9 +233,9 @@ public class RestLiDataValidator
    *                          (e.g. "strlen" as key and StrlenValidator.class as value)
    */
   public RestLiDataValidator(Map<String, List<String>> annotations,
-                             Class<? extends RecordTemplate> valueClass,
-                             ResourceMethod resourceMethod,
-                             Map<String, Class<? extends Validator>> validatorClassMap)
+      Class<? extends RecordTemplate> valueClass,
+      ResourceMethod resourceMethod,
+      Map<String, Class<? extends Validator>> validatorClassMap)
   {
     List<Predicate> readOnly = new ArrayList<>();
     List<Predicate> createOnly = new ArrayList<>();
@@ -323,7 +323,8 @@ public class RestLiDataValidator
       case BATCH_GET:
       case FINDER:
       case GET_ALL:
-        return validateOutputEntity((RecordTemplate) dataTemplate, null, new DataSchemaAnnotationValidator(null));
+        return ValidateDataAgainstSchema.validate(((RecordTemplate) dataTemplate).data(), null,
+            new ValidationOptions(), new DataSchemaAnnotationValidator(null));
       default:
         throw new IllegalArgumentException("Cannot perform Rest.li validation for " + _resourceMethod.toString());
     }
@@ -443,26 +444,11 @@ public class RestLiDataValidator
     }
 
     return validateOutputAgainstSchema(dataTemplate,
-        () -> validateOutputEntity(dataTemplate, validatingSchema, new DataSchemaAnnotationValidator(validatingSchema)));
+        () -> ValidateDataAgainstSchema.validate(dataTemplate.data(), validatingSchema, new ValidationOptions(),
+            new DataSchemaAnnotationValidator(validatingSchema)));
   }
 
-  /**
-   * Validate Rest.li output data (single entity) against a validating schema.
-   *
-   * @param dataTemplate data to validate
-   * @param validatingSchema schema to use when validating
-   * @param schemaValidator validator to use on the data
-   * @return validation result
-   * @throws IllegalArgumentException if any argument is null or if the provided data template has no data
-   */
-  protected ValidationResult validateOutputAgainstSchema(RecordTemplate dataTemplate, DataSchema validatingSchema,
-      DataSchemaAnnotationValidator schemaValidator)
-  {
-    return validateOutputAgainstSchema(dataTemplate,
-        () -> validateOutputEntity(dataTemplate, validatingSchema, schemaValidator));
-  }
-
-  private ValidationResult validateOutputAgainstSchema(RecordTemplate dataTemplate,
+  protected ValidationResult validateOutputAgainstSchema(RecordTemplate dataTemplate,
       Supplier<ValidationResult> validationResultSupplier)
   {
     if (dataTemplate == null)
@@ -632,11 +618,6 @@ public class RestLiDataValidator
     //  similarly for update requests used as upsert (update to create), they are treated as optional.
     validationOptions.setTreatOptional(_readOnlyOptionalPredicate);
     return ValidateDataAgainstSchema.validate(entity, validationOptions, new DataValidator(entity.schema()));
-  }
-
-  private ValidationResult validateOutputEntity(RecordTemplate entity, DataSchema validatingSchema, DataSchemaAnnotationValidator validator)
-  {
-    return ValidateDataAgainstSchema.validate(entity.data(), validatingSchema, new ValidationOptions(), validator);
   }
 
   private static ValidationErrorResult validationResultWithErrorMessage(String errorMessage)

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
@@ -617,11 +617,13 @@ public class RestLiDataValidator
         getValidatorForOutputEntityValidation(validatingSchema));
   }
 
-  protected Validator getValidatorForOutputEntityValidation(DataSchema validatingSchema) {
+  protected Validator getValidatorForOutputEntityValidation(DataSchema validatingSchema)
+  {
     return new DataSchemaAnnotationValidator(validatingSchema);
   }
 
-  protected Validator getValidatorForInputEntityValidation(DataSchema validatingSchema) {
+  protected Validator getValidatorForInputEntityValidation(DataSchema validatingSchema)
+  {
     return new DataValidator(validatingSchema);
   }
 

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
@@ -168,12 +168,12 @@ public class RestLiDataValidator
         if (annotation.annotationType() == ReadOnly.class)
         {
           annotationMap.put(ReadOnly.class.getAnnotation(RestSpecAnnotation.class).name(),
-              Arrays.asList(((ReadOnly) annotation).value()));
+                            Arrays.asList(((ReadOnly) annotation).value()));
         }
         else if (annotation.annotationType() == CreateOnly.class)
         {
           annotationMap.put(CreateOnly.class.getAnnotation(RestSpecAnnotation.class).name(),
-              Arrays.asList(((CreateOnly) annotation).value()));
+                            Arrays.asList(((CreateOnly) annotation).value()));
         }
       }
     }
@@ -201,9 +201,9 @@ public class RestLiDataValidator
    * @param validatorClassMap custom validator class map (see {@link #RestLiDataValidator(Map, Class, ResourceMethod, Map)} for explanation)
    */
   public RestLiDataValidator(Annotation[] annotations,
-      Class<? extends RecordTemplate> valueClass,
-      ResourceMethod resourceMethod,
-      Map<String, Class<? extends Validator>> validatorClassMap)
+                             Class<? extends RecordTemplate> valueClass,
+                             ResourceMethod resourceMethod,
+                             Map<String, Class<? extends Validator>> validatorClassMap)
   {
     this(annotationsToMap(annotations), valueClass, resourceMethod, validatorClassMap);
   }
@@ -216,8 +216,8 @@ public class RestLiDataValidator
    * @param resourceMethod resource method type
    */
   public RestLiDataValidator(Map<String, List<String>> annotations,
-      Class<? extends RecordTemplate> valueClass,
-      ResourceMethod resourceMethod)
+                             Class<? extends RecordTemplate> valueClass,
+                             ResourceMethod resourceMethod)
   {
     this(annotations, valueClass, resourceMethod, Collections.emptyMap());
   }
@@ -233,9 +233,9 @@ public class RestLiDataValidator
    *                          (e.g. "strlen" as key and StrlenValidator.class as value)
    */
   public RestLiDataValidator(Map<String, List<String>> annotations,
-      Class<? extends RecordTemplate> valueClass,
-      ResourceMethod resourceMethod,
-      Map<String, Class<? extends Validator>> validatorClassMap)
+                             Class<? extends RecordTemplate> valueClass,
+                             ResourceMethod resourceMethod,
+                             Map<String, Class<? extends Validator>> validatorClassMap)
   {
     List<Predicate> readOnly = new ArrayList<>();
     List<Predicate> createOnly = new ArrayList<>();

--- a/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
@@ -150,7 +150,8 @@ public class RestLiValidationFilter implements Filter
     }
 
     ResourceMethod method = requestContext.getMethodType();
-    RestLiDataValidator validator = createRestLiDataValidator(requestContext);
+    RestLiDataValidator validator = new RestLiDataValidator(resourceClass.getAnnotations(),
+        requestContext.getFilterResourceModel().getValueClass(), method);
     RestLiRequestData requestData = requestContext.getRequestData();
 
     ValidationResult result;

--- a/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
@@ -475,7 +475,8 @@ public class RestLiValidationFilter implements Filter
    * @param requestContext {@link FilterRequestContext} to provide input to the data validator
    * @return a {@link RestLiDataValidator}
    */
-  protected RestLiDataValidator createRequestRestLiDataValidator(FilterRequestContext requestContext) {
+  protected RestLiDataValidator createRequestRestLiDataValidator(FilterRequestContext requestContext)
+  {
     return new RestLiDataValidator(requestContext.getFilterResourceModel().getResourceClass().getAnnotations(),
         requestContext.getFilterResourceModel().getValueClass(), requestContext.getMethodType());
   }
@@ -487,7 +488,8 @@ public class RestLiValidationFilter implements Filter
    * @param requestContext {@link FilterRequestContext} to provide input to the data validator
    * @return a {@link RestLiDataValidator}
    */
-  protected RestLiDataValidator createResponseRestLiDataValidator(FilterRequestContext requestContext) {
+  protected RestLiDataValidator createResponseRestLiDataValidator(FilterRequestContext requestContext)
+  {
     // Get validating schema if it was already built in onRequest
     DataSchema validatingSchema = (DataSchema) requestContext.getFilterScratchpad().get(VALIDATING_SCHEMA_KEY);
 

--- a/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
@@ -469,11 +469,11 @@ public class RestLiValidationFilter implements Filter
   }
 
   /**
-   * Creates a {@link RestLiValidationFilter} to use for validation onRequest.
+   * Creates a {@link RestLiDataValidator} to use for validation onRequest.
    * Other implementations that extend this class can override this method to gain access to the validator.
    *
    * @param requestContext {@link FilterRequestContext} to provide input to the data validator
-   * @return a {@link RestLiValidationFilter}
+   * @return a {@link RestLiDataValidator}
    */
   protected RestLiDataValidator createRequestRestLiDataValidator(FilterRequestContext requestContext) {
     return new RestLiDataValidator(requestContext.getFilterResourceModel().getResourceClass().getAnnotations(),
@@ -481,11 +481,11 @@ public class RestLiValidationFilter implements Filter
   }
 
   /**
-   * Creates a {@link RestLiValidationFilter} to use for validation onResponse.
+   * Creates a {@link RestLiDataValidator} to use for validation onResponse.
    * Other implementations that extend this class can override this method to gain access to the validator.
    *
    * @param requestContext {@link FilterRequestContext} to provide input to the data validator
-   * @return a {@link RestLiValidationFilter}
+   * @return a {@link RestLiDataValidator}
    */
   protected RestLiDataValidator createResponseRestLiDataValidator(FilterRequestContext requestContext) {
     // Get validating schema if it was already built in onRequest

--- a/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
@@ -150,8 +150,7 @@ public class RestLiValidationFilter implements Filter
     }
 
     ResourceMethod method = requestContext.getMethodType();
-    RestLiDataValidator validator = new RestLiDataValidator(resourceClass.getAnnotations(),
-        requestContext.getFilterResourceModel().getValueClass(), method);
+    RestLiDataValidator validator = createRequestRestLiDataValidator(requestContext);
     RestLiRequestData requestData = requestContext.getRequestData();
 
     ValidationResult result;
@@ -282,7 +281,7 @@ public class RestLiValidationFilter implements Filter
     {
 
       ResourceMethod method = requestContext.getMethodType();
-      RestLiDataValidator validator = createRestLiDataValidator(requestContext);
+      RestLiDataValidator validator = createResponseRestLiDataValidator(requestContext);
 
       switch (method)
       {
@@ -470,13 +469,25 @@ public class RestLiValidationFilter implements Filter
   }
 
   /**
-   * Creates a {@link RestLiValidationFilter}.
+   * Creates a {@link RestLiValidationFilter} to use for validation onRequest.
    * Other implementations that extend this class can override this method to gain access to the validator.
    *
    * @param requestContext {@link FilterRequestContext} to provide input to the data validator
    * @return a {@link RestLiValidationFilter}
    */
-  protected RestLiDataValidator createRestLiDataValidator(FilterRequestContext requestContext) {
+  protected RestLiDataValidator createRequestRestLiDataValidator(FilterRequestContext requestContext) {
+    return new RestLiDataValidator(requestContext.getFilterResourceModel().getResourceClass().getAnnotations(),
+        requestContext.getFilterResourceModel().getValueClass(), requestContext.getMethodType());
+  }
+
+  /**
+   * Creates a {@link RestLiValidationFilter} to use for validation onResponse.
+   * Other implementations that extend this class can override this method to gain access to the validator.
+   *
+   * @param requestContext {@link FilterRequestContext} to provide input to the data validator
+   * @return a {@link RestLiValidationFilter}
+   */
+  protected RestLiDataValidator createResponseRestLiDataValidator(FilterRequestContext requestContext) {
     // Get validating schema if it was already built in onRequest
     DataSchema validatingSchema = (DataSchema) requestContext.getFilterScratchpad().get(VALIDATING_SCHEMA_KEY);
 


### PR DESCRIPTION
There are three main changes in this PR:

- in RestLiValidatorFilter, exposes the creation of the request and response RestLiDataValidator. This will allow for other use cases that extend the RestLiValidatorFilter to override this creation and have their own implementation

- Within RestLiDataValidator, a new DataSchemaAnnotationValidator each time 'validateOutput' is called. Inside the RestLiDataSchemaDataValidator, now it creates the validator in the constructor and pass that instance along each time.

- Within RestLiDataValidator, exposes the creation of the input entity validator

Existing unit tests pass. No functionality should be changed in the PR.