### PR TITLE
Add an option to configure ProtoWriter buffer size. Set the default to 4096 to prevent thrashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.7.5] - 2020-10-05
+- Add an option to configure ProtoWriter buffer size. Set the default to 4096 to prevent thrashing.
+- Use an identity hashmap implementation that uses DataComplex#dataComplexHashCode under the hood for better performance
+
 ## [29.7.4] - 2020-10-03
 Fix bug affecting record fields named "fields".
 
@@ -4683,7 +4687,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.5...master
+[29.7.5]: https://github.com/linkedin/rest.li/compare/v29.7.4...v29.7.5
 [29.7.4]: https://github.com/linkedin/rest.li/compare/v29.7.3...v29.7.4
 [29.7.3]: https://github.com/linkedin/rest.li/compare/v29.7.2...v29.7.3
 [29.7.2]: https://github.com/linkedin/rest.li/compare/v29.7.1...v29.7.2

--- a/data/src/main/java/com/linkedin/data/DataComplexIdentitySet.java
+++ b/data/src/main/java/com/linkedin/data/DataComplexIdentitySet.java
@@ -1,0 +1,131 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.data;
+
+import java.util.IdentityHashMap;
+
+
+/**
+ * A space and time efficient {@link IdentityHashMap} equivalent optimized for checking {@link DataComplex} by
+ * identity. We don't use {@link IdentityHashMap} as-is since {@link System#identityHashCode(Object)} performs
+ * significantly worse than {@link DataComplex#dataComplexHashCode()} under multi-threaded conditions.
+ *
+ * <p>Instances of this class are typically used for cycle detection.</p>
+ */
+class DataComplexIdentitySet
+{
+  private static final int CAPACITY = 16;
+
+  private final Node[] _table;
+
+  /**
+   * Constructor.
+   */
+  DataComplexIdentitySet()
+  {
+    _table = new Node[CAPACITY];
+  }
+
+  /**
+   * Add the given {@link DataComplex} to the set.
+   *
+   * @param dataComplex The {@link DataComplex} to add.
+   *
+   * @return True if the {@link DataComplex} was already present and not added, false otherwise.
+   */
+  boolean add(DataComplex dataComplex)
+  {
+    final int index = dataComplex.dataComplexHashCode() & (CAPACITY - 1);
+    Node node = _table[index];
+
+    // No entries in bucket, add and return false.
+    if (node == null)
+    {
+      _table[index] = new Node(dataComplex);
+      return false;
+    }
+
+    Node previous = null;
+    while (node != null)
+    {
+      if (node._dataComplex == dataComplex)
+      {
+        // Entry found, return true and bail!
+        return true;
+      }
+
+      previous = node;
+      node = node._next;
+    }
+
+    // No entry found for given data complex. Add it to the end, and return false.
+    previous._next = new Node(dataComplex);
+    return false;
+  }
+
+  /**
+   * Removes the given {@link DataComplex} from the set if it exists.
+   *
+   * @param dataComplex The {@link DataComplex} to remove.
+   */
+  void remove(DataComplex dataComplex)
+  {
+    final int index = dataComplex.dataComplexHashCode() & (CAPACITY - 1);
+    Node node = _table[index];
+
+    // If there is no node at the given index there is nothing to do.
+    if (node == null)
+    {
+      return;
+    }
+
+    Node previous = null;
+    while (node != null)
+    {
+      if (node._dataComplex == dataComplex)
+      {
+        // Entry found, remove it.
+        if (previous == null)
+        {
+          // This is the first node, set table index to point to the next node.
+          _table[index] = node._next;
+        }
+        else
+        {
+          // Make the previous node point to the next node, cutting this node out.
+          previous._next = node._next;
+        }
+
+        return;
+      }
+
+      previous = node;
+      node = node._next;
+    }
+  }
+
+  private static class Node
+  {
+    private final DataComplex _dataComplex;
+    private Node _next;
+
+    public Node(DataComplex dataComplex)
+    {
+      _dataComplex = dataComplex;
+    }
+  }
+}

--- a/data/src/main/java/com/linkedin/data/DataMap.java
+++ b/data/src/main/java/com/linkedin/data/DataMap.java
@@ -431,5 +431,5 @@ public final class DataMap extends CheckedMap<String,Object> implements DataComp
   private boolean _madeReadOnly = false;
   private boolean _instrumented = false;
   private Map<String, Integer> _accessMap;
-  private int _dataComplexHashCode = DataComplexHashCode.nextHashCode();
+  int _dataComplexHashCode = DataComplexHashCode.nextHashCode();
 }

--- a/data/src/main/java/com/linkedin/data/codec/ProtobufCodecOptions.java
+++ b/data/src/main/java/com/linkedin/data/codec/ProtobufCodecOptions.java
@@ -28,6 +28,11 @@ import com.linkedin.data.codec.symbol.SymbolTable;
 public class ProtobufCodecOptions
 {
   /**
+   * Default protobuf writer buffer size.
+   */
+  public static final int DEFAULT_BUFFER_SIZE = 4096;
+
+  /**
    * The symbol table to use for serialization and deserialization.
    *
    * <p>Set to {@link EmptySymbolTable#SHARED}, if unspecified.</p>
@@ -65,15 +70,23 @@ public class ProtobufCodecOptions
    */
   private final boolean _shouldTolerateInvalidSurrogatePairs;
 
+  /**
+   * The size of the {@link com.linkedin.data.protobuf.ProtoWriter} buffer when serializing payloads. Defaults to
+   * {@link #DEFAULT_BUFFER_SIZE}.
+   */
+  private final int _protoWriterBufferSize;
+
   private ProtobufCodecOptions(SymbolTable symbolTable,
                                boolean enableASCIIOnlyStrings,
                                boolean enableFixedLengthFloatDoubles,
-                               boolean tolerateInvalidSurrogatePairs)
+                               boolean tolerateInvalidSurrogatePairs,
+                               int protoWriterBufferSize)
   {
     _symbolTable = symbolTable == null ? EmptySymbolTable.SHARED : symbolTable;
     _enableASCIIOnlyStrings = enableASCIIOnlyStrings;
     _enableFixedLengthFloatDoubles = enableFixedLengthFloatDoubles;
     _shouldTolerateInvalidSurrogatePairs = tolerateInvalidSurrogatePairs;
+    _protoWriterBufferSize = protoWriterBufferSize;
   }
 
   /**
@@ -108,6 +121,13 @@ public class ProtobufCodecOptions
    */
   public boolean shouldTolerateInvalidSurrogatePairs() {
     return _shouldTolerateInvalidSurrogatePairs;
+  }
+
+  /**
+   * @return The size of the {@link com.linkedin.data.protobuf.ProtoWriter} buffer when serializing payloads.
+   */
+  public int getProtoWriterBufferSize() {
+    return _protoWriterBufferSize;
   }
 
   /**
@@ -154,12 +174,19 @@ public class ProtobufCodecOptions
      */
     private boolean _shouldTolerateInvalidSurrogatePairs;
 
+    /**
+     * The size of the {@link com.linkedin.data.protobuf.ProtoWriter} buffer when serializing payloads. Defaults to
+     * {@link #DEFAULT_BUFFER_SIZE}.
+     */
+    private int _protoWriterBufferSize;
+
     public Builder()
     {
       _symbolTable = null;
       _enableASCIIOnlyStrings = false;
       _enableFixedLengthFloatDoubles = false;
       _shouldTolerateInvalidSurrogatePairs = true;
+      _protoWriterBufferSize = DEFAULT_BUFFER_SIZE;
     }
 
     /**
@@ -209,6 +236,16 @@ public class ProtobufCodecOptions
     }
 
     /**
+     * Set the size of the {@link com.linkedin.data.protobuf.ProtoWriter} buffer when serializing payloads.
+     */
+    public Builder setProtoWriterBufferSize(int protoWriterBufferSize)
+    {
+      assert protoWriterBufferSize > 0;
+      this._protoWriterBufferSize = protoWriterBufferSize;
+      return this;
+    }
+
+    /**
      * Build an options instance.
      */
     public ProtobufCodecOptions build()
@@ -216,7 +253,8 @@ public class ProtobufCodecOptions
       return new ProtobufCodecOptions(_symbolTable,
           _enableASCIIOnlyStrings,
           _enableFixedLengthFloatDoubles,
-          _shouldTolerateInvalidSurrogatePairs);
+          _shouldTolerateInvalidSurrogatePairs,
+          _protoWriterBufferSize);
     }
   }
 }

--- a/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
@@ -129,7 +129,7 @@ public class ProtobufDataCodec implements DataCodec
   @Override
   public byte[] mapToBytes(DataMap map) throws IOException
   {
-    FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
+    FastByteArrayOutputStream baos = new FastByteArrayOutputStream(_options.getProtoWriterBufferSize());
     writeMap(map, baos);
     return baos.toByteArray();
   }
@@ -137,7 +137,7 @@ public class ProtobufDataCodec implements DataCodec
   @Override
   public byte[] listToBytes(DataList list) throws IOException
   {
-    FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
+    FastByteArrayOutputStream baos = new FastByteArrayOutputStream(_options.getProtoWriterBufferSize());
     writeList(list, baos);
     return baos.toByteArray();
   }
@@ -145,7 +145,7 @@ public class ProtobufDataCodec implements DataCodec
   @Override
   public void writeMap(DataMap map, OutputStream out) throws IOException
   {
-    try(TraverseCallback callback = createTraverseCallback(new ProtoWriter(out)))
+    try(TraverseCallback callback = createTraverseCallback(new ProtoWriter(out, _options.getProtoWriterBufferSize())))
     {
       Data.traverse(map, callback);
     }
@@ -154,7 +154,7 @@ public class ProtobufDataCodec implements DataCodec
   @Override
   public void writeList(DataList list, OutputStream out) throws IOException
   {
-    try(TraverseCallback callback = createTraverseCallback(new ProtoWriter(out)))
+    try(TraverseCallback callback = createTraverseCallback(new ProtoWriter(out, _options.getProtoWriterBufferSize())))
     {
       Data.traverse(list, callback);
     }

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/ProtobufDataEncoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/ProtobufDataEncoder.java
@@ -21,8 +21,6 @@ import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.codec.ProtobufCodecOptions;
 import com.linkedin.data.codec.ProtobufDataCodec;
-import com.linkedin.data.codec.symbol.EmptySymbolTable;
-import com.linkedin.data.codec.symbol.SymbolTable;
 import com.linkedin.data.protobuf.ProtoWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -46,12 +44,12 @@ public class ProtobufDataEncoder extends AbstractDataEncoder
 
   public ProtobufDataEncoder(DataMap dataMap, int bufferSize)
   {
-    this(dataMap, bufferSize, new ProtobufCodecOptions.Builder().build());
+    this(dataMap, bufferSize, new ProtobufCodecOptions.Builder().setProtoWriterBufferSize(bufferSize).build());
   }
 
   public ProtobufDataEncoder(DataList dataList, int bufferSize)
   {
-    this(dataList, bufferSize, new ProtobufCodecOptions.Builder().build());
+    this(dataList, bufferSize, new ProtobufCodecOptions.Builder().setProtoWriterBufferSize(bufferSize).build());
   }
 
   public ProtobufDataEncoder(DataMap dataMap, int bufferSize, ProtobufCodecOptions options)

--- a/data/src/test/java/com/linkedin/data/TestDataComplexIdentitySet.java
+++ b/data/src/test/java/com/linkedin/data/TestDataComplexIdentitySet.java
@@ -1,0 +1,90 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.linkedin.data;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestDataComplexIdentitySet
+{
+  @Test
+  void testBasicOperations() throws CloneNotSupportedException
+  {
+    DataComplexIdentitySet set = new DataComplexIdentitySet();
+    DataMap dataMap = new DataMap();
+
+    // Adding a DataComplex that doesn't exist should return false.
+    Assert.assertFalse(set.add(dataMap));
+
+    // Adding a DataComplex that already exists should return true.
+    Assert.assertTrue(set.add(dataMap));
+
+    DataMap clone = dataMap.clone();
+
+    // Adding a clone, ie. equal but not the same instance must return false.
+    Assert.assertFalse(set.add(clone));
+
+    // Remove the original map.
+    set.remove(dataMap);
+
+    // Ensure that the original map got removed by testing that adding it again returns false.
+    Assert.assertFalse(set.add(dataMap));
+
+    // Ensure that the clone still exists in the map by testing that adding it again returns true.
+    Assert.assertTrue(set.add(clone));
+
+    // Create a new map and override its hashcode to be same as the original map.
+    DataMap sameHashCodeMap = new DataMap();
+    sameHashCodeMap._dataComplexHashCode = dataMap.dataComplexHashCode();
+
+    // Ensure that adding the same hashcode map returns false the first time since it doesn't yet exist.
+    Assert.assertFalse(set.add(sameHashCodeMap));
+
+    // Ensure that adding the same hashcode map again returns true.
+    Assert.assertTrue(set.add(sameHashCodeMap));
+
+    // Ensure that the original and cloned maps still exist.
+    Assert.assertTrue(set.add(dataMap));
+    Assert.assertTrue(set.add(clone));
+
+    // Remove the same hashcode map.
+    set.remove(sameHashCodeMap);
+
+    // Ensure that the same hashcode map got removed by testing that adding it again returns false.
+    Assert.assertFalse(set.add(sameHashCodeMap));
+
+    // Remove both data map and same hash code map.
+    set.remove(dataMap);
+    set.remove(sameHashCodeMap);
+
+    // Add datamap
+    set.add(dataMap);
+
+    // Add same hashcode map.
+    set.add(sameHashCodeMap);
+
+    // Remove datamap
+    set.remove(dataMap);
+
+    // Ensure that same hashcode map still exists.
+    Assert.assertTrue(set.add(sameHashCodeMap));
+
+    // Ensure that datamap got removed.
+    Assert.assertFalse(set.add(dataMap));
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.4
+version=29.7.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/li-protobuf/src/main/java/com/linkedin/data/protobuf/ProtoWriter.java
+++ b/li-protobuf/src/main/java/com/linkedin/data/protobuf/ProtoWriter.java
@@ -74,9 +74,17 @@ public class ProtoWriter implements Closeable
    */
   public ProtoWriter(OutputStream out)
   {
+    this(out, DEFAULT_BUFFER_SIZE);
+  }
+
+  /**
+   * Create a new {@code ProtoWriter} wrapping the given {@code OutputStream} with the given buffer size.
+   */
+  public ProtoWriter(OutputStream out, int bufferSize)
+  {
     _out = out;
-    _buffer = new byte[DEFAULT_BUFFER_SIZE];
-    _limit = DEFAULT_BUFFER_SIZE;
+    _buffer = new byte[bufferSize];
+    _limit = bufferSize;
   }
 
   /**


### PR DESCRIPTION
Use an identity hashset implementation that uses DataComplex#dataComplexHashCode under the hood for better performance when detecting cycles