### PR TITLE
Extend checkPegasusSchemaSnapshot task to be able to check schema annotation compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Extend checkPegasusSchemaSnapshot task to be enable to check schema annotation compatibility.
+  - The annotation compatibility will be triggered if SchemaANnotationHandler config is provided.
+  - Update SchemaAnnotationHandler interface to have a new api - annotationCompatibilityCheck, which can be used to check the custom annotation compatibility check.
 
 ## [29.7.8] - 2020-10-12
 - Encoding performance improvements
@@ -21,14 +24,14 @@ and what APIs have changed, if applicable.
 - Adding dark cluster response validation metrics
 
 ## [29.7.6] - 2020-10-05
-Fix bug referring to coercer before registration.
+- Fix bug referring to coercer before registration.
 
 ## [29.7.5] - 2020-10-05
 - Add an option to configure ProtoWriter buffer size. Set the default to 4096 to prevent thrashing.
 - Use an identity hashmap implementation that uses DataComplex#dataComplexHashCode under the hood for better performance
 
 ## [29.7.4] - 2020-10-03
-Fix bug affecting record fields named "fields".
+- Fix bug affecting record fields named "fields".
 
 ## [29.7.3] - 2020-10-02
 - Bump `parseq` dependency from `2.6.31` to `4.1.6`.

--- a/data/src/main/java/com/linkedin/data/schema/annotation/AnnotationCheckResolvedPropertiesVisitor.java
+++ b/data/src/main/java/com/linkedin/data/schema/annotation/AnnotationCheckResolvedPropertiesVisitor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.data.schema.annotation;
+
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.DataSchemaTraverse;
+import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.annotation.SchemaAnnotationHandler.CompatibilityCheckContext;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+
+/**
+ * This visitor is used to get node in schema to it's resolvedProperties.
+ * The nodesToResolvedPropertiesMap will be used for schema annotation compatibility check
+ *
+ * @author Yingjie Bi
+ */
+public class AnnotationCheckResolvedPropertiesVisitor implements SchemaVisitor
+{
+  private Map<PathSpec, Pair<CompatibilityCheckContext, Map<String, Object>>> _nodeToResolvedPropertiesMap = new HashMap<>();
+
+  @Override
+  public void callbackOnContext(TraverserContext context, DataSchemaTraverse.Order order)
+  {
+    // Skip execute when order is POST_ORDER to avoid traverse the same node twice.
+    // Only execute this callback when order is PRE_ORDER.
+    if (order == DataSchemaTraverse.Order.POST_ORDER)
+    {
+      return;
+    }
+
+    DataSchema currentSchema = context.getCurrentSchema();
+
+    ArrayDeque<String> pathToSchema = context.getSchemaPathSpec().clone();
+    pathToSchema.addFirst(((NamedDataSchema)context.getTopLevelSchema()).getName());
+    PathSpec pathSpec = new PathSpec(pathToSchema);
+
+    CompatibilityCheckContext compatibilityCheckContext = new CompatibilityCheckContext();
+
+    compatibilityCheckContext.setCurrentDataSchema(currentSchema);
+    compatibilityCheckContext.setSchemaField(context.getEnclosingField());
+    compatibilityCheckContext.setUnionMember(context.getEnclosingUnionMember());
+    compatibilityCheckContext.setPathSpecToSchema(pathSpec);
+
+    // If there is no resolvedProperties but properties, used the properties for annotation check.
+    Map<String, Object> properties;
+    if (context.getEnclosingField() != null)
+    {
+      RecordDataSchema.Field field = context.getEnclosingField();
+      properties = chooseProperties(field.getResolvedProperties(), field.getProperties());
+    }
+    else if (context.getEnclosingUnionMember() != null)
+    {
+      // There is no resolvedProperty for unionMember
+      properties = context.getEnclosingUnionMember().getProperties();
+    }
+    else
+    {
+      properties = chooseProperties(currentSchema.getResolvedProperties(), currentSchema.getProperties());
+    }
+
+    _nodeToResolvedPropertiesMap.put(pathSpec, new ImmutablePair<>(compatibilityCheckContext, properties));
+  }
+
+  @Override
+  public VisitorContext getInitialVisitorContext()
+  {
+    return new VisitorContext(){};
+  }
+
+  @Override
+  public SchemaVisitorTraversalResult getSchemaVisitorTraversalResult()
+  {
+    return null;
+  }
+
+  public Map<PathSpec, Pair<CompatibilityCheckContext, Map<String, Object>>>  getNodeToResolvedPropertiesMap()
+  {
+    return _nodeToResolvedPropertiesMap;
+  }
+
+  private Map<String, Object> chooseProperties(Map<String, Object> preferredProperties, Map<String, Object> fallbackProperties)
+  {
+    return preferredProperties.isEmpty() ? fallbackProperties : preferredProperties;
+  }
+}

--- a/data/src/main/java/com/linkedin/data/schema/annotation/IdentitySchemaVisitor.java
+++ b/data/src/main/java/com/linkedin/data/schema/annotation/IdentitySchemaVisitor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.data.schema.annotation;
+
+import com.linkedin.data.schema.DataSchemaTraverse;
+
+
+/**
+ * This SchemaVisitor is used when annotation override is not needed.
+ * It will not traverse the data schema.
+ *
+ * @author Yingjie Bi
+ */
+public class IdentitySchemaVisitor implements SchemaVisitor
+{
+
+  @Override
+  public void callbackOnContext(TraverserContext context, DataSchemaTraverse.Order order) {
+    // skip post order traverse
+    if (order == DataSchemaTraverse.Order.POST_ORDER)
+    {
+      return;
+    }
+
+    // If current schema is a root node, set shouldContinue to false to avoid traverse schema.
+    if (context.getParentSchema() == null)
+    {
+      context.setShouldContinue(false);
+    }
+  }
+
+  @Override
+  public VisitorContext getInitialVisitorContext()
+  {
+    return new VisitorContext(){};
+  }
+
+  @Override
+  public SchemaVisitorTraversalResult getSchemaVisitorTraversalResult()
+  {
+    return new SchemaVisitorTraversalResult();
+  }
+}

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/AnnotationCompatibilityChecker.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/AnnotationCompatibilityChecker.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.data.schema.compatibility;
+
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.schema.annotation.DataSchemaRichContextTraverser;
+import com.linkedin.data.schema.annotation.AnnotationCheckResolvedPropertiesVisitor;
+import com.linkedin.data.schema.annotation.SchemaAnnotationHandler;
+import com.linkedin.data.schema.annotation.SchemaAnnotationHandler.CompatibilityCheckContext;
+import com.linkedin.data.schema.annotation.SchemaAnnotationHandler.AnnotationCompatibilityResult;
+import com.linkedin.data.schema.annotation.SchemaAnnotationProcessor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ *  The annotation compatibility check is part of the annotation processing framework.
+ *  If users use annotation processor to resolve properties,
+ *  they may also provide a annotation compatibility method to define the way to check annotation's compatibility.
+ *  In this checker, it will call the {@link SchemaAnnotationHandler#checkCompatibility} method.
+ *
+ * @author Yingjie Bi
+ */
+public class AnnotationCompatibilityChecker
+{
+  private static final Logger _log = LoggerFactory.getLogger(AnnotationCompatibilityChecker.class);
+
+  /**
+   * Check the pegasus schema annotation compatibility
+   * Process prevSchema and currSchema in the SchemaAnnotationProcessor to get the resolved result with resolvedProperties.
+   * then using the resolvedProperties to do the annotation compatibility check.
+   * @param prevSchema previous data schema
+   * @param currSchema current data schema
+   * @param handlers SchemaAnnotationHandler list
+   * @return List<AnnotationCompatibilityResult>
+   */
+  public static List<AnnotationCompatibilityResult> checkPegasusSchemaAnnotation(DataSchema prevSchema, DataSchema currSchema,
+      List<SchemaAnnotationHandler> handlers)
+  {
+    // Update handler list to only contain handlers with implementation of checkCompatibility.
+    handlers = handlers
+        .stream()
+        .filter( h -> h.implementsCheckCompatibility())
+        .collect(Collectors.toList());
+    SchemaAnnotationProcessor.SchemaAnnotationProcessResult prevSchemaResult = processSchemaAnnotation(prevSchema, handlers);
+    SchemaAnnotationProcessor.SchemaAnnotationProcessResult currSchemaResult = processSchemaAnnotation(currSchema, handlers);
+    Map<PathSpec, Pair<CompatibilityCheckContext, Map<String, Object>>> prevResolvedPropertiesMap
+        = getNodeToResolvedProperties(prevSchemaResult);
+    Map<PathSpec, Pair<CompatibilityCheckContext, Map<String, Object>>> currResolvedPropertiesMap
+        = getNodeToResolvedProperties(currSchemaResult);
+
+    return getCompatibilityResult(prevResolvedPropertiesMap, currResolvedPropertiesMap, handlers);
+  }
+
+  /**
+   * Iterate the nodeToResolverPropertiesMap, if a node's resolvedProperty contains the same annotationNamespace as SchemaAnnotationHandler,
+   * calling annotationCompatibilityCheck api which is provided in the SchemaAnnotationHandler to do the annotation compatibility check.
+   */
+  private static List<AnnotationCompatibilityResult> getCompatibilityResult(Map<PathSpec, Pair<CompatibilityCheckContext,
+      Map<String, Object>>> prevResolvedPropertiesMap, Map<PathSpec, Pair<CompatibilityCheckContext,
+      Map<String, Object>>> currResolvedPropertiesMap, List<SchemaAnnotationHandler> handlers)
+  {
+    List<AnnotationCompatibilityResult> results = new ArrayList<>();
+
+    prevResolvedPropertiesMap.forEach((pathSpec, prevCheckContextAndResolvedProperty) ->
+    {
+      Map<String, Object> prevResolvedProperties = prevCheckContextAndResolvedProperty.getValue();
+      handlers.forEach(handler ->
+      {
+        String annotationNamespace = handler.getAnnotationNamespace();
+        if (currResolvedPropertiesMap.containsKey(pathSpec))
+        {
+          // If previous schema node and current schema node have the same pathSpec,
+          // they may or may not contain the same annotation namespace as SchemaAnnotationHandler, we need to check further.
+          Pair<CompatibilityCheckContext, Map<String, Object>>
+              currCheckContextAndResolvedProperty = currResolvedPropertiesMap.get(pathSpec);
+          Map<String, Object> currResolvedProperties = currCheckContextAndResolvedProperty.getValue();
+
+          // If prevResolvedProperties or currResolvedProperties contains the same namespace as the provided SchemaAnnotationHandler,
+          // we do the annotation check.
+          if (prevResolvedProperties.containsKey(annotationNamespace) || currResolvedProperties.containsKey(
+              annotationNamespace))
+          {
+            AnnotationCompatibilityResult result =
+                handler.checkCompatibility(prevResolvedProperties, currResolvedProperties,
+                    prevCheckContextAndResolvedProperty.getKey(), currCheckContextAndResolvedProperty.getKey());
+            results.add(result);
+          }
+        }
+        else
+        {
+          if (prevResolvedProperties.containsKey(annotationNamespace))
+          {
+            // prevResolvedPropertiesMap has a pathSpec which the newResolvedPropertiesMap does not have,
+            // it means an existing field is removed.
+            // pass an empty currResolvedPropertiesMap and empty currAnnotationContext to the annotation check.
+            AnnotationCompatibilityResult result =
+                handler.checkCompatibility(prevResolvedProperties, new HashMap<>(),
+                    prevCheckContextAndResolvedProperty.getKey(), new CompatibilityCheckContext());
+            results.add(result);
+          }
+        }
+      });
+      if (currResolvedPropertiesMap.containsKey(pathSpec))
+      {
+        currResolvedPropertiesMap.remove(pathSpec);
+      }
+    });
+
+    currResolvedPropertiesMap.forEach((pathSpec, currCheckContextAndResolvedProperty) ->
+    {
+      handlers.forEach(handler ->
+      {
+        String annotationNamespace = handler.getAnnotationNamespace();
+        Map<String, Object> currResolvedProperties = currCheckContextAndResolvedProperty.getValue();
+        if (currResolvedPropertiesMap.containsKey(annotationNamespace))
+        {
+          // currResolvedPropertiesMap has a PathSpec which the prevResolvedPropertiesMap does not have,
+          // it means there is a new field with new annotations,
+          // pass an empty prevResolvedPropertiesMap and empty prevAnnotationContext to the annotation check.
+          AnnotationCompatibilityResult result = handler.checkCompatibility(new HashMap<>(), currResolvedProperties,
+              new CompatibilityCheckContext(), currCheckContextAndResolvedProperty.getKey());
+          results.add(result);
+        }
+      });
+    });
+    return results;
+  }
+
+  private static Map<PathSpec, Pair<CompatibilityCheckContext, Map<String, Object>>> getNodeToResolvedProperties(
+      SchemaAnnotationProcessor.SchemaAnnotationProcessResult result)
+  {
+    AnnotationCheckResolvedPropertiesVisitor visitor = new AnnotationCheckResolvedPropertiesVisitor();
+    DataSchemaRichContextTraverser traverser = new DataSchemaRichContextTraverser(visitor);
+    traverser.traverse(result.getResultSchema());
+    return visitor.getNodeToResolvedPropertiesMap();
+  }
+
+  private static SchemaAnnotationProcessor.SchemaAnnotationProcessResult processSchemaAnnotation(DataSchema dataSchema,
+      List<SchemaAnnotationHandler> handlers)
+  {
+    SchemaAnnotationProcessor.SchemaAnnotationProcessResult result =
+        SchemaAnnotationProcessor.process(handlers, dataSchema, new SchemaAnnotationProcessor.AnnotationProcessOption(), false);
+    // If any of the nameDataSchema failed to be processed, throw exception
+    if (result.hasError())
+    {
+      String schemaName = ((NamedDataSchema) dataSchema).getFullName();
+      _log.error("Annotation processing for data schema [{}] failed, detailed error: \n",
+          schemaName);
+      _log.error(result.getErrorMsgs());
+      throw new RuntimeException("Could not process annotation of data schema: " + schemaName + " while processing annotation compatibility check.");
+    }
+    return result;
+  }
+}

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
@@ -18,6 +18,7 @@ package com.linkedin.data.schema.compatibility;
 
 
 import com.linkedin.data.message.Message;
+import com.linkedin.data.schema.PathSpec;
 import java.util.Formatter;
 
 
@@ -60,7 +61,15 @@ public class CompatibilityMessage extends Message
     /**
      * Deleting an schema is incompatible change, it breaks old clients.
      */
-    BREAK_OLD_CLIENTS(true);
+    BREAK_OLD_CLIENTS(true),
+    /**
+     * Annotation incompatible change, which can be used in custom annotation compatibility check
+     */
+    ANNOTATION_INCOMPATIBLE_CHANGE(true),
+    /**
+     * Annotation compatible change, which can be used in custom annotation compatibility check
+     */
+    ANNOTATION_COMPATIBLE_CHANGE(false);
 
     private final boolean _error;
 
@@ -80,6 +89,12 @@ public class CompatibilityMessage extends Message
   public CompatibilityMessage(Object[] path, Impact impact, String format, Object... args)
   {
     super(path, impact.isError(), format, args);
+    _impact = impact;
+  }
+
+  public CompatibilityMessage(PathSpec pathSpec, Impact impact, String format, Object... args)
+  {
+    super(pathSpec.getPathComponents().toArray(), impact.isError(), format, args);
     _impact = impact;
   }
 

--- a/data/src/test/java/com/linkedin/data/schema/compatibility/TestAnnotationCompatibilityChecker.java
+++ b/data/src/test/java/com/linkedin/data/schema/compatibility/TestAnnotationCompatibilityChecker.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.data.schema.compatibility;
+
+import com.linkedin.data.DataMap;
+import com.linkedin.data.TestUtil;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.schema.annotation.IdentitySchemaVisitor;
+import com.linkedin.data.schema.annotation.PegasusSchemaAnnotationHandlerImpl;
+import com.linkedin.data.schema.annotation.SchemaAnnotationHandler;
+import com.linkedin.data.schema.annotation.SchemaAnnotationHandler.CompatibilityCheckContext;
+import com.linkedin.data.schema.annotation.SchemaAnnotationHandler.AnnotationCompatibilityResult;
+import com.linkedin.data.schema.annotation.SchemaVisitor;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TestAnnotationCompatibilityChecker
+{
+  private final static String BAR_ANNOTATION_NAMESPACE = "bar";
+  private final static String BAZ_ANNOTATION_NAMESPACE = "baz";
+  private final static String ANNOTATION_FIELD_NAME = "foo";
+
+  @Test(dataProvider = "annotationCompatibilityCheckTestData")
+  public void testCheckCompatibility(String prevSchemaFile, String currSchemaFile, List<SchemaAnnotationHandler> handlers, List<AnnotationCompatibilityResult> expectedResults)
+      throws IOException
+  {
+    DataSchema prevSchema = TestUtil.dataSchemaFromPdlInputStream(getClass().getResourceAsStream(prevSchemaFile));
+    DataSchema currSchema = TestUtil.dataSchemaFromPdlInputStream(getClass().getResourceAsStream(currSchemaFile));
+    List<AnnotationCompatibilityResult> results = AnnotationCompatibilityChecker
+        .checkPegasusSchemaAnnotation(prevSchema, currSchema, handlers);
+    Assert.assertEquals(results.size(), expectedResults.size());
+    for (int i = 0; i < results.size(); i++)
+    {
+      Assert.assertEquals(results.get(i).getMessages().size(), expectedResults.get(i).getMessages().size());
+      List<CompatibilityMessage> actualCompatibilityMessage = (List<CompatibilityMessage>) results.get(i).getMessages();
+      List<CompatibilityMessage> expectCompatibilityMessage = (List<CompatibilityMessage>) expectedResults.get(i).getMessages();
+      for (int j = 0; j < actualCompatibilityMessage.size(); j++)
+      {
+        Assert.assertEquals(actualCompatibilityMessage.get(j).toString(), expectCompatibilityMessage.get(j).toString());
+      }
+    }
+  }
+
+  @DataProvider
+  private Object[][] annotationCompatibilityCheckTestData() throws IOException {
+    // Set up expected result: both previous schema and current schema contain the same PathSpecs.
+    CompatibilityCheckContext checkContext = generateAnnotationCheckContext(new PathSpec("TestSchema1/field1"));
+    CompatibilityCheckContext checkContext1 = generateAnnotationCheckContext(new PathSpec("TestSchema1/field2"));
+
+    AnnotationCompatibilityResult expectResultWithCompatibleChange1 = generateExpectResult(new CompatibilityMessage(checkContext.getPathSpecToSchema(),
+      CompatibilityMessage.Impact.ANNOTATION_COMPATIBLE_CHANGE,
+        "Updating annotation field \"%s\" value is backward compatible change", ANNOTATION_FIELD_NAME));
+    AnnotationCompatibilityResult expectResultWithInCompatibleChange1 = generateExpectResult(new CompatibilityMessage(checkContext1.getPathSpecToSchema(),
+        CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+        "Deleting existed annotation \"%s\" is backward incompatible change", BAR_ANNOTATION_NAMESPACE));
+
+    // Set up expected result: only previous schema contains the resolvedProperty with the same annotation namespace as SchemaAnnotationHandler
+    CompatibilityCheckContext checkContext2 = generateAnnotationCheckContext(new PathSpec("TestSchema2/field1"));
+
+    AnnotationCompatibilityResult expectResult2 = generateExpectResult(new CompatibilityMessage(checkContext2.getPathSpecToSchema(),
+      CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+        "Adding new annotation \"%s\" is backward compatible change", BAR_ANNOTATION_NAMESPACE));
+
+    // Set up expected result: only current schema contains the resolvedProperty with the same annotation namespace as SchemaAnnotationHandler
+    CompatibilityCheckContext checkContext3 = generateAnnotationCheckContext(new PathSpec("TestSchema3/field1"));
+    AnnotationCompatibilityResult expectResult3 = generateExpectResult(new CompatibilityMessage(checkContext3.getPathSpecToSchema(),
+        CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE, "Deleting existed annotation \"%s\" is backward incompatible change", BAR_ANNOTATION_NAMESPACE));
+
+    // Set up expected results: multiple handlers.
+    CompatibilityCheckContext checkContext4 = generateAnnotationCheckContext(new PathSpec("TestSchema4/field1"));
+    AnnotationCompatibilityResult barHandlerExpectResult = generateExpectResult(new CompatibilityMessage(checkContext4.getPathSpecToSchema(),
+        CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+        "Adding new annotation \"%s\" is backward compatible change", BAR_ANNOTATION_NAMESPACE));
+    AnnotationCompatibilityResult bazHandlerExpectResult = generateExpectResult(new CompatibilityMessage(checkContext4.getPathSpecToSchema(),
+        CompatibilityMessage.Impact.ANNOTATION_COMPATIBLE_CHANGE,
+        "Updating annotation field \"%s\" value is backward compatible change", ANNOTATION_FIELD_NAME));
+
+    return new Object[][]
+        {
+            {
+                "previousSchema/TestSchema1.pdl",
+                "currentSchema/TestSchema1.pdl",
+                Collections.singletonList(generateSchemaAnnotationHandler(BAR_ANNOTATION_NAMESPACE)),
+                Arrays.asList(expectResultWithCompatibleChange1, expectResultWithInCompatibleChange1)
+            },
+            {
+                "previousSchema/TestSchema2.pdl",
+                "currentSchema/TestSchema2.pdl",
+                Collections.singletonList(generateSchemaAnnotationHandler(BAR_ANNOTATION_NAMESPACE)),
+                Collections.singletonList(expectResult2)
+            },
+            {
+                "previousSchema/TestSchema3.pdl",
+                "currentSchema/TestSchema3.pdl",
+                Collections.singletonList(generateSchemaAnnotationHandler(BAR_ANNOTATION_NAMESPACE)),
+                Collections.singletonList(expectResult3)
+            },
+            {
+                "previousSchema/TestSchema4.pdl",
+                "currentSchema/TestSchema4.pdl",
+                Arrays.asList(generateSchemaAnnotationHandler(BAR_ANNOTATION_NAMESPACE), generateSchemaAnnotationHandler(BAZ_ANNOTATION_NAMESPACE)),
+                Arrays.asList(barHandlerExpectResult, bazHandlerExpectResult)
+            },
+        };
+  }
+
+  private SchemaAnnotationHandler generateSchemaAnnotationHandler(String annotationNamespace)
+  {
+    SchemaAnnotationHandler handler = new PegasusSchemaAnnotationHandlerImpl(annotationNamespace)
+    {
+      @Override
+      public String getAnnotationNamespace()
+      {
+        return annotationNamespace;
+      }
+
+      @Override
+      public boolean implementsCheckCompatibility()
+      {
+        return true;
+      }
+
+      @Override
+      public SchemaVisitor getVisitor()
+      {
+        return new IdentitySchemaVisitor();
+      }
+
+      @Override
+      public AnnotationCompatibilityResult checkCompatibility(Map<String,Object> prevResolvedProperties, Map<String, Object> currResolvedProperties,
+          CompatibilityCheckContext prevContext, CompatibilityCheckContext currContext)
+      {
+        AnnotationCompatibilityResult result = new AnnotationCompatibilityResult();
+
+        if (prevResolvedProperties.get(annotationNamespace) == null)
+        {
+          if (prevContext.getPathSpecToSchema() != null)
+          {
+            result.getMessages().add(new CompatibilityMessage(currContext.getPathSpecToSchema(),
+                CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE, "Adding new annotation \"%s\" is backward compatible change", annotationNamespace));
+          }
+        }
+        else if (currResolvedProperties.get(annotationNamespace) == null)
+        {
+          if (currContext.getPathSpecToSchema() != null)
+          {
+            result.getMessages().add(new CompatibilityMessage(prevContext.getPathSpecToSchema(),
+                CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE, "Deleting existed annotation \"%s\" is backward incompatible change", annotationNamespace));
+          }
+        }
+        else
+        {
+          DataMap prev = (DataMap) prevResolvedProperties.get(annotationNamespace);
+          DataMap curr = (DataMap) currResolvedProperties.get(annotationNamespace);
+          if (prev.containsKey(ANNOTATION_FIELD_NAME) && !curr.containsKey(ANNOTATION_FIELD_NAME))
+          {
+            result.getMessages().add(new CompatibilityMessage(prevContext.getPathSpecToSchema(),
+                CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE, "remove annotation field \"%s\" is backward incompatible change", ANNOTATION_FIELD_NAME));
+          }
+          if (prev.containsKey(ANNOTATION_FIELD_NAME) && curr.containsKey(ANNOTATION_FIELD_NAME))
+          {
+            if (prev.get(ANNOTATION_FIELD_NAME) != curr.get(ANNOTATION_FIELD_NAME))
+            {
+              result.getMessages().add(new CompatibilityMessage(prevContext.getPathSpecToSchema(),
+                  CompatibilityMessage.Impact.ANNOTATION_COMPATIBLE_CHANGE, "Updating annotation field \"%s\" value is backward compatible change", ANNOTATION_FIELD_NAME));
+            }
+          }
+        }
+        return result;
+      }
+    };
+    return handler;
+  }
+
+  private CompatibilityCheckContext generateAnnotationCheckContext(PathSpec pathSpec)
+  {
+    CompatibilityCheckContext context = new CompatibilityCheckContext();
+    context.setPathSpecToSchema(pathSpec);
+    return context;
+  }
+
+  private AnnotationCompatibilityResult generateExpectResult(CompatibilityMessage compatibilityMessage)
+  {
+    SchemaAnnotationHandler.AnnotationCompatibilityResult result = new SchemaAnnotationHandler.AnnotationCompatibilityResult();
+    result.addMessage(compatibilityMessage);
+    return result;
+  }
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema1.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema1.pdl
@@ -1,0 +1,5 @@
+record TestSchema1 {
+  @bar.foo = 2
+  field1: string,
+  field2: string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema2.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema2.pdl
@@ -1,0 +1,4 @@
+record TestSchema2 {
+  @bar.foo = 1
+  field1: string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema3.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema3.pdl
@@ -1,0 +1,3 @@
+record TestSchema3 {
+  field1: string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema4.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema4.pdl
@@ -1,0 +1,7 @@
+record TestSchema4 {
+  @bar.foo = 1
+  @baz.foo = 2
+  field1: record Test {
+    f: int
+  }
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema1.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema1.pdl
@@ -1,0 +1,6 @@
+record TestSchema1 {
+  @bar.foo = 1
+  field1: string,
+  @bar.foo = 2
+  field2: string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema2.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema2.pdl
@@ -1,0 +1,3 @@
+record TestSchema2 {
+  field1: string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema3.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema3.pdl
@@ -1,0 +1,4 @@
+record TestSchema3 {
+  @bar.foo = 1
+  field1: string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema4.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema4.pdl
@@ -1,0 +1,6 @@
+record TestSchema4 {
+  @baz.foo = 1
+  field1: record Test {
+    f: int
+  }
+}

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/SchemaAnnotationHandlerClassUtil.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/SchemaAnnotationHandlerClassUtil.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pegasus.gradle;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+
+
+/**
+ * a utility class which is used to get SchemaAnnotationHandler class names
+ */
+public class SchemaAnnotationHandlerClassUtil
+{
+  public static final String SCHEMA_HANDLER_JAVA_ANNOTATION = "RestLiSchemaAnnotationHandler";
+  private static final char FILE_SEPARATOR = File.separatorChar;
+  private static final char UNIX_FILE_SEPARATOR = '/';
+  private static final char PACKAGE_SEPARATOR = '.';
+  private static final String CLASS_SUFFIX = ".class";
+  private static final String JAR = "jar";
+  private static ClassLoader _classLoader;
+
+  /**
+   * A helper method to get SchemaAnnotationHandler class names
+   * @param handlerJarPath
+   * @param project
+   * @return a list of handler class names. List<String>
+   * @throws IOException
+   */
+  public static List<String> getAnnotationHandlerClassNames(FileCollection handlerJarPath, ClassLoader classLoader, Project project)
+      throws IOException
+  {
+    _classLoader = classLoader;
+    List<String> foundClassNames = new ArrayList<>();
+    // prevent duplicate scans
+    Set<String> scannedClass = new HashSet<>();
+    for (File f : handlerJarPath)
+    {
+      scanHandlersInClassPathJar(f, foundClassNames, scannedClass, project);
+    }
+    return foundClassNames;
+  }
+
+  /**
+   * A helper method which is used to get annotation handler jar path URLs based on the given handler jar path.
+   * @param handlerJarPath
+   * @return a list of annotation handler jar path URLs. List<URL>
+   */
+  public static List<URL> getAnnotationHandlerJarPathUrls(FileCollection handlerJarPath)
+  {
+    List<URL> handlerJarPathUrls = new ArrayList<>();
+
+    for (File f : handlerJarPath)
+    {
+      try
+      {
+        handlerJarPathUrls.add(f.toURI().toURL());
+      }
+      catch (MalformedURLException e)
+      {
+        throw new GradleException("Could not get schema annotation handler jar " + f.getName() + " to url. " + e.getMessage());
+      }
+    }
+    return handlerJarPathUrls;
+  }
+
+  /**
+   * For now, every schema annotation handler should be in its own module.
+   * If the number of found handlers doesn't match number of configured modules, will throw exception
+   * @param handlerClassNames
+   * @param expectedHandlersNumber
+   */
+  public static void checkAnnotationClassNumber(List<String> handlerClassNames, int expectedHandlersNumber)
+  {
+    if (handlerClassNames.size() != expectedHandlersNumber)
+    {
+      String errorMsg = String.format("Encountered errors when searching for annotation handlers: total %s dependencies configured, but %s handlers found: [%s].",
+          expectedHandlersNumber,
+          handlerClassNames.size(),
+          String.join(",", handlerClassNames));
+      throw new GradleException("Error while getting schema annotation handlers: "  + errorMsg);
+    }
+  }
+
+  private static void scanHandlersInClassPathJar(File f, List<String> foundClasses, Set<String> scannedClass,
+      Project project)
+      throws IOException
+  {
+    if (!f.toURI().toString().toLowerCase().endsWith(JAR))
+    {
+      return;
+    }
+
+    try(
+        InputStream in = f.toURI().toURL().openStream();
+        JarInputStream jarIn = new JarInputStream(in);
+    )
+    {
+
+      for (JarEntry e = jarIn.getNextJarEntry(); e != null; e = jarIn.getNextJarEntry())
+      {
+        if (!e.isDirectory() && !scannedClass.contains(e.getName()))
+        {
+          scannedClass.add(e.getName());
+          checkHandlerAnnotation(toNativePath(e.getName()), foundClasses, project);
+        }
+        jarIn.closeEntry();
+      }
+    } catch (FileNotFoundException e)
+    {
+      // Skip if file not found
+      project.getLogger().error("Encountered unexpected File not found error", e);
+    }
+  }
+
+  private static String toNativePath(final String path)
+  {
+    return path.replace(UNIX_FILE_SEPARATOR, FILE_SEPARATOR);
+  }
+
+  /**
+   * This method will check the java class annotation on the class instantiated by a className;
+   * It will search if that class has an annotation matching schema handler java annotation,
+   * if found, this class name will be added to "foundClasses" list.
+   * if exceptions or errors detected during instantiation of the class, this method will return without doing anything.
+   *
+   * @param name the name of class to be search annotation from.
+   * @param foundClasses a list of class names of the classes that contains schema handler java annotation
+   */
+  private static void checkHandlerAnnotation(String name, List<String> foundClasses, Project project)
+  {
+    if (name.endsWith(CLASS_SUFFIX))
+    {
+      int end = name.lastIndexOf(CLASS_SUFFIX);
+      String clazzPath = name.substring(0, end);
+      String clazzName = pathToName(clazzPath);
+
+      Class<?> clazz = null;
+      try
+      {
+        clazz = classForName(clazzName);
+      }
+      catch (Exception | Error e)
+      {
+        project.getLogger()
+            .info("During search for annotation handlers, encountered an unexpected exception or error [{}] when instantiating the class, "
+                    + "will skip checking this class: [{}]", e.getClass(), clazzName);
+        project.getLogger()
+            .debug("Unexpected exceptions or errors found during instantiating the class [{}], detailed error: ",
+                clazzName, e);
+        return;
+      }
+      for (Annotation a : clazz.getAnnotations())
+      {
+        if (a.annotationType().getName().contains(SCHEMA_HANDLER_JAVA_ANNOTATION))
+        {
+          foundClasses.add(clazzName);
+          return;
+        }
+      }
+    }
+  }
+
+  private static Class<?> classForName(final String name) throws ClassNotFoundException
+  {
+    return Class.forName(name, false, _classLoader);
+  }
+
+  private static String pathToName(final String path)
+  {
+    return path.replace(FILE_SEPARATOR, PACKAGE_SEPARATOR);
+  }
+}

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/internal/CompatibilityLogChecker.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/internal/CompatibilityLogChecker.java
@@ -32,6 +32,11 @@ public class CompatibilityLogChecker extends OutputStream
    */
   boolean isModelCompatible = true;
 
+  /**
+   * Holds the status of annotation compatibility.
+   */
+  boolean isAnnotationCompatible = true;
+
   @Override
   public void write(int b)
       throws IOException
@@ -77,6 +82,10 @@ public class CompatibilityLogChecker extends OutputStream
     {
       modelCompatibility.add(new FileCompatibility(message, false));
     }
+    else if (s.startsWith("[SCHEMA-ANNOTATION-COMPAT]"))
+    {
+      isAnnotationCompatible = Boolean.parseBoolean(message.trim());
+    }
   }
 
   public String getWholeText()
@@ -108,6 +117,14 @@ public class CompatibilityLogChecker extends OutputStream
   public boolean isModelCompatible()
   {
     return isModelCompatible;
+  }
+
+  /**
+   * @return if annotation was compatible.
+   */
+  public boolean isAnnotationCompatible()
+  {
+    return isAnnotationCompatible;
   }
 
   public static class FileCompatibility

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateSchemaAnnotationTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateSchemaAnnotationTask.java
@@ -15,24 +15,16 @@
 */
 package com.linkedin.pegasus.gradle.tasks;
 
+import com.linkedin.pegasus.gradle.SchemaAnnotationHandlerClassUtil;
 import com.linkedin.pegasus.gradle.internal.ArgumentFileGenerator;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarInputStream;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration;
 import org.gradle.api.tasks.CacheableTask;
@@ -62,12 +54,7 @@ import org.gradle.api.tasks.TaskAction;
 @CacheableTask
 public class ValidateSchemaAnnotationTask extends DefaultTask
 {
-  public static final String SCHEMA_HANDLER_JAVA_ANNOTATION = "RestLiSchemaAnnotationHandler";
-  private static final char FILE_SEPARATOR = File.separatorChar;
   private static final String DEFAULT_PATH_SEPARATOR = File.pathSeparator;
-  private static final char UNIX_FILE_SEPARATOR = '/';
-  private static final char PACKAGE_SEPARATOR = '.';
-  private static final String CLASS_SUFFIX = ".class";
   private ClassLoader _classLoader;
   private boolean _enableArgFile;
 
@@ -105,36 +92,16 @@ public class ValidateSchemaAnnotationTask extends DefaultTask
       return;
     }
 
-    List<URL> handlerJarPathUrls = new ArrayList<>();
-
-    for (File f : _handlerJarPath)
-    {
-      handlerJarPathUrls.add(f.toURI().toURL());
-    }
+    List<URL> handlerJarPathUrls = SchemaAnnotationHandlerClassUtil.getAnnotationHandlerJarPathUrls(_handlerJarPath);
 
     _classLoader = new URLClassLoader(handlerJarPathUrls.toArray(new URL[handlerJarPathUrls.size()]),
         getClass().getClassLoader());
 
     getProject().getLogger().info("search for schema annotation handlers...");
 
-    List<String> foundClassNames = new ArrayList<>();
-    Set<String> scannedClass = new HashSet<>(); // prevent duplicate scans
-    for (File f : _handlerJarPath)
-    {
-      scanHandlersInClassPathJar(f, foundClassNames, scannedClass);
-    }
+    List<String> foundClassNames = SchemaAnnotationHandlerClassUtil.getAnnotationHandlerClassNames(_handlerJarPath, _classLoader, getProject());
 
-    // For now, every schema annotation handler should be in its own module
-    // if the number of found handlers doesn't match number of configured modules, will throw exception
-    if (foundClassNames.size() != expectedHandlersNumber)
-    {
-      String errorMsg = String.format("Encountered errors when searching for annotation handlers: total %s dependencies configured, but %s handlers found: [%s].",
-          expectedHandlersNumber,
-          foundClassNames.size(),
-          String.join(",", foundClassNames));
-      getProject().getLogger().error(errorMsg);
-      throw new GradleException("ValidationSchemaAnnotation task failed during search for annotation handlers.");
-    }
+    SchemaAnnotationHandlerClassUtil.checkAnnotationClassNumber(foundClassNames, expectedHandlersNumber);
 
     getProject().getLogger()
         .info("Found Schema annotation processing handlers: " + Arrays.toString(foundClassNames.toArray()));
@@ -158,95 +125,6 @@ public class ValidateSchemaAnnotationTask extends DefaultTask
                             javaExecSpec.args("--resolverPath");
                             javaExecSpec.args(resolverPathArg);
                           });
-  }
-
-  private void scanHandlersInClassPathJar(File f, List<String> foundClasses, Set<String> scannedClass)
-      throws IOException
-  {
-    if (!f.toURI().toString().toLowerCase().endsWith("jar"))
-    {
-      return;
-    }
-
-    try(
-        InputStream in = f.toURI().toURL().openStream();
-        JarInputStream jarIn = new JarInputStream(in);
-    )
-    {
-
-      for (JarEntry e = jarIn.getNextJarEntry(); e != null; e = jarIn.getNextJarEntry())
-      {
-        if (!e.isDirectory() && !scannedClass.contains(e.getName()))
-        {
-          scannedClass.add(e.getName());
-          checkHandlerAnnotation(toNativePath(e.getName()), foundClasses);
-        }
-        jarIn.closeEntry();
-      }
-    } catch (FileNotFoundException e)
-    {
-      // Skip if file not found
-      getProject().getLogger().error("Encountered unexpected File not found error", e);
-    }
-  }
-
-  private String toNativePath(final String path)
-  {
-    return path.replace(UNIX_FILE_SEPARATOR, FILE_SEPARATOR);
-  }
-
-  /**
-   * This method will check the java class annotation on the class instantiated by a className;
-   * It will search if that class has an annotation matching {@link SCHEMA_HANDLER_JAVA_ANNOTATION},
-   * if found, this class name will be added to "foundClasses" list.
-   * if exceptions or errors detected during instantiation of the class, this method will return without doing anything.
-   *
-   * @param name the name of class to be search annotation from.
-   * @param foundClasses a list of class names of the classes that contains {@link SCHEMA_HANDLER_JAVA_ANNOTATION}
-   */
-  private void checkHandlerAnnotation(String name, List<String> foundClasses)
-  {
-    if (name.endsWith(CLASS_SUFFIX))
-    {
-      int end = name.lastIndexOf(CLASS_SUFFIX);
-      String clazzPath = name.substring(0, end);
-      String clazzName = pathToName(clazzPath);
-
-      Class<?> clazz = null;
-      try
-      {
-        clazz = classForName(clazzName);
-      } catch (Exception | Error e)
-      {
-        getProject().getLogger().info("During search for annotation handlers, encountered an unexpected exception or error [{}] when instantiating the class, " +
-            "will skip checking this class: [{}]", e.getClass(), clazzName);
-        getProject().getLogger().debug("Unexpected exceptions or errors found during instantiating the class [{}], detailed error: ", clazzName, e);
-        return;
-      }
-      for (Annotation a : clazz.getAnnotations())
-      {
-        if (a.annotationType().getName().contains(SCHEMA_HANDLER_JAVA_ANNOTATION))
-        {
-          foundClasses.add(clazzName);
-          return;
-        }
-      }
-    }
-  }
-
-  private String pathToName(final String path)
-  {
-    return path.replace(FILE_SEPARATOR, PACKAGE_SEPARATOR);
-  }
-
-  private String toUnixPath(final String path)
-  {
-    return path.replace(FILE_SEPARATOR, UNIX_FILE_SEPARATOR);
-  }
-
-  public Class<?> classForName(final String name) throws ClassNotFoundException
-  {
-    return Class.forName(name, false, _classLoader);
   }
 
   @Classpath

--- a/restli-tools/src/main/java/com/linkedin/restli/internal/tools/ClassJarPathUtil.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/internal/tools/ClassJarPathUtil.java
@@ -1,0 +1,85 @@
+package com.linkedin.restli.internal.tools;
+
+import com.linkedin.data.schema.annotation.SchemaAnnotationHandler;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringTokenizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This utility is used to get Java classes based on the provided class jar paths
+ *
+ * @author Yingjie
+ */
+public class ClassJarPathUtil
+{
+  private static final Logger _logger = LoggerFactory.getLogger(ClassJarPathUtil.class);
+  private static final String DEFAULT_PATH_SEPARATOR = File.pathSeparator;
+
+  /**
+   * A helper method which is used to get the SchemaAnnotationHandler classes based on the given handlerJarPaths and class names
+   * @param handlerJarPaths
+   * @param classNames
+   * @return a list of SchemaAnnotationHandler classes. List<SchemaAnnotationHandler>
+   * @throws IllegalStateException if it could not instantiate the given class.
+   */
+  public static List<SchemaAnnotationHandler> getAnnotationHandlers(String handlerJarPaths, String classNames) throws IllegalStateException
+  {
+    List<SchemaAnnotationHandler> handlers = new ArrayList<>();
+    ClassLoader classLoader = new URLClassLoader(parsePaths(handlerJarPaths)
+        .stream()
+        .map(str ->
+        {
+          try
+          {
+            return Paths.get(str).toUri().toURL();
+          }
+          catch (Exception e)
+          {
+            _logger.error("Parsing class jar path URL {} parsing failed", str, e);
+          }
+          return null;
+        }).filter(Objects::nonNull).toArray(URL[]::new));
+
+    for (String className: parsePaths(classNames))
+    {
+      try
+      {
+        Class<?> handlerClass = Class.forName(className, false, classLoader);
+        SchemaAnnotationHandler handler = (SchemaAnnotationHandler) handlerClass.newInstance();
+        handlers.add(handler);
+      }
+      catch (Exception e)
+      {
+        throw new IllegalStateException("Error instantiating class: " + className + e.getMessage(), e);
+      }
+    }
+    return handlers;
+  }
+
+  /**
+   * A helper method to get a list of class paths from a pathString.
+   * @param pathAsStr
+   * @return a list of class paths. List<String>
+   */
+  public static List<String> parsePaths(String pathAsStr)
+  {
+    List<String> list = new ArrayList<>();
+    if (pathAsStr != null)
+    {
+      StringTokenizer tokenizer = new StringTokenizer(pathAsStr, DEFAULT_PATH_SEPARATOR);
+      while (tokenizer.hasMoreTokens())
+      {
+        list.add(tokenizer.nextToken());
+      }
+    }
+    return list;
+  }
+}

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/annotation/SchemaAnnotationValidatorCmdLineApp.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/annotation/SchemaAnnotationValidatorCmdLineApp.java
@@ -22,6 +22,7 @@ import com.linkedin.data.schema.NamedDataSchema;
 import com.linkedin.data.schema.annotation.SchemaAnnotationHandler;
 import com.linkedin.data.schema.annotation.SchemaAnnotationProcessor;
 import com.linkedin.pegasus.generator.DataSchemaParser;
+import com.linkedin.restli.internal.tools.ClassJarPathUtil;
 import com.linkedin.restli.internal.tools.RestLiToolsUtils;
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +51,6 @@ import org.slf4j.LoggerFactory;
  */
 public class SchemaAnnotationValidatorCmdLineApp
 {
-  private static final String DEFAULT_PATH_SEPARATOR = File.pathSeparator;
   private static final Logger _log = LoggerFactory.getLogger(SchemaAnnotationValidatorCmdLineApp.class);
 
   private static final Options _options = new Options();
@@ -116,34 +116,15 @@ public class SchemaAnnotationValidatorCmdLineApp
       System.exit(1);
     }
 
-    List<String> handlerJarPathsArray = parsePaths(handlerJarPaths);
-    // Use Jar Paths to initiate URL class loaders.
-    ClassLoader classLoader = new URLClassLoader(handlerJarPathsArray.stream().map(str -> {
-      try
-      {
-        return Paths.get(str).toUri().toURL();
-      } catch (Exception e)
-      {
-        _log.error("URL {} parsing failed", str, e);
-      }
-      return null;
-    }).filter(Objects::nonNull).toArray(URL[]::new));
-    List<SchemaAnnotationHandler> handlers = new ArrayList<>();
-    for (String className: parsePaths(handlerClassNames))
+    List<SchemaAnnotationHandler> handlers = null;
+    try
     {
-      try
-      {
-        Class<?> handlerClass = Class.forName(className, false, classLoader);
-        SchemaAnnotationHandler handler = (SchemaAnnotationHandler) handlerClass.newInstance();
-        handlers.add(handler);
-        _log.info("added handler {} for annotation namespace \"{}\"", className, handler.getAnnotationNamespace());
-      }
-      catch (Exception e)
-      {
-        _log.error("Error instantiating handler class {} ", className, e);
-        // fail even just one handler fails
-        throw new IllegalStateException("ValidateSchemaAnnotation task failed");
-      }
+      handlers = ClassJarPathUtil.getAnnotationHandlers(handlerJarPaths, handlerClassNames);
+    }
+    catch (IllegalStateException e)
+    {
+      _log.error(e.getMessage());
+      throw new IllegalStateException("ValidateSchemaAnnotation task failed");
     }
 
     boolean hasError = false;
@@ -174,20 +155,6 @@ public class SchemaAnnotationValidatorCmdLineApp
       // Throw exception at the end if any of
       throw new IllegalStateException("ValidateSchemaAnnotation task failed");
     }
-  }
-
-  private static List<String> parsePaths(String pathAsStr)
-  {
-    List<String> list = new ArrayList<>();
-    if (pathAsStr != null)
-    {
-      StringTokenizer tokenizer = new StringTokenizer(pathAsStr, DEFAULT_PATH_SEPARATOR);
-      while (tokenizer.hasMoreTokens())
-      {
-        list.add(tokenizer.nextToken());
-      }
-    }
-    return list;
   }
 
   private static List<DataSchema> parseSchemas(String resolverPath, String modelsLocation) throws IOException

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityReport.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityReport.java
@@ -55,11 +55,27 @@ public class CompatibilityReport
         .map(it -> "[MD-I]:" + it)
         .collect(Collectors.joining("\n"));
 
+    String annotationCompat = "";
+    String annotationIncompat = "";
+    String annotationIsCompat = "";
+    if(_infoMap.getAnnotationInfo(CompatibilityInfo.Level.INCOMPATIBLE).size() > 0 || _infoMap.getAnnotationInfo(CompatibilityInfo.Level.COMPATIBLE).size() > 0)
+    {
+      annotationCompat = _infoMap.getAnnotationInfo(CompatibilityInfo.Level.COMPATIBLE)
+          .stream()
+          .map(it -> "[SCHEMA-ANNOTATION-C]:" + it)
+          .collect(Collectors.joining("\n"));
+      annotationIncompat = _infoMap.getAnnotationInfo(CompatibilityInfo.Level.INCOMPATIBLE)
+          .stream()
+          .map(it -> "[SCHEMA-ANNOTATION-I]:" + it)
+          .collect(Collectors.joining("\n"));
+      annotationIsCompat = String.format("[SCHEMA-ANNOTATION-COMPAT]: %b", _infoMap.isAnnotationCompatible());
+    }
+
     String restSpecIsCompat = String.format("[RS-COMPAT]: %b", _infoMap.isRestSpecCompatible(_compatibilityLevel));
 
     String modelIsCompat = String.format("[MD-COMPAT]: %b", _infoMap.isModelCompatible(_compatibilityLevel));
 
-    return Arrays.asList(restSpecIsCompat, modelIsCompat, restSpecCompat, restSpecIncompat, modelCompat, modelIncompat)
+    return Arrays.asList(restSpecIsCompat, modelIsCompat, restSpecCompat, restSpecIncompat, modelCompat, modelIncompat, annotationIsCompat, annotationCompat, annotationIncompat)
         .stream()
         .filter(it -> !it.isEmpty())
         .collect(Collectors.joining("\n")) + '\n';

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityInfo.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityInfo.java
@@ -65,7 +65,9 @@ public class CompatibilityInfo
     PAGING_ADDED(Level.COMPATIBLE, "Method added paging support"),
     PAGING_REMOVED(Level.INCOMPATIBLE, "Method removed paging support"),
     SERVICE_ERROR_ADDED(Level.INCOMPATIBLE, "Service error \"%s\" now applies"),
-    SERVICE_ERROR_REMOVED(Level.COMPATIBLE, "Service error \"%s\" no longer applies");
+    SERVICE_ERROR_REMOVED(Level.COMPATIBLE, "Service error \"%s\" no longer applies"),
+    BREAK_OLD_CLIENTS(Level.INCOMPATIBLE, "Deleting a schema is incompatible change, it breaks old clients"),
+    SCHEMA_ANNOTATION_INCOMPATIBLE_CHANGE(Level.INCOMPATIBLE, "Schema annotation incompatible change: %s");
 
     public String getDescription(Object[] parameters)
     {


### PR DESCRIPTION
Extend checkPegasusSchemaSnapshot task to be enable to check schema annotation compatibility, if SchemaAnnotationHandler is provided.

1. Update SchemaAnnotationHandler interface to have new api - annotationCompatibilityCheck, which can be used to check the custom annotation compatibility check
2. Create a new SchemaVisitor - AnnotationCheckResolvedPropertiesVisitor, which is to get a map of node in a schema to it's resolvedProperties. It can be used to check the annotation compatibility for olderResolvedProperties and newerResolvedProperties.
3. AnnotationCompatibilityChecker which leverages the annotation processor to check the compatibilities of annotation changes.


Test:
Unit tests
Manual test in sample repos.