### PR TITLE
Add checkPegasusSchemaSnapshotTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add `checkPegasusSchemaSnapshot` task. 
+   - The task will be used to check any pegasus schema compatible and incompatible changes.
+   - The pegasus schema may or may not be part of a rest.li resource.
+   - The task will be triggered at build time, if user provides gradle property: "pegasusPlugin.enablePegasusSchemaCompatibilityCheck=true".
 
 ## [29.7.2] - 2020-09-25
 - Move from lambdas to explicit change listeners since lambda garbage collection is unreliable in Java

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
@@ -52,7 +52,15 @@ public class CompatibilityMessage extends Message
     /**
      * Numeric promotion.
      */
-    VALUES_MAY_BE_TRUNCATED_OR_OVERFLOW(false);
+    VALUES_MAY_BE_TRUNCATED_OR_OVERFLOW(false),
+    /**
+     * Adding new schema is compatible change.
+     */
+    NEW_SCHEMA_ADDED(false),
+    /**
+     * Deleting an schema is incompatible change, it breaks old clients.
+     */
+    BREAK_OLD_CLIENTS(true);
 
     private final boolean _error;
 

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/FileCompatibilityType.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/FileCompatibilityType.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pegasus.gradle;
 
 public enum FileCompatibilityType {
   SNAPSHOT,
   IDL,
+  PEGASUS_SCHEMA_SNAPSHOT
 }

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PropertyUtil.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PropertyUtil.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pegasus.gradle;
 
 import org.gradle.api.Project;
 
 import static com.linkedin.pegasus.gradle.PegasusPlugin.SNAPSHOT_COMPAT_REQUIREMENT;
 import static com.linkedin.pegasus.gradle.PegasusPlugin.IDL_COMPAT_REQUIREMENT;
+import static com.linkedin.pegasus.gradle.PegasusPlugin.PEGASUS_SCHEMA_SNAPSHOT_REQUIREMENT;
 
 
 public class PropertyUtil
@@ -11,6 +27,19 @@ public class PropertyUtil
   public static String findCompatLevel(Project project, FileCompatibilityType type)
   {
     return findCompatLevel(project, findProperty(type));
+  }
+
+  public static String findCompatMode(Project project, String propertyName)
+  {
+    if (project.hasProperty(propertyName))
+    {
+      String compatMode = project.property(propertyName).toString().toUpperCase();
+      if (compatMode.equals("SCHEMA") || compatMode.equals("DATA"))
+      {
+        return compatMode;
+      }
+    }
+    return "SCHEMA";
   }
 
   public static String findProperty(FileCompatibilityType type)
@@ -21,6 +50,8 @@ public class PropertyUtil
         return SNAPSHOT_COMPAT_REQUIREMENT;
       case IDL:
         return IDL_COMPAT_REQUIREMENT;
+      case PEGASUS_SCHEMA_SNAPSHOT:
+        return PEGASUS_SCHEMA_SNAPSHOT_REQUIREMENT;
       default:
         return null;
     }
@@ -43,7 +74,7 @@ public class PropertyUtil
     }
     else
     {
-      if (propertyName.equals(SNAPSHOT_COMPAT_REQUIREMENT))
+      if (propertyName.equals(SNAPSHOT_COMPAT_REQUIREMENT) || propertyName.equals(PEGASUS_SCHEMA_SNAPSHOT_REQUIREMENT))
       {
         // backwards compatible by default.
         return "BACKWARDS";

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/SharedFileUtils.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/SharedFileUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pegasus.gradle;
 
 import java.io.File;

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckPegasusSnapshotTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckPegasusSnapshotTask.java
@@ -1,32 +1,176 @@
 /*
-   Copyright (c) 2020 LinkedIn Corp.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-*/
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pegasus.gradle.tasks;
 
+
+import com.linkedin.pegasus.gradle.PathingJarUtil;
+import com.linkedin.pegasus.gradle.internal.CompatibilityLogChecker;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 
 
 @CacheableTask
 public class CheckPegasusSnapshotTask extends DefaultTask
 {
+  private File _currentSnapshotDirectory;
+  private File _previousSnapshotDirectory;
+  private String _compatibilityLevel;
+  private FileCollection _codegenClasspath;
+  private String _compatibilityMode;
+  private FileCollection _handlerJarPath;
+  private boolean _isExtensionSchema = false;
+  private static String PEGASUS_SCHEMA_COMPATIBILITY_SUMMARY_FILE = "reports/checkPegasusSchema/compatibilityReport.txt";
+  private static String PEGASUS_EXTENSION_SCHEMA_COMPATIBILITY_SUMMARY_FILE = "reports/checkPegasusExtensionSchema/compatibilityReport.txt";
+
   @TaskAction
   public void checkPegasusSnapshot()
   {
-    // TODO: implement CheckPegasusSnapshotTask
+    getLogger().info("Checking pegasus schema compatibility ...");
+
+    FileCollection pathedCodegenClasspath;
+    try
+    {
+      pathedCodegenClasspath = PathingJarUtil.generatePathingJar(getProject(), getName(),
+          _codegenClasspath, false);
+    }
+    catch (IOException e)
+    {
+      throw new GradleException("Error occurred generating pathing JAR.", e);
+    }
+
+    File reportOutput = new File(getProject().getBuildDir(), _isExtensionSchema ? PEGASUS_EXTENSION_SCHEMA_COMPATIBILITY_SUMMARY_FILE :
+        PEGASUS_SCHEMA_COMPATIBILITY_SUMMARY_FILE);
+    reportOutput.getParentFile().mkdirs();
+
+    getProject().javaexec(javaExecSpec ->
+    {
+      javaExecSpec.setMain("com.linkedin.restli.tools.snapshot.check.PegasusSchemaSnapshotCompatibilityChecker");
+      javaExecSpec.setClasspath(pathedCodegenClasspath);
+      javaExecSpec.args("--compatLevel", _compatibilityLevel);
+      javaExecSpec.args("--compatMode", _compatibilityMode);
+      javaExecSpec.args("--report", reportOutput);
+      javaExecSpec.args(_previousSnapshotDirectory);
+      javaExecSpec.args(_currentSnapshotDirectory);
+    });
+
+    CompatibilityLogChecker logChecker = new CompatibilityLogChecker();
+    try
+    {
+      logChecker.write(Files.readAllBytes(reportOutput.toPath()));
+    }
+    catch (IOException e)
+    {
+      new GradleException("Error whiling processing compatibility report: " + e.getMessage());
+    }
+    if (!logChecker.isModelCompatible())
+    {
+      throw new GradleException("There are incompatible changes, find details in " + reportOutput.getAbsolutePath());
+    }
   }
 
+  @InputDirectory
+  @SkipWhenEmpty
+  @PathSensitive(PathSensitivity.RELATIVE)
+  public File getCurrentSnapshotDirectory()
+  {
+    return _currentSnapshotDirectory;
+  }
+
+  public void setCurrentSnapshotDirectory(File currentSnapshotDirectory)
+  {
+    _currentSnapshotDirectory = currentSnapshotDirectory;
+  }
+
+  @InputDirectory
+  @SkipWhenEmpty
+  @PathSensitive(PathSensitivity.RELATIVE)
+  public File getPreviousSnapshotDirectory()
+  {
+    return _previousSnapshotDirectory;
+  }
+
+  public void setPreviousSnapshotDirectory(File previousSnapshotDirectory)
+  {
+    _previousSnapshotDirectory = previousSnapshotDirectory;
+  }
+
+  @Input
+  public String getCompatibilityLevel()
+  {
+    return _compatibilityLevel;
+  }
+
+  public void setCompatibilityLevel(String compatibilityLevel)
+  {
+    _compatibilityLevel = compatibilityLevel;
+  }
+
+  @Input
+  public String getCompatibilityMode()
+  {
+    return _compatibilityMode;
+  }
+
+  public void setCompatibilityMode(String compatibilityMode)
+  {
+    _compatibilityMode = compatibilityMode;
+  }
+
+  @Classpath
+  public FileCollection getCodegenClasspath()
+  {
+    return _codegenClasspath;
+  }
+
+  public void setCodegenClasspath(FileCollection codegenClasspath)
+  {
+    _codegenClasspath = codegenClasspath;
+  }
+
+  @Input
+  public boolean isExtensionSchema()
+  {
+    return _isExtensionSchema;
+  }
+
+  public void setExtensionSchema(boolean isExtensionSchema)
+  {
+    _isExtensionSchema = isExtensionSchema;
+  }
+
+  @Classpath
+  public FileCollection getHandlerJarPath()
+  {
+    return _handlerJarPath;
+  }
+
+  public void setHandlerJarPath(FileCollection handlerJarPath)
+  {
+    _handlerJarPath = handlerJarPath;
+  }
 }

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckRestModelTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckRestModelTask.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pegasus.gradle.tasks;
 
 import com.linkedin.pegasus.gradle.IOUtil;
@@ -368,7 +383,6 @@ public class CheckRestModelTask extends DefaultTask
         filePairs.add(absolutePath);
       }
     });
-
     previousFilenameToAbsolutePath.forEach((filename, absolutePath) ->
     {
       //Add missing file

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/check/PegasusSchemaSnapshotCompatibilityChecker.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/check/PegasusSchemaSnapshotCompatibilityChecker.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.restli.tools.snapshot.check;
+
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.schema.compatibility.CompatibilityChecker;
+import com.linkedin.data.schema.compatibility.CompatibilityMessage;
+import com.linkedin.data.schema.compatibility.CompatibilityOptions;
+import com.linkedin.data.schema.compatibility.CompatibilityResult;
+import com.linkedin.data.schema.grammar.PdlSchemaParser;
+import com.linkedin.data.schema.resolver.DefaultDataSchemaResolver;
+import com.linkedin.restli.tools.compatibility.CompatibilityInfoMap;
+import com.linkedin.restli.tools.compatibility.CompatibilityReport;
+import com.linkedin.restli.tools.idlcheck.CompatibilityLevel;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Check Compatibility between pairs of Pegasus Schema Snapshots (.pdl files).
+ *
+ * @author Yingjie Bi
+ */
+public class PegasusSchemaSnapshotCompatibilityChecker
+{
+
+  private static final Options _options = new Options();
+  private static final Logger _logger = LoggerFactory.getLogger(
+      PegasusSchemaSnapshotCompatibilityChecker.class);
+  private final CompatibilityInfoMap _infoMap = new CompatibilityInfoMap();
+  private static final String PDL = ".pdl";
+
+
+  static
+  {
+    _options.addOption(OptionBuilder.withLongOpt("help")
+        .withDescription("Print help")
+        .create('h'));
+    _options.addOption(OptionBuilder.withArgName("compatibility_level")
+        .withLongOpt("compatLevel")
+        .hasArg()
+        .withDescription("Compatibility level " + listCompatLevelOptions())
+        .create("cl"));
+    _options.addOption(OptionBuilder.withArgName("compatibilityOption_mode")
+        .withLongOpt("compatMode")
+        .hasArg()
+        .withDescription("CompatibilityOption Mode " + listCompatModeOptions())
+        .create("cm"));
+    _options.addOption(OptionBuilder.withArgName("compatibility_report")
+        .withLongOpt("report")
+        .hasArg()
+        .withDescription("Write the compatibility report into the provided file at the end of the execution.")
+        .create("report"));
+  }
+
+  public static void main(String[] args) throws Exception
+  {
+    final CommandLineParser parser = new GnuParser();
+    CommandLine cl = parser.parse(_options, args);
+
+    if (cl.hasOption('h'))
+    {
+      help();
+      System.exit(0);
+    }
+
+    String[] cliArgs = cl.getArgs();
+
+    if (cliArgs.length != 2)
+    {
+      _logger.error("Invalid arguments!");
+      help();
+      System.exit(1);
+    }
+
+    String prevSnapshotDir = cliArgs[0];
+    String currSnapshotDir = cliArgs[1];
+
+    List<String> prevSnapshotAndCurrSnapshotPairs = getMatchingPrevAndCurrSnapshotPairs(prevSnapshotDir, currSnapshotDir);
+
+    CompatibilityLevel compatLevel = null;
+    if (cl.hasOption("cl"))
+    {
+      try
+      {
+        compatLevel = CompatibilityLevel.valueOf(cl.getOptionValue("cl").toUpperCase());
+      }
+      catch (IllegalArgumentException e)
+      {
+        _logger.error("Invalid compatibilityLevel: " + cl.getOptionValue("cl") + e.getMessage());
+        help();
+        System.exit(1);
+      }
+    }
+    else
+    {
+      compatLevel = CompatibilityLevel.DEFAULT;
+    }
+
+    CompatibilityOptions.Mode compatMode = null;
+    if (cl.hasOption("cm"))
+    {
+      try
+      {
+        compatMode = CompatibilityOptions.Mode.valueOf(cl.getOptionValue("cm").toUpperCase());
+      }
+      catch (IllegalArgumentException e)
+      {
+        _logger.error("Invalid compatibilityOption Mode: " + cl.getOptionValue("cm") + e.getMessage());
+        help();
+        System.exit(1);
+      }
+    }
+    else
+    {
+      compatMode = CompatibilityOptions.Mode.SCHEMA;
+    }
+
+    PegasusSchemaSnapshotCompatibilityChecker compatibilityChecker = new PegasusSchemaSnapshotCompatibilityChecker();
+    for (int i = 1; i < prevSnapshotAndCurrSnapshotPairs.size(); i += 2)
+    {
+      String prevSnapshot = prevSnapshotAndCurrSnapshotPairs.get(i-1);
+      String currentSnapshot = prevSnapshotAndCurrSnapshotPairs.get(i);
+      compatibilityChecker.checkPegasusSchemaCompatibility(prevSnapshot, currentSnapshot, compatMode);
+    }
+
+    if (cl.hasOption("report"))
+    {
+      File reportFile = new File(cl.getOptionValue("report"));
+      String compatibilityReport = new CompatibilityReport(compatibilityChecker._infoMap, compatLevel).createReport();
+      Files.write(reportFile.toPath(), compatibilityReport.getBytes(StandardCharsets.UTF_8));
+      System.exit(0);
+    }
+
+    System.exit(compatibilityChecker._infoMap.isModelCompatible(compatLevel) ? 0 : 1);
+  }
+
+  /**
+   * Check backwards compatibility between a pegasusSchemaSnapshot (.pdl) and a pegasusSchemaSnapshot (.pdl) file.
+   *
+   * @param prevPegasusSchemaPath previously existing snapshot file
+   * @param currentPegasusSchemaPath current snapshot file
+   * @param compatMode compatibilityOptions mode which defines the compatibility check mode.
+   * @return CompatibilityInfoMap which contains information whether the given two files are compatible or not.
+   */
+  public CompatibilityInfoMap checkPegasusSchemaCompatibility(String prevPegasusSchemaPath, String currentPegasusSchemaPath,
+      CompatibilityOptions.Mode compatMode)
+  {
+    boolean newSchemaCreated = false;
+    boolean preSchemaRemoved = false;
+
+    DataSchema preSchema = null;
+    try
+    {
+      preSchema = parseSchema(new File(prevPegasusSchemaPath));
+    }
+    catch(FileNotFoundException e)
+    {
+      newSchemaCreated = true;
+    }
+
+    DataSchema currSchema = null;
+    try
+    {
+      currSchema = parseSchema(new File(currentPegasusSchemaPath));
+    }
+    catch(FileNotFoundException e)
+    {
+      preSchemaRemoved = true;
+    }
+
+    if (newSchemaCreated && !preSchemaRemoved)
+    {
+      constructCompatibilityMessage(CompatibilityMessage.Impact.NEW_SCHEMA_ADDED,
+          "New schema %s is created.", currentPegasusSchemaPath);
+    }
+    if (!newSchemaCreated && preSchemaRemoved)
+    {
+      constructCompatibilityMessage(CompatibilityMessage.Impact.BREAK_OLD_CLIENTS,
+          "Schema %s is removed.", prevPegasusSchemaPath);
+    }
+
+    if (preSchema == null || currSchema == null)
+    {
+      return _infoMap;
+    }
+
+    CompatibilityOptions compatibilityOptions = new CompatibilityOptions().setMode(compatMode).setAllowPromotions(true);
+    CompatibilityResult result = CompatibilityChecker.checkCompatibility(preSchema, currSchema, compatibilityOptions);
+
+    if (!result.getMessages().isEmpty())
+    {
+      result.getMessages().forEach(message -> _infoMap.addModelInfo(message));
+    }
+
+    return _infoMap;
+  }
+
+  private void constructCompatibilityMessage(CompatibilityMessage.Impact impact, String format, Object... args)
+  {
+    CompatibilityMessage message = new CompatibilityMessage(new Object[]{}, impact, format, args);
+    _infoMap.addModelInfo(message);
+  }
+
+  private DataSchema parseSchema(File schemaFile) throws FileNotFoundException
+  {
+    PdlSchemaParser parser = new PdlSchemaParser(new DefaultDataSchemaResolver());
+    parser.parse(new FileInputStream(schemaFile));
+    if (parser.hasError())
+    {
+      throw new RuntimeException(parser.errorMessage() + " Error while parsing file: " + schemaFile.toString());
+    }
+
+    List<DataSchema> topLevelDataSchemas = parser.topLevelDataSchemas();
+    if (topLevelDataSchemas.size() != 1)
+    {
+      throw new RuntimeException("Could not parse schema : " + schemaFile.getAbsolutePath() + " The size of top level schemas is not 1.");
+    }
+    DataSchema topLevelDataSchema = topLevelDataSchemas.get(0);
+    if (!(topLevelDataSchema instanceof NamedDataSchema))
+    {
+      throw new RuntimeException("Invalid schema : " + schemaFile.getAbsolutePath() + ", the schema is not a named schema.");
+    }
+    return topLevelDataSchema;
+  }
+
+  private static String listCompatLevelOptions()
+  {
+    StringJoiner stringJoiner = new StringJoiner("|", "<", ">");
+    Stream.of(CompatibilityLevel.values()).forEach(e -> stringJoiner.add(e.name()));
+    return stringJoiner.toString();
+  }
+
+  private static String listCompatModeOptions()
+  {
+    StringJoiner stringJoiner = new StringJoiner("|", "<", ">");
+    Stream.of(CompatibilityOptions.Mode.values()).forEach(e -> stringJoiner.add(e.name()));
+    return stringJoiner.toString();
+  }
+
+  private static void help()
+  {
+    final HelpFormatter formatter = new HelpFormatter();
+    formatter.printHelp(120,
+        PegasusSchemaSnapshotCompatibilityChecker.class.getSimpleName(),
+        "[compatibility_level], [compatibilityOption_mode], [report], [prevSnapshotDir], [currSnapshotDir]",
+        _options,
+        "",
+        true);
+  }
+
+  /**
+   * Generate a file pair list, the same snapshot names of prevSnapshot and currSnapshot will be grouped together.
+   *
+   * @param prevSnapshotDir
+   * @param currSnapshotDir
+   * @return filePairList List<String>
+   */
+  static List<String> getMatchingPrevAndCurrSnapshotPairs(String prevSnapshotDir, String currSnapshotDir)
+  {
+    Map<String, String> prevFilesMap = createMapFromFiles(prevSnapshotDir);
+    Map<String, String> currFilesMap = createMapFromFiles(currSnapshotDir);
+    List<String> filePairs = new ArrayList<>();
+
+    currFilesMap.forEach((filename, absolutePath) ->
+    {
+      if (prevFilesMap.containsKey(filename))
+      {
+        filePairs.add(prevFilesMap.get(filename));
+        filePairs.add(absolutePath);
+        prevFilesMap.remove(filename);
+      }
+      else
+      {
+        filePairs.add("");
+        filePairs.add(absolutePath);
+      }
+    });
+
+    prevFilesMap.forEach((filename, absolutePath) ->
+    {
+      filePairs.add(absolutePath);
+      filePairs.add("");
+    });
+
+    return filePairs;
+  }
+
+  /**
+   * Create a map for all the files under snapshot directory.
+   * The key is the file name, the value is the absolutePath of the file
+   * @param snapshotFileDir
+   * @return filesMap Map<String, String>
+   */
+  static Map<String, String> createMapFromFiles(String snapshotFileDir)
+  {
+    try (Stream<Path> paths = Files.walk(Paths.get(snapshotFileDir)))
+    {
+      return paths
+          .filter(path -> path.toString().endsWith(PDL))
+          .map(path -> path.toFile())
+          .collect(Collectors.toMap(File::getName, File:: getAbsolutePath, (first, second) -> first));
+    }
+    catch (IOException e)
+    {
+      _logger.error ("Error while reading snapshot directory: " + snapshotFileDir);
+      System.exit(1);
+    }
+    return null;
+  }
+}

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/check/TestPegasusSchemaSnapshotCompatibilityChecker.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/check/TestPegasusSchemaSnapshotCompatibilityChecker.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.restli.tools.snapshot.check;
+
+import com.linkedin.data.schema.compatibility.CompatibilityOptions;
+import com.linkedin.restli.tools.compatibility.CompatibilityInfoMap;
+import com.linkedin.restli.tools.idlcheck.CompatibilityInfo;
+import com.linkedin.restli.tools.idlcheck.CompatibilityLevel;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TestPegasusSchemaSnapshotCompatibilityChecker
+{
+  private final String FS = File.separator;
+  private String testDir = System.getProperty("testDir", new File("src/test").getAbsolutePath());
+  private String snapshotDir = testDir + FS + "pegasusSchemaSnapshot";
+
+  @Test(dataProvider = "compatibleInputFiles")
+  public void testCompatiblePegasusSchemaSnapshot(String prevSchema, String currSchema)
+  {
+    PegasusSchemaSnapshotCompatibilityChecker checker = new PegasusSchemaSnapshotCompatibilityChecker();
+    CompatibilityInfoMap infoMap = checker.checkPegasusSchemaCompatibility(snapshotDir + FS + prevSchema, snapshotDir + FS + currSchema,
+        CompatibilityOptions.Mode.DATA);
+    Assert.assertTrue(infoMap.isModelCompatible(CompatibilityLevel.EQUIVALENT));
+  }
+
+  @Test(dataProvider = "incompatibleInputFiles")
+  public void testIncompatiblePegasusSchemaSnapshot(String prevSchema, String currSchema,
+      Collection<CompatibilityInfo> expectedIncompatibilityErrors, Collection<CompatibilityInfo> expectedCompatibilityDiffs )
+  {
+    PegasusSchemaSnapshotCompatibilityChecker checker = new PegasusSchemaSnapshotCompatibilityChecker();
+    CompatibilityInfoMap infoMap = checker.checkPegasusSchemaCompatibility(snapshotDir + FS + prevSchema, snapshotDir + FS + currSchema,
+        CompatibilityOptions.Mode.DATA);
+    Assert.assertFalse(infoMap.isModelCompatible(CompatibilityLevel.BACKWARDS));
+    Assert.assertFalse(infoMap.isModelCompatible(CompatibilityLevel.EQUIVALENT));
+    Assert.assertTrue(infoMap.isModelCompatible(CompatibilityLevel.IGNORE));
+
+    final Collection<CompatibilityInfo> modelIncompatibles = infoMap.getModelIncompatibles();
+    final Collection<CompatibilityInfo> modelCompatibles = infoMap.getModelCompatibles();
+
+    for (CompatibilityInfo error : expectedIncompatibilityErrors)
+    {
+      Assert.assertTrue(modelIncompatibles.contains(error), "Reported model incompatibles should contain: " + error.toString());
+      modelIncompatibles.remove(error);
+    }
+    for (CompatibilityInfo diff : expectedCompatibilityDiffs)
+    {
+      Assert.assertTrue(modelCompatibles.contains(diff), "Reported model compatibles should contain: " + diff.toString());
+      modelCompatibles.remove(diff);
+    }
+
+    Assert.assertTrue(modelIncompatibles.isEmpty());
+    Assert.assertTrue(modelCompatibles.isEmpty());
+  }
+
+  @Test(dataProvider = "fileMapTestData")
+  public void testCreateMapFromFiles(String inputDir, Map<String, String> expectedFileMap)
+  {
+    PegasusSchemaSnapshotCompatibilityChecker checker = new PegasusSchemaSnapshotCompatibilityChecker();
+    Map<String,String> actualResult = checker.createMapFromFiles(inputDir);
+    Assert.assertEquals(actualResult.size(), expectedFileMap.size());
+    actualResult.forEach((fileName, path)-> {
+      Assert.assertTrue(expectedFileMap.containsKey(fileName));
+      Assert.assertEquals(actualResult.get(fileName), expectedFileMap.get(fileName));
+    });
+  }
+
+  @Test(dataProvider = "matchingFilePairTestData")
+  public void testGetMatchingPrevAndCurrSnapshotPairs(String preSnapshotDir, String currSnapshotDir, List<String> expectedFilePairList)
+  {
+    PegasusSchemaSnapshotCompatibilityChecker checker = new PegasusSchemaSnapshotCompatibilityChecker();
+    List<String> actualFilePairList = checker.getMatchingPrevAndCurrSnapshotPairs(preSnapshotDir, currSnapshotDir);
+    Assert.assertEquals(actualFilePairList.size(), expectedFilePairList.size());
+    for (int i = 0; i < actualFilePairList.size(); i++)
+    {
+      Assert.assertEquals(actualFilePairList.get(0), expectedFilePairList.get(0));
+    }
+  }
+
+  @DataProvider
+  private Object[][] matchingFilePairTestData()
+  {
+    String prevSnapshotDir = snapshotDir + FS + "prevSnapshot";
+    String currSnapshotDir = snapshotDir + FS + "currSnapshot";
+    List<String> pairList = Arrays.asList(
+        prevSnapshotDir + FS + "BirthInfo.pdl",
+        currSnapshotDir + FS + "BirthInfo.pdl",
+        "",
+        currSnapshotDir + FS + "com.linkedin.test.BirthInfo.pdl",
+        prevSnapshotDir + FS + "com.linkedin.test.Data.pdl",
+        ""
+    );
+    return new Object[][]
+        {
+            {
+                prevSnapshotDir,
+                currSnapshotDir,
+                pairList
+            }
+        };
+  }
+
+  @DataProvider
+  private Object[][] fileMapTestData()
+  {
+    String inputDir = snapshotDir + FS + "currSnapshot";
+    String fileName1 = "com.linkedin.test.BirthInfo.pdl";
+    String fileName2 = "BirthInfo.pdl";
+    Map<String, String> fileMap = new HashMap<>();
+    fileMap.put(fileName1, inputDir + FS + fileName1);
+    fileMap.put(fileName2, inputDir + FS + fileName2);
+
+    return new Object[][]
+        {
+            {   inputDir,
+                fileMap
+            }
+        };
+  }
+
+  @DataProvider
+  private Object[][] compatibleInputFiles()
+  {
+    return new Object[][]
+        {
+            { "BirthInfo.pdl", "compatibleSchemaSnapshot/BirthInfo.pdl"},
+        };
+  }
+
+  @DataProvider
+  private Object[][] incompatibleInputFiles()
+  {
+    final Collection<CompatibilityInfo> incompatibilityErrors = new HashSet<CompatibilityInfo>();
+    final Collection<CompatibilityInfo> compatibilityDiffs = new HashSet<CompatibilityInfo>();
+    incompatibilityErrors.add(new CompatibilityInfo(Arrays.<Object>asList("BirthInfo"),
+        CompatibilityInfo.Type.TYPE_BREAKS_NEW_READER, "new record added required fields name"));
+    incompatibilityErrors.add(new CompatibilityInfo(Arrays.<Object>asList("BirthInfo"),
+        CompatibilityInfo.Type.TYPE_BREAKS_OLD_READER, "new record removed required fields year"));
+    incompatibilityErrors.add(new CompatibilityInfo(Arrays.<Object>asList("BirthInfo", "day", "string"),
+        CompatibilityInfo.Type.TYPE_BREAKS_NEW_AND_OLD_READERS, "schema type changed from int to string"));
+    compatibilityDiffs.add(new CompatibilityInfo(Arrays.<Object>asList("BirthInfo", "month", "long"),
+        CompatibilityInfo.Type.TYPE_INFO, "numeric type promoted from int to long"));
+
+    return new Object[][]
+        {
+            {   "BirthInfo.pdl",
+                "incompatibleSchemaSnapshot/BirthInfo.pdl",
+                incompatibilityErrors,
+                compatibilityDiffs
+            }
+        };
+  }
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/BirthInfo.pdl
@@ -1,0 +1,14 @@
+/**
+ * This schema is used as a genereted pegasus schema snapshot(.pdl)
+ * to test pegasusSchemaSnapshotCompatibilityChecker
+ */
+record BirthInfo {
+  day: int
+  month: int
+  year: int
+  location: optional record Location {
+    latitude: float
+    longitude: float
+    name: optional string
+  }
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/currSnapshot/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/currSnapshot/BirthInfo.pdl
@@ -1,0 +1,14 @@
+/**
+ * This schema is used as a genereted pegasus schema snapshot(.pdl)
+ * to test pegasusSchemaSnapshotCompatibilityChecker
+ */
+record BirthInfo {
+  day: int
+  month: int
+  year: int
+  location: optional record Location {
+    latitude: float
+    longitude: float
+    name: optional string
+  }
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/currSnapshot/com.linkedin.test.BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/currSnapshot/com.linkedin.test.BirthInfo.pdl
@@ -1,0 +1,14 @@
+/**
+ * This schema is used as a genereted pegasus schema snapshot(.pdl)
+ * to test pegasusSchemaSnapshotCompatibilityChecker
+ */
+record BirthInfo {
+  day: int
+  month: int
+  year: int
+  location: optional record Location {
+    latitude: float
+    longitude: float
+    name: optional string
+  }
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/incompatibleSchemaSnapshot/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/incompatibleSchemaSnapshot/BirthInfo.pdl
@@ -1,0 +1,15 @@
+/**
+ * This schema is used as a genereted pegasus schema snapshot(.pdl)
+ * to test pegasusSchemaSnapshotCompatibilityChecker
+ * This one represents incompatible changes
+ */
+record BirthInfo {
+  day: string
+  month: long
+  location: optional record Location {
+    latitude: float
+    longitude: float
+    name: optional string
+  }
+  name: string
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/prevSnapshot/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/prevSnapshot/BirthInfo.pdl
@@ -1,0 +1,14 @@
+/**
+ * This schema is used as a genereted pegasus schema snapshot(.pdl)
+ * to test pegasusSchemaSnapshotCompatibilityChecker
+ */
+record BirthInfo {
+  day: int
+  month: int
+  year: int
+  location: optional record Location {
+    latitude: float
+    longitude: float
+    name: optional string
+  }
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/prevSnapshot/com.linkedin.test.Date.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/prevSnapshot/com.linkedin.test.Date.pdl
@@ -1,0 +1,9 @@
+/**
+ * This schema is used as a genereted pegasus schema snapshot(.pdl)
+ * to test pegasusSchemaSnapshotCompatibilityChecker
+ */
+record Date {
+  day: int
+  month: int
+  year: int
+}


### PR DESCRIPTION
checkPegasusSchemaSnapshotTask is used to check the pegasus schema's compatibility.
The check is based on the snapshots(.pdl files) which are generated in generatePegasusSchemaSnapshotTask.