### PR TITLE
Bug/fix naming of extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Fix inconsistent issue in extension schema file names: from `Extension` to `Extensions`
 - Fix a bug in `FileFormatDataSchemaParser` and remove `isExtensionEntry` method call to simplify the logic.
 - Update ExtensionSchemaValidationCmdLineApp with more validations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.6.4] - 2020-09-08
 - Fix inconsistent issue in extension schema file names: from `Extension` to `Extensions`
 - Fix a bug in `FileFormatDataSchemaParser` and remove `isExtensionEntry` method call to simplify the logic.
 - Update ExtensionSchemaValidationCmdLineApp with more validations.
@@ -4635,7 +4637,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.4...master
+[29.6.4]: https://github.com/linkedin/rest.li/compare/v29.6.3...v29.6.4
 [29.6.3]: https://github.com/linkedin/rest.li/compare/v29.6.2...v29.6.3
 [29.6.2]: https://github.com/linkedin/rest.li/compare/v29.6.1...v29.6.2
 [29.6.1]: https://github.com/linkedin/rest.li/compare/v29.6.0...v29.6.1

--- a/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
@@ -209,6 +209,7 @@ public class DataSchemaParser
    */
   public static class ParseResult
   {
+    private static final String EXTENSION_FILENAME_SUFFIX = "Extensions.pdl";
     // The purpose of the sorting is to keep generated java meta classes consistent accross different input file orders
     private final Map<DataSchema, DataSchemaLocation> _schemaAndLocations = new TreeMap<>(Comparator.comparing(DataSchema::toString));
     private final Set<File> _sourceFiles = new HashSet<>();
@@ -232,7 +233,7 @@ public class DataSchemaParser
         else if (dataSchemaLocation instanceof FileDataSchemaLocation)
         {
           FileDataSchemaLocation fileDataSchemaLocation = (FileDataSchemaLocation) dataSchemaLocation;
-          return fileDataSchemaLocation.getSourceFile().getName().endsWith("Extension.pdl") &&
+          return fileDataSchemaLocation.getSourceFile().getName().endsWith(EXTENSION_FILENAME_SUFFIX) &&
             fileDataSchemaLocation.getSourceFile().getParent().indexOf(SchemaDirectoryName.EXTENSIONS.getName()) > 0;
         }
         return false;

--- a/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
+++ b/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
@@ -109,32 +109,32 @@ public class TestDataSchemaParser
         {
             {
                 new String[]{
-                    "extensions/BarExtension.pdl",
-                    "extensions/FooExtension.pdl",
-                    "extensions/FuzzExtension.pdl",
+                    "extensions/BarExtensions.pdl",
+                    "extensions/FooExtensions.pdl",
+                    "extensions/FuzzExtensions.pdl",
                     "pegasus/Foo.pdl",
                     "pegasus/Bar.pdl",
                     "pegasus/Fuzz.pdsc"
                 },
                 new String[]{
-                    "FuzzExtension",
-                    "FooExtension",
-                    "BarExtension"
+                    "FuzzExtensions",
+                    "FooExtensions",
+                    "BarExtensions"
                 }
             },
             {
                 new String[]{
-                    "extensions/BarExtension.pdl",
-                    "extensions/FooExtension.pdl",
-                    "extensions/FuzzExtension.pdl",
+                    "extensions/BarExtensions.pdl",
+                    "extensions/FooExtensions.pdl",
+                    "extensions/FuzzExtensions.pdl",
                     "pegasus/Foo.pdl",
                     "pegasus/Bar.pdl",
                     "pegasus/Fuzz.pdsc"
                 },
                 new String[]{
-                    "FooExtension",
-                    "FuzzExtension",
-                    "BarExtension"
+                    "FooExtensions",
+                    "FuzzExtensions",
+                    "BarExtensions"
                 }
             },
             {

--- a/generator/src/test/resources/generator/extensionSchemas/extensions/BarExtension.pdl
+++ b/generator/src/test/resources/generator/extensionSchemas/extensions/BarExtension.pdl
@@ -1,3 +1,0 @@
-record BarExtension includes Bar {
-  b1: int
-}

--- a/generator/src/test/resources/generator/extensionSchemas/extensions/BarExtensions.pdl
+++ b/generator/src/test/resources/generator/extensionSchemas/extensions/BarExtensions.pdl
@@ -1,0 +1,3 @@
+record BarExtensions includes Bar {
+  b1: int
+}

--- a/generator/src/test/resources/generator/extensionSchemas/extensions/FooExtension.pdl
+++ b/generator/src/test/resources/generator/extensionSchemas/extensions/FooExtension.pdl
@@ -1,3 +1,0 @@
-record FooExtension includes Foo {
-  ext1: string
-}

--- a/generator/src/test/resources/generator/extensionSchemas/extensions/FooExtensions.pdl
+++ b/generator/src/test/resources/generator/extensionSchemas/extensions/FooExtensions.pdl
@@ -1,0 +1,3 @@
+record FooExtensions includes Foo {
+  ext1: string
+}

--- a/generator/src/test/resources/generator/extensionSchemas/extensions/FuzzExtension.pdl
+++ b/generator/src/test/resources/generator/extensionSchemas/extensions/FuzzExtension.pdl
@@ -1,3 +1,0 @@
-record FuzzExtension includes Fuzz {
-  ext1: string
-}

--- a/generator/src/test/resources/generator/extensionSchemas/extensions/FuzzExtensions.pdl
+++ b/generator/src/test/resources/generator/extensionSchemas/extensions/FuzzExtensions.pdl
@@ -1,0 +1,3 @@
+record FuzzExtensions includes Fuzz {
+  ext1: string
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.6.3
+version=29.6.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
We want to keep the naming convention consistent for ExtensionSchema files. All the extension schema ends with `Extensions.pdl`