### PR TITLE
Remove final from nested generated classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.6.6] - 2020-09-17
 - Loosen `ReadOnly`/`CreateOnly` validation when setting array-descendant fields in a patch request.
 - Add generatePegasusSchemeSnapshot task.
+- Remove final from nested generated classes, such as inline unions.
 
 ## [29.6.5] - 2020-09-09
 - Update RestLiValidatorFilter and RestLiDataValidator to expose creation of restli validators
@@ -4642,7 +4645,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.6...master
+[29.6.6]: https://github.com/linkedin/rest.li/compare/v29.6.5...v29.6.6
 [29.6.5]: https://github.com/linkedin/rest.li/compare/v29.6.5...master
 [29.6.4]: https://github.com/linkedin/rest.li/compare/v29.6.3...v29.6.4
 [29.6.3]: https://github.com/linkedin/rest.li/compare/v29.6.2...v29.6.3

--- a/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
@@ -792,7 +792,7 @@ public class TemplateSpecGenerator
         // enclosingClass flag indicates whether a class is nested or not.
         classTemplateSpec.setEnclosingClass(enclosingClass);
         classTemplateSpec.setClassName(classInfo.name);
-        classTemplateSpec.setModifiers(ModifierSpec.PUBLIC, ModifierSpec.STATIC, ModifierSpec.FINAL);
+        classTemplateSpec.setModifiers(ModifierSpec.PUBLIC, ModifierSpec.STATIC);
       }
       else
       {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.6.5
+version=29.6.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This enables certain techniques that use subclassing to work, such as
some using CGLib to intercept method calls.

Creating this as a follow-up to an email thread I started over the weekend.