### PR TITLE
Add partition support in relative load balancer inGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.7.9] - 2020-10-15
+- Add partition validation when getting relative load balancer metrics.
 - Extend checkPegasusSchemaSnapshot task to be enable to check schema annotation compatibility.
-  - The annotation compatibility will be triggered if SchemaANnotationHandler config is provided.
-  - Update SchemaAnnotationHandler interface to have a new api - annotationCompatibilityCheck, which can be used to check the custom annotation compatibility check.
+- The annotation compatibility will be triggered if SchemaANnotationHandler config is provided.
+- Update SchemaAnnotationHandler interface to have a new api - annotationCompatibilityCheck, which can be used to check the custom annotation compatibility check.
 
 ## [29.7.8] - 2020-10-12
 - Encoding performance improvements
@@ -4700,7 +4703,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.9...master
+[29.7.9]: https://github.com/linkedin/rest.li/compare/v29.7.8...v29.7.9
 [29.7.8]: https://github.com/linkedin/rest.li/compare/v29.7.7...v29.7.8
 [29.7.7]: https://github.com/linkedin/rest.li/compare/v29.7.6...v29.7.7
 [29.7.6]: https://github.com/linkedin/rest.li/compare/v29.7.5...v29.7.6

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
@@ -96,9 +96,9 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
     return _stateUpdater.getPartitionState(partitionId);
   }
 
-  public int getValidPartitionId()
+  public int getFirstValidPartitionId()
   {
-    return _stateUpdater.getValidPartitionId();
+    return _stateUpdater.getFirstValidPartitionId();
   }
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
@@ -96,6 +96,11 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
     return _stateUpdater.getPartitionState(partitionId);
   }
 
+  public int getValidPartitionId()
+  {
+    return _stateUpdater.getValidPartitionId();
+  }
+
   /**
    * Exposed for testings
    */

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -149,7 +149,7 @@ public class StateUpdater
   /**
    * Return the first valid partition id. This is mainly used for monitoring at least one valid partition.
    */
-  int getValidPartitionId()
+  int getFirstValidPartitionId()
   {
     return _firstPartitionId;
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -62,6 +62,7 @@ public class StateUpdater
   private final List<PartitionStateUpdateListener.Factory<PartitionState>> _listenerFactories;
 
   private ConcurrentMap<Integer, PartitionState> _partitionLoadBalancerStateMap;
+  private int _firstPartitionId = -1;
 
   StateUpdater(D2RelativeStrategyProperties relativeStrategyProperties,
                        QuarantineManager quarantineManager,
@@ -140,12 +141,17 @@ public class StateUpdater
         : _partitionLoadBalancerStateMap.get(partitionId).getPointsMap();
   }
 
-  /**
-   * Exposed for testings
-   */
   PartitionState getPartitionState(int partitionId)
   {
     return _partitionLoadBalancerStateMap.get(partitionId);
+  }
+
+  /**
+   * Return the first valid partition id. This is mainly used for monitoring at least one valid partition.
+   */
+  int getValidPartitionId()
+  {
+    return _firstPartitionId;
   }
 
   /**
@@ -270,6 +276,12 @@ public class StateUpdater
           // If it is above high latency, we reduce the health score by down step
           newHealthScore = Double.max(trackerClientState.getHealthScore() - _relativeStrategyProperties.getDownStep(), MIN_HEALTH_SCORE);
           trackerClientState.setHealthState(TrackerClientState.HealthState.UNHEALTHY);
+
+          LOG.debug("Host is unhealthy. Host: " + trackerClient.toString()
+                  + ", errorRate: " + errorRate
+                  + ", latency: " + avgClusterLatency
+                  + ", callCount: " + callCount
+                  + ", healthScore dropped from " + trackerClientState.getHealthScore() + " to " + newHealthScore);
         }
         else if (trackerClientState.getHealthScore() < MAX_HEALTH_SCORE
             && isHealthy(trackerClientState, avgClusterLatency, callCount, avgLatency, errorRate))
@@ -393,6 +405,11 @@ public class StateUpdater
           _listenerFactories.stream().map(factory -> factory.create(partitionId)).collect(Collectors.toList()));
 
       updateStateForPartition(trackerClients, partitionId, partitionState, clusterGenerationId);
+
+      if (_firstPartitionId < 0)
+      {
+        _firstPartitionId = partitionId;
+      }
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
@@ -21,7 +21,6 @@ import com.linkedin.d2.balancer.strategies.LoadBalancerQuarantine;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.relative.StateUpdater;
 import com.linkedin.d2.balancer.strategies.relative.TrackerClientState;
-import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
 import com.linkedin.util.degrader.CallTracker;
 import java.net.URI;
 import java.util.List;
@@ -32,6 +31,8 @@ import java.util.stream.Collectors;
 
 public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStrategyJmxMBean
 {
+  private static final double DEFAULT_DOUBLE_METRICS = 0;
+  private static final int DEFAULT_INT_METRICS = 0;
   private final RelativeLoadBalancerStrategy _strategy;
 
   public RelativeLoadBalancerStrategyJmx(RelativeLoadBalancerStrategy strategy)
@@ -42,8 +43,13 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   @Override
   public double getLatencyStandardDeviation()
   {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_DOUBLE_METRICS;
+    }
+
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
 
     return calculateStandardDeviation(stateMap.keySet());
   }
@@ -51,8 +57,13 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   @Override
   public double getLatencyMeanAbsoluteDeviation()
   {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_DOUBLE_METRICS;
+    }
+
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
 
     double avgLatency = getAvgClusterLatency(stateMap.keySet());
 
@@ -67,8 +78,13 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   @Override
   public double getAboveAverageLatencyStandardDeviation()
   {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_DOUBLE_METRICS;
+    }
+
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
 
     double avgLatency = getAvgClusterLatency(stateMap.keySet());
 
@@ -82,8 +98,13 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   @Override
   public double getMaxLatencyRelativeFactor()
   {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_DOUBLE_METRICS;
+    }
+
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
 
     double avgLatency = getAvgClusterLatency(stateMap.keySet());
     long maxLatency = stateMap.keySet().stream()
@@ -98,12 +119,17 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   @Override
   public double getNthPercentileLatencyRelativeFactor(double pct)
   {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_DOUBLE_METRICS;
+    }
+
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
 
     if (stateMap.size() == 0)
     {
-      return 0.0;
+      return DEFAULT_DOUBLE_METRICS;
     }
 
     double avgLatency = getAvgClusterLatency(stateMap.keySet());
@@ -122,8 +148,13 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   @Override
   public int getUnhealthyHostsCount()
   {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_INT_METRICS;
+    }
+
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
 
     return (int) stateMap.values().stream()
         .filter(TrackerClientState::isUnhealthy)
@@ -133,8 +164,13 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   @Override
   public int getQuarantineHostsCount()
   {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_INT_METRICS;
+    }
+
     Map<TrackerClient, LoadBalancerQuarantine> quarantineMap =
-        _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getQuarantineMap();
+        _strategy.getPartitionState(_strategy.getValidPartitionId()).getQuarantineMap();
 
     return (int) quarantineMap.values().stream()
         .filter(LoadBalancerQuarantine::isInQuarantine)
@@ -144,7 +180,12 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   @Override
   public int getTotalPointsInHashRing()
   {
-    Map<URI, Integer> uris = _strategy.getPartitionState(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getPointsMap();
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_INT_METRICS;
+    }
+
+    Map<URI, Integer> uris = _strategy.getPartitionState(_strategy.getValidPartitionId()).getPointsMap();
 
     return uris.values().stream()
         .mapToInt(Integer::intValue)
@@ -192,5 +233,10 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     return callCountSum + outstandingCallCountSum == 0
         ? 0
         : Math.round((latencySum + outstandingLatencySum) / (double) (callCountSum + outstandingCallCountSum));
+  }
+
+  private boolean isPartitionDataUnavailable()
+  {
+    return _strategy.getPartitionState(_strategy.getValidPartitionId()) == null;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
@@ -49,7 +49,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     }
 
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getTrackerClientStateMap();
 
     return calculateStandardDeviation(stateMap.keySet());
   }
@@ -63,7 +63,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     }
 
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getTrackerClientStateMap();
 
     double avgLatency = getAvgClusterLatency(stateMap.keySet());
 
@@ -84,7 +84,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     }
 
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getTrackerClientStateMap();
 
     double avgLatency = getAvgClusterLatency(stateMap.keySet());
 
@@ -104,7 +104,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     }
 
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getTrackerClientStateMap();
 
     double avgLatency = getAvgClusterLatency(stateMap.keySet());
     long maxLatency = stateMap.keySet().stream()
@@ -125,7 +125,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     }
 
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getTrackerClientStateMap();
 
     if (stateMap.size() == 0)
     {
@@ -154,7 +154,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     }
 
     Map<TrackerClient, TrackerClientState> stateMap =
-        _strategy.getPartitionState(_strategy.getValidPartitionId()).getTrackerClientStateMap();
+        _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getTrackerClientStateMap();
 
     return (int) stateMap.values().stream()
         .filter(TrackerClientState::isUnhealthy)
@@ -170,7 +170,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
     }
 
     Map<TrackerClient, LoadBalancerQuarantine> quarantineMap =
-        _strategy.getPartitionState(_strategy.getValidPartitionId()).getQuarantineMap();
+        _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getQuarantineMap();
 
     return (int) quarantineMap.values().stream()
         .filter(LoadBalancerQuarantine::isInQuarantine)
@@ -185,7 +185,7 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
       return DEFAULT_INT_METRICS;
     }
 
-    Map<URI, Integer> uris = _strategy.getPartitionState(_strategy.getValidPartitionId()).getPointsMap();
+    Map<URI, Integer> uris = _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getPointsMap();
 
     return uris.values().stream()
         .mapToInt(Integer::intValue)
@@ -237,6 +237,6 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
 
   private boolean isPartitionDataUnavailable()
   {
-    return _strategy.getPartitionState(_strategy.getValidPartitionId()) == null;
+    return _strategy.getPartitionState(_strategy.getFirstValidPartitionId()) == null;
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -52,6 +52,7 @@ import static org.testng.Assert.fail;
 public class StateUpdaterTest
 {
   private static final int DEFAULT_PARTITION_ID = 0;
+  private static final int CUSTOMIZED_PARTITION_ID = 1;
   private static final long DEFAULT_CLUSTER_GENERATION_ID = 0;
   private static final int HEALTHY_POINTS = 100;
   private static final int INITIAL_RECOVERY_POINTS = 1;
@@ -68,20 +69,31 @@ public class StateUpdaterTest
         partitionLoadBalancerStateMap, Collections.emptyList());
   }
 
-  @Test
-  public void testInitializePartition()
+  @Test(dataProvider = "partitionId")
+  public void testInitializePartition(int partitionId)
   {
     setup(new D2RelativeStrategyProperties(), new ConcurrentHashMap<>());
 
     List<TrackerClient> trackerClients = TrackerClientMockHelper.mockTrackerClients(2,
         Arrays.asList(20, 20), Arrays.asList(10, 10), Arrays.asList(200L, 500L), Arrays.asList(100L, 200L), Arrays.asList(0, 0));
 
-    assertTrue(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).isEmpty(), "There should be no state before initialization");
+    assertTrue(_stateUpdater.getPointsMap(partitionId).isEmpty(), "There should be no state before initialization");
 
-    _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, DEFAULT_CLUSTER_GENERATION_ID);
+    _stateUpdater.updateState(new HashSet<>(trackerClients), partitionId, DEFAULT_CLUSTER_GENERATION_ID);
 
-    assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(0).getUri()).intValue(), HEALTHY_POINTS);
-    assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(1).getUri()).intValue(), HEALTHY_POINTS);
+    assertEquals(_stateUpdater.getPointsMap(partitionId).get(trackerClients.get(0).getUri()).intValue(), HEALTHY_POINTS);
+    assertEquals(_stateUpdater.getPointsMap(partitionId).get(trackerClients.get(1).getUri()).intValue(), HEALTHY_POINTS);
+    assertEquals(_stateUpdater.getValidPartitionId(), partitionId);
+  }
+
+  @DataProvider(name = "partitionId")
+  public Object[][] partitionId()
+  {
+    return new Object[][]
+        {
+            {DEFAULT_PARTITION_ID},
+            {CUSTOMIZED_PARTITION_ID}
+        };
   }
 
   @Test

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -83,7 +83,7 @@ public class StateUpdaterTest
 
     assertEquals(_stateUpdater.getPointsMap(partitionId).get(trackerClients.get(0).getUri()).intValue(), HEALTHY_POINTS);
     assertEquals(_stateUpdater.getPointsMap(partitionId).get(trackerClients.get(1).getUri()).intValue(), HEALTHY_POINTS);
-    assertEquals(_stateUpdater.getValidPartitionId(), partitionId);
+    assertEquals(_stateUpdater.getFirstValidPartitionId(), partitionId);
   }
 
   @DataProvider(name = "partitionId")

--- a/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
@@ -47,7 +47,7 @@ public class RelativeLoadBalancerStrategyJmxTest {
     RelativeLoadBalancerStrategy strategy = Mockito.mock(RelativeLoadBalancerStrategy.class);
     PartitionState state = Mockito.mock(PartitionState.class);
     Mockito.when(state.getTrackerClientStateMap()).thenReturn(trackerClientsMap);
-    Mockito.when(strategy.getValidPartitionId()).thenReturn(DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
+    Mockito.when(strategy.getFirstValidPartitionId()).thenReturn(DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
     Mockito.when(strategy.getPartitionState(anyInt())).thenReturn(state);
 
     return new RelativeLoadBalancerStrategyJmx(strategy);
@@ -148,7 +148,7 @@ public class RelativeLoadBalancerStrategyJmxTest {
   public void testNoValidPartitionData()
   {
     RelativeLoadBalancerStrategy strategy = Mockito.mock(RelativeLoadBalancerStrategy.class);
-    Mockito.when(strategy.getValidPartitionId()).thenReturn(DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
+    Mockito.when(strategy.getFirstValidPartitionId()).thenReturn(DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
     Mockito.when(strategy.getPartitionState(anyInt())).thenReturn(null);
 
     RelativeLoadBalancerStrategyJmx jmx = new RelativeLoadBalancerStrategyJmx(strategy);

--- a/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxTest.java
@@ -21,6 +21,7 @@ import com.linkedin.d2.balancer.strategies.relative.PartitionState;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.relative.TrackerClientMockHelper;
 import com.linkedin.d2.balancer.strategies.relative.TrackerClientState;
+import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,6 +47,7 @@ public class RelativeLoadBalancerStrategyJmxTest {
     RelativeLoadBalancerStrategy strategy = Mockito.mock(RelativeLoadBalancerStrategy.class);
     PartitionState state = Mockito.mock(PartitionState.class);
     Mockito.when(state.getTrackerClientStateMap()).thenReturn(trackerClientsMap);
+    Mockito.when(strategy.getValidPartitionId()).thenReturn(DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
     Mockito.when(strategy.getPartitionState(anyInt())).thenReturn(state);
 
     return new RelativeLoadBalancerStrategyJmx(strategy);
@@ -132,6 +134,24 @@ public class RelativeLoadBalancerStrategyJmxTest {
         Arrays.asList(0, 0, 0), Arrays.asList(0, 0, 0), Arrays.asList(0L, 0L, 0L), Arrays.asList(0L, 0L, 0L), Arrays.asList(0, 0, 0));
 
     RelativeLoadBalancerStrategyJmx jmx = mockRelativeLoadBalancerStrategyJmx(trackerClients);
+    assertEquals(jmx.getLatencyStandardDeviation(), 0.0);
+    assertEquals(jmx.getLatencyMeanAbsoluteDeviation(), 0.0);
+    assertEquals(jmx.getAboveAverageLatencyStandardDeviation(), 0.0);
+    assertEquals(jmx.getMaxLatencyRelativeFactor(), 0.0);
+    assertEquals(jmx.getNthPercentileLatencyRelativeFactor(0.95), 0.0);
+    assertEquals(jmx.getTotalPointsInHashRing(), 0);
+    assertEquals(jmx.getUnhealthyHostsCount(), 0);
+    assertEquals(jmx.getQuarantineHostsCount(), 0);
+  }
+
+  @Test
+  public void testNoValidPartitionData()
+  {
+    RelativeLoadBalancerStrategy strategy = Mockito.mock(RelativeLoadBalancerStrategy.class);
+    Mockito.when(strategy.getValidPartitionId()).thenReturn(DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
+    Mockito.when(strategy.getPartitionState(anyInt())).thenReturn(null);
+
+    RelativeLoadBalancerStrategyJmx jmx = new RelativeLoadBalancerStrategyJmx(strategy);
     assertEquals(jmx.getLatencyStandardDeviation(), 0.0);
     assertEquals(jmx.getLatencyMeanAbsoluteDeviation(), 0.0);
     assertEquals(jmx.getAboveAverageLatencyStandardDeviation(), 0.0);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.8
+version=29.7.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
**Background**
For relative load balancer onboarding, we're trying to find different type of services to onboard, one type is services with partitions. However, one problem with today's inGraph is that we always emit metrics for partition 0, it turns out one of the client that I'm onboarding, they only talk to partition 1, they never talk to partition 0.

To perfectly solve this problem, I think we should fire one inGraph for each partition, however, it's really hard since at inGraph registration time, we do not know how many partitions are there, partitions can be very dynamic. So the trick here is to always emit metrics for the 1st added partition, so that at least we have some meaningful data.

**Changes include**
1. Emit metrics for the first added partition
2. Add a small debug log when health score reduces