### PR TITLE
Move from lambdas to explicit change listeners since lambda garbage collection is unreliable in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.7.2] - 2020-09-25
+- Move from lambdas to explicit change listeners since lambda garbage collection is unreliable in Java
+
 ## [29.7.1] - 2020-09-24
 - Handle setting map change listener correctly on copy and clone
 
@@ -4667,7 +4670,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.2...master
+[29.7.2]: https://github.com/linkedin/rest.li/compare/v29.7.1...v29.7.2
 [29.7.1]: https://github.com/linkedin/rest.li/compare/v29.7.0...v29.7.1
 [29.7.0]: https://github.com/linkedin/rest.li/compare/v29.6.9...v29.7.0
 [29.6.9]: https://github.com/linkedin/rest.li/compare/v29.6.8...v29.6.9

--- a/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
+++ b/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
@@ -516,6 +516,12 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
    */
   public interface ChangeListener<K, V>
   {
+    /**
+     * Listener method called whenever an entry in the underlying map is updated or removed.
+     * 
+     * @param key Key being updated.
+     * @param value Updated value, can be null when entries are removed.
+     */
     void onUnderlyingMapChanged(K key, V value);
   }
 

--- a/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
+++ b/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 
 
 /**
@@ -334,7 +333,7 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
    *
    * @param listener The listener to register.
    */
-  public final void addChangeListener(BiFunction<K, V, Void> listener)
+  public final void addChangeListener(ChangeListener<K, V> listener)
   {
     if (_changeListeners == null)
     {
@@ -472,10 +471,10 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
     }
 
     _changeListeners.forEach(listenerRef -> {
-      BiFunction<K, V, Void> listener = listenerRef.get();
+      ChangeListener<K, V> listener = listenerRef.get();
       if (listener != null)
       {
-        listener.apply(key, value);
+        listener.onUnderlyingMapChanged(key, value);
       }
     });
   }
@@ -488,10 +487,10 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
     }
 
     _changeListeners.forEach(listenerRef -> {
-      BiFunction<K, V, Void> listener = listenerRef.get();
+      ChangeListener<K, V> listener = listenerRef.get();
       if (listener != null)
       {
-        map.forEach(listener::apply);
+        map.forEach(listener::onUnderlyingMapChanged);
       }
     });
   }
@@ -504,16 +503,24 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
     }
 
     _changeListeners.forEach(listenerRef -> {
-      BiFunction<K, V, Void> listener = listenerRef.get();
+      ChangeListener<K, V> listener = listenerRef.get();
       if (listener != null)
       {
-        keys.forEach(key -> listener.apply(key, null));
+        keys.forEach(key -> listener.onUnderlyingMapChanged(key, null));
       }
     });
+  }
+
+  /**
+   * Change listener interface invoked when the underlying map changes.
+   */
+  public interface ChangeListener<K, V>
+  {
+    void onUnderlyingMapChanged(K key, V value);
   }
 
   private boolean _readOnly = false;
   protected MapChecker<K,V> _checker;
   private HashMap<K,V> _map;
-  private List<WeakReference<BiFunction<K, V, Void>>> _changeListeners;
+  private List<WeakReference<ChangeListener<K, V>>> _changeListeners;
 }

--- a/data/src/main/java/com/linkedin/data/template/RecordTemplate.java
+++ b/data/src/main/java/com/linkedin/data/template/RecordTemplate.java
@@ -18,8 +18,8 @@ package com.linkedin.data.template;
 
 
 import com.linkedin.data.DataMap;
+import com.linkedin.data.collections.CheckedMap;
 import com.linkedin.data.schema.RecordDataSchema;
-import java.util.function.BiFunction;
 
 
 /**
@@ -407,7 +407,7 @@ public abstract class RecordTemplate implements DataTemplate<DataMap>
   /**
    * Register a change listener to get notified when the underlying map changes.
    */
-  protected void addChangeListener(BiFunction<String, Object, Void> listener)
+  protected void addChangeListener(CheckedMap.ChangeListener<String, Object> listener)
   {
     //
     // This UGLY hack is needed because IdResponse breaks the implicit RecordTemplate contract and passes in

--- a/data/src/main/java/com/linkedin/data/template/UnionTemplate.java
+++ b/data/src/main/java/com/linkedin/data/template/UnionTemplate.java
@@ -18,10 +18,10 @@ package com.linkedin.data.template;
 
 import com.linkedin.data.Data;
 import com.linkedin.data.DataMap;
+import com.linkedin.data.collections.CheckedMap;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaConstants;
 import com.linkedin.data.schema.UnionDataSchema;
-import java.util.function.BiFunction;
 
 
 /**
@@ -443,7 +443,7 @@ public class UnionTemplate implements DataTemplate<Object>
   /**
    * Register a change listener to get notified when the underlying map changes.
    */
-  protected void addChangeListener(BiFunction<String, Object, Void> listener)
+  protected void addChangeListener(CheckedMap.ChangeListener<String, Object> listener)
   {
     //
     // This UGLY hack is needed because IdResponse breaks the implicit RecordTemplate contract and passes in

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.1
+version=29.7.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The changes in this PR are backwards incompatible with the changes introduced in 29.7.0 (and 29.7.1). Both these versions have the [GC issue](http://squeakytech.blogspot.com/2015/10/lambda-expressions-events-and-weak.html#:~:text=What%20happens%20when%20you%20store,Your%20assumption%20may%20be%20wrong) and should be deprecated.