### PR TITLE
Add method in ParseResult class to get base schema

### DIFF
--- a/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
@@ -21,7 +21,6 @@ import com.linkedin.data.schema.DataSchemaLocation;
 import com.linkedin.data.schema.DataSchemaParserFactory;
 import com.linkedin.data.schema.DataSchemaResolver;
 import com.linkedin.data.schema.resolver.AbstractMultiFormatDataSchemaResolver;
-import com.linkedin.data.schema.resolver.ExtensionsDataSchemaResolver;
 import com.linkedin.data.schema.resolver.FileDataSchemaLocation;
 import com.linkedin.data.schema.resolver.InJarFileDataSchemaLocation;
 import com.linkedin.data.schema.resolver.MultiFormatDataSchemaResolver;
@@ -31,7 +30,6 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -211,24 +209,33 @@ public class DataSchemaParser
       return _schemaAndLocations;
     }
 
+    public Map<DataSchema, DataSchemaLocation> getBaseDataSchemaAndLocations()
+    {
+      return _schemaAndLocations.entrySet().stream().filter(entry -> !isExtensionSchemaLocation(entry))
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
     public Map<DataSchema, DataSchemaLocation> getExtensionDataSchemaAndLocations()
     {
-      return _schemaAndLocations.entrySet().stream().filter(entry ->
+      return _schemaAndLocations.entrySet().stream().filter(DataSchemaParser.ParseResult::isExtensionSchemaLocation)
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    static boolean isExtensionSchemaLocation(Map.Entry<DataSchema, DataSchemaLocation> entry)
+    {
+      DataSchemaLocation dataSchemaLocation = entry.getValue();
+      if (dataSchemaLocation instanceof InJarFileDataSchemaLocation)
       {
-        DataSchemaLocation dataSchemaLocation = entry.getValue();
-        if (dataSchemaLocation instanceof InJarFileDataSchemaLocation)
-        {
-          InJarFileDataSchemaLocation inJarFileDataSchemaLocation = (InJarFileDataSchemaLocation) dataSchemaLocation;
-          return inJarFileDataSchemaLocation.getPathInJar().startsWith(SchemaDirectoryName.EXTENSIONS.getName());
-        }
-        else if (dataSchemaLocation instanceof FileDataSchemaLocation)
-        {
-          FileDataSchemaLocation fileDataSchemaLocation = (FileDataSchemaLocation) dataSchemaLocation;
-          return fileDataSchemaLocation.getSourceFile().getName().endsWith(EXTENSION_FILENAME_SUFFIX) &&
+        InJarFileDataSchemaLocation inJarFileDataSchemaLocation = (InJarFileDataSchemaLocation) dataSchemaLocation;
+        return inJarFileDataSchemaLocation.getPathInJar().startsWith(SchemaDirectoryName.EXTENSIONS.getName());
+      }
+      else if (dataSchemaLocation instanceof FileDataSchemaLocation)
+      {
+        FileDataSchemaLocation fileDataSchemaLocation = (FileDataSchemaLocation) dataSchemaLocation;
+        return fileDataSchemaLocation.getSourceFile().getName().endsWith(EXTENSION_FILENAME_SUFFIX) &&
             fileDataSchemaLocation.getSourceFile().getParent().indexOf(SchemaDirectoryName.EXTENSIONS.getName()) > 0;
-        }
-        return false;
-      }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      }
+      return false;
     }
 
     public Set<File> getSourceFiles()

--- a/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
@@ -204,17 +204,31 @@ public class DataSchemaParser
     private final Set<File> _sourceFiles = new HashSet<>();
     protected final StringBuilder _messageBuilder = new StringBuilder();
 
+    /**
+     * Get all schema and schemaLocations in one shot
+     * @return a map of data schema locations keyed by DataSchema object
+     */
     public Map<DataSchema, DataSchemaLocation> getSchemaAndLocations()
     {
       return _schemaAndLocations;
     }
 
+    /**
+     * Get all base schemas from the parsing result. The base schema is judged by non-extension schemas.
+     * @return a map of non-extension data schema locations keyed by DataSchema object
+     */
     public Map<DataSchema, DataSchemaLocation> getBaseDataSchemaAndLocations()
     {
       return _schemaAndLocations.entrySet().stream().filter(entry -> !isExtensionSchemaLocation(entry))
           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
+    /**
+     * Get all extension schema, the criteria is as:
+     * 1. The path suffix is like Extensions.pdl
+     * 2. The path prefix contains "extensions" substring.
+     * @return a map of extension schema and location
+     */
     public Map<DataSchema, DataSchemaLocation> getExtensionDataSchemaAndLocations()
     {
       return _schemaAndLocations.entrySet().stream().filter(DataSchemaParser.ParseResult::isExtensionSchemaLocation)

--- a/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
+++ b/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
@@ -212,6 +212,59 @@ public class TestDataSchemaParser
   }
 
 
+  @DataProvider(name = "ERFilesForBaseSchema")
+  private Object[][] dataSchemaFiles()
+  {
+    return new Object[][]
+        {
+            {
+                new String[]{
+                    "extensions/BarExtensions.pdl",
+                    "extensions/FooExtensions.pdl",
+                    "extensions/FuzzExtensions.pdl",
+                    "pegasus/Foo.pdl",
+                    "pegasus/Bar.pdl",
+                    "pegasus/Fuzz.pdsc"
+                },
+                new String[]{
+                    "Foo",
+                    "Bar",
+                    "Fuzz",
+                    "InlineRecord"
+                }
+            }
+        };
+  }
+
+  @Test(dataProvider = "ERFilesForBaseSchema")
+  public void testParseResultToGetBaseSchemas(String[] files, String[] expectedSchemaNames) throws Exception
+  {
+    String pegasusWithFS = pegasusDir + FS;
+    String resolverPath = pegasusWithFS + "extensionSchemas/extensions:"
+        + pegasusWithFS + "extensionSchemas/others:"
+        + pegasusWithFS + "extensionSchemas/pegasus";
+    try
+    {
+      DataSchemaParser parser = new DataSchemaParser(resolverPath);
+      String[] schemaFiles = Arrays.stream(files).map(casename -> pegasusDir + FS + "extensionSchemas" + FS + casename).toArray(String[]::new);
+      DataSchemaParser.ParseResult parseResult = parser.parseSources(schemaFiles);
+      Map<DataSchema, DataSchemaLocation> bases = parseResult.getBaseDataSchemaAndLocations();
+      assertEquals(bases.size(), expectedSchemaNames.length);
+      Set<String> actualNames = bases
+          .keySet()
+          .stream()
+          .map(dataSchema -> (NamedDataSchema) dataSchema)
+          .map(NamedDataSchema::getName)
+          .collect(Collectors.toSet());
+      assertEquals(actualNames, Arrays.stream(expectedSchemaNames).collect(Collectors.toSet()));
+    }
+    catch (Exception e)
+    {
+      Assert.fail("Test failed");
+    }
+
+  }
+
   @Test
   public void testParseFromJarFileWithTranslatedSchemas() throws Exception
   {

--- a/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
+++ b/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
@@ -160,24 +160,17 @@ public class TestDataSchemaParser
     createTempJarFile(entryToFileMap, jarFile);
 
     ExtensionsDataSchemaResolver resolver = new ExtensionsDataSchemaResolver(jarFile);
-    try
-    {
-      DataSchemaParser parser = new DataSchemaParser(jarFile, resolver);
-      DataSchemaParser.ParseResult parseResult = parser.parseSources(new String[]{jarFile});
-      Map<DataSchema, DataSchemaLocation> extensions = parseResult.getExtensionDataSchemaAndLocations();
-      assertEquals(extensions.size(), expectedExtensions.length);
-      Set<String> actualNames = extensions
-          .keySet()
-          .stream()
-          .map(dataSchema -> (NamedDataSchema) dataSchema)
-          .map(NamedDataSchema::getName)
-          .collect(Collectors.toSet());
-      assertEquals(actualNames, Arrays.stream(expectedExtensions).collect(Collectors.toSet()));
-    }
-    catch (Exception e)
-    {
-      Assert.fail("Test failed");
-    }
+    DataSchemaParser parser = new DataSchemaParser(jarFile, resolver);
+    DataSchemaParser.ParseResult parseResult = parser.parseSources(new String[]{jarFile});
+    Map<DataSchema, DataSchemaLocation> extensions = parseResult.getExtensionDataSchemaAndLocations();
+    assertEquals(extensions.size(), expectedExtensions.length);
+    Set<String> actualNames = extensions
+        .keySet()
+        .stream()
+        .map(dataSchema -> (NamedDataSchema) dataSchema)
+        .map(NamedDataSchema::getName)
+        .collect(Collectors.toSet());
+    assertEquals(actualNames, Arrays.stream(expectedExtensions).collect(Collectors.toSet()));
   }
 
 
@@ -189,26 +182,18 @@ public class TestDataSchemaParser
         + pegasusWithFS + "extensionSchemas/others:"
         + pegasusWithFS + "extensionSchemas/pegasus";
     ExtensionsDataSchemaResolver resolver = new ExtensionsDataSchemaResolver(resolverPath);
-    try
-    {
-      DataSchemaParser parser = new DataSchemaParser(resolverPath, resolver);
-      String[] schemaFiles = Arrays.stream(files).map(casename -> pegasusDir + FS + "extensionSchemas" + FS + casename).toArray(String[]::new);
-      DataSchemaParser.ParseResult parseResult = parser.parseSources(schemaFiles);
-      Map<DataSchema, DataSchemaLocation> extensions = parseResult.getExtensionDataSchemaAndLocations();
-      assertEquals(extensions.size(), expectedExtensions.length);
-      Set<String> actualNames = extensions
-          .keySet()
-          .stream()
-          .map(dataSchema -> (NamedDataSchema) dataSchema)
-          .map(NamedDataSchema::getName)
-          .collect(Collectors.toSet());
-      assertEquals(actualNames, Arrays.stream(expectedExtensions).collect(Collectors.toSet()));
-    }
-    catch (Exception e)
-    {
-      Assert.fail("Test failed");
-    }
-
+    DataSchemaParser parser = new DataSchemaParser(resolverPath, resolver);
+    String[] schemaFiles = Arrays.stream(files).map(casename -> pegasusDir + FS + "extensionSchemas" + FS + casename).toArray(String[]::new);
+    DataSchemaParser.ParseResult parseResult = parser.parseSources(schemaFiles);
+    Map<DataSchema, DataSchemaLocation> extensions = parseResult.getExtensionDataSchemaAndLocations();
+    assertEquals(extensions.size(), expectedExtensions.length);
+    Set<String> actualNames = extensions
+        .keySet()
+        .stream()
+        .map(dataSchema -> (NamedDataSchema) dataSchema)
+        .map(NamedDataSchema::getName)
+        .collect(Collectors.toSet());
+    assertEquals(actualNames, Arrays.stream(expectedExtensions).collect(Collectors.toSet()));
   }
 
 
@@ -243,26 +228,18 @@ public class TestDataSchemaParser
     String resolverPath = pegasusWithFS + "extensionSchemas/extensions:"
         + pegasusWithFS + "extensionSchemas/others:"
         + pegasusWithFS + "extensionSchemas/pegasus";
-    try
-    {
-      DataSchemaParser parser = new DataSchemaParser(resolverPath);
-      String[] schemaFiles = Arrays.stream(files).map(casename -> pegasusDir + FS + "extensionSchemas" + FS + casename).toArray(String[]::new);
-      DataSchemaParser.ParseResult parseResult = parser.parseSources(schemaFiles);
-      Map<DataSchema, DataSchemaLocation> bases = parseResult.getBaseDataSchemaAndLocations();
-      assertEquals(bases.size(), expectedSchemaNames.length);
-      Set<String> actualNames = bases
-          .keySet()
-          .stream()
-          .map(dataSchema -> (NamedDataSchema) dataSchema)
-          .map(NamedDataSchema::getName)
-          .collect(Collectors.toSet());
-      assertEquals(actualNames, Arrays.stream(expectedSchemaNames).collect(Collectors.toSet()));
-    }
-    catch (Exception e)
-    {
-      Assert.fail("Test failed");
-    }
-
+    DataSchemaParser parser = new DataSchemaParser(resolverPath);
+    String[] schemaFiles = Arrays.stream(files).map(casename -> pegasusDir + FS + "extensionSchemas" + FS + casename).toArray(String[]::new);
+    DataSchemaParser.ParseResult parseResult = parser.parseSources(schemaFiles);
+    Map<DataSchema, DataSchemaLocation> bases = parseResult.getBaseDataSchemaAndLocations();
+    assertEquals(bases.size(), expectedSchemaNames.length);
+    Set<String> actualNames = bases
+        .keySet()
+        .stream()
+        .map(dataSchema -> (NamedDataSchema) dataSchema)
+        .map(NamedDataSchema::getName)
+        .collect(Collectors.toSet());
+    assertEquals(actualNames, Arrays.stream(expectedSchemaNames).collect(Collectors.toSet()));
   }
 
   @Test


### PR DESCRIPTION
This is for parsing result easy to get base schema. when both extension and base schemas are in the resolver path.