### PR TITLE
Fix bug affecting record fields named "fields".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.7.4] - 2020-10-03
+Fix bug affecting record fields named "fields".
+
 ## [29.7.3] - 2020-10-02
 - Bump `parseq` dependency from `2.6.31` to `4.1.6`.
 - Add `checkPegasusSchemaSnapshot` task. 
@@ -4680,7 +4683,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.4...master
+[29.7.4]: https://github.com/linkedin/rest.li/compare/v29.7.3...v29.7.4
 [29.7.3]: https://github.com/linkedin/rest.li/compare/v29.7.2...v29.7.3
 [29.7.2]: https://github.com/linkedin/rest.li/compare/v29.7.1...v29.7.2
 [29.7.1]: https://github.com/linkedin/rest.li/compare/v29.7.0...v29.7.1

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/records/WithSpecialFieldsRecord.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/records/WithSpecialFieldsRecord.pdl
@@ -1,0 +1,7 @@
+record WithSpecialFieldsRecord {
+  /**
+   * This tests that field with name "fields" does not conflict with
+   * the static member "_fields" generated in the Java template class.
+   */
+  fields: string
+}

--- a/generator/src/main/java/com/linkedin/pegasus/generator/JavaDataTemplateGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/JavaDataTemplateGenerator.java
@@ -733,7 +733,7 @@ public class JavaDataTemplateGenerator extends JavaCodeGeneratorBase
     {
       final String fieldName = field.getSchemaField().getName();
       final JVar fieldVar =
-          templateClass.field(JMod.PRIVATE, generate(field.getType()), "_" + fieldName, JExpr._null());
+          templateClass.field(JMod.PRIVATE, generate(field.getType()), "_" + fieldName + "Field", JExpr._null());
       fieldVarMap.put(fieldName, fieldVar);
     }
 
@@ -1111,7 +1111,7 @@ public class JavaDataTemplateGenerator extends JavaCodeGeneratorBase
       {
         final String memberName = CodeUtil.uncapitalize(CodeUtil.getUnionMemberName(member));
         final JVar memberVar =
-            unionClass.field(JMod.PRIVATE, generate(member.getClassTemplateSpec()), "_" + memberName, JExpr._null());
+            unionClass.field(JMod.PRIVATE, generate(member.getClassTemplateSpec()), "_" + memberName + "Member", JExpr._null());
         memberVarMap.put(member.getUnionMemberKey(), memberVar);
       }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.3
+version=29.7.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The code generator generates a private member variable per field with the name of the field prefixed by an underscore. If a record field is named "fields", this conflicts with the static member variable of the same name that is generated in each record class.