### PR TITLE
Address a few flaky tests

### DIFF
--- a/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerStrategy.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerStrategy.java
@@ -534,7 +534,7 @@ public class TestLoadBalancerStrategy
     assertEquals(pointsMap.get(testRunner.getUri(4)).intValue(), HEALTHY_POINTS);
   }
 
-  @Test(dataProvider = "highFactor")
+  @Test(dataProvider = "highFactor", retryAnalyzer = SingleRetry.class)
   public void testDifferentHighLatencyFactors(double highFactor)
   {
     long unhealthyLatency = 800L;

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -18,6 +18,7 @@ package com.linkedin.d2.balancer.strategies.relative;
 
 import com.linkedin.d2.D2RelativeStrategyProperties;
 import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.test.util.retry.SingleRetry;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -143,7 +144,7 @@ public class StateUpdaterTest
     executorService.shutdown();
   }
 
-  @Test
+  @Test(retryAnalyzer = SingleRetry.class) // May need a warmup iteration
   public void testClusterGenerationIdChange() throws InterruptedException {
     PartitionState state = new PartitionStateTestDataBuilder()
         .setClusterGenerationId(DEFAULT_CLUSTER_GENERATION_ID)


### PR DESCRIPTION
Adds retries to a couple D2 tests and improves a Multiplexer unit test to be tolerant of failures in CI.

This is motivated by the recent high rate of flaky tests in CI.