### PR TITLE
Optimize logger in degrader load balancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.6.8] - 2020-09-22
+- Optimized logger initialization in d2 degrader.
+
 ## [29.6.7] - 2020-09-18
 - Added async call to Zookeeper in backup request client.
 
@@ -4648,7 +4651,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.8...master
+[29.6.8]: https://github.com/linkedin/rest.li/compare/v29.6.7...v29.6.8
 [29.6.7]: https://github.com/linkedin/rest.li/compare/v29.6.6...v29.6.7
 [29.6.6]: https://github.com/linkedin/rest.li/compare/v29.6.5...v29.6.6
 [29.6.5]: https://github.com/linkedin/rest.li/compare/v29.6.5...master

--- a/degrader/src/main/java/com/linkedin/util/degrader/DegraderImpl.java
+++ b/degrader/src/main/java/com/linkedin/util/degrader/DegraderImpl.java
@@ -144,6 +144,7 @@ public class DegraderImpl implements Degrader
   public static final double   DEFAULT_SLOW_START_THRESHOLD = 0.0d;
   public static final double   DEFAULT_LOG_THRESHOLD = 0.5d;
   public static final double   DEFAULT_PREEMPTIVE_REQUEST_TIMEOUT_RATE = 1.0d;
+  public static final Logger   DEFAULT_LOGGER = LoggerFactory.getLogger(ImmutableConfig.class);
 
   private ImmutableConfig _config;
   private String _name;
@@ -695,7 +696,7 @@ public class DegraderImpl implements Degrader
     protected int _overrideMinCallCount = DEFAULT_OVERRIDE_MIN_CALL_COUNT;
     protected double _initialDropRate = DEFAULT_INITIAL_DROP_RATE;
     protected double _slowStartThreshold = DEFAULT_SLOW_START_THRESHOLD;
-    protected Logger _logger = LoggerFactory.getLogger(ImmutableConfig.class);
+    protected Logger _logger = DEFAULT_LOGGER;
     protected double _logThreshold = DEFAULT_LOG_THRESHOLD;
     protected double _preemptiveRequestTimeoutRate = DEFAULT_PREEMPTIVE_REQUEST_TIMEOUT_RATE;
 

--- a/degrader/src/test/java/com/linkedin/util/degrader/TestDegrader.java
+++ b/degrader/src/test/java/com/linkedin/util/degrader/TestDegrader.java
@@ -234,6 +234,7 @@ public class TestDegrader
     assertTrue(config.getLowOutstanding() == DegraderImpl.DEFAULT_LOW_OUTSTANDING);
     assertTrue(config.getMinOutstandingCount() == DegraderImpl.DEFAULT_MIN_OUTSTANDING_COUNT);
     assertTrue(config.getPreemptiveRequestTimeoutRate() == DegraderImpl.DEFAULT_PREEMPTIVE_REQUEST_TIMEOUT_RATE);
+    assertTrue(config.getLogger() == DegraderImpl.DEFAULT_LOGGER);
 
     String testName = "aaaa";
     config.setName(testName);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.6.7
+version=29.6.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
There are complaints from service owners that DegraderImpl LoggerFactory.getLogger is taking long time, and the call occurs very frequently that may impact client side performance. After looking into the code, I found that whenever we instantiate a new ImmutableConfig in DegraderImpl, we will call LoggerFactory.getLogger once to get the default value for the logger. This change will create a static variable for the default logger.