### PR TITLE
Optimize schema parsing by reusing ParseResult instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-- Include HttpStatus code while throwing IllegalArgumentException
+- Mitigate schema parsing performance regression introduced in `29.5.1` by reusing `ParseResult` instances
+  in `DataSchemaParser` to avoid unnecessary `TreeMap` sorting.
+- Include `HttpStatus` code while throwing `IllegalArgumentException`.
 
 ## [29.6.8] - 2020-09-22
 - Optimized logger initialization in d2 degrader.
@@ -23,27 +25,27 @@ and what APIs have changed, if applicable.
 
 ## [29.6.6] - 2020-09-17
 - Loosen `ReadOnly`/`CreateOnly` validation when setting array-descendant fields in a patch request.
-- Add generatePegasusSchemeSnapshot task.
-- Remove final from nested generated classes, such as inline unions.
+- Add `generatePegasusSchemaSnapshot` task.
+- Remove `final` from nested generated classes, such as inline unions.
 
 ## [29.6.5] - 2020-09-09
-- Update RestLiValidatorFilter and RestLiDataValidator to expose creation of restli validators
+- Update `RestLiValidationFilter` and `RestLiDataValidator` to expose creation of Rest.li validators.
 
 ## [29.6.4] - 2020-09-08
 - Fix inconsistent issue in extension schema file names: from `Extension` to `Extensions`
 - Fix a bug in `FileFormatDataSchemaParser` and remove `isExtensionEntry` method call to simplify the logic.
-- Update ExtensionSchemaValidationCmdLineApp with more validations.
+- Update `ExtensionSchemaValidationCmdLineApp` with more validations.
 
 ## [29.6.3] - 2020-09-03
-- Updated HTTP/2 parent channel idle timeout logging level to info from error 
+- Updated HTTP/2 parent channel idle timeout logging level to info from error.
 
 ## [29.6.2] - 2020-08-31
 - Updated d2 client default config values.
 
 ## [29.6.1] - 2020-08-31
-- Update R2's HTTP client API to support other Netty EventLoopGroup in addition to NioEventLoopGroup
-- Fix a RetryClient bug where NullPointerException is raised when excluded hosts hint is not set at retry
-- Update ExtensionSchemaAnnotation schema: remove resource field, add versionSuffix as an optional field.
+- Update R2's HTTP client API to support other Netty `EventLoopGroup` in addition to `NioEventLoopGroup`.
+- Fix a `RetryClient` bug where `NullPointerException` is raised when excluded hosts hint is not set at retry.
+- Update `ExtensionSchemaAnnotation` schema: remove resource field, add `versionSuffix` as an optional field.
 
 ## [29.6.0] - 2020-08-28
 - Refactored the existing d2 degrader load balancer.
@@ -53,15 +55,16 @@ and what APIs have changed, if applicable.
 - Make `ChangedFileReportTask` gradle task compatible with Gradle 6.0
 
 ## [29.5.7] - 2020-08-26
-- Add pdsc support for ExtensionsDataSchemaResolver for support legacy files in pdsc
-- Add/patch default values in restli response, controlled by $sendDefault flag in URL or server configs
+- Add pdsc support for `ExtensionsDataSchemaResolver` for support legacy files in pdsc.
+- Add/patch default values in Rest.li responses, controlled by the `$sendDefault` flag in the URL or server configs.
 
 ## [29.5.6] - 2020-08-21
-- Add a constructor for DataSchemaParser, which is able to pass ExtensionsDataSchemaResolver to the DataSchemaParser to parse schemas from both extensions and pegasus directories.
+- Add a constructor for `DataSchemaParser`, which is able to pass `ExtensionsDataSchemaResolver` to
+  the `DataSchemaParser` to parse schemas from both `extensions` and `pegasus` directories.
 
 ## [29.5.5] - 2020-08-21
-- Updated File and class path DataSchemaResolvers to resolve extension schemas from /extensions directory if specified.
-- Added DarkGateKeeper to enable users to provide custom implementation to determine if requests are to be dispatched to dark clusters.
+- Updated File and class path DataSchemaResolvers to resolve extension schemas from `/extensions` directory if specified.
+- Added `DarkGateKeeper` to enable users to provide custom implementation to determine if requests are to be dispatched to dark clusters.
 
 ## [29.5.4] - 2020-08-17
 - Increase default timeout for symbol table fetch to 1s.
@@ -4669,7 +4672,8 @@ patch operations can re-use these classes for generating patch messages.
 [29.5.4]: https://github.com/linkedin/rest.li/compare/v29.5.3...v29.5.4
 [29.5.3]: https://github.com/linkedin/rest.li/compare/v29.5.2...v29.5.3
 [29.5.2]: https://github.com/linkedin/rest.li/compare/v29.5.1...v29.5.2
-[29.5.1]: https://github.com/linkedin/rest.li/compare/v29.4.14...v29.5.1
+[29.5.1]: https://github.com/linkedin/rest.li/compare/v29.5.0...v29.5.1
+[29.5.0]: https://github.com/linkedin/rest.li/compare/v29.4.14...v29.5.0
 [29.4.14]: https://github.com/linkedin/rest.li/compare/v29.4.13...v29.4.14
 [29.4.13]: https://github.com/linkedin/rest.li/compare/v29.4.12...v29.4.13
 [29.4.12]: https://github.com/linkedin/rest.li/compare/v29.4.11...v29.4.12

--- a/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
@@ -48,7 +48,8 @@ import java.util.jar.JarFile;
  * @author Keren Jin
  * @author Joe Betz
  */
-public class FileFormatDataSchemaParser {
+public class FileFormatDataSchemaParser
+{
   static final String SCHEMA_PATH_PREFIX = SchemaDirectoryName.PEGASUS.getName() + "/";
   static final String EXTENSION_PATH_ENTRY = SchemaDirectoryName.EXTENSIONS.getName() + "/";
   private final String _resolverPath;
@@ -62,10 +63,15 @@ public class FileFormatDataSchemaParser {
     _schemaParserFactory = schemaParserFactory;
   }
 
-  public DataSchemaParser.ParseResult parseSources(String sources[]) throws IOException
+  public DataSchemaParser.ParseResult parseSources(String[] sources) throws IOException
   {
     final DataSchemaParser.ParseResult result = new DataSchemaParser.ParseResult();
+    parseSources(sources, result);
+    return result;
+  }
 
+  void parseSources(String[] sources, DataSchemaParser.ParseResult result) throws IOException
+  {
     try
     {
       for (String source : sources)
@@ -132,8 +138,6 @@ public class FileFormatDataSchemaParser {
         final DataSchema schema = _schemaResolver.bindings().get(entry.getKey());
         result.getSchemaAndLocations().put(schema, entry.getValue());
       }
-
-      return result;
     }
     catch (RuntimeException e)
     {


### PR DESCRIPTION
This is meant to replace PR #416 

PR #376 made schema parsing deterministic in part by sorting parser
results. When using `DataSchemaParser` to parse data schemas from multiple
sources, a separate `ParseResult` instance is constructed for each source
then ultimately combined into a new singular instance. This introduced a
performance regression when parsing from many sources due to unnecessary
sorting. This change fixes that by allowing `FileFormatDataSchemaParser`
to reuse the root instance rather than constructing a new one.

Also adds more comments for clarity.