### PR TITLE
Add generatePegasusSchemeSnapshot task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 - Loosen `ReadOnly`/`CreateOnly` validation when setting array-descendant fields in a patch request.
+- Add generatePegasusSchemeSnapshot task.
 
 ## [29.6.5] - 2020-09-09
 - Update RestLiValidatorFilter and RestLiDataValidator to expose creation of restli validators

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckPegasusSnapshotTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckPegasusSnapshotTask.java
@@ -1,0 +1,32 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.linkedin.pegasus.gradle.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.TaskAction;
+
+
+@CacheableTask
+public class CheckPegasusSnapshotTask extends DefaultTask
+{
+  @TaskAction
+  public void checkPegasusSnapshot()
+  {
+    // TODO: implement CheckPegasusSnapshotTask
+  }
+
+}

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GeneratePegasusSnapshotTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GeneratePegasusSnapshotTask.java
@@ -1,0 +1,180 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.linkedin.pegasus.gradle.tasks;
+
+import com.linkedin.pegasus.gradle.PathingJarUtil;
+import com.linkedin.pegasus.gradle.PegasusPlugin;
+import com.linkedin.pegasus.gradle.internal.ArgumentFileGenerator;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
+
+import static com.linkedin.pegasus.gradle.SharedFileUtils.*;
+
+
+/**
+ * Generate pegasus schema's snapshot, which will be used for pegasus schema compatibility check
+ *
+ * @author Yingjie Bi
+ */
+@CacheableTask
+public class GeneratePegasusSnapshotTask extends DefaultTask
+{
+  private File _inputDir;
+  private FileCollection _resolverPath;
+  private File _pegasusSchemaSnapshotDestinationDir;
+  private FileCollection _classPath;
+  private boolean _enableArgFile;
+  private boolean _extensionSchema;
+
+  @TaskAction
+  public void generatePegasusSnapshot()
+  {
+    FileTree inputDataSchemaFiles = _extensionSchema ? getSuffixedFiles(getProject(), _inputDir,
+        PegasusPlugin.PDL_FILE_SUFFIX) : getSuffixedFiles(getProject(), _inputDir,
+        PegasusPlugin.DATA_TEMPLATE_FILE_SUFFIXES);
+
+    List<String> inputDataSchemaFilenames = StreamSupport.stream(inputDataSchemaFiles.spliterator(), false)
+        .map(File::getPath)
+        .collect(Collectors.toList());
+
+    if (inputDataSchemaFilenames.isEmpty())
+    {
+      getLogger().lifecycle("There are no Pegasus schema input files. Skip generating Pegasus schema snapshots.");
+      return;
+    }
+    getLogger().info("Generating Pegasus schema snapshot...");
+
+    String resolverPathStr = _resolverPath.plus(getProject().files(_inputDir)).getAsPath();
+
+    FileCollection _pathedClasspath;
+    try
+    {
+      _pathedClasspath = PathingJarUtil.generatePathingJar(getProject(), getName(),
+          _classPath, false);
+    }
+    catch (IOException e)
+    {
+      throw new GradleException("Error occurred generating pathing JAR.", e);
+    }
+
+    getProject().javaexec(javaExecSpec ->
+    {
+      String resolverPathArg = resolverPathStr;
+      if (isEnableArgFile())
+      {
+        resolverPathArg = ArgumentFileGenerator.getArgFileSyntax(ArgumentFileGenerator.createArgFile(
+            "generatePegasusSchemaSnapshot_resolverPath", Collections.singletonList(resolverPathArg), getTemporaryDir()));
+      }
+      javaExecSpec.setMain("com.linkedin.restli.tools.snapshot.gen.PegasusSchemaSnapshotGenerationCmdLineApp");
+      javaExecSpec.setClasspath(_pathedClasspath);
+      javaExecSpec.args(resolverPathArg);
+      javaExecSpec.args(_inputDir.getAbsolutePath());
+      javaExecSpec.args(_pegasusSchemaSnapshotDestinationDir);
+    });
+  }
+
+  /**
+   * Directory containing pegasus schema files.
+   */
+  @InputDirectory
+  @SkipWhenEmpty
+  @PathSensitive(PathSensitivity.RELATIVE)
+  public File getInputDir()
+  {
+    return _inputDir;
+  }
+
+  public void setInputDir(File inputDir)
+  {
+    _inputDir = inputDir;
+  }
+
+  /**
+   * The resolver path.
+   */
+  @Classpath
+  public FileCollection getResolverPath()
+  {
+    return _resolverPath;
+  }
+
+  public void setResolverPath(FileCollection resolverPath)
+  {
+    _resolverPath = resolverPath;
+  }
+
+  @OutputDirectory
+  public File getPegasusSchemaSnapshotDestinationDir()
+  {
+    return _pegasusSchemaSnapshotDestinationDir;
+  }
+
+  public void setPegasusSchemaSnapshotDestinationDir(File pegasusSchemaSnapshotDestinationDir )
+  {
+    _pegasusSchemaSnapshotDestinationDir = pegasusSchemaSnapshotDestinationDir;
+  }
+
+
+  @Classpath
+  public FileCollection getClassPath()
+  {
+    return _classPath;
+  }
+
+  public void setClassPath(FileCollection classPath)
+  {
+    _classPath = classPath;
+  }
+
+  @Input
+  public boolean isEnableArgFile()
+  {
+    return _enableArgFile;
+  }
+
+  public void setEnableArgFile(boolean enable)
+  {
+    _enableArgFile = enable;
+  }
+
+  @Input
+  public boolean isExtensionSchema()
+  {
+    return _extensionSchema;
+  }
+
+  public void setExtensionSchema(boolean extensionSchema)
+  {
+    _extensionSchema = extensionSchema;
+  }
+}

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/gen/PegasusSchemaSnapshotExporter.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/gen/PegasusSchemaSnapshotExporter.java
@@ -1,0 +1,127 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.linkedin.restli.tools.snapshot.gen;
+
+import com.linkedin.data.schema.AbstractSchemaEncoder;
+import com.linkedin.data.schema.AbstractSchemaParser;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.DataSchemaResolver;
+import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.PegasusSchemaParser;
+import com.linkedin.data.schema.SchemaToPdlEncoder;
+import com.linkedin.data.schema.resolver.MultiFormatDataSchemaResolver;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+/**
+ * PegasusSchemaSnapshotExporter, generating pegasus schema snapshot(.pdl) files
+ *
+ * @author Yingjie Bi
+ */
+public class PegasusSchemaSnapshotExporter
+{
+  private static final String PDL = ".pdl";
+
+  private static final String PDSC = ".pdsc";
+
+  /**
+   * Generate pegasus schema snapshot(pegasusSchemaSnapshot.pdl) files to the provided output directory
+   * based on the given input pegasus schemas.
+   *
+   * @param resolverPath schema resolver path
+   * @param inputPath input files directory
+   * @param outputDir output files directory
+   * @throws IOException
+   */
+  public void export(String resolverPath, String inputPath, File outputDir) throws IOException
+  {
+    List<DataSchema> dataSchemas = parseDataSchema(resolverPath, inputPath);
+    for (DataSchema dataSchema : dataSchemas)
+    {
+      writeSnapshotFile(outputDir, ((NamedDataSchema) dataSchema).getFullName(), dataSchema);
+    }
+  }
+
+  private static List<DataSchema> parseDataSchema(String resolverPath, String inputPath)
+      throws RuntimeException, IOException
+  {
+    try (Stream<Path> paths = Files.walk(Paths.get(inputPath)))
+    {
+      return paths
+          .filter(path -> path.toString().endsWith(PDL) || path.toString().endsWith(PDSC))
+          .map(path ->
+              {
+                File inputFile = path.toFile();
+                DataSchemaResolver resolver = MultiFormatDataSchemaResolver.withBuiltinFormats(resolverPath);
+                String fileExtension = getFileExtension(inputFile.getName());
+                PegasusSchemaParser parser = AbstractSchemaParser.parserForFileExtension(fileExtension, resolver);
+                try
+                {
+                  parser.parse(new FileInputStream(inputFile));
+                }
+                catch (FileNotFoundException e)
+                {
+                  throw new RuntimeException(e);
+                }
+                if (parser.hasError())
+                {
+                  throw new RuntimeException("Error: " + parser.errorMessage() + ", while parsing schema: " + inputFile.getAbsolutePath());
+                }
+
+                List<DataSchema> topLevelDataSchemas = parser.topLevelDataSchemas();
+                if (topLevelDataSchemas.size() != 1)
+                {
+                  throw new RuntimeException("The number of top level schemas is not 1, while parsing schema: " + inputFile.getAbsolutePath());
+                }
+                DataSchema topLevelDataSchema = topLevelDataSchemas.get(0);
+                if (!(topLevelDataSchema instanceof NamedDataSchema))
+                {
+                  throw new RuntimeException("Invalid schema : " + inputFile.getAbsolutePath() + ", the schema is not a named schema.");
+                }
+                return topLevelDataSchema;
+              })
+          .collect(Collectors.toList());
+    }
+  }
+
+  private static void writeSnapshotFile(File outputDir, String fileName, DataSchema dataSchema) throws IOException
+  {
+    StringWriter stringWriter = new StringWriter();
+    SchemaToPdlEncoder schemaToPdlEncoder = new SchemaToPdlEncoder(stringWriter);
+    schemaToPdlEncoder.setTypeReferenceFormat(AbstractSchemaEncoder.TypeReferenceFormat.DENORMALIZE);
+    schemaToPdlEncoder.encode(dataSchema);
+
+    File generatedSnapshotFile = new File(outputDir, fileName + PDL);
+
+    Files.write(generatedSnapshotFile.toPath(), stringWriter.toString().getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String getFileExtension(String fileName)
+  {
+    return fileName.substring(fileName.lastIndexOf('.') + 1);
+  }
+}

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/gen/PegasusSchemaSnapshotGenerationCmdLineApp.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/gen/PegasusSchemaSnapshotGenerationCmdLineApp.java
@@ -1,0 +1,114 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.linkedin.restli.tools.snapshot.gen;
+
+import com.linkedin.restli.internal.tools.RestLiToolsUtils;
+import java.io.File;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Tool that encodes pegasus schemas to pegasusSchemaSnapshot files
+ *
+ * @author Yingjie Bi
+ */
+public class PegasusSchemaSnapshotGenerationCmdLineApp
+{
+  private static final Logger _logger = LoggerFactory.getLogger(
+      PegasusSchemaSnapshotGenerationCmdLineApp.class);
+
+  private static final Options _options = new Options();
+
+  static
+  {
+    _options.addOption(OptionBuilder.withLongOpt("help")
+        .withDescription("Print help")
+        .create('h'));
+  }
+
+  public static void main(String[] args) throws Exception
+  {
+    final CommandLineParser parser = new GnuParser();
+    CommandLine cl = parser.parse(_options, args);
+
+    if (cl.hasOption('h'))
+    {
+      help();
+      System.exit(0);
+    }
+
+    String[] cliArgs = cl.getArgs();
+    if (cliArgs.length != 3)
+    {
+      _logger.error("Invalid arguments");
+      help();
+      System.exit(1);
+    }
+
+    String resolverPath = RestLiToolsUtils.readArgFromFileIfNeeded(cliArgs[0]);
+    String inputPath = cliArgs[1];
+    String outputPath = cliArgs[2];
+
+    try
+    {
+      File outputDir = new File(outputPath);
+      if (!outputDir.exists())
+      {
+        if (!outputDir.mkdirs())
+        {
+          throw new RuntimeException("Output directory '" + outputDir + "' could not be created!");
+        }
+      }
+      if (!outputDir.isDirectory())
+      {
+        throw new RuntimeException("Output directory '" + outputDir + "' is not a directory");
+      }
+      if (!outputDir.canRead() || !outputDir.canWrite())
+      {
+        throw new RuntimeException("Output directory '" + outputDir + "' must be readable and writeable");
+      }
+
+      PegasusSchemaSnapshotExporter exporter = new PegasusSchemaSnapshotExporter();
+      exporter.export(resolverPath, inputPath, outputDir);
+
+    }
+    catch (Exception e)
+    {
+      _logger.error("Error while generate pegasus schema snapshot: " + e.getMessage());
+      System.exit(1);
+    }
+  }
+
+
+
+  private static void help()
+  {
+    final HelpFormatter formatter = new HelpFormatter();
+    formatter.printHelp(120,
+        PegasusSchemaSnapshotGenerationCmdLineApp.class.getSimpleName(),
+        "[resolverPath], [inputPath], [pegasusSchemaSnapshotDirectory]",
+        _options,
+        "",
+        true);
+  }
+}

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/ExporterTestUtils.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/ExporterTestUtils.java
@@ -85,6 +85,14 @@ public class ExporterTestUtils
     }
   }
 
+  public static void comparePegasusSchemaSnapshotFiles(String actualFileName, String expectedFileName)
+      throws IOException
+  {
+    String actualContent = ExporterTestUtils.readFile(actualFileName);
+    String expectedContent = ExporterTestUtils.readFile(expectedFileName);
+    Assert.assertEquals(actualContent, expectedContent);
+  }
+
   public static File createTmpDir() throws IOException
   {
     File temp = File.createTempFile("temp", Long.toString(System.nanoTime()));

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/gen/TestPegasusSchemaSnapshotExporter.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/gen/TestPegasusSchemaSnapshotExporter.java
@@ -1,0 +1,73 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.linkedin.restli.tools.snapshot.gen;
+
+import com.linkedin.restli.tools.ExporterTestUtils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TestPegasusSchemaSnapshotExporter
+{
+  private final String FS = File.separator;
+  private String testDir = System.getProperty("testDir", new File("src/test").getAbsolutePath());
+  private String pegasusDir  = testDir + FS + "pegasus" + FS ;
+  private String snapshotDir = testDir + FS + "pegasusSchemaSnapshot";
+
+  private File outDir;
+
+  @BeforeMethod
+  private void beforeMethod() throws IOException
+  {
+    outDir = Files.createTempDirectory(this.getClass().getSimpleName() + System.currentTimeMillis()).toFile();
+  }
+
+  @AfterMethod
+  private void afterMethod() throws IOException
+  {
+    FileUtils.forceDelete(outDir);
+  }
+
+  @Test
+  public void testExportSnapshot() throws Exception
+  {
+    String[] expectedFiles = new String[]
+        {
+            "BirthInfo.pdl",
+            "FullName.pdl",
+            "Date.pdl"
+        };
+    String inputDir =  pegasusDir + "com/linkedin/restli/tools/pegasusSchemaSnapshotTest";
+    PegasusSchemaSnapshotExporter exporter = new PegasusSchemaSnapshotExporter();
+    exporter.export(pegasusDir, inputDir, outDir);
+
+    Assert.assertEquals(outDir.list().length, expectedFiles.length);
+
+    for (String file : expectedFiles)
+    {
+      String actualFile = outDir + FS + file;
+      String expectedFile = snapshotDir + FS + file;
+
+      ExporterTestUtils.comparePegasusSchemaSnapshotFiles(actualFile, expectedFile);
+    }
+  }
+}

--- a/restli-tools/src/test/pegasus/Location.pdl
+++ b/restli-tools/src/test/pegasus/Location.pdl
@@ -1,0 +1,7 @@
+record Location {
+  latitude: float
+
+  longitude: float
+
+  name: optional string
+}

--- a/restli-tools/src/test/pegasus/com/linkedin/restli/tools/pegasusSchemaSnapshotTest/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasus/com/linkedin/restli/tools/pegasusSchemaSnapshotTest/BirthInfo.pdl
@@ -1,0 +1,9 @@
+record BirthInfo {
+  day: int
+
+  month: int
+
+  year: int
+
+  location: optional Location
+}

--- a/restli-tools/src/test/pegasus/com/linkedin/restli/tools/pegasusSchemaSnapshotTest/Date.pdsc
+++ b/restli-tools/src/test/pegasus/com/linkedin/restli/tools/pegasusSchemaSnapshotTest/Date.pdsc
@@ -1,0 +1,14 @@
+{
+  "type" : "record",
+  "name" : "Date",
+  "fields" : [ {
+    "name" : "day",
+    "type" : "int"
+  }, {
+    "name" : "month",
+    "type" : "int"
+  }, {
+    "name" : "year",
+    "type" : "int"
+  } ]
+}

--- a/restli-tools/src/test/pegasus/com/linkedin/restli/tools/pegasusSchemaSnapshotTest/FullName.pdl
+++ b/restli-tools/src/test/pegasus/com/linkedin/restli/tools/pegasusSchemaSnapshotTest/FullName.pdl
@@ -1,0 +1,5 @@
+record FullName {
+  firstName: string
+
+  lastName: string
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/BirthInfo.pdl
@@ -1,0 +1,10 @@
+record BirthInfo {
+  day: int
+  month: int
+  year: int
+  location: optional record Location {
+    latitude: float
+    longitude: float
+    name: optional string
+  }
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/Date.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/Date.pdl
@@ -1,0 +1,5 @@
+record Date {
+  day: int
+  month: int
+  year: int
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/FullName.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/FullName.pdl
@@ -1,0 +1,4 @@
+record FullName {
+  firstName: string
+  lastName: string
+}


### PR DESCRIPTION
Add generatePegasusSchemaSnapshot task

The task will read pegasus schema files from input directory and generate snapshots of pegasus schemas.

It will be triggered if extension schema exist or if "enablePegasusSchemaCompatibilityCheck" configuration is provided.


Test: Unit test and manual test in other repos.