### PR TITLE
Add ExtensionSchemaAnnotationHandler 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 - Clear the destination directory for generateRestClientTask before the task runs.
+- Add 'ExtensionSchemaAnnotationHandler' for extension schema annotation compatibility check
 
 ## [29.7.10] - 2020-10-15
 - Minimize memory copies and object creation during encoding.

--- a/data/src/main/java/com/linkedin/data/schema/annotation/ExtensionSchemaAnnotationHandler.java
+++ b/data/src/main/java/com/linkedin/data/schema/annotation/ExtensionSchemaAnnotationHandler.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.data.schema.annotation;
+
+import com.linkedin.data.DataMap;
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.schema.compatibility.CompatibilityMessage;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+
+
+/**
+ * This SchemaAnnotationHandler is used to check extension schema annotation(@extension) compatibility
+ *
+ * @author Yingjie Bi
+ */
+public class ExtensionSchemaAnnotationHandler implements SchemaAnnotationHandler
+{
+  public final static String EXTENSION_ANNOTATION_NAMESPACE = "extension";
+
+  @Override
+  public ResolutionResult resolve(List<Pair<String, Object>> propertiesOverrides,
+      ResolutionMetaData resolutionMetadata)
+  {
+    // No-op, for extension schema there is no property resolve need.
+    return new ResolutionResult();
+  }
+
+  @Override
+  public String getAnnotationNamespace()
+  {
+    return EXTENSION_ANNOTATION_NAMESPACE;
+  }
+
+  @Override
+  public AnnotationValidationResult validate(Map<String, Object> resolvedProperties, ValidationMetaData metaData)
+  {
+    // No-op, for extension schema there is no property resolve need, therefore there is no annotation validate need.
+    return new AnnotationValidationResult();
+  }
+
+  @Override
+  public SchemaVisitor getVisitor()
+  {
+    // No need to override properties, use IdentitySchemaVisitor to skip schema traverse.
+    return new IdentitySchemaVisitor();
+  }
+
+  @Override
+  public boolean implementsCheckCompatibility()
+  {
+    return true;
+  }
+
+  @Override
+  public AnnotationCompatibilityResult checkCompatibility(Map<String, Object> prevResolvedProperties, Map<String, Object> currResolvedProperties,
+      CompatibilityCheckContext prevContext, CompatibilityCheckContext currContext)
+  {
+    AnnotationCompatibilityResult result = new AnnotationCompatibilityResult();
+    // Both prevResolvedProperties and currResolvedProperties contain extension annotation namespace, check any changes of annotations on the existing fields.
+    if (prevResolvedProperties.containsKey(EXTENSION_ANNOTATION_NAMESPACE) && currResolvedProperties.containsKey(EXTENSION_ANNOTATION_NAMESPACE))
+    {
+      DataMap prevAnnotations = (DataMap) prevResolvedProperties.get(EXTENSION_ANNOTATION_NAMESPACE);
+      DataMap currAnnotations = (DataMap) currResolvedProperties.get(EXTENSION_ANNOTATION_NAMESPACE);
+      prevAnnotations.forEach((key, value) ->
+      {
+        if (currAnnotations.containsKey(key))
+        {
+          // Check annotation value changes.
+          if (!prevAnnotations.get(key).equals(currAnnotations.get(key)))
+          {
+            appendCompatibilityMessage(result, CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+                "Updating extension annotation field: \"%s\" value is considering as a backward incompatible change.",
+                key, currContext.getPathSpecToSchema());
+          }
+          currAnnotations.remove(key);
+        }
+        else
+        {
+          // An existing annotation field is removed.
+          appendCompatibilityMessage(result, CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+              "Removing extension annotation field: \"%s\" is considering as a backward incompatible change.",
+              key, currContext.getPathSpecToSchema());
+        }
+      });
+
+      currAnnotations.forEach((key, value) ->
+      {
+        // Adding an extension annotation field.
+        appendCompatibilityMessage(result, CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+            "Adding extension annotation field: \"%s\" is a backward incompatible change.",
+            key, currContext.getPathSpecToSchema());
+      });
+    }
+    else if (prevResolvedProperties.containsKey(EXTENSION_ANNOTATION_NAMESPACE))
+    {
+      // Only previous schema has extension annotation, it means the extension annotation is removed in the current schema.
+      if (currContext.getPathSpecToSchema() != null)
+      {
+        appendCompatibilityMessage(result, CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+            "Removing extension annotation is a backward incompatible change.",
+            null, prevContext.getPathSpecToSchema());
+      }
+      else
+      {
+        // an existing field with extension annotation is removed
+        appendCompatibilityMessage(result, CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+            "Removing field: \"%s\" with extension annotation is a backward incompatible change.",
+            prevContext.getSchemaField().getName(), prevContext.getPathSpecToSchema());
+      }
+    }
+    else
+    {
+      if (prevContext.getPathSpecToSchema() != null)
+      {
+        appendCompatibilityMessage(result, CompatibilityMessage.Impact.ANNOTATION_INCOMPATIBLE_CHANGE,
+            "Adding extension annotation on an existing field: \"%s\" is backward incompatible change",
+            prevContext.getSchemaField().getName() , currContext.getPathSpecToSchema());
+      }
+      else
+      {
+        // Adding a new injected field with extension annotation.
+        appendCompatibilityMessage(result, CompatibilityMessage.Impact.ANNOTATION_COMPATIBLE_CHANGE,
+            "Adding extension annotation on new field: \"%s\" is backward compatible change", currContext.getSchemaField().getName() , currContext.getPathSpecToSchema());
+      }
+    }
+    return result;
+  }
+
+  private void appendCompatibilityMessage(AnnotationCompatibilityResult result, CompatibilityMessage.Impact impact, String message, String context, PathSpec pathSpec)
+  {
+    CompatibilityMessage compatibilityMessage = new CompatibilityMessage(pathSpec, impact, message, context);
+    result.addMessage(compatibilityMessage);
+  }
+}

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/AnnotationCompatibilityChecker.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/AnnotationCompatibilityChecker.java
@@ -134,7 +134,7 @@ public class AnnotationCompatibilityChecker
       {
         String annotationNamespace = handler.getAnnotationNamespace();
         Map<String, Object> currResolvedProperties = currCheckContextAndResolvedProperty.getValue();
-        if (currResolvedPropertiesMap.containsKey(annotationNamespace))
+        if (currResolvedProperties.containsKey(annotationNamespace))
         {
           // currResolvedPropertiesMap has a PathSpec which the prevResolvedPropertiesMap does not have,
           // it means there is a new field with new annotations,

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/AlbumExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/AlbumExtensions.pdl
@@ -1,0 +1,8 @@
+record AlbumExtensions includes
+record Album {
+  name: string,
+  id: long
+}
+{
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/BookExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/BookExtensions.pdl
@@ -1,0 +1,9 @@
+record BookExtensions includes
+record Book {
+  name: string,
+  id: long
+}
+{
+  @extension.params = {"id" : "$URN.bookId"}
+  barField: typeref BarUrn = string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/CompanyExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/CompanyExtensions.pdl
@@ -1,0 +1,10 @@
+record CompanyExtensions includes
+record Company {
+  name: string,
+  id: long
+}
+{
+  @extension.using = "test"
+  @extension.params = {"id" : "$URN.companyId"}
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/FooExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/FooExtensions.pdl
@@ -1,0 +1,13 @@
+record FooExtensions includes
+record Foo {
+  name: string,
+  id: long
+}
+{
+  @extension.using = "finder:test"
+  @extension.params = {"id" : "$URN.fooId"}
+  testField: array[typeref TestUrn = string]
+
+  @extension.params = {"id" : "$URN.fooId"}
+  barField: typeref BarUrn = string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/FruitExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/FruitExtensions.pdl
@@ -1,0 +1,9 @@
+record FruitExtensions includes
+  record Fruit {
+    name: string,
+    id: long
+  }
+{
+  @extension.using = "finder:test"
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/IdentityExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/IdentityExtensions.pdl
@@ -1,0 +1,10 @@
+record IdentityExtensions includes
+record Identity {
+  name: string,
+  id: long
+}
+{
+  @extension.using = "finder:test"
+  @extension.params = {"id" : "$URN.identityId"}
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/JobExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/JobExtensions.pdl
@@ -1,0 +1,9 @@
+record JobExtensions includes
+record Job {
+  name: string,
+  id: long
+}
+{
+  @extension.params = {"id" : "$URN.jobId"}
+  testField: typeref BarUrn = string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/SchoolExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/SchoolExtensions.pdl
@@ -1,0 +1,10 @@
+record SchoolExtensions includes
+  record School {
+    name: string,
+    id: long
+  }
+{
+  @extension.using = "finder: other"
+  @extension.params = { "id" : "$URN.schoolId"}
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema5.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema5.pdl
@@ -1,0 +1,6 @@
+record TestSchema5 {
+  @bar.foo = 1
+  field1:
+  @baz.foo = 2
+  array[typeref Test = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema6.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/currentSchema/TestSchema6.pdl
@@ -1,0 +1,10 @@
+record TestSchema6 {
+  field1:
+  union[
+    @baz.foo = 2
+    u1:
+    @bar.foo = 2
+    record A{},
+    u2: record B{}
+    ]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/AlbumExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/AlbumExtensions.pdl
@@ -1,0 +1,9 @@
+record AlbumExtensions includes
+record Album {
+  name: string,
+  id: long
+}
+{
+  @extension.params = {"id" : "$URN.albumId"}
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/BookExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/BookExtensions.pdl
@@ -1,0 +1,13 @@
+record BookExtensions includes
+record Book {
+  name: string,
+  id: long
+}
+{
+  @extension.using = "finder:test"
+  @extension.params = {"id" : "$URN.bookId"}
+  testField: array[typeref TestUrn = string]
+
+  @extension.params = {"id" : "$URN.bookId"}
+  barField: typeref BarUrn = string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/CompanyExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/CompanyExtensions.pdl
@@ -1,0 +1,9 @@
+record CompanyExtensions includes
+record Company {
+  name: string,
+  id: long
+}
+{
+  @extension.params = {"id" : "$URN.companyId"}
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/FooExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/FooExtensions.pdl
@@ -1,0 +1,10 @@
+record FooExtensions includes
+record Foo {
+  name: string,
+  id: long
+}
+{
+  @extension.using = "finder:test"
+  @extension.params = {"id" : "$URN.fooId"}
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/FruitExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/FruitExtensions.pdl
@@ -1,0 +1,11 @@
+record FruitExtensions includes
+record Fruit {
+  name: string,
+  id: long
+}
+{
+  @extension.using = "finder:test"
+  @extension.params = {"id" : "$URN.fruitId"}
+  testField: array[typeref TestUrn = string]
+}
+

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/IdentityExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/IdentityExtensions.pdl
@@ -1,0 +1,10 @@
+record IdentityExtensions includes
+record Identity {
+  name: string,
+  id: long
+}
+{
+  @extension.using = "finder:test"
+  @extension.params = {"id" : "$URN.identityId"}
+  testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/JobExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/JobExtensions.pdl
@@ -1,0 +1,8 @@
+record JobExtensions includes
+record Job {
+  name: string,
+  id: long
+}
+{
+  testField: typeref BarUrn = string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/SchoolExtensions.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/SchoolExtensions.pdl
@@ -1,0 +1,10 @@
+record SchoolExtensions includes
+  record School {
+    name: string,
+    id: long
+  }
+{
+    @extension.using = "finder:test"
+    @extension.params = { "id" : "$URN.schoolId"}
+    testField: array[typeref TestUrn = string]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema5.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema5.pdl
@@ -1,0 +1,6 @@
+record TestSchema5 {
+  @bar.foo = 1
+  field1:
+  @baz.foo = 1
+  typeref Test = string
+}

--- a/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema6.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/compatibility/previousSchema/TestSchema6.pdl
@@ -1,0 +1,10 @@
+record TestSchema6 {
+  field1:
+  union[
+    @baz.foo = 1
+    u1:
+    @bar.foo = 1
+    record A{},
+    u2: record B{}
+  ]
+}

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/data/ExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/data/ExtensionSchemaValidationCmdLineApp.java
@@ -22,12 +22,8 @@ import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaResolver;
 import com.linkedin.data.schema.NamedDataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
-import com.linkedin.data.schema.TyperefDataSchema;
 import com.linkedin.data.schema.grammar.PdlSchemaParser;
-import com.linkedin.data.schema.resolver.ExtensionsDataSchemaResolver;
 import com.linkedin.data.schema.resolver.MultiFormatDataSchemaResolver;
-import com.linkedin.pegasus.generator.DataSchemaParser;
-import com.linkedin.pegasus.generator.FileFormatDataSchemaParser;
 import com.linkedin.restli.internal.tools.RestLiToolsUtils;
 import com.linkedin.data.schema.validation.CoercionMode;
 import com.linkedin.data.schema.validation.RequiredMode;
@@ -54,6 +50,8 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.linkedin.data.schema.annotation.ExtensionSchemaAnnotationHandler.EXTENSION_ANNOTATION_NAMESPACE;
+
 
 /**
  * This class is used to validate extension schemas, the validation covers following parts:
@@ -74,7 +72,6 @@ public class ExtensionSchemaValidationCmdLineApp
   private static final Logger _logger = LoggerFactory.getLogger(ExtensionSchemaValidationCmdLineApp.class);
   private static final Options _options = new Options();
   private static final String PDL = "pdl";
-  private static final String EXTENSION_ANNOTATION_NAMESPACE= "extension";
   private static final String RESOURCE_KEY_ANNOTATION_NAMESPACE = "resourceKey";
   private static final String EXTENSIONS_SUFFIX = "Extensions";
   private static final String VERSION_SUFFIX = "versionSuffix";
@@ -193,7 +190,8 @@ public class ExtensionSchemaValidationCmdLineApp
     {
       // check extension schema field annotation
       Map<String, Object> properties = field.getProperties();
-      if (properties.isEmpty() || properties.keySet().size() != 1 || !properties.containsKey(EXTENSION_ANNOTATION_NAMESPACE))
+      if (properties.isEmpty() || properties.keySet().size() != 1 || !properties.containsKey(
+          EXTENSION_ANNOTATION_NAMESPACE))
       {
         throw new InvalidExtensionSchemaException("The field : " + field.getName() + " of extension schema must and only be annotated with 'extension'");
       }

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/check/PegasusSchemaSnapshotCompatibilityChecker.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/check/PegasusSchemaSnapshotCompatibilityChecker.java
@@ -17,6 +17,7 @@ package com.linkedin.restli.tools.snapshot.check;
 
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.annotation.ExtensionSchemaAnnotationHandler;
 import com.linkedin.data.schema.annotation.SchemaAnnotationHandler;
 import com.linkedin.data.schema.compatibility.AnnotationCompatibilityChecker;
 import com.linkedin.data.schema.compatibility.CompatibilityChecker;
@@ -33,8 +34,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,9 +41,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.cli.CommandLine;
@@ -69,12 +66,9 @@ public class PegasusSchemaSnapshotCompatibilityChecker
   private static final Logger _logger = LoggerFactory.getLogger(
       PegasusSchemaSnapshotCompatibilityChecker.class);
   private final CompatibilityInfoMap _infoMap = new CompatibilityInfoMap();
-  private static boolean _checkExtensionSchemaAnnotation = false;
   private static List<SchemaAnnotationHandler> _handlers = new ArrayList<>();
 
   private static final String PDL = ".pdl";
-
-  private static List<SchemaAnnotationHandler.AnnotationCompatibilityResult> annotationCompatibilityResults = new ArrayList<>();
 
 
   static
@@ -177,9 +171,9 @@ public class PegasusSchemaSnapshotCompatibilityChecker
       compatMode = CompatibilityOptions.Mode.SCHEMA;
     }
 
-    if(cl.hasOption('e'))
+    if (cl.hasOption('e'))
     {
-      _checkExtensionSchemaAnnotation = true;
+      _handlers.add(new ExtensionSchemaAnnotationHandler());
     }
 
     if (cl.hasOption("jar") && cl.hasOption("className"))


### PR DESCRIPTION
Add ExtensionSchemaAnnotationHandler for extension schema annotation compatibility check.

The new handler implements 'checkCompatibility' method, which introduces specific rules for extension annotation compatibility check.

Test:
unit tests
manual test.