### PR TITLE
Add monitoring metrics for relative strategy in DegraderLoadBalancerStrategyV3Jmx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.6.9] - 2020-09-22
 - Mitigate schema parsing performance regression introduced in `29.5.1` by reusing `ParseResult` instances
   in `DataSchemaParser` to avoid unnecessary `TreeMap` sorting.
 - Include `HttpStatus` code while throwing `IllegalArgumentException`.
+- Add monitoring metrics for relative strategy in DegraderLoadBalancerStrategyV3Jmx
 
 ## [29.6.8] - 2020-09-22
 - Optimized logger initialization in d2 degrader.
@@ -4655,7 +4658,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.6.9...master
+[29.6.9]: https://github.com/linkedin/rest.li/compare/v29.6.8...v29.6.9
 [29.6.8]: https://github.com/linkedin/rest.li/compare/v29.6.7...v29.6.8
 [29.6.7]: https://github.com/linkedin/rest.li/compare/v29.6.6...v29.6.7
 [29.6.6]: https://github.com/linkedin/rest.li/compare/v29.6.5...v29.6.6

--- a/d2/src/main/java/com/linkedin/d2/jmx/DegraderLoadBalancerStrategyV3JmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/DegraderLoadBalancerStrategyV3JmxMBean.java
@@ -83,4 +83,24 @@ public interface DegraderLoadBalancerStrategyV3JmxMBean
    */
   double getCurrentAvgClusterLatency(int partitionId);
 
+  /**
+   * Used for relative strategy monitoring mode
+   *
+   * @return the standard deviation of cluster latencies
+   */
+  double getLatencyStandardDeviation();
+
+  /**
+   * Used for relative strategy monitoring mode
+   *
+   * @return the relative ratio between max latency and average cluster latency
+   */
+  double getMaxLatencyRelativeFactor();
+
+  /**
+   * Used for relative strategy monitoring mode
+   *
+   * @return the relative ratio between nth percentile latency and average cluster latency
+   */
+  double getNthPercentileLatencyRelativeFactor(double pct);
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
@@ -57,7 +57,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     double avgLatency = getAvgClusterLatency(stateMap.keySet());
 
     return stateMap.keySet().stream()
-        .filter(this::hasTraffic)
+        .filter(RelativeLoadBalancerStrategyJmx::hasTraffic)
         .map(trackerClient -> Math.abs(StateUpdater.getAvgHostLatency(trackerClient.getCallTracker().getCallStats()) - avgLatency))
         .mapToDouble(Double::doubleValue)
         .average()
@@ -151,17 +151,17 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
         .sum();
   }
 
-  private boolean hasTraffic(TrackerClient trackerClient)
+  static boolean hasTraffic(TrackerClient trackerClient)
   {
     CallTracker.CallStats stats = trackerClient.getCallTracker().getCallStats();
     return stats.getOutstandingCount() + stats.getCallCount() > 0;
   }
 
-  private double calculateStandardDeviation(Set<TrackerClient> trackerClients)
+  static double calculateStandardDeviation(Set<? extends TrackerClient> trackerClients)
   {
     double avgLatency = getAvgClusterLatency(trackerClients);
     double variance = trackerClients.stream()
-        .filter(this::hasTraffic)
+        .filter(RelativeLoadBalancerStrategyJmx::hasTraffic)
         .map(trackerClient -> Math.pow(StateUpdater.getAvgHostLatency(trackerClient.getCallTracker().getCallStats()) - avgLatency, 2))
         .mapToDouble(Double::doubleValue)
         .average()
@@ -170,7 +170,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     return Math.sqrt(variance);
   }
 
-  private long getAvgClusterLatency(Set<TrackerClient> trackerClients)
+  static long getAvgClusterLatency(Set<? extends TrackerClient> trackerClients)
   {
     long latencySum = 0;
     long outstandingLatencySum = 0;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.6.8
+version=29.6.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
- Add relative strategy monitoring metrics in DegraderLoadBalancerStrategyV3Jmx
- It is a safe practice to ensure relative strategy works correctly before broader roll-out.
- Also a useful tool for tuning relative factor based on degrader strategy performance.