### PR TITLE
Fix bug referring to coercer before registration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.7.6] - 2020-10-05
+Fix bug referring to coercer before registration.
+
 ## [29.7.5] - 2020-10-05
 - Add an option to configure ProtoWriter buffer size. Set the default to 4096 to prevent thrashing.
 - Use an identity hashmap implementation that uses DataComplex#dataComplexHashCode under the hood for better performance
@@ -4687,7 +4690,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.6...master
+[29.7.6]: https://github.com/linkedin/rest.li/compare/v29.7.5...v29.7.6
 [29.7.5]: https://github.com/linkedin/rest.li/compare/v29.7.4...v29.7.5
 [29.7.4]: https://github.com/linkedin/rest.li/compare/v29.7.3...v29.7.4
 [29.7.3]: https://github.com/linkedin/rest.li/compare/v29.7.2...v29.7.3

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/WithCustomTypeDefaultsTest.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/WithCustomTypeDefaultsTest.java
@@ -1,0 +1,39 @@
+/*
+ Copyright 2015 Coursera Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.linkedin.pegasus.generator.test.pdl;
+
+import com.linkedin.pegasus.generator.test.idl.records.WithCustomTypeDefaults;
+import org.testng.annotations.Test;
+
+
+public class WithCustomTypeDefaultsTest
+{
+  @Test
+  public void testInitializeWithCustomTypeDefaults()
+  {
+    // Regression test to ensure that a type with a custom type and coercer can
+    // load properly. This was broken once because static statements in the code
+    // that was generated were out of order.
+    //
+    // It's important for the function of this test that the custom type and its
+    // coercer defined in the PDL are only used in this PDL to make sure that no
+    // other code could accidentally initialize the coercer and trick this test
+    // into thinking everything is fine.
+    //
+    new WithCustomTypeDefaults();
+  }
+}

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/fixtures/WithCustomTypeDefaultsCustomInt.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/fixtures/WithCustomTypeDefaultsCustomInt.java
@@ -1,0 +1,35 @@
+package com.linkedin.pegasus.generator.test.pdl.fixtures;
+
+public class WithCustomTypeDefaultsCustomInt
+{
+  private final int _i;
+
+  public WithCustomTypeDefaultsCustomInt(int i)
+  {
+    _i = i;
+  }
+
+  public int getValue()
+  {
+    return _i;
+  }
+
+  @Override
+  public boolean equals(Object obj)
+  {
+    if (obj instanceof WithCustomTypeDefaultsCustomInt)
+    {
+      return _i == ((WithCustomTypeDefaultsCustomInt) obj)._i;
+    }
+    else
+    {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return _i;
+  }
+}

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/fixtures/WithCustomTypeDefaultsCustomIntCoercer.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/fixtures/WithCustomTypeDefaultsCustomIntCoercer.java
@@ -1,0 +1,32 @@
+package com.linkedin.pegasus.generator.test.pdl.fixtures;
+
+import com.linkedin.data.template.Custom;
+import com.linkedin.data.template.DirectCoercer;
+import com.linkedin.data.template.TemplateOutputCastException;
+
+
+public class WithCustomTypeDefaultsCustomIntCoercer implements DirectCoercer<WithCustomTypeDefaultsCustomInt>
+{
+  static
+  {
+    Custom.registerCoercer(new WithCustomTypeDefaultsCustomIntCoercer(), WithCustomTypeDefaultsCustomInt.class);
+  }
+
+  private WithCustomTypeDefaultsCustomIntCoercer()
+  {
+  }
+
+  @Override
+  public Object coerceInput(WithCustomTypeDefaultsCustomInt object)
+      throws ClassCastException
+  {
+    return object.getValue();
+  }
+
+  @Override
+  public WithCustomTypeDefaultsCustomInt coerceOutput(Object object)
+      throws TemplateOutputCastException
+  {
+    return new WithCustomTypeDefaultsCustomInt((Integer) object);
+  }
+}

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/records/WithCustomTypeDefaults.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/idl/records/WithCustomTypeDefaults.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.pegasus.generator.test.idl.records
+
+record WithCustomTypeDefaults {
+  intField:
+    @java.class = "com.linkedin.pegasus.generator.test.pdl.fixtures.WithCustomTypeDefaultsCustomInt"
+    @java.coercerClass = "com.linkedin.pegasus.generator.test.pdl.fixtures.WithCustomTypeDefaultsCustomIntCoercer"
+    typeref WithCustomTypeDefaultsCustomInt = int = 0
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.5
+version=29.7.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The new static DEFAULT_ fields that are code generated need to reference
coercers that might not be initialized until a subsequent static block.

All that is required to fix this is to reorder those statements, but it
does not seem possible with JCodeModel. What we can do instead is break
up the declaration from the initialization and order the assignment and
coercer registration statements the way we want to within a single init
block.

The generated code now looks like:

    private static final T DEFAULT_field;

    static {
      Custom.initializeCustomClass(T.class);
      Custom.initializeCoercerClass(...);
      DEFAULT_field = ...;
    }