### PR TITLE
Add getClient async call in warmup load balancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [30.0.0] - 2020-10-15
+- Backward incompatible change: Removed D2 default async implementation. Implemented async call in warm up load balancer.
 - Extend checkPegasusSchemaSnapshot task to be enable to check schema annotation compatibility.
-  - The annotation compatibility will be triggered if SchemaANnotationHandler config is provided.
-  - Update SchemaAnnotationHandler interface to have a new api - annotationCompatibilityCheck, which can be used to check the custom annotation compatibility check.
+- The annotation compatibility will be triggered if SchemaANnotationHandler config is provided.
+- Update SchemaAnnotationHandler interface to have a new api - annotationCompatibilityCheck, which can be used to check the custom annotation compatibility check.
 
 ## [29.7.8] - 2020-10-12
 - Encoding performance improvements
@@ -4703,7 +4706,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v30.0.0...master
+[30.0.0]: https://github.com/linkedin/rest.li/compare/v29.7.8...v30.0.0
 [29.7.8]: https://github.com/linkedin/rest.li/compare/v29.7.7...v29.7.8
 [29.7.7]: https://github.com/linkedin/rest.li/compare/v29.7.6...v29.7.7
 [29.7.6]: https://github.com/linkedin/rest.li/compare/v29.7.5...v29.7.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and what APIs have changed, if applicable.
 ## [29.7.8] - 2020-10-12
 - Encoding performance improvements
 
+## [29.7.8] - 2020-10-11
+- Adding async implementation of getClient call in warmup load balancer.
+
 ## [29.7.7] - 2020-10-06
 - Adding dark cluster response validation metrics
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancer.java
@@ -47,17 +47,7 @@ public interface LoadBalancer
    * @throws ServiceUnavailableException If the load balancer can't figure out how to reach a service for the given
    *                                     URN, an ServiceUnavailableException will be thrown.
    */
-  default void getClient(Request request, RequestContext requestContext, Callback<TransportClient> clientCallback)
-  {
-    try
-    {
-      clientCallback.onSuccess(getClient(request, requestContext));
-    }
-    catch (ServiceUnavailableException e)
-    {
-      clientCallback.onError(e);
-    }
-  }
+  void getClient(Request request, RequestContext requestContext, Callback<TransportClient> clientCallback);
 
   /**
    * Given a Service name, returns a TransportClient that can handle requests for the Request.
@@ -72,17 +62,7 @@ public interface LoadBalancer
    * @throws ServiceUnavailableException If the load balancer can't figure out how to reach a service for the given
    *                                     URN, an ServiceUnavailableException will be thrown.
    */
-  default void getLoadBalancedServiceProperties(String serviceName, Callback<ServiceProperties> clientCallback)
-  {
-    try
-    {
-      clientCallback.onSuccess(getLoadBalancedServiceProperties(serviceName));
-    }
-    catch (ServiceUnavailableException e)
-    {
-      clientCallback.onError(e);
-    }
-  }
+  void getLoadBalancedServiceProperties(String serviceName, Callback<ServiceProperties> clientCallback);
 
   void start(Callback<None> callback);
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesDelegator.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesDelegator.java
@@ -89,4 +89,9 @@ public abstract class LoadBalancerWithFacilitiesDelegator implements LoadBalance
   {
     return _loadBalancer.getLoadBalancedServiceProperties(serviceName);
   }
+
+  @Override
+  public void getLoadBalancedServiceProperties(String serviceName, Callback<ServiceProperties> clientCallback) {
+    _loadBalancer.getLoadBalancedServiceProperties(serviceName, clientCallback);
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesDelegator.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesDelegator.java
@@ -68,6 +68,11 @@ public abstract class LoadBalancerWithFacilitiesDelegator implements LoadBalance
   }
 
   @Override
+  public void getClient(Request request, RequestContext requestContext, Callback<TransportClient> clientCallback) {
+    _loadBalancer.getClient(request, requestContext, clientCallback);
+  }
+
+  @Override
   public void start(Callback<None> callback)
   {
     _loadBalancer.start(callback);

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/TogglingLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/TogglingLoadBalancer.java
@@ -54,7 +54,7 @@ import java.util.Map;
 
 public class TogglingLoadBalancer implements LoadBalancer, HashRingProvider, ClientFactoryProvider, PartitionInfoProvider, WarmUpService, ClusterInfoProvider
 {
-  private final LoadBalancer _balancer;
+  private final SimpleLoadBalancer _balancer;
   private final WarmUpService _warmUpService;
   private final HashRingProvider _hashRingProvider;
   private final PartitionInfoProvider _partitionInfoProvider;

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
@@ -288,4 +288,22 @@ public class WarmUpLoadBalancer extends LoadBalancerWithFacilitiesDelegator
     _usedServices.add(serviceName);
     return client;
   }
+
+  @Override
+  public void getClient(Request request, RequestContext requestContext, Callback<TransportClient> clientCallback)
+  {
+    _loadBalancer.getClient(request, requestContext, new Callback<TransportClient>() {
+      @Override
+      public void onError(Throwable e) {
+        clientCallback.onError(e);
+      }
+
+      @Override
+      public void onSuccess(TransportClient result) {
+        String serviceName = LoadBalancerUtil.getServiceNameFromUri(request.getURI());
+        _usedServices.add(serviceName);
+        clientCallback.onSuccess(result);
+      }
+    });
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
@@ -306,4 +306,9 @@ public class WarmUpLoadBalancer extends LoadBalancerWithFacilitiesDelegator
       }
     });
   }
+
+  @Override
+  public void getLoadBalancedServiceProperties(String serviceName, Callback<ServiceProperties> clientCallback) {
+    _loadBalancer.getLoadBalancedServiceProperties(serviceName, clientCallback);
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.8
+version=30.0.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
**Background**
Recently voyager-api found another blocking call that caused a host being shutdown manually after all threads are blocked. After taking a look into the log, we found that there is another blocking call when calling getClient.
In LoadBalancer.java, there are 2 methods in this interface: 1) getClient, 2) getLoadBalancedServiceProperties, both methods have sync and async implementations. Last time we fixed getLoadBalancedServiceProperties by letting the last client going through as async path, however, looks like getClient method is another source that leads to blocked threads.

**How to fix**
After looking into the code, we believe warmUpLoadBalancer is the only load balancer that is making the sync call to get client, the upstream class makes call using the async way, however, because warmUpLoadBalancer and LoadBalancerWithFacilitiesDelegator do not have the async implementation, it defaults to LoadBalancer.java, which is faking the async implementation by waiting for the response. Therefore, as long as we add the async implementation of getClient, the problem should be solved.

Please note, this change is not guarded by any config, since the change is fairly straight forward.