### PR TITLE
Change D2 call to async in BackupRequestClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.6.7] - 2020-09-18
+- Added async call to Zookeeper in backup request client.
+
 ## [29.6.6] - 2020-09-17
 - Loosen `ReadOnly`/`CreateOnly` validation when setting array-descendant fields in a patch request.
 - Add generatePegasusSchemeSnapshot task.
@@ -4645,7 +4648,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.7...master
+[29.6.7]: https://github.com/linkedin/rest.li/compare/v29.6.6...v29.6.7
 [29.6.6]: https://github.com/linkedin/rest.li/compare/v29.6.5...v29.6.6
 [29.6.5]: https://github.com/linkedin/rest.li/compare/v29.6.5...master
 [29.6.4]: https://github.com/linkedin/rest.li/compare/v29.6.3...v29.6.4

--- a/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerStrategy.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerStrategy.java
@@ -28,6 +28,7 @@ import com.linkedin.d2.balancer.strategies.framework.LoadBalancerStrategyTestRun
 import com.linkedin.d2.balancer.strategies.framework.LoadBalancerStrategyTestRunnerBuilder;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategyFactory;
 import com.linkedin.d2.loadBalancerStrategyType;
+import com.linkedin.test.util.retry.SingleRetry;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -386,7 +387,7 @@ public class TestLoadBalancerStrategy
     assertTrue(hasPointsInHistory(pointHistory, Arrays.asList(2)), "Fast recovery should recover the points from 1 to 2 initially");
   }
 
-  @Test(dataProvider = "strategy")
+  @Test(dataProvider = "strategy", retryAnalyzer = SingleRetry.class)
   public void testSlowStart(loadBalancerStrategyType type) {
     Map<String, String> degraderPropertiesWithSlowStart = new HashMap<>();
     D2RelativeStrategyProperties relativePropertiesWithSlowStart = new D2RelativeStrategyProperties();

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -154,6 +154,7 @@ public class D2ClientBuilder
                   _config.backupRequestsStrategyStatsConsumer,
                   _config.backupRequestsLatencyNotificationInterval,
                   _config.backupRequestsLatencyNotificationIntervalUnit,
+                  _config.enableBackupRequestsClientAsync,
                   _config._backupRequestsExecutorService,
                   _config.eventEmitter,
                   _config.partitionAccessorRegistry,
@@ -196,7 +197,7 @@ public class D2ClientBuilder
       }
       d2Client = new BackupRequestsClient(d2Client, loadBalancer, executor,
           _config.backupRequestsStrategyStatsConsumer, _config.backupRequestsLatencyNotificationInterval,
-          _config.backupRequestsLatencyNotificationIntervalUnit);
+          _config.backupRequestsLatencyNotificationIntervalUnit, _config.enableBackupRequestsClientAsync);
     }
 
     if (_config.retry)
@@ -357,6 +358,12 @@ public class D2ClientBuilder
   public D2ClientBuilder setBackupRequestsLatencyNotificationIntervalUnit(TimeUnit backupRequestsLatencyNotificationIntervalUnit)
   {
     _config.backupRequestsLatencyNotificationIntervalUnit = backupRequestsLatencyNotificationIntervalUnit;
+    return this;
+  }
+
+  public D2ClientBuilder setEnableBackupRequestsClientAsync(boolean enableBackupRequestsClientAsync)
+  {
+    _config.enableBackupRequestsClientAsync = enableBackupRequestsClientAsync;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -79,11 +79,13 @@ public class D2ClientConfig
   BackupRequestsStrategyStatsConsumer backupRequestsStrategyStatsConsumer = null;
   long backupRequestsLatencyNotificationInterval = 1;
   TimeUnit backupRequestsLatencyNotificationIntervalUnit = TimeUnit.MINUTES;
+  // TODO: Once the change is fully verified, we should always enable the async feature
+  boolean enableBackupRequestsClientAsync = false;
   EventEmitter eventEmitter = null;
   PartitionAccessorRegistry partitionAccessorRegistry = null;
   Function<ZooKeeper, ZooKeeper> zooKeeperDecorator = null;
   Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories = Collections.emptyMap();
-  boolean requestTimeoutHandlerEnabled = true;
+  boolean requestTimeoutHandlerEnabled = false;
   SslSessionValidatorFactory sslSessionValidatorFactory = null;
   ZKPersistentConnection zkConnectionToUseForLB = null;
   ScheduledExecutorService startUpExecutorService = null;
@@ -128,6 +130,7 @@ public class D2ClientConfig
                  BackupRequestsStrategyStatsConsumer backupRequestsStrategyStatsConsumer,
                  long backupRequestsLatencyNotificationInterval,
                  TimeUnit backupRequestsLatencyNotificationIntervalUnit,
+                 boolean enableBackupRequestsClientAsync,
                  ScheduledExecutorService backupRequestsExecutorService,
                  EventEmitter emitter,
                  PartitionAccessorRegistry partitionAccessorRegistry,
@@ -174,6 +177,7 @@ public class D2ClientConfig
     this.backupRequestsStrategyStatsConsumer = backupRequestsStrategyStatsConsumer;
     this.backupRequestsLatencyNotificationInterval = backupRequestsLatencyNotificationInterval;
     this.backupRequestsLatencyNotificationIntervalUnit = backupRequestsLatencyNotificationIntervalUnit;
+    this.enableBackupRequestsClientAsync = enableBackupRequestsClientAsync;
     this._backupRequestsExecutorService = backupRequestsExecutorService;
     this.eventEmitter = emitter;
     this.partitionAccessorRegistry = partitionAccessorRegistry;

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/BackupRequestsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/BackupRequestsClient.java
@@ -54,7 +54,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.HdrHistogram.AbstractHistogram;
-import org.checkerframework.checker.nullness.Opt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/clients/TestBackupRequestsClient.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clients/TestBackupRequestsClient.java
@@ -34,6 +34,7 @@ import com.linkedin.d2.backuprequests.ResponseTimeDistribution;
 import com.linkedin.d2.backuprequests.TestTrackingBackupRequestsStrategy;
 import com.linkedin.d2.backuprequests.TrackingBackupRequestsStrategy;
 import com.linkedin.d2.balancer.KeyMapper;
+import com.linkedin.d2.balancer.ServiceUnavailableException;
 import com.linkedin.d2.balancer.StaticLoadBalancerState;
 import com.linkedin.d2.balancer.LoadBalancer;
 import com.linkedin.d2.balancer.properties.PartitionData;
@@ -80,6 +81,7 @@ import org.HdrHistogram.AbstractHistogram;
 import org.HdrHistogram.Histogram;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -112,12 +114,12 @@ public class TestBackupRequestsClient
     _executor.shutdown();
   }
 
-  @Test
-  public void testRequest() throws Exception
+  @Test(dataProvider = "isD2Async")
+  public void testRequest(boolean isD2Async) throws Exception
   {
     AtomicReference<ServiceProperties> serviceProperties = new AtomicReference<>();
     serviceProperties.set(createServiceProperties(null));
-    BackupRequestsClient client = createClient(serviceProperties::get);
+    BackupRequestsClient client = createClient(serviceProperties::get, isD2Async);
     URI uri = URI.create("d2://testService");
     RestRequest restRequest = new RestRequestBuilder(uri).setEntity(CONTENT).build();
     Future<RestResponse> response = client.restRequest(restRequest);
@@ -127,8 +129,8 @@ public class TestBackupRequestsClient
   /**
    * Backup Request should still work when a hint is given together with the flag indicating that the hint is only a preference, not requirement.
    */
-  @Test(invocationCount = 3)
-  public void testRequestWithHint() throws Exception
+  @Test(invocationCount = 3, dataProvider = "isD2Async")
+  public void testRequestWithHint(boolean isD2Async) throws Exception
   {
     int responseDelayNano = 100000000; //1s till response comes back
     int backupDelayNano = 50000000; // make backup request after 0.5 second
@@ -137,7 +139,8 @@ public class TestBackupRequestsClient
             Arrays.asList("http://test1.com:123", "http://test2.com:123"),
             hostsReceivingRequest,
             responseDelayNano,
-            backupDelayNano
+            backupDelayNano,
+            isD2Async
         );
 
     URI uri = URI.create("d2://testService");
@@ -184,7 +187,7 @@ public class TestBackupRequestsClient
     AtomicReference<ServiceProperties> serviceProperties = new AtomicReference<>();
     TestBackupRequestsStrategyStatsConsumer statsConsumer = new TestBackupRequestsStrategyStatsConsumer();
     serviceProperties.set(createServiceProperties(null));
-    final BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer);
+    final BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer, false);
     final URI uri = URI.create("d2://testService");
 
     Thread loadGenerator = new Thread(() -> {
@@ -318,13 +321,13 @@ public class TestBackupRequestsClient
     }
   }
 
-  @Test
-  public void testStatsConsumerAddRemove() throws Exception
+  @Test(dataProvider = "isD2Async")
+  public void testStatsConsumerAddRemove(boolean isD2Async) throws Exception
   {
     AtomicReference<ServiceProperties> serviceProperties = new AtomicReference<>();
     TestBackupRequestsStrategyStatsConsumer statsConsumer = new TestBackupRequestsStrategyStatsConsumer();
     serviceProperties.set(createServiceProperties(null));
-    BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer);
+    BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer, isD2Async);
     URI uri = URI.create("d2://testService");
     RestRequest restRequest = new RestRequestBuilder(uri).setEntity(CONTENT).build();
     RequestContext requestContext = new RequestContext();
@@ -372,7 +375,7 @@ public class TestBackupRequestsClient
     serviceProperties.set(createServiceProperties(null));
 
     BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer,
-        new ConstantResponseTimeDistribution(1, TimeUnit.NANOSECONDS));
+        new ConstantResponseTimeDistribution(1, TimeUnit.NANOSECONDS), false);
     URI uri = URI.create("d2://testService");
     RestRequest restRequest = new RestRequestBuilder(uri).setEntity(CONTENT).build();
     RequestContext requestContext = new RequestContext();
@@ -414,13 +417,13 @@ public class TestBackupRequestsClient
       "Expected: " + expected + "+-" + (expected * .01) + ", but actual: " + actual);
   }
 
-  @Test
-  public void testStatsConsumerRemoveOne() throws Exception
+  @Test(dataProvider = "isD2Async")
+  public void testStatsConsumerRemoveOne(boolean isD2Async) throws Exception
   {
     AtomicReference<ServiceProperties> serviceProperties = new AtomicReference<>();
     TestBackupRequestsStrategyStatsConsumer statsConsumer = new TestBackupRequestsStrategyStatsConsumer();
     serviceProperties.set(createServiceProperties(null));
-    BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer);
+    BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer, isD2Async);
     URI uri = URI.create("d2://testService");
     RestRequest restRequest = new RestRequestBuilder(uri).setEntity(CONTENT).build();
     RequestContext requestContext = new RequestContext();
@@ -467,13 +470,13 @@ public class TestBackupRequestsClient
     assertSame(statsProvider2, removedStatsProvider);
   }
 
-  @Test
-  public void testStatsConsumerUpdateAndRemove() throws Exception
+  @Test(dataProvider = "isD2Async")
+  public void testStatsConsumerUpdateAndRemove(boolean isD2Async) throws Exception
   {
     AtomicReference<ServiceProperties> serviceProperties = new AtomicReference<>();
     TestBackupRequestsStrategyStatsConsumer statsConsumer = new TestBackupRequestsStrategyStatsConsumer();
     serviceProperties.set(createServiceProperties(null));
-    BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer);
+    BackupRequestsClient client = createClient(serviceProperties::get, statsConsumer, isD2Async);
     URI uri = URI.create("d2://testService");
     RestRequest restRequest = new RestRequestBuilder(uri).setEntity(CONTENT).build();
     RequestContext requestContext = new RequestContext();
@@ -533,6 +536,34 @@ public class TestBackupRequestsClient
     assertSame(statsProvider2, removedStatsProvider2);
   }
 
+  @Test(dataProvider = "isD2Async")
+  public void testD2ServiceUnavailable(boolean isD2Async) throws Exception
+  {
+    LoadBalancer loadBalancer = new TestLoadBalancer(new ConstantResponseTimeDistribution(1, TimeUnit.NANOSECONDS),
+        null, new ServiceUnavailableException("", ""));
+    TestBackupRequestsStrategyStatsConsumer statsConsumer = new TestBackupRequestsStrategyStatsConsumer();
+    BackupRequestsClient client = createClient(statsConsumer, loadBalancer, isD2Async);
+    URI uri = URI.create("d2://testService");
+    RestRequest restRequest = new RestRequestBuilder(uri).setEntity(CONTENT).build();
+    RequestContext requestContext = new RequestContext();
+    requestContext.putLocalAttr(R2Constants.OPERATION, "get");
+
+    Future<RestResponse> response = client.restRequest(restRequest, requestContext);
+    assertEquals(response.get().getStatus(), 200, "If D2 call fails, we should fallback to request without backup");
+    List<StatsConsumerEvent> events = statsConsumer.getEvents();
+    assertEquals(events.size(), 0);
+  }
+
+  @DataProvider(name = "isD2Async")
+  public Object[][] isD2Async()
+  {
+    return new Object[][]
+        {
+            {true},
+            {false}
+        };
+  }
+
   private ServiceProperties createServiceProperties(List<Map<String, Object>> backupRequests)
   {
     return new ServiceProperties(SERVICE_NAME, CLUSTER_NAME, PATH, Arrays.asList(STRATEGY_NAME),
@@ -541,31 +572,39 @@ public class TestBackupRequestsClient
         Collections.<String, Object> emptyMap(), backupRequests);
   }
 
-  private BackupRequestsClient createClient(Supplier<ServiceProperties> servicePropertiesSupplier)
+  private BackupRequestsClient createClient(Supplier<ServiceProperties> servicePropertiesSupplier, boolean isD2Async)
   {
-    return createClient(servicePropertiesSupplier, null);
+    return createClient(servicePropertiesSupplier, null, isD2Async);
+  }
+
+  private BackupRequestsClient createClient(TestBackupRequestsStrategyStatsConsumer statsConsumer, LoadBalancer loadBalancer,
+      boolean isD2Async)
+  {
+    DynamicClient dynamicClient = new DynamicClient(loadBalancer, null);
+    return new BackupRequestsClient(dynamicClient, loadBalancer, _executor, statsConsumer, 10, TimeUnit.SECONDS, isD2Async);
   }
 
   private BackupRequestsClient createClient(Supplier<ServiceProperties> servicePropertiesSupplier,
-      TestBackupRequestsStrategyStatsConsumer statsConsumer)
+      TestBackupRequestsStrategyStatsConsumer statsConsumer, boolean isD2Async)
   {
     ResponseTimeDistribution hiccupDistribution =
         new GaussianResponseTimeDistribution(500, 1000, 500, TimeUnit.MILLISECONDS);
     ResponseTimeDistribution responseTime =
         new GaussianWithHiccupResponseTimeDistribution(2, 10, 5, TimeUnit.MILLISECONDS, hiccupDistribution, 0.02);
 
-    return createClient(servicePropertiesSupplier, statsConsumer, responseTime);
+    return createClient(servicePropertiesSupplier, statsConsumer, responseTime, isD2Async);
   }
 
   private BackupRequestsClient createClient(Supplier<ServiceProperties> servicePropertiesSupplier,
-      TestBackupRequestsStrategyStatsConsumer statsConsumer, ResponseTimeDistribution responseTime)
+      TestBackupRequestsStrategyStatsConsumer statsConsumer, ResponseTimeDistribution responseTime, boolean isD2Async)
   {
     TestLoadBalancer loadBalancer = new TestLoadBalancer(responseTime, servicePropertiesSupplier);
     DynamicClient dynamicClient = new DynamicClient(loadBalancer, null);
-    return new BackupRequestsClient(dynamicClient, loadBalancer, _executor, statsConsumer, 10, TimeUnit.SECONDS);
+    return new BackupRequestsClient(dynamicClient, loadBalancer, _executor, statsConsumer, 10, TimeUnit.SECONDS, isD2Async);
   }
 
-  private BackupRequestsClient createAlwaysBackupClientWithHosts(List<String> uris, Deque<URI> hostsReceivingRequestList, int responseDelayNano, int backupDelayNano)
+  private BackupRequestsClient createAlwaysBackupClientWithHosts(List<String> uris, Deque<URI> hostsReceivingRequestList,
+      int responseDelayNano, int backupDelayNano, boolean isD2Async)
       throws IOException
   {
     Map<URI,Map<Integer, PartitionData>> partitionDescriptions = new HashMap<URI, Map<Integer, PartitionData>>();
@@ -599,9 +638,9 @@ public class TestBackupRequestsClient
     LoadBalancer loadBalancer = new SimpleLoadBalancer(LbState, _executor);
     DynamicClient dynamicClient = new DynamicClient(loadBalancer, null);
 
-    return new BackupRequestsClient(dynamicClient, loadBalancer, _executor, null, 10, TimeUnit.SECONDS) {
+    return new BackupRequestsClient(dynamicClient, loadBalancer, _executor, null, 10, TimeUnit.SECONDS, isD2Async) {
       @Override
-      Optional<TrackingBackupRequestsStrategy> getStrategy(final String serviceName, final String operation)
+      Optional<TrackingBackupRequestsStrategy> getStrategyAfterUpdate(final String serviceName, final String operation)
       {
         // constantly enable backup request after backupDelayNano time.
         BackupRequestsStrategy alwaysBackup = new TestTrackingBackupRequestsStrategy.MockBackupRequestsStrategy(
@@ -618,11 +657,19 @@ public class TestBackupRequestsClient
 
     private final TransportClient _transportClient;
     private final Supplier<ServiceProperties> _servicePropertiesSupplier;
+    private final Exception _exception;
 
     public TestLoadBalancer(final ResponseTimeDistribution responseTime,
         Supplier<ServiceProperties> servicePropertiesSupplier)
     {
+      this(responseTime, servicePropertiesSupplier, null);
+    }
+
+    public TestLoadBalancer(final ResponseTimeDistribution responseTime,
+        Supplier<ServiceProperties> servicePropertiesSupplier, Exception exception)
+    {
       _servicePropertiesSupplier = servicePropertiesSupplier;
+      _exception = exception;
       _transportClient = new TransportClient()
       {
 
@@ -661,7 +708,12 @@ public class TestBackupRequestsClient
     @Override
     public void getLoadBalancedServiceProperties(String serviceName, Callback<ServiceProperties> clientCallback)
     {
-      clientCallback.onSuccess(_servicePropertiesSupplier.get());
+      if (_exception == null)
+      {
+        clientCallback.onSuccess(_servicePropertiesSupplier.get());
+        return;
+      }
+      clientCallback.onError(_exception);
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.6.6
+version=29.6.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
**Background**
Recently we found some corner cases that is causing D2 Zookeeper call taking a long time and eventually exhausted all threads. After doing some investigation, we found there are 2 places that are making blocking calls to Zookeeper:
1. TimeoutRequestClient
2. BackupRequestClient
We decided to directly deprecate the usage of TimeoutRequestClient, and change the call to be async in BackupRequestClient.

**Changes include**
1. Change the TimeoutRequestClient to be disabled by default (The actual switch is in global config which we will also turn off)
2. Exposed a config to enable the async call in BackupRequestClient.
2. Added the support to make the Zookeeper call to be async in BackupRequestClient.