### PR TITLE
Add configurable Predicate to constructor of RetryClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Make `isRetryException` in RetryClient configurable
 
 ## [29.7.5] - 2020-10-05
 - Add an option to configure ProtoWriter buffer size. Set the default to 4096 to prevent thrashing.

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -146,6 +146,7 @@ public class D2ClientBuilder
                   _config._executorService,
                   _config.retry,
                   _config.retryLimit,
+                  _config.isRetryableException,
                   _config.warmUp,
                   _config.warmUpTimeoutSeconds,
                   _config.warmUpConcurrentRequests,
@@ -202,7 +203,7 @@ public class D2ClientBuilder
 
     if (_config.retry)
     {
-      d2Client = new RetryClient(d2Client, _config.retryLimit);
+      d2Client = new RetryClient(d2Client, _config.retryLimit, _config.isRetryableException);
     }
 
     // If we created default transport client factories, we need to shut them down when d2Client

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -31,14 +31,18 @@ import com.linkedin.d2.discovery.stores.zk.ZooKeeper;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperStore;
 import com.linkedin.d2.jmx.JmxManager;
 import com.linkedin.d2.jmx.NoOpJmxManager;
+import com.linkedin.r2.RetriableRequestException;
 import com.linkedin.r2.transport.common.TransportClientFactory;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 
 public class D2ClientConfig
 {
@@ -70,6 +74,7 @@ public class D2ClientConfig
   ScheduledExecutorService _backupRequestsExecutorService = null;
   boolean retry = false;
   int retryLimit = DEAULT_RETRY_LIMIT;
+  Predicate<Throwable> isRetryableException = e -> ExceptionUtils.indexOfType(e, RetriableRequestException.class) != -1;
   boolean warmUp = true;
   int warmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
   int zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
@@ -122,6 +127,7 @@ public class D2ClientConfig
                  ScheduledExecutorService executorService,
                  boolean retry,
                  int retryLimit,
+                 Predicate<Throwable> isRetryableException,
                  boolean warmUp,
                  int warmUpTimeoutSeconds,
                  int warmUpConcurrentRequests,
@@ -169,6 +175,7 @@ public class D2ClientConfig
     this._executorService = executorService;
     this.retry = retry;
     this.retryLimit = retryLimit;
+    this.isRetryableException = isRetryableException;
     this.warmUp = warmUp;
     this.warmUpTimeoutSeconds = warmUpTimeoutSeconds;
     this.warmUpConcurrentRequests = warmUpConcurrentRequests;

--- a/d2/src/test/java/com/linkedin/d2/balancer/clients/RetryClientTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clients/RetryClientTest.java
@@ -28,6 +28,7 @@ import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategy
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessException;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
 import com.linkedin.data.ByteString;
+import com.linkedin.r2.RetriableRequestException;
 import com.linkedin.r2.message.RequestContext;
 import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestRequestBuilder;
@@ -49,6 +50,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Predicate;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -64,6 +66,7 @@ import static org.testng.Assert.assertTrue;
 public class RetryClientTest
 {
   private static final ByteString CONTENT = ByteString.copy(new byte[8092]);
+  public static final Predicate<Throwable> DEFAULT_RETRYABLE_PREDICATE = e -> e instanceof RetriableRequestException;
 
   private ScheduledExecutorService _executor;
 
@@ -85,7 +88,7 @@ public class RetryClientTest
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/good"));
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, 3);
+    RetryClient client = new RetryClient(dynamicClient, 3, DEFAULT_RETRYABLE_PREDICATE);
     URI uri = URI.create("d2://retryService?arg1arg2");
     RestRequest restRequest = new RestRequestBuilder(uri).setEntity(CONTENT).build();
     TrackerClientTest.TestCallback<RestResponse> restCallback = new TrackerClientTest.TestCallback<RestResponse>();
@@ -101,7 +104,7 @@ public class RetryClientTest
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/good"));
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, 3);
+    RetryClient client = new RetryClient(dynamicClient, 3, DEFAULT_RETRYABLE_PREDICATE);
     URI uri = URI.create("d2://retryService?arg1arg2");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.newEntityStream(new ByteStringWriter(CONTENT)));
     TrackerClientTest.TestCallback<StreamResponse> restCallback = new TrackerClientTest.TestCallback<StreamResponse>();
@@ -117,7 +120,7 @@ public class RetryClientTest
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/bad"));
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, 3);
+    RetryClient client = new RetryClient(dynamicClient, 3, DEFAULT_RETRYABLE_PREDICATE);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     RestRequest restRequest = new RestRequestBuilder(uri).build();
     TrackerClientTest.TestCallback<RestResponse> restCallback = new TrackerClientTest.TestCallback<RestResponse>();
@@ -137,7 +140,7 @@ public class RetryClientTest
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/bad"));
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, 3);
+    RetryClient client = new RetryClient(dynamicClient, 3, DEFAULT_RETRYABLE_PREDICATE);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.emptyStream());
     TrackerClientTest.TestCallback<StreamResponse> streamCallback = new TrackerClientTest.TestCallback<StreamResponse>();
@@ -157,7 +160,7 @@ public class RetryClientTest
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/retry2"));
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, 1);
+    RetryClient client = new RetryClient(dynamicClient, 1, DEFAULT_RETRYABLE_PREDICATE);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     RestRequest restRequest = new RestRequestBuilder(uri).build();
     TrackerClientTest.TestCallback<RestResponse> restCallback = new TrackerClientTest.TestCallback<RestResponse>();
@@ -174,7 +177,7 @@ public class RetryClientTest
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/retry2"));
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, 1);
+    RetryClient client = new RetryClient(dynamicClient, 1, DEFAULT_RETRYABLE_PREDICATE);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.emptyStream());
     TrackerClientTest.TestCallback<StreamResponse> streamCallback = new TrackerClientTest.TestCallback<StreamResponse>();
@@ -191,7 +194,7 @@ public class RetryClientTest
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/retry2"));
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, 3);
+    RetryClient client = new RetryClient(dynamicClient, 3, DEFAULT_RETRYABLE_PREDICATE);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     RestRequest restRequest = new RestRequestBuilder(uri).build();
     TrackerClientTest.TestCallback<RestResponse> restCallback = new TrackerClientTest.TestCallback<RestResponse>();
@@ -208,7 +211,7 @@ public class RetryClientTest
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/retry2"));
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, 3);
+    RetryClient client = new RetryClient(dynamicClient, 3, DEFAULT_RETRYABLE_PREDICATE);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.emptyStream());
     FutureCallback<StreamResponse> streamCallback = new FutureCallback<>();


### PR DESCRIPTION
Allow consumers to provide a custom predicate to determine whether an exception is retryable. 