### PR TITLE
Minimize memory copies and object creation during encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.7.10] - 2020-10-15
+- Minimize memory copies and object creation during encoding.
+- Use String switch instead of map lookup in traverse callback for better performance
+- Reset isTraversing when cloning
+- Cache data objects in wrapped mapped/lists lazily on get.
+- Compute dataComplexHashCode lazily for DataList and DataMap
+
 ## [29.7.9] - 2020-10-15
 - Add partition validation when getting relative load balancer metrics.
 - Extend checkPegasusSchemaSnapshot task to be enable to check schema annotation compatibility.
@@ -4703,7 +4710,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.10...master
+[29.7.10]: https://github.com/linkedin/rest.li/compare/v29.7.9...v29.7.10
 [29.7.9]: https://github.com/linkedin/rest.li/compare/v29.7.8...v29.7.9
 [29.7.8]: https://github.com/linkedin/rest.li/compare/v29.7.7...v29.7.8
 [29.7.7]: https://github.com/linkedin/rest.li/compare/v29.7.6...v29.7.7

--- a/data/src/main/java/com/linkedin/data/ByteString.java
+++ b/data/src/main/java/com/linkedin/data/ByteString.java
@@ -270,6 +270,25 @@ public final class ByteString
     return new ByteString(bos.getBytes(), 0, bos.getBytesCount());
   }
 
+  /**
+   * This is used to get a {@link ByteString} from a {@link com.linkedin.util.FastByteArrayOutputStream}.
+   */
+  public ByteString(List<byte[]> chunks, int lastChunkLength)
+  {
+    ArgumentUtil.notNull(chunks, "chunks");
+    ByteArray[] byteArrays = new ByteArray[chunks.size()];
+
+    int index = 0;
+    for (byte[] chunk : chunks)
+    {
+      final int length = (index == chunks.size() - 1) ? lastChunkLength : chunk.length;
+      byteArrays[index] = new ByteArray(chunk, 0, length);
+      index++;
+    }
+
+    _byteArrays = new ByteArrayVector(byteArrays);
+  }
+
   private ByteString(byte[] bytes)
   {
     this(ArgumentUtil.ensureNotNull(bytes, "bytes"), 0, bytes.length);

--- a/data/src/main/java/com/linkedin/data/DataList.java
+++ b/data/src/main/java/com/linkedin/data/DataList.java
@@ -96,7 +96,8 @@ public final class DataList extends CheckedList<Object> implements DataComplex
     o._madeReadOnly = false;
     o._instrumented = false;
     o._accessList = null;
-    o._dataComplexHashCode = DataComplexHashCode.nextHashCode();
+    o._dataComplexHashCode = 0;
+    o._isTraversing = new ThreadLocal<>();
 
     return o;
   }
@@ -222,6 +223,19 @@ public final class DataList extends CheckedList<Object> implements DataComplex
   @Override
   public int dataComplexHashCode()
   {
+    if (_dataComplexHashCode != 0)
+    {
+      return _dataComplexHashCode;
+    }
+
+    synchronized (this)
+    {
+      if (_dataComplexHashCode == 0)
+      {
+        _dataComplexHashCode = DataComplexHashCode.nextHashCode();
+      }
+    }
+
     return _dataComplexHashCode;
   }
 
@@ -257,14 +271,7 @@ public final class DataList extends CheckedList<Object> implements DataComplex
     }
   }
 
-  private final static ListChecker<Object> _checker = new ListChecker<Object>()
-  {
-    @Override
-    public void check(CommonList<Object> list, Object e)
-    {
-      Data.checkAllowed((DataComplex) list, e);
-    }
-  };
+  private final static ListChecker<Object> _checker = (list, e) -> Data.checkAllowed((DataComplex) list, e);
 
   /**
    * Indicates if this {@link DataList} is currently being traversed by a {@link Data.TraverseCallback} if this value is
@@ -277,5 +284,5 @@ public final class DataList extends CheckedList<Object> implements DataComplex
   private boolean _madeReadOnly = false;
   private boolean _instrumented = false;
   private ArrayList<Integer> _accessList;
-  private int _dataComplexHashCode = DataComplexHashCode.nextHashCode();
+  private int _dataComplexHashCode = 0;
 }

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -344,7 +344,7 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
       }
       else
       {
-        return map.entrySet();
+        return null;
       }
     }
 

--- a/data/src/main/java/com/linkedin/data/codec/DataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/DataCodec.java
@@ -20,6 +20,7 @@ package com.linkedin.data.codec;
 import com.linkedin.data.ByteString;
 import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
+import com.linkedin.util.FastByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,6 +54,34 @@ public interface DataCodec
    * @throws IOException if there is a serialization error.
    */
   byte[] listToBytes(DataList list) throws IOException;
+
+  /**
+   * Serialize a {@link DataMap} to a {@link ByteString}.
+   *
+   * @param map to serialize.
+   * @return the output serialized from the {@link DataMap}.
+   * @throws IOException if there is a serialization error.
+   */
+  default ByteString mapToByteString(DataMap map) throws IOException
+  {
+    FastByteArrayOutputStream outputStream = new FastByteArrayOutputStream();
+    writeMap(map, outputStream);
+    return outputStream.toUnsafeByteString();
+  }
+
+  /**
+   * Serialize a {@link DataList} to a {@link ByteString}
+   *
+   * @param list to serialize.
+   * @return the output serialized from the {@link DataList}.
+   * @throws IOException if there is a serialization error.
+   */
+  default ByteString listToByteString(DataList list) throws IOException
+  {
+    FastByteArrayOutputStream outputStream = new FastByteArrayOutputStream();
+    writeList(list, outputStream);
+    return outputStream.toUnsafeByteString();
+  }
 
   /**
    * De-serialize a byte array to a {@link DataMap}.

--- a/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
@@ -145,7 +145,7 @@ public class ProtobufDataCodec implements DataCodec
   @Override
   public void writeMap(DataMap map, OutputStream out) throws IOException
   {
-    try(TraverseCallback callback = createTraverseCallback(new ProtoWriter(out, _options.getProtoWriterBufferSize())))
+    try (TraverseCallback callback = createTraverseCallback(new ProtoWriter(out, _options.getProtoWriterBufferSize())))
     {
       Data.traverse(map, callback);
     }
@@ -154,7 +154,7 @@ public class ProtobufDataCodec implements DataCodec
   @Override
   public void writeList(DataList list, OutputStream out) throws IOException
   {
-    try(TraverseCallback callback = createTraverseCallback(new ProtoWriter(out, _options.getProtoWriterBufferSize())))
+    try (TraverseCallback callback = createTraverseCallback(new ProtoWriter(out, _options.getProtoWriterBufferSize())))
     {
       Data.traverse(list, callback);
     }

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/AbstractDataEncoder.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/AbstractDataEncoder.java
@@ -286,35 +286,36 @@ public abstract class AbstractDataEncoder implements DataEncoder
       return;
     }
 
-    switch (Data.TYPE_MAP.get(value.getClass()))
+    // We intentionally use a string switch here for performance.
+    switch (value.getClass().getName())
     {
-      case 1:
+      case "java.lang.String":
         _traverseCallback.stringValue((String) value);
         break;
-      case 2:
+      case "java.lang.Integer":
         _traverseCallback.integerValue((int) value);
         break;
-      case 3:
+      case "com.linkedin.data.DataMap":
         _stack.push((DataMap) value);
         _typeStack.push(MAP);
         break;
-      case 4:
+      case "com.linkedin.data.DataList":
         _stack.push((DataList) value);
         _typeStack.push(LIST);
         break;
-      case 5:
+      case "java.lang.Boolean":
         _traverseCallback.booleanValue((boolean) value);
         break;
-      case 6:
+      case "java.lang.Long":
         _traverseCallback.longValue((long) value);
         break;
-      case 7:
+      case "java.lang.Float":
         _traverseCallback.floatValue((float) value);
         break;
-      case 8:
+      case "java.lang.Double":
         _traverseCallback.doubleValue((double) value);
         break;
-      case 9:
+      case "com.linkedin.data.ByteString":
         _traverseCallback.byteStringValue((ByteString) value);
         break;
       default:

--- a/data/src/main/java/com/linkedin/data/collections/CheckedList.java
+++ b/data/src/main/java/com/linkedin/data/collections/CheckedList.java
@@ -20,6 +20,7 @@ import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
 
 /**
@@ -259,6 +260,12 @@ public class CheckedList<E> extends AbstractList<E> implements CommonList<E>, Cl
   public int size()
   {
     return _list.size();
+  }
+
+  @Override
+  public void forEach(Consumer<? super E> action)
+  {
+    _list.forEach(action);
   }
 
   @Override

--- a/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
+++ b/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
@@ -27,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 
 /**
@@ -282,6 +283,12 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
   public String toString()
   {
     return _map.toString();
+  }
+
+  @Override
+  public void forEach(BiConsumer<? super K, ? super V> action)
+  {
+    _map.forEach(action);
   }
 
   @Override

--- a/data/src/main/java/com/linkedin/data/template/WrappingArrayTemplate.java
+++ b/data/src/main/java/com/linkedin/data/template/WrappingArrayTemplate.java
@@ -49,9 +49,7 @@ public class WrappingArrayTemplate<E extends DataTemplate<?>> extends AbstractAr
   @Override
   public boolean add(E element) throws ClassCastException
   {
-    Object unwrapped;
-    boolean result = CheckedUtil.addWithoutChecking(_list, unwrapped = unwrap(element));
-    _cache.put(unwrapped, element);
+    boolean result = CheckedUtil.addWithoutChecking(_list, unwrap(element));
     modCount++;
     return result;
   }
@@ -59,9 +57,7 @@ public class WrappingArrayTemplate<E extends DataTemplate<?>> extends AbstractAr
   @Override
   public void add(int index, E element) throws ClassCastException
   {
-    Object unwrapped;
-    CheckedUtil.addWithoutChecking(_list, index, unwrapped = unwrap(element));
-    _cache.put(unwrapped, element);
+    CheckedUtil.addWithoutChecking(_list, index, unwrap(element));
     modCount++;
   }
 

--- a/data/src/main/java/com/linkedin/data/template/WrappingMapTemplate.java
+++ b/data/src/main/java/com/linkedin/data/template/WrappingMapTemplate.java
@@ -95,9 +95,7 @@ public abstract class WrappingMapTemplate<V extends DataTemplate<?>> extends Abs
   @Override
   public V put(String key, V value) throws ClassCastException, TemplateOutputCastException
   {
-    Object unwrapped;
-    Object found = CheckedUtil.putWithoutChecking(_map, key, unwrapped = unwrap(value));
-    _cache.put(unwrapped, value);
+    Object found = CheckedUtil.putWithoutChecking(_map, key, unwrap(value));
     return cacheLookup(found, null);
   }
 
@@ -200,12 +198,7 @@ public abstract class WrappingMapTemplate<V extends DataTemplate<?>> extends Abs
     {
       V value = entry.getValue();
       Object unwrapped = unwrap(value);
-      boolean added = _map.entrySet().add(new AbstractMap.SimpleEntry<>(entry.getKey(), unwrapped));
-      if (added)
-      {
-        _cache.put(unwrapped, value);
-      }
-      return added;
+      return _map.entrySet().add(new AbstractMap.SimpleEntry<>(entry.getKey(), unwrapped));
     }
 
     @Override
@@ -318,9 +311,7 @@ public abstract class WrappingMapTemplate<V extends DataTemplate<?>> extends Abs
         @Override
         public V setValue(V value) throws ClassCastException, TemplateOutputCastException
         {
-          Object unwrapped;
-          Object ret =_entry.setValue(unwrapped = unwrap(value));
-          _cache.put(unwrapped, value);
+          Object ret =_entry.setValue(unwrap(value));
           _value = null;
           return cacheLookup(ret, null);
         }

--- a/data/src/main/java/com/linkedin/util/FastByteArrayOutputStream.java
+++ b/data/src/main/java/com/linkedin/util/FastByteArrayOutputStream.java
@@ -19,14 +19,11 @@
 
 package com.linkedin.util;
 
-
-import java.io.IOException;
-import java.io.InputStream;
+import com.linkedin.data.ByteString;
 import java.io.OutputStream;
-import java.lang.IllegalArgumentException;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
+
 
 /**
  * This code is derived from org.springframework.util.FastByteArrayOutputStream.
@@ -48,7 +45,7 @@ public class FastByteArrayOutputStream extends OutputStream
   private static final int DEFAULT_BUFFER_SIZE = 256;
 
   // The internal buffer list to store contents.
-  private final LinkedList<byte[]> _bufferList = new LinkedList<byte[]>();
+  private final LinkedList<byte[]> _bufferList = new LinkedList<>();
 
   // The size of the next buffer to allocate in the list.
   private int _nextBufferSize = 0;
@@ -192,6 +189,24 @@ public class FastByteArrayOutputStream extends OutputStream
       }
       return targetBuffer;
     }
+  }
+
+  /**
+   * Wrap the contents as a {@link ByteString}.
+   *
+   * <p>The internal buffers are referenced directly in the {@link ByteString}, so modifying the {@link ByteString},
+   * will cause this stream's contents to change. This is exposed primarily as a performance optimization to
+   * minimize memory copies when serializing data.</p>
+   */
+  public ByteString toUnsafeByteString()
+  {
+    if (this._bufferList.peekFirst() == null)
+    {
+      // Return an empty ByteString if the output stream is empty
+      return ByteString.empty();
+    }
+
+    return new ByteString(_bufferList, _index);
   }
 
   /**

--- a/data/src/test/java/com/linkedin/data/TestData.java
+++ b/data/src/test/java/com/linkedin/data/TestData.java
@@ -1915,4 +1915,22 @@ public class TestData
     root.put("d", sub);
     new JacksonDataCodec().mapToString(root);
   }
+
+  @Test
+  public void testNonCyclicMapWithClone() throws Exception
+  {
+    DataMap root = new DataMap();
+    root.put("key", "a");
+    root.put("map", root.clone());
+    new JacksonDataCodec().mapToString(root);
+  }
+
+  @Test
+  public void testNonCyclicListWithClone() throws Exception
+  {
+    DataList list = new DataList();
+    list.add("a");
+    list.add(list.clone());
+    new JacksonDataCodec().listToString(list);
+  }
 }

--- a/data/src/test/java/com/linkedin/data/codec/TestCodec.java
+++ b/data/src/test/java/com/linkedin/data/codec/TestCodec.java
@@ -82,9 +82,13 @@ public class TestCodec
     TestUtil.assertEquivalent(map3, map);
     TestUtil.assertEquivalent(map3, map2);
 
+    // test mapToByteString
+
+    ByteString byteString = codec.mapToByteString(map);
+
     // test readMap (ByteString)
 
-    DataMap map4 = codec.readMap(toByteString(outputStreamBytes));
+    DataMap map4 = codec.readMap(byteString);
     StringBuilder sb4 = new StringBuilder();
     Data.dump("map", map4, "", sb4);
 
@@ -153,6 +157,18 @@ public class TestCodec
 
     assertEquals(sb3.toString(), sb1.toString());
 
+    // test listToByteString
+
+    ByteString byteString = codec.listToByteString(list);
+
+    // test readList (ByteString)
+
+    DataList list4 = codec.readList(byteString);
+    StringBuilder sb4 = new StringBuilder();
+    Data.dump("list", list4, "", sb4);
+
+    TestUtil.assertEquivalent(list4, list);
+    TestUtil.assertEquivalent(list4, list2);
 
     if (codec instanceof TextDataCodec)
     {
@@ -164,10 +180,10 @@ public class TestCodec
 
       // test stringToList
 
-      DataList list4 = textCodec.stringToList(string);
-      StringBuilder sb4 = new StringBuilder();
-      Data.dump("list", list4, "", sb4);
-      assertEquals(sb4.toString(), sb1.toString());
+      DataList list5 = textCodec.stringToList(string);
+      StringBuilder sb5 = new StringBuilder();
+      Data.dump("list", list5, "", sb5);
+      assertEquals(sb5.toString(), sb1.toString());
 
       // test writeList
 
@@ -178,9 +194,9 @@ public class TestCodec
       // test readList
 
       StringReader reader = new StringReader(string);
-      DataList list5 = textCodec.readList(reader);
-      StringBuilder sb5 = new StringBuilder();
-      Data.dump("list", list5, "", sb5);
+      DataList list6 = textCodec.readList(reader);
+      StringBuilder sb6 = new StringBuilder();
+      Data.dump("list", list6, "", sb6);
     }
   }
 

--- a/data/src/test/java/com/linkedin/data/template/TestArrayTemplate.java
+++ b/data/src/test/java/com/linkedin/data/template/TestArrayTemplate.java
@@ -139,8 +139,9 @@ public class TestArrayTemplate
       {
         E value = adds.get(i);
         assertTrue(array3.add(value));
+        Object getValue = array3.get(i);
         assertEquals(array3.get(i), value);
-        assertSame(array3.get(i), value);
+        assertSame(array3.get(i), getValue);
         assertTrue(array3.toString().contains(value.toString()));
       }
       assertEquals(array3, adds);
@@ -151,8 +152,9 @@ public class TestArrayTemplate
       {
         E value = adds.get(adds.size() - i - 1);
         array4.add(0, value);
+        Object getValue = array4.get(0);
         assertEquals(array4.get(0), value);
-        assertSame(array4.get(0), value);
+        assertSame(array4.get(0), getValue);
       }
       assertEquals(array4, adds);
 

--- a/data/src/test/java/com/linkedin/data/template/TestMapTemplate.java
+++ b/data/src/test/java/com/linkedin/data/template/TestMapTemplate.java
@@ -206,7 +206,7 @@ public class TestMapTemplate
         E got = map3.get(key);
         assertTrue(got != null);
         assertEquals(value, got);
-        assertSame(value, got);
+        assertSame(map3.get(key), got);
         assertTrue(map3.containsKey(key));
         assertTrue(map3.containsValue(value));
         assertTrue(map3.toString().contains(key + "=" + value));
@@ -230,7 +230,8 @@ public class TestMapTemplate
         E replaced = map3.put(key, newValue);
         assertTrue(replaced != null);
         assertEquals(replaced, value);
-        assertSame(replaced, value);
+        E got = map3.get(key);
+        assertSame(map3.get(key), got);
         assertTrue(map3.containsKey(key));
         assertTrue(map3.containsValue(newValue));
         assertTrue(map3.toString().contains(key));
@@ -264,7 +265,6 @@ public class TestMapTemplate
         E removed = map4.remove(key);
         assertTrue(removed != null);
         assertEquals(value, removed);
-        assertSame(value, removed);
         assertFalse(map4.containsKey(key));
         assertFalse(map4.containsValue(value));
         map4Size--;

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/override/TestCustomAnyRecord.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/override/TestCustomAnyRecord.java
@@ -121,7 +121,7 @@ public class TestCustomAnyRecord
     input = new CustomAnyRecord();
     array.add(input);
     CustomAnyRecord output = array.get(0);
-    assertSame(input, output);
+    assertEquals(input, output);
 
     // test array field
     r.setArray(array);
@@ -132,7 +132,7 @@ public class TestCustomAnyRecord
     input = new CustomAnyRecord();
     map.put("0", input);
     output = map.get("0");
-    assertSame(input, output);
+    assertEquals(input, output);
 
     // test map field
     r.setMap(map);

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/TestCustomAnyRecord.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/TestCustomAnyRecord.java
@@ -122,7 +122,7 @@ public class TestCustomAnyRecord
     input = new CustomAnyRecord();
     array.add(input);
     CustomAnyRecord output = array.get(0);
-    assertSame(input, output);
+    assertEquals(input, output);
 
     // test array field
     r.setArray(array);
@@ -133,7 +133,7 @@ public class TestCustomAnyRecord
     input = new CustomAnyRecord();
     map.put("0", input);
     output = map.get("0");
-    assertSame(input, output);
+    assertEquals(input, output);
 
     // test map field
     r.setMap(map);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.9
+version=29.7.10
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-client/src/main/java/com/linkedin/restli/client/RestClient.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/RestClient.java
@@ -744,7 +744,7 @@ public class RestClient implements Client {
         requestBuilder, multiplexedPayload, multiplexedRequest.getRequestOptions().getContentType(), requestUri);
     assert (type != null);
     requestBuilder.setHeader(RestConstants.HEADER_CONTENT_TYPE, type.getHeaderKey());
-    requestBuilder.setEntity(type.getCodec().mapToBytes(multiplexedPayload));
+    requestBuilder.setEntity(type.getCodec().mapToByteString(multiplexedPayload));
 
     requestBuilder.setHeader(RestConstants.HEADER_RESTLI_PROTOCOL_VERSION,
                              AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion().toString());
@@ -892,8 +892,7 @@ public class RestClient implements Client {
     if (type != null)
     {
       requestBuilder.setHeader(RestConstants.HEADER_CONTENT_TYPE, type.getHeaderKey());
-      // Use unsafe wrap to avoid copying the bytes when request builder creates ByteString.
-      requestBuilder.setEntity(ByteString.unsafeWrap(type.getCodec().mapToBytes(dataMap)));
+      requestBuilder.setEntity(type.getCodec().mapToByteString(dataMap));
     }
 
     addProtocolVersionHeader(requestBuilder, protocolVersion);
@@ -941,7 +940,7 @@ public class RestClient implements Client {
       //eligible to have attachments. This is because all such requests are POST or PUTs. Even an action request
       //with empty action parameters will have an empty JSON ({}) as the body.
       assert (type != null);
-      firstPartWriter = new ByteStringWriter(ByteString.copy(type.getCodec().mapToBytes(dataMap)));
+      firstPartWriter = new ByteStringWriter(type.getCodec().mapToByteString(dataMap));
 
       //Our protocol does not use an epilogue or a preamble.
       final MultiPartMIMEWriter.Builder attachmentsBuilder = new MultiPartMIMEWriter.Builder();

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestClientBuilders.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestClientBuilders.java
@@ -975,7 +975,7 @@ public class TestClientBuilders
     testRecord.data().makeReadOnly();
     request = builder.build();
     createInput = (CollectionRequest<TestRecord>) request.getInputRecord();
-    Assert.assertSame(createInput.getElements().get(0), testRecord);
+    Assert.assertEquals(createInput.getElements().get(0), testRecord);
   }
 
   @Test
@@ -998,7 +998,7 @@ public class TestClientBuilders
     testRecord.data().makeReadOnly();
     request = builder.build();
     createInput = (CollectionRequest<TestRecord>) request.getInputRecord();
-    Assert.assertSame(createInput.getElements().get(0), testRecord);
+    Assert.assertEquals(createInput.getElements().get(0), testRecord);
   }
 
   @Test(dataProvider = TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "noEntity")

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/response/ResponseUtils.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/response/ResponseUtils.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.restli.internal.server.response;
 
-
 import com.linkedin.data.ByteString;
 import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
@@ -49,7 +48,6 @@ import com.linkedin.restli.internal.server.util.DataMapUtils;
 import com.linkedin.restli.restspec.ResourceEntityType;
 import com.linkedin.restli.server.RestLiServiceException;
 
-import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.Map;
 import javax.activation.MimeTypeParseException;
@@ -220,8 +218,7 @@ public class ResponseUtils
               "Requested mime type for encoding is not supported. Mimetype: " + mimeType));
       assert type != null;
       builder.setHeader(RestConstants.HEADER_CONTENT_TYPE, type.getHeaderKey());
-      // Use unsafe wrap to avoid copying the bytes when request builder creates ByteString.
-      builder.setEntity(ByteString.unsafeWrap(DataMapUtils.mapToBytes(dataMap, type.getCodec())));
+      builder.setEntity(DataMapUtils.mapToByteString(dataMap, type.getCodec()));
     }
     catch (MimeTypeParseException e)
     {
@@ -247,10 +244,7 @@ public class ResponseUtils
 
     if (restLiResponse.hasData())
     {
-      DataMap dataMap = restLiResponse.getDataMap();
-      ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
-      DataMapUtils.write(dataMap, baos, responseBuilder.getHeaders());
-      responseBuilder.setEntity(ByteString.unsafeWrap(baos.toByteArray()));
+      responseBuilder.setEntity(DataMapUtils.mapToByteString(restLiResponse.getDataMap(), responseBuilder.getHeaders()));
     }
 
     RestResponse restResponse = responseBuilder.build();

--- a/restli-server/src/main/java/com/linkedin/restli/server/multiplexer/MultiplexedRequestHandlerImpl.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/multiplexer/MultiplexedRequestHandlerImpl.java
@@ -17,6 +17,7 @@
 package com.linkedin.restli.server.multiplexer;
 
 import com.linkedin.common.callback.Callback;
+import com.linkedin.data.ByteString;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.parseq.Engine;
@@ -294,7 +295,7 @@ public class MultiplexedRequestHandlerImpl implements MultiplexedRequestHandler
   {
     MultiplexedResponseContent aggregatedResponseContent = new MultiplexedResponseContent();
     aggregatedResponseContent.setResponses(responses);
-    byte[] aggregatedResponseData = DataMapUtils.mapToBytes(aggregatedResponseContent.data(),
+    ByteString aggregatedResponseData = DataMapUtils.mapToByteString(aggregatedResponseContent.data(),
         Collections.singletonMap(RestConstants.HEADER_CONTENT_TYPE, RestConstants.HEADER_VALUE_APPLICATION_JSON));
     return new RestResponseBuilder()
         .setStatus(HttpStatus.S_200_OK.getCode())

--- a/restli-server/src/test/java/com/linkedin/restli/server/multiplexer/TestMultiplexedRequestHandlerImpl.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/multiplexer/TestMultiplexedRequestHandlerImpl.java
@@ -224,7 +224,7 @@ public class TestMultiplexedRequestHandlerImpl
         .andReturn(individualRequestMap);
     // Map request from /modifiedRequest to FOO_URL so that mock handler will be able to handle the request.
     // Map response's body from FOO_ENTITY to BAR_JSON_BODY to simulate filtering on response
-    expect(mockMuxFilter.filterIndividualRequest(EasyMock.same(modifiedRequest)))
+    expect(mockMuxFilter.filterIndividualRequest(EasyMock.eq(modifiedRequest)))
                         .andReturn(fakeIndRequest(FOO_URL))
                         .once();
     expect(mockMuxFilter.filterIndividualResponse(EasyMock.anyObject(IndividualResponse.class)))


### PR DESCRIPTION
Minimize memory copies and object creation during encoding
Use String switch instead of map lookup in traverse callback for better performance
Reset isTraversing when cloning
Cache data objects in wrapped mapped/lists lazily on get
Compute dataComplexHashCode lazily for DataList and DataMap