### PR TITLE
Deprecate old constructor in FileFormatDataSchemaParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Deprecate `FileFormatDataSchemaParser#new(String, DataSchemaResolver, DataSchemaParserFactory)`. 
 
 ## [29.22.14] - 2021-11-24
 - Fix bug where content type was not set for stream requests

--- a/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
@@ -54,17 +54,21 @@ public class FileFormatDataSchemaParser
   private final DataSchemaParserFactory _schemaParserFactory;
   private final List<SchemaDirectory> _sourceDirectories;
 
-  public FileFormatDataSchemaParser(String resolverPath, DataSchemaResolver schemaResolver, DataSchemaParserFactory schemaParserFactory)
-  {
-    this(schemaResolver, schemaParserFactory, schemaResolver.getSchemaDirectories());
-  }
-
   public FileFormatDataSchemaParser(DataSchemaResolver schemaResolver,
       DataSchemaParserFactory schemaParserFactory, List<SchemaDirectory> sourceDirectories)
   {
     _schemaResolver = schemaResolver;
     _schemaParserFactory = schemaParserFactory;
     _sourceDirectories = sourceDirectories;
+  }
+
+  /**
+   * @deprecated Use {@link #FileFormatDataSchemaParser(DataSchemaResolver, DataSchemaParserFactory, List)} instead.
+   */
+  @Deprecated
+  public FileFormatDataSchemaParser(String resolverPath, DataSchemaResolver schemaResolver, DataSchemaParserFactory schemaParserFactory)
+  {
+    this(schemaResolver, schemaParserFactory, schemaResolver.getSchemaDirectories());
   }
 
   public DataSchemaParser.ParseResult parseSources(String[] sources) throws IOException


### PR DESCRIPTION
Follow-up to #417 