### PR TITLE
Loosen validation for array-descendant patch fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Loosen `ReadOnly`/`CreateOnly` validation when setting array-descendant fields in a patch request.
 
 ## [29.6.5] - 2020-09-09
 - Update RestLiValidatorFilter and RestLiDataValidator to expose creation of restli validators

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
@@ -104,6 +104,10 @@ public class RestLiDataValidator
   private static final Set<ResourceMethod> CREATE_ONLY_RESTRICTED_METHODS = new HashSet<>(Arrays.asList(
       ResourceMethod.PARTIAL_UPDATE, ResourceMethod.BATCH_PARTIAL_UPDATE));
 
+  // ReadOnly and CreateOnly fields descended from an array field can be specified for these types of requests
+  private static final Set<ResourceMethod> ARRAY_DESCENDANT_ACCEPTED_METHODS = new HashSet<>(Arrays.asList(
+      ResourceMethod.PARTIAL_UPDATE, ResourceMethod.BATCH_PARTIAL_UPDATE));
+
   // Resource methods that require validation on response
   public static final Set<ResourceMethod>  METHODS_VALIDATED_ON_RESPONSE = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
       ResourceMethod.GET, ResourceMethod.CREATE, ResourceMethod.PARTIAL_UPDATE, ResourceMethod.GET_ALL,
@@ -274,6 +278,11 @@ public class RestLiDataValidator
     _validatorClassMap = Collections.unmodifiableMap(validatorClassMap);
   }
 
+  /**
+   * Validates input data and patches using a given resource's {@link ReadOnly} and {@link CreateOnly} annotations.
+   * Since it's an extension of {@link DataSchemaAnnotationValidator}, it also validates the data using whatever custom
+   * validators are defined in the schema.
+   */
   protected class DataValidator extends DataSchemaAnnotationValidator
   {
     protected DataValidator(DataSchema schema)
@@ -286,14 +295,36 @@ public class RestLiDataValidator
     {
       super.validate(context);
       DataElement element = context.dataElement();
-      if (_readOnlyRestrictedPredicate.evaluate(element))
+      if (_readOnlyRestrictedPredicate.evaluate(element) && !grantArrayDescendantException(element))
       {
         context.addResult(new Message(element.path(), "ReadOnly field present in a %s request", _resourceMethod.toString()));
       }
-      if (_createOnlyPredicate.evaluate(element))
+      if (_createOnlyPredicate.evaluate(element) && !grantArrayDescendantException(element))
       {
         context.addResult(new Message(element.path(), "CreateOnly field present in a %s request", _resourceMethod.toString()));
       }
+    }
+
+    /**
+     * Determines if the given data element can be set despite being {@link ReadOnly} or {@link CreateOnly}.
+     * A given field is granted this exception if it's the descendant of an array field and if it's in a patch input
+     * (i.e. partial_update or batch_partial_update).
+     */
+    private boolean grantArrayDescendantException(DataElement element)
+    {
+      if (element == null || !ARRAY_DESCENDANT_ACCEPTED_METHODS.contains(_resourceMethod))
+      {
+        return false;
+      }
+      DataElement currentElement = element.getParent();
+      while (currentElement != null)
+      {
+        if (currentElement.getSchema().getType() == DataSchema.Type.ARRAY) {
+          return true;
+        }
+        currentElement = currentElement.getParent();
+      }
+      return false;
     }
   }
 
@@ -462,22 +493,14 @@ public class RestLiDataValidator
 
   /**
    * Checks that if the patch is applied to a valid entity, the modified entity will also be valid.
-   * This method
+   * This method...
    * (1) Checks that required/ReadOnly/CreateOnly fields are not deleted.
    * (2) Checks that new values for record templates contain all required fields (treating ReadOnly fields as optional).
    * (3) Applies the patch to an empty entity and validates the entity for custom validation rules
-   * and Rest.li annotations (Allows required fields to be absent by using {@link RequiredMode#IGNORE},
-   * because a patch does not necessarily contain all fields).
-   *
-   * NOTE: There are two remaining support gaps with this method:
-   * (1) Updating a part of an array is not supported if the object contains a descendant required CreateOnly field.
-   * Because of the current lack of support for patching array elements, setting an array field is always treated as
-   * setting the entire array with all-new elements. Since this is effectively a "Create", we should support setting
-   * CreateOnly fields in array patch operations. TODO: allow setting CreateOnly fields in array elements
-   * (2) Similar to the above problem, if an array element contains a ReadOnly field, then the user currently has no way
-   * to patch that array element while keeping the server-provided value. The user can omit the field in the patch
-   * request, but since the server has no concept of "patching elements", it can't assume a given element's existing
-   * value. TODO: allow setting ReadOnly fields in array elements
+   *     and Rest.li annotations, allowing the following exceptions:
+   *     - Allows required fields to be absent by using {@link RequiredMode#IGNORE},
+   *       because a patch does not necessarily contain all fields.
+   *     - Allows array-descendant ReadOnly/CreateOnly fields to be set, since there's currently no way to "patch" arrays.
    *
    * @param patchRequest the patch
    * @return the final validation result

--- a/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.autoValidationDemos.restspec.json
+++ b/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.autoValidationDemos.restspec.json
@@ -1,7 +1,7 @@
 {
   "annotations" : {
     "createOnly" : {
-      "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id" ]
+      "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3" ]
     },
     "readOnly" : {
       "value" : [ "stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1", "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord" ]

--- a/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.autoValidationWithProjection.restspec.json
+++ b/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.autoValidationWithProjection.restspec.json
@@ -1,7 +1,7 @@
 {
   "annotations" : {
     "createOnly" : {
-      "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id" ]
+      "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3" ]
     },
     "readOnly" : {
       "value" : [ "stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1", "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord" ]

--- a/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.validationDemos.restspec.json
+++ b/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.validationDemos.restspec.json
@@ -1,7 +1,7 @@
 {
   "annotations" : {
     "createOnly" : {
-      "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id" ]
+      "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3" ]
     },
     "readOnly" : {
       "value" : [ "stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1", "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord" ]

--- a/restli-int-test-api/src/main/pegasus/com/linkedin/restli/examples/greetings/api/ValidationDemo.pdl
+++ b/restli-int-test-api/src/main/pegasus/com/linkedin/restli/examples/greetings/api/ValidationDemo.pdl
@@ -1,20 +1,33 @@
 namespace com.linkedin.restli.examples.greetings.api
 
+/**
+ * Sample record for testing Rest.li validation. Comments indicate how fields are treated in ValidationDemoResource,
+ * AutomaticValidationDemoResource, and AutomaticValidationWithProjectionResource.
+ */
 record ValidationDemo includes IncludeMe {
 
+  // ReadOnly at the root
   @validate.strlen = {
     "max" : 10,
     "min" : 1
   }
   stringA: string
+
+  // ReadOnly at the root
   intA: optional int
+
+  // CreateOnly at the root, ReadOnly when inside field validationDemoNext
   stringB: string
 
+  // CreateOnly at the root
   @validate.seven = { }
   intB: optional int
 
+  // ReadOnly when inside field validationDemoNext
   UnionFieldWithInlineRecord: union[record myRecord {
+    // ReadOnly at the root
     foo1: int
+    // CreateOnly at the root
     foo2: optional int
   }, enum myEnum {
     FOOFOO
@@ -22,10 +35,14 @@ record ValidationDemo includes IncludeMe {
   }]
 
   ArrayWithInlineRecord: optional array[record myItem {
+    // ReadOnly at the root
     bar1: string
     bar2: string
+    // CreateOnly at the root
+    bar3: optional string
   }]
 
+  // Greeting field id is CreateOnly at the root
   MapWithTyperefs: optional map[string, typeref myGreeting = Greeting]
   validationDemoNext: optional ValidationDemo
 }

--- a/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.autoValidationDemos.snapshot.json
+++ b/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.autoValidationDemos.snapshot.json
@@ -55,6 +55,7 @@
     "type" : "record",
     "name" : "ValidationDemo",
     "namespace" : "com.linkedin.restli.examples.greetings.api",
+    "doc" : "Sample record for testing Rest.li validation. Comments indicate how fields are treated in ValidationDemoResource,\nAutomaticValidationDemoResource, and AutomaticValidationWithProjectionResource.",
     "include" : [ "IncludeMe" ],
     "fields" : [ {
       "name" : "stringA",
@@ -110,6 +111,10 @@
           }, {
             "name" : "bar2",
             "type" : "string"
+          }, {
+            "name" : "bar3",
+            "type" : "string",
+            "optional" : true
           } ]
         }
       },
@@ -146,7 +151,7 @@
   "schema" : {
     "annotations" : {
       "createOnly" : {
-        "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id" ]
+        "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3" ]
       },
       "readOnly" : {
         "value" : [ "stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1", "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord" ]

--- a/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.autoValidationWithProjection.snapshot.json
+++ b/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.autoValidationWithProjection.snapshot.json
@@ -50,6 +50,7 @@
     "type" : "record",
     "name" : "ValidationDemo",
     "namespace" : "com.linkedin.restli.examples.greetings.api",
+    "doc" : "Sample record for testing Rest.li validation. Comments indicate how fields are treated in ValidationDemoResource,\nAutomaticValidationDemoResource, and AutomaticValidationWithProjectionResource.",
     "include" : [ "IncludeMe" ],
     "fields" : [ {
       "name" : "stringA",
@@ -105,6 +106,10 @@
           }, {
             "name" : "bar2",
             "type" : "string"
+          }, {
+            "name" : "bar3",
+            "type" : "string",
+            "optional" : true
           } ]
         }
       },
@@ -129,7 +134,7 @@
   "schema" : {
     "annotations" : {
       "createOnly" : {
-        "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id" ]
+        "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3" ]
       },
       "readOnly" : {
         "value" : [ "stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1", "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord" ]

--- a/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.validationDemos.snapshot.json
+++ b/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.validationDemos.snapshot.json
@@ -55,6 +55,7 @@
     "type" : "record",
     "name" : "ValidationDemo",
     "namespace" : "com.linkedin.restli.examples.greetings.api",
+    "doc" : "Sample record for testing Rest.li validation. Comments indicate how fields are treated in ValidationDemoResource,\nAutomaticValidationDemoResource, and AutomaticValidationWithProjectionResource.",
     "include" : [ "IncludeMe" ],
     "fields" : [ {
       "name" : "stringA",
@@ -110,6 +111,10 @@
           }, {
             "name" : "bar2",
             "type" : "string"
+          }, {
+            "name" : "bar3",
+            "type" : "string",
+            "optional" : true
           } ]
         }
       },
@@ -146,7 +151,7 @@
   "schema" : {
     "annotations" : {
       "createOnly" : {
-        "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id" ]
+        "value" : [ "stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2", "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3" ]
       },
       "readOnly" : {
         "value" : [ "stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1", "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord" ]

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/AutomaticValidationDemoResource.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/AutomaticValidationDemoResource.java
@@ -64,7 +64,7 @@ import java.util.Set;
 @ReadOnly({"stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1",
            "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord"})
 @CreateOnly({"stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2",
-             "MapWithTyperefs/*/id"})
+             "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3"})
 public class AutomaticValidationDemoResource implements KeyValueResource<Integer, ValidationDemo>
 {
   private static ValidationDemo _validReturnEntity;

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/AutomaticValidationWithProjectionResource.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/AutomaticValidationWithProjectionResource.java
@@ -60,7 +60,7 @@ import com.linkedin.restli.server.resources.KeyValueResource;
 @ReadOnly({"stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1",
            "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord"})
 @CreateOnly({"stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2",
-             "MapWithTyperefs/*/id"})
+             "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3"})
 public class AutomaticValidationWithProjectionResource implements KeyValueResource<Integer, ValidationDemo>
 {
   // A return entity that contains mix of valid and invalid fields in all levels for projection testing.

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/ValidationDemoResource.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/ValidationDemoResource.java
@@ -67,7 +67,7 @@ import java.util.Set;
 @ReadOnly({"stringA", "intA", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1",
            "ArrayWithInlineRecord/*/bar1", "validationDemoNext/stringB", "validationDemoNext/UnionFieldWithInlineRecord"})
 @CreateOnly({"stringB", "intB", "UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo2",
-             "MapWithTyperefs/*/id"})
+             "MapWithTyperefs/*/id", "ArrayWithInlineRecord/*/bar3"})
 public class ValidationDemoResource implements KeyValueResource<Integer, ValidationDemo>
 {
   @RestMethod.Create

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRestLiValidation.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRestLiValidation.java
@@ -482,7 +482,7 @@ public class TestRestLiValidation extends RestLiIntegrationTest
                 "ERROR :: /validationDemoNext/stringA :: cannot delete a required field\n"},
             {"{\"patch\": {\"MapWithTyperefs\": {\"key1\": {\"$delete\": [\"message\"]}}}}",
                 "ERROR :: /MapWithTyperefs/key1/message :: cannot delete a required field\n"},
-            // Cannot set ReadOnly or CreateOnly fields in a partial update request
+            // Cannot set ReadOnly or CreateOnly fields in a partial_update request (unless the field is the descendant of an array)
             {"{\"patch\": {\"$set\": {\"stringA\": \"abc\"}}}",
                 "ERROR :: /stringA :: ReadOnly field present in a partial_update request\n"},
             {"{\"patch\": {\"$set\": {\"intA\": 123}}}",
@@ -491,8 +491,6 @@ public class TestRestLiValidation extends RestLiIntegrationTest
                 "ERROR :: /UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1 :: ReadOnly field present in a partial_update request\n"},
             {"{\"patch\": {\"$set\": {\"UnionFieldWithInlineRecord\": {\"com.linkedin.restli.examples.greetings.api.myRecord\": {\"foo1\": 1234}}}}}",
                 "ERROR :: /UnionFieldWithInlineRecord/com.linkedin.restli.examples.greetings.api.myRecord/foo1 :: ReadOnly field present in a partial_update request\n"},
-            {"{\"patch\": {\"$set\": {\"ArrayWithInlineRecord\": [{\"bar1\": \"bbb\", \"bar2\": \"barbar\"}]}}}",
-                "ERROR :: /ArrayWithInlineRecord/0/bar1 :: ReadOnly field present in a partial_update request\n"},
             {"{\"patch\": {\"validationDemoNext\": {\"$set\": {\"stringB\": \"abc\"}}}}",
                 "ERROR :: /validationDemoNext/stringB :: ReadOnly field present in a partial_update request\n"},
             {"{\"patch\": {\"validationDemoNext\": {\"UnionFieldWithInlineRecord\": {\"$set\": {\"com.linkedin.restli.examples.greetings.api.myEnum\": \"FOOFOO\"}}}}}",
@@ -557,12 +555,18 @@ public class TestRestLiValidation extends RestLiIntegrationTest
             "{\"patch\": {\"validationDemoNext\": {\"$set\": {\"stringA\": \"some value\"}}}}",
             // A field (MapWithTyperefs/key1) containing a CreateOnly field (MapWithTyperefs/key1/id) has to be partially set
             "{\"patch\": {\"MapWithTyperefs\": {\"key1\": {\"$set\": {\"message\": \"some message\", \"tone\": \"SINCERE\"}}}}}",
-            // Okay to set a field containing a ReadOnly field by omitting the ReadOnly field
+            // Okay to set a field containing a ReadOnly field if the ReadOnly field is omitted
             "{\"patch\": {\"$set\": {\"ArrayWithInlineRecord\": [{\"bar2\": \"missing bar1\"}]}}}",
+            "{\"patch\": {\"$set\": {\"UnionFieldWithInlineRecord\": {\"com.linkedin.restli.examples.greetings.api.myRecord\": {}}}}}",
+            "{\"patch\": {\"$set\": {\"validationDemoNext\": {\"stringA\": \"no stringB\"}}}}",
             // Okay to delete a field containing a ReadOnly field
             "{\"patch\": {\"$delete\": [\"ArrayWithInlineRecord\"]}}",
             // Okay to delete a field containing a CreateOnly field
-            "{\"patch\": {\"MapWithTyperefs\": {\"$delete\": [\"key1\"]}}}"
+            "{\"patch\": {\"MapWithTyperefs\": {\"$delete\": [\"key1\"]}}}",
+            // Okay to set a ReadOnly field if it's the descendant of an array
+            "{\"patch\": {\"$set\": {\"ArrayWithInlineRecord\": [{\"bar1\": \"setting ReadOnly field\", \"bar2\": \"foo\"}]}}}",
+            // Okay to set a CreateOnly field if it's the descendant of an array
+            "{\"patch\": {\"$set\": {\"ArrayWithInlineRecord\": [{\"bar3\": \"setting CreateOnly field\", \"bar2\": \"foo\"}]}}}"
         };
   }
 


### PR DESCRIPTION
This change allows a `PARTIAL_UPDATE` or `BATCH_PARTIAL_UPDATE` request to
set a `ReadOnly`/`CreateOnly` field if that field is the descendant of an
array. This is needed because there's no real way to "patch" individual
array elements in Rest.li, so array patching actually sets the entire
array. Thus, users need a way to "patch" an array while maintaining the
existing values of `ReadOnly`/`CreateOnly` fields.

**Note:**
- The IDL/snapshot changes are just so I can test the logic for `CreateOnly` by adding the create-only field `bar3` inside the array in the PDL model.
- I renamed `DataValidator` to `RestLiAnnotationDataValidator` because it makes more sense, IMO.