### PR TITLE
Fix the bug so properties for typeref in unionWithAlias should be pro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.7.12] - 2020-10-20
+Fix the bug of not propagating schema properties in typeref with UnionWithAlias during pegasus to avro translation
+
 ## [29.7.11] - 2020-10-19
 - Clear the destination directory for generateRestClientTask before the task runs.
 - Add 'ExtensionSchemaAnnotationHandler' for extension schema annotation compatibility check
@@ -4714,7 +4717,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.12...master
+[29.7.12]: https://github.com/linkedin/rest.li/compare/v29.7.11...v29.7.12
 [29.7.11]: https://github.com/linkedin/rest.li/compare/v29.7.10...v29.7.11
 [29.7.10]: https://github.com/linkedin/rest.li/compare/v29.7.9...v29.7.10
 [29.7.9]: https://github.com/linkedin/rest.li/compare/v29.7.8...v29.7.9

--- a/data-avro/src/main/java/com/linkedin/data/avro/PegasusUnionToAvroRecordConvertCallback.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/PegasusUnionToAvroRecordConvertCallback.java
@@ -63,9 +63,11 @@ class PegasusUnionToAvroRecordConvertCallback implements DataSchemaTraverse.Call
     {
       DataSchema fieldSchema = field.getType().getDereferencedDataSchema();
 
-      Map<String, Object>  propagatedProperties = new HashMap<>();
+      Map<String, Object>  propagatedProperties = fieldSchema.getProperties();
       if (field.getType().getType() == DataSchema.Type.TYPEREF)
       {
+        // If the field schema type is TypeRef,
+        // then use the merged typeref properties instead
         propagatedProperties = ((TyperefDataSchema) field.getType()).getMergedTyperefProperties();
       }
 
@@ -185,6 +187,7 @@ class PegasusUnionToAvroRecordConvertCallback implements DataSchemaTraverse.Call
    * @param field Reference to the field whose schema and default value is being overridden
    * @param modifiedSchema The override schema to use for the specified field
    * @param modifiedDefaultValue The override default value to use for the specified field
+   * @param propagatedProperties The properties value to use for the specified field
    */
   private void overrideUnionFieldSchemaAndDefault(RecordDataSchema.Field field,
       DataSchema modifiedSchema, Object modifiedDefaultValue, Map<String, Object> propagatedProperties)

--- a/data-avro/src/main/java/com/linkedin/data/avro/PegasusUnionToAvroRecordConvertCallback.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/PegasusUnionToAvroRecordConvertCallback.java
@@ -12,6 +12,7 @@ import com.linkedin.data.schema.EnumDataSchema;
 import com.linkedin.data.schema.MapDataSchema;
 import com.linkedin.data.schema.Name;
 import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.TyperefDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -62,6 +63,12 @@ class PegasusUnionToAvroRecordConvertCallback implements DataSchemaTraverse.Call
     {
       DataSchema fieldSchema = field.getType().getDereferencedDataSchema();
 
+      Map<String, Object>  propagatedProperties = new HashMap<>();
+      if (field.getType().getType() == DataSchema.Type.TYPEREF)
+      {
+        propagatedProperties = ((TyperefDataSchema) field.getType()).getMergedTyperefProperties();
+      }
+
       // The conversion from Pegasus union type to an Avro record is performed when the union appears as either the
       // field's direct type or when the field's type is an array or a map whose (nested) elements is of union type.
       // This conversion ignores the default value when specified on an array or map typed field. Since the elements in
@@ -74,7 +81,7 @@ class PegasusUnionToAvroRecordConvertCallback implements DataSchemaTraverse.Call
 
       if (modifiedSchema != null)
       {
-        overrideUnionFieldSchemaAndDefault(field, modifiedSchema, modifiedDefaultValue);
+        overrideUnionFieldSchemaAndDefault(field, modifiedSchema, modifiedDefaultValue, propagatedProperties);
       }
     }
   }
@@ -180,7 +187,7 @@ class PegasusUnionToAvroRecordConvertCallback implements DataSchemaTraverse.Call
    * @param modifiedDefaultValue The override default value to use for the specified field
    */
   private void overrideUnionFieldSchemaAndDefault(RecordDataSchema.Field field,
-      DataSchema modifiedSchema, Object modifiedDefaultValue)
+      DataSchema modifiedSchema, Object modifiedDefaultValue, Map<String, Object> propagatedProperties)
   {
     // Stash the field's original type and default value, so that we can use this for reverting them back after
     // the schema translation is complete. This is because we don't want the input schema to have any modifications
@@ -190,6 +197,7 @@ class PegasusUnionToAvroRecordConvertCallback implements DataSchemaTraverse.Call
 
     field.setType(modifiedSchema);
     field.setDefault(modifiedDefaultValue);
+    field.setProperties(propagatedProperties);
   }
 
   /**

--- a/data-avro/src/main/java/com/linkedin/data/avro/PegasusUnionToAvroRecordConvertCallback.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/PegasusUnionToAvroRecordConvertCallback.java
@@ -262,6 +262,7 @@ class PegasusUnionToAvroRecordConvertCallback implements DataSchemaTraverse.Call
     fields.add(discriminatorField);
 
     recordDataSchema.setFields(fields, errorMessageBuilder);
+    recordDataSchema.setProperties(unionDataSchema.getProperties());
     return  recordDataSchema;
   }
 

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -75,161 +75,217 @@ public class TestSchemaTranslator
   {
     return new Object[][]
         {
+//            {
+//                "record test {" +
+//                    "  unionTyperef:" +
+//                    "  @compliance = {" +
+//                    "    \"/string\": \"NONE\"" +
+//                    "  }" +
+//                    "  typeref unionRefNoAlias =" +
+//                    "  union[int, string]" +
+//                    "}",
+//                "{" +
+//                    "    \"type\": \"record\"," +
+//                    "    \"name\": \"test\"," +
+//                    "    \"fields\": [" +
+//                    "        {" +
+//                    "            \"name\": \"unionTyperef\"," +
+//                    "            \"type\": [" +
+//                    "                \"int\"," +
+//                    "                \"string\"" +
+//                    "            ]," +
+//                    "            \"compliance\": {" +
+//                    "                \"/string\": \"NONE\"" +
+//                    "            }" +
+//                    "        }" +
+//                    "    ]" +
+//                    "}"
+//            },
+//            {
+//                "record test {" +
+//                    "  unionTyperef:" +
+//                    "  @compliance = {" +
+//                    "    \"/*/f1\": \"NONE\"" +
+//                    "  }" +
+//                    "  typeref arrayToUnionWithAlias = array[" +
+//                    "  union[f1:int, f2:string]" +
+//                    "  ]" +
+//                    "}",
+//                "{" +
+//                    "    \"type\": \"record\"," +
+//                    "    \"name\": \"test\"," +
+//                    "    \"fields\": [" +
+//                    "        {" +
+//                    "            \"name\": \"unionTyperef\"," +
+//                    "            \"type\": {" +
+//                    "                \"type\": \"array\"," +
+//                    "                \"items\": {" +
+//                    "                    \"type\": \"record\"," +
+//                    "                    \"name\": \"testUnionTyperef\"," +
+//                    "                    \"fields\": [" +
+//                    "                        {" +
+//                    "                            \"name\": \"f1\"," +
+//                    "                            \"type\": [" +
+//                    "                                \"null\"," +
+//                    "                                \"int\"" +
+//                    "                            ]," +
+//                    "                            \"default\": null" +
+//                    "                        }," +
+//                    "                        {" +
+//                    "                            \"name\": \"f2\"," +
+//                    "                            \"type\": [" +
+//                    "                                \"null\"," +
+//                    "                                \"string\"" +
+//                    "                            ]," +
+//                    "                            \"default\": null" +
+//                    "                        }," +
+//                    "                        {" +
+//                    "                            \"name\": \"fieldDiscriminator\"," +
+//                    "                            \"type\": {" +
+//                    "                                \"type\": \"enum\"," +
+//                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
+//                    "                                \"symbols\": [" +
+//                    "                                    \"f1\"," +
+//                    "                                    \"f2\"" +
+//                    "                                ]" +
+//                    "                            }," +
+//                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
+//                    "                        }" +
+//                    "                    ]" +
+//                    "                }" +
+//                    "            }," +
+//                    "            \"compliance\": {" +
+//                    "                \"/*/f1\": \"NONE\"" +
+//                    "            }" +
+//                    "        }" +
+//                    "    ]" +
+//                    "}"
+//            },
+//            {
+//                "record test {" +
+//                    "  unionTyperef:" +
+//                    "  @compliance = {" +
+//                    "    \"/$key\": \"None\"," +
+//                    "    \"/*/f1\": \"NONE\"" +
+//                    "  }" +
+//                    "  typeref unionRefNoAlias = map[string, " +
+//                    "  union[f1:int, f2:string]" +
+//                    "  ]" +
+//                    "}",
+//                "{" +
+//                    "    \"type\": \"record\"," +
+//                    "    \"name\": \"test\"," +
+//                    "    \"fields\": [" +
+//                    "        {" +
+//                    "            \"name\": \"unionTyperef\"," +
+//                    "            \"type\": {" +
+//                    "                \"type\": \"map\"," +
+//                    "                \"values\": {" +
+//                    "                    \"type\": \"record\"," +
+//                    "                    \"name\": \"testUnionTyperef\"," +
+//                    "                    \"fields\": [" +
+//                    "                        {" +
+//                    "                            \"name\": \"f1\"," +
+//                    "                            \"type\": [" +
+//                    "                                \"null\"," +
+//                    "                                \"int\"" +
+//                    "                            ]," +
+//                    "                            \"default\": null" +
+//                    "                        }," +
+//                    "                        {" +
+//                    "                            \"name\": \"f2\"," +
+//                    "                            \"type\": [" +
+//                    "                                \"null\"," +
+//                    "                                \"string\"" +
+//                    "                            ]," +
+//                    "                            \"default\": null" +
+//                    "                        }," +
+//                    "                        {" +
+//                    "                            \"name\": \"fieldDiscriminator\"," +
+//                    "                            \"type\": {" +
+//                    "                                \"type\": \"enum\"," +
+//                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
+//                    "                                \"symbols\": [" +
+//                    "                                    \"f1\"," +
+//                    "                                    \"f2\"" +
+//                    "                                ]" +
+//                    "                            }," +
+//                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
+//                    "                        }" +
+//                    "                    ]" +
+//                    "                }" +
+//                    "            }," +
+//                    "            \"compliance\": {" +
+//                    "                \"/$key\": \"None\"," +
+//                    "                \"/*/f1\": \"NONE\"" +
+//                    "            }" +
+//                    "        }" +
+//                    "    ]" +
+//                    "}"
+//            },
+//            {
+//                "record test {" +
+//                    "  unionTyperef:" +
+//                    "  @compliance = {" +
+//                    "    \"/f1\": \"NONE\"" +
+//                    "  }" +
+//                    "  typeref unionRefWithAlias =" +
+//                    "  union[f1:int, f2:string]" +
+//                    "}",
+//                "{" +
+//                    "    \"type\": \"record\"," +
+//                    "    \"name\": \"test\"," +
+//                    "    \"fields\": [" +
+//                    "        {" +
+//                    "            \"name\": \"unionTyperef\"," +
+//                    "            \"type\": {" +
+//                    "                \"type\": \"record\"," +
+//                    "                \"name\": \"testUnionTyperef\"," +
+//                    "                \"fields\": [" +
+//                    "                    {" +
+//                    "                        \"name\": \"f1\"," +
+//                    "                        \"type\": [" +
+//                    "                            \"null\"," +
+//                    "                            \"int\"" +
+//                    "                        ]," +
+//                    "                        \"default\": null" +
+//                    "                    }," +
+//                    "                    {" +
+//                    "                        \"name\": \"f2\"," +
+//                    "                        \"type\": [" +
+//                    "                            \"null\"," +
+//                    "                            \"string\"" +
+//                    "                        ]," +
+//                    "                        \"default\": null" +
+//                    "                    }," +
+//                    "                    {" +
+//                    "                        \"name\": \"fieldDiscriminator\"," +
+//                    "                        \"type\": {" +
+//                    "                            \"type\": \"enum\"," +
+//                    "                            \"name\": \"testUnionTyperefDiscriminator\"," +
+//                    "                            \"symbols\": [" +
+//                    "                                \"f1\"," +
+//                    "                                \"f2\"" +
+//                    "                            ]" +
+//                    "                        }," +
+//                    "                        \"doc\": \"Contains the name of the field that has its value set.\"" +
+//                    "                    }" +
+//                    "                ]" +
+//                    "            }," +
+//                    "            \"compliance\": {" +
+//                    "                \"/f1\": \"NONE\"" +
+//                    "            }" +
+//                    "        }" +
+//                    "    ]" +
+//                    "}"
+//             },
             {
                 "record test {" +
                     "  unionTyperef:" +
-                    "  @compliance = {" +
-                    "    \"/string\": \"NONE\"" +
-                    "  }" +
-                    "  typeref unionRefNoAlias =" +
-                    "  union[int, string]" +
-                    "}",
-                "{" +
-                    "    \"type\": \"record\"," +
-                    "    \"name\": \"test\"," +
-                    "    \"fields\": [" +
-                    "        {" +
-                    "            \"name\": \"unionTyperef\"," +
-                    "            \"type\": [" +
-                    "                \"int\"," +
-                    "                \"string\"" +
-                    "            ]," +
-                    "            \"compliance\": {" +
-                    "                \"/string\": \"NONE\"" +
-                    "            }" +
-                    "        }" +
-                    "    ]" +
-                    "}"
-            },
-            {
-                "record test {" +
-                    "  unionTyperef:" +
-                    "  @compliance = {" +
-                    "    \"/*/f1\": \"NONE\"" +
-                    "  }" +
-                    "  typeref arrayToUnionWithAlias = array[" +
-                    "  union[f1:int, f2:string]" +
-                    "  ]" +
-                    "}",
-                "{" +
-                    "    \"type\": \"record\"," +
-                    "    \"name\": \"test\"," +
-                    "    \"fields\": [" +
-                    "        {" +
-                    "            \"name\": \"unionTyperef\"," +
-                    "            \"type\": {" +
-                    "                \"type\": \"array\"," +
-                    "                \"items\": {" +
-                    "                    \"type\": \"record\"," +
-                    "                    \"name\": \"testUnionTyperef\"," +
-                    "                    \"fields\": [" +
-                    "                        {" +
-                    "                            \"name\": \"f1\"," +
-                    "                            \"type\": [" +
-                    "                                \"null\"," +
-                    "                                \"int\"" +
-                    "                            ]," +
-                    "                            \"default\": null" +
-                    "                        }," +
-                    "                        {" +
-                    "                            \"name\": \"f2\"," +
-                    "                            \"type\": [" +
-                    "                                \"null\"," +
-                    "                                \"string\"" +
-                    "                            ]," +
-                    "                            \"default\": null" +
-                    "                        }," +
-                    "                        {" +
-                    "                            \"name\": \"fieldDiscriminator\"," +
-                    "                            \"type\": {" +
-                    "                                \"type\": \"enum\"," +
-                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
-                    "                                \"symbols\": [" +
-                    "                                    \"f1\"," +
-                    "                                    \"f2\"" +
-                    "                                ]" +
-                    "                            }," +
-                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
-                    "                        }" +
-                    "                    ]" +
-                    "                }" +
-                    "            }," +
-                    "            \"compliance\": {" +
-                    "                \"/*/f1\": \"NONE\"" +
-                    "            }" +
-                    "        }" +
-                    "    ]" +
-                    "}"
-            },
-            {
-                "record test {" +
-                    "  unionTyperef:" +
-                    "  @compliance = {" +
-                    "    \"/$key\": \"None\"," +
-                    "    \"/*/f1\": \"NONE\"" +
-                    "  }" +
-                    "  typeref unionRefNoAlias = map[string, " +
-                    "  union[f1:int, f2:string]" +
-                    "  ]" +
-                    "}",
-                "{" +
-                    "    \"type\": \"record\"," +
-                    "    \"name\": \"test\"," +
-                    "    \"fields\": [" +
-                    "        {" +
-                    "            \"name\": \"unionTyperef\"," +
-                    "            \"type\": {" +
-                    "                \"type\": \"map\"," +
-                    "                \"values\": {" +
-                    "                    \"type\": \"record\"," +
-                    "                    \"name\": \"testUnionTyperef\"," +
-                    "                    \"fields\": [" +
-                    "                        {" +
-                    "                            \"name\": \"f1\"," +
-                    "                            \"type\": [" +
-                    "                                \"null\"," +
-                    "                                \"int\"" +
-                    "                            ]," +
-                    "                            \"default\": null" +
-                    "                        }," +
-                    "                        {" +
-                    "                            \"name\": \"f2\"," +
-                    "                            \"type\": [" +
-                    "                                \"null\"," +
-                    "                                \"string\"" +
-                    "                            ]," +
-                    "                            \"default\": null" +
-                    "                        }," +
-                    "                        {" +
-                    "                            \"name\": \"fieldDiscriminator\"," +
-                    "                            \"type\": {" +
-                    "                                \"type\": \"enum\"," +
-                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
-                    "                                \"symbols\": [" +
-                    "                                    \"f1\"," +
-                    "                                    \"f2\"" +
-                    "                                ]" +
-                    "                            }," +
-                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
-                    "                        }" +
-                    "                    ]" +
-                    "                }" +
-                    "            }," +
-                    "            \"compliance\": {" +
-                    "                \"/$key\": \"None\"," +
-                    "                \"/*/f1\": \"NONE\"" +
-                    "            }" +
-                    "        }" +
-                    "    ]" +
-                    "}"
-            },
-            {
-                "record test {" +
-                    "  unionTyperef:" +
+                    "  typeref unionRefWithAlias =" +
                     "  @compliance = {" +
                     "    \"/f1\": \"NONE\"" +
                     "  }" +
-                    "  typeref unionRefWithAlias =" +
                     "  union[f1:int, f2:string]" +
                     "}",
                 "{" +
@@ -270,15 +326,15 @@ public class TestSchemaTranslator
                     "                        }," +
                     "                        \"doc\": \"Contains the name of the field that has its value set.\"" +
                     "                    }" +
-                    "                ]" +
-                    "            }," +
-                    "            \"compliance\": {" +
-                    "                \"/f1\": \"NONE\"" +
+                    "                ]," +
+                    "                \"compliance\": {" +
+                    "                    \"/f1\": \"NONE\"" +
+                    "                }" +
                     "            }" +
                     "        }" +
                     "    ]" +
                     "}"
-             }
+            }
             };
  }
 

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -69,6 +69,217 @@ public class TestSchemaTranslator
 
     assertSame(DataToAvroSchemaTranslationOptions.DEFAULT_OPTIONAL_DEFAULT_MODE, OptionalDefaultMode.TRANSLATE_DEFAULT);
   }
+  @DataProvider
+  public Object[][] toAvroSchemaData_testTypeRefAnnotationPropagationUnionWithAlias()
+  {
+    return new Object[][]
+        {
+            {
+                "record test {" +
+                    "  unionTyperef:" +
+                    "  @compliance = {" +
+                    "    \"/string\": \"NONE\"" +
+                    "  }" +
+                    "  typeref unionRefNoAlias =" +
+                    "  union[int, string]" +
+                    "}",
+                "{" +
+                    "    \"type\": \"record\"," +
+                    "    \"name\": \"test\"," +
+                    "    \"fields\": [" +
+                    "        {" +
+                    "            \"name\": \"unionTyperef\"," +
+                    "            \"type\": [" +
+                    "                \"int\"," +
+                    "                \"string\"" +
+                    "            ]," +
+                    "            \"compliance\": {" +
+                    "                \"/string\": \"NONE\"" +
+                    "            }" +
+                    "        }" +
+                    "    ]" +
+                    "}"
+            },
+            {
+                "record test {" +
+                    "  unionTyperef:" +
+                    "  @compliance = {" +
+                    "    \"/*/f1\": \"NONE\"" +
+                    "  }" +
+                    "  typeref arrayToUnionWithAlias = array[" +
+                    "  union[f1:int, f2:string]" +
+                    "  ]" +
+                    "}",
+                "{" +
+                    "    \"type\": \"record\"," +
+                    "    \"name\": \"test\"," +
+                    "    \"fields\": [" +
+                    "        {" +
+                    "            \"name\": \"unionTyperef\"," +
+                    "            \"type\": {" +
+                    "                \"type\": \"array\"," +
+                    "                \"items\": {" +
+                    "                    \"type\": \"record\"," +
+                    "                    \"name\": \"testUnionTyperef\"," +
+                    "                    \"fields\": [" +
+                    "                        {" +
+                    "                            \"name\": \"f1\"," +
+                    "                            \"type\": [" +
+                    "                                \"null\"," +
+                    "                                \"int\"" +
+                    "                            ]," +
+                    "                            \"default\": null" +
+                    "                        }," +
+                    "                        {" +
+                    "                            \"name\": \"f2\"," +
+                    "                            \"type\": [" +
+                    "                                \"null\"," +
+                    "                                \"string\"" +
+                    "                            ]," +
+                    "                            \"default\": null" +
+                    "                        }," +
+                    "                        {" +
+                    "                            \"name\": \"fieldDiscriminator\"," +
+                    "                            \"type\": {" +
+                    "                                \"type\": \"enum\"," +
+                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
+                    "                                \"symbols\": [" +
+                    "                                    \"f1\"," +
+                    "                                    \"f2\"" +
+                    "                                ]" +
+                    "                            }," +
+                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
+                    "                        }" +
+                    "                    ]" +
+                    "                }" +
+                    "            }," +
+                    "            \"compliance\": {" +
+                    "                \"/*/f1\": \"NONE\"" +
+                    "            }" +
+                    "        }" +
+                    "    ]" +
+                    "}"
+            },
+            {
+                "record test {" +
+                    "  unionTyperef:" +
+                    "  @compliance = {" +
+                    "    \"/$key\": \"None\"," +
+                    "    \"/*/f1\": \"NONE\"" +
+                    "  }" +
+                    "  typeref unionRefNoAlias = map[string, " +
+                    "  union[f1:int, f2:string]" +
+                    "  ]" +
+                    "}",
+                "{" +
+                    "    \"type\": \"record\"," +
+                    "    \"name\": \"test\"," +
+                    "    \"fields\": [" +
+                    "        {" +
+                    "            \"name\": \"unionTyperef\"," +
+                    "            \"type\": {" +
+                    "                \"type\": \"map\"," +
+                    "                \"values\": {" +
+                    "                    \"type\": \"record\"," +
+                    "                    \"name\": \"testUnionTyperef\"," +
+                    "                    \"fields\": [" +
+                    "                        {" +
+                    "                            \"name\": \"f1\"," +
+                    "                            \"type\": [" +
+                    "                                \"null\"," +
+                    "                                \"int\"" +
+                    "                            ]," +
+                    "                            \"default\": null" +
+                    "                        }," +
+                    "                        {" +
+                    "                            \"name\": \"f2\"," +
+                    "                            \"type\": [" +
+                    "                                \"null\"," +
+                    "                                \"string\"" +
+                    "                            ]," +
+                    "                            \"default\": null" +
+                    "                        }," +
+                    "                        {" +
+                    "                            \"name\": \"fieldDiscriminator\"," +
+                    "                            \"type\": {" +
+                    "                                \"type\": \"enum\"," +
+                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
+                    "                                \"symbols\": [" +
+                    "                                    \"f1\"," +
+                    "                                    \"f2\"" +
+                    "                                ]" +
+                    "                            }," +
+                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
+                    "                        }" +
+                    "                    ]" +
+                    "                }" +
+                    "            }," +
+                    "            \"compliance\": {" +
+                    "                \"/$key\": \"None\"," +
+                    "                \"/*/f1\": \"NONE\"" +
+                    "            }" +
+                    "        }" +
+                    "    ]" +
+                    "}"
+            },
+            {
+                "record test {" +
+                    "  unionTyperef:" +
+                    "  @compliance = {" +
+                    "    \"/f1\": \"NONE\"" +
+                    "  }" +
+                    "  typeref unionRefWithAlias =" +
+                    "  union[f1:int, f2:string]" +
+                    "}",
+                "{" +
+                    "    \"type\": \"record\"," +
+                    "    \"name\": \"test\"," +
+                    "    \"fields\": [" +
+                    "        {" +
+                    "            \"name\": \"unionTyperef\"," +
+                    "            \"type\": {" +
+                    "                \"type\": \"record\"," +
+                    "                \"name\": \"testUnionTyperef\"," +
+                    "                \"fields\": [" +
+                    "                    {" +
+                    "                        \"name\": \"f1\"," +
+                    "                        \"type\": [" +
+                    "                            \"null\"," +
+                    "                            \"int\"" +
+                    "                        ]," +
+                    "                        \"default\": null" +
+                    "                    }," +
+                    "                    {" +
+                    "                        \"name\": \"f2\"," +
+                    "                        \"type\": [" +
+                    "                            \"null\"," +
+                    "                            \"string\"" +
+                    "                        ]," +
+                    "                        \"default\": null" +
+                    "                    }," +
+                    "                    {" +
+                    "                        \"name\": \"fieldDiscriminator\"," +
+                    "                        \"type\": {" +
+                    "                            \"type\": \"enum\"," +
+                    "                            \"name\": \"testUnionTyperefDiscriminator\"," +
+                    "                            \"symbols\": [" +
+                    "                                \"f1\"," +
+                    "                                \"f2\"" +
+                    "                            ]" +
+                    "                        }," +
+                    "                        \"doc\": \"Contains the name of the field that has its value set.\"" +
+                    "                    }" +
+                    "                ]" +
+                    "            }," +
+                    "            \"compliance\": {" +
+                    "                \"/f1\": \"NONE\"" +
+                    "            }" +
+                    "        }" +
+                    "    ]" +
+                    "}"
+             }
+            };
+ }
 
  @DataProvider
  public Object[][] toAvroSchemaData_testTypeRefAnnotationPropagation()
@@ -308,11 +519,11 @@ public class TestSchemaTranslator
 
  }
 
- @Test(dataProvider = "toAvroSchemaData_testTypeRefAnnotationPropagation")
- public void testToAvroSchema_testTypeRefAnnotationPropagation(String schemaBeforeTranslation,
+ @Test(dataProvider = "toAvroSchemaData_testTypeRefAnnotationPropagationUnionWithAlias")
+ public void testToAvroSchema_testTypeRefAnnotationPropagationUnionWithAlias(String schemaBeforeTranslation,
                                                                String expectedAvroSchemaAsString) throws Exception
  {
-   DataSchema schema = TestUtil.dataSchemaFromString(schemaBeforeTranslation);
+   DataSchema schema = TestUtil.dataSchemaFromPdlString(schemaBeforeTranslation);
    DataToAvroSchemaTranslationOptions transOptions = new DataToAvroSchemaTranslationOptions(OptionalDefaultMode.TRANSLATE_DEFAULT, JsonBuilder.Pretty.SPACES, EmbedSchemaMode.NONE);
    transOptions.setTyperefPropertiesExcludeSet(new HashSet<>(Arrays.asList("validate", "java")));
 
@@ -321,6 +532,20 @@ public class TestSchemaTranslator
    DataMap fieldsPropertiesMap = TestUtil.dataMapFromString(expectedAvroSchemaAsString);
    assertEquals(fieldsPropertiesMap, avroSchemaAsDataMap);
  }
+
+  @Test(dataProvider = "toAvroSchemaData_testTypeRefAnnotationPropagation")
+  public void testToAvroSchema_testTypeRefAnnotationPropagation(String schemaBeforeTranslation,
+      String expectedAvroSchemaAsString) throws Exception
+  {
+    DataSchema schema = TestUtil.dataSchemaFromString(schemaBeforeTranslation);
+    DataToAvroSchemaTranslationOptions transOptions = new DataToAvroSchemaTranslationOptions(OptionalDefaultMode.TRANSLATE_DEFAULT, JsonBuilder.Pretty.SPACES, EmbedSchemaMode.NONE);
+    transOptions.setTyperefPropertiesExcludeSet(new HashSet<>(Arrays.asList("validate", "java")));
+
+    String avroSchemaText = SchemaTranslator.dataToAvroSchemaJson(schema, transOptions);
+    DataMap avroSchemaAsDataMap = TestUtil.dataMapFromString(avroSchemaText);
+    DataMap fieldsPropertiesMap = TestUtil.dataMapFromString(expectedAvroSchemaAsString);
+    assertEquals(fieldsPropertiesMap, avroSchemaAsDataMap);
+  }
 
 
   @DataProvider

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -521,7 +521,7 @@ public class TestSchemaTranslator
  }
 
  @Test(dataProvider = "toAvroSchemaDataTestTypeRefAnnotationPropagationUnionWithAlias")
- public void testToAvroSchema_testTypeRefAnnotationPropagationUnionWithAlias(String schemaBeforeTranslation,
+ public void testToAvroSchemaTestTypeRefAnnotationPropagationUnionWithAlias(String schemaBeforeTranslation,
                                                                String expectedAvroSchemaAsString) throws Exception
  {
    DataSchema schema = TestUtil.dataSchemaFromPdlString(schemaBeforeTranslation);

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -535,7 +535,7 @@ public class TestSchemaTranslator
  }
 
   @Test(dataProvider = "toAvroSchemaDataTestTypeRefAnnotationPropagation")
-  public void testToAvroSchema_testTypeRefAnnotationPropagation(String schemaBeforeTranslation,
+  public void testToAvroSchemaTestTypeRefAnnotationPropagation(String schemaBeforeTranslation,
       String expectedAvroSchemaAsString) throws Exception
   {
     DataSchema schema = TestUtil.dataSchemaFromString(schemaBeforeTranslation);

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -75,210 +75,210 @@ public class TestSchemaTranslator
   {
     return new Object[][]
         {
-//            {
-//                "record test {" +
-//                    "  unionTyperef:" +
-//                    "  @compliance = {" +
-//                    "    \"/string\": \"NONE\"" +
-//                    "  }" +
-//                    "  typeref unionRefNoAlias =" +
-//                    "  union[int, string]" +
-//                    "}",
-//                "{" +
-//                    "    \"type\": \"record\"," +
-//                    "    \"name\": \"test\"," +
-//                    "    \"fields\": [" +
-//                    "        {" +
-//                    "            \"name\": \"unionTyperef\"," +
-//                    "            \"type\": [" +
-//                    "                \"int\"," +
-//                    "                \"string\"" +
-//                    "            ]," +
-//                    "            \"compliance\": {" +
-//                    "                \"/string\": \"NONE\"" +
-//                    "            }" +
-//                    "        }" +
-//                    "    ]" +
-//                    "}"
-//            },
-//            {
-//                "record test {" +
-//                    "  unionTyperef:" +
-//                    "  @compliance = {" +
-//                    "    \"/*/f1\": \"NONE\"" +
-//                    "  }" +
-//                    "  typeref arrayToUnionWithAlias = array[" +
-//                    "  union[f1:int, f2:string]" +
-//                    "  ]" +
-//                    "}",
-//                "{" +
-//                    "    \"type\": \"record\"," +
-//                    "    \"name\": \"test\"," +
-//                    "    \"fields\": [" +
-//                    "        {" +
-//                    "            \"name\": \"unionTyperef\"," +
-//                    "            \"type\": {" +
-//                    "                \"type\": \"array\"," +
-//                    "                \"items\": {" +
-//                    "                    \"type\": \"record\"," +
-//                    "                    \"name\": \"testUnionTyperef\"," +
-//                    "                    \"fields\": [" +
-//                    "                        {" +
-//                    "                            \"name\": \"f1\"," +
-//                    "                            \"type\": [" +
-//                    "                                \"null\"," +
-//                    "                                \"int\"" +
-//                    "                            ]," +
-//                    "                            \"default\": null" +
-//                    "                        }," +
-//                    "                        {" +
-//                    "                            \"name\": \"f2\"," +
-//                    "                            \"type\": [" +
-//                    "                                \"null\"," +
-//                    "                                \"string\"" +
-//                    "                            ]," +
-//                    "                            \"default\": null" +
-//                    "                        }," +
-//                    "                        {" +
-//                    "                            \"name\": \"fieldDiscriminator\"," +
-//                    "                            \"type\": {" +
-//                    "                                \"type\": \"enum\"," +
-//                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
-//                    "                                \"symbols\": [" +
-//                    "                                    \"f1\"," +
-//                    "                                    \"f2\"" +
-//                    "                                ]" +
-//                    "                            }," +
-//                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
-//                    "                        }" +
-//                    "                    ]" +
-//                    "                }" +
-//                    "            }," +
-//                    "            \"compliance\": {" +
-//                    "                \"/*/f1\": \"NONE\"" +
-//                    "            }" +
-//                    "        }" +
-//                    "    ]" +
-//                    "}"
-//            },
-//            {
-//                "record test {" +
-//                    "  unionTyperef:" +
-//                    "  @compliance = {" +
-//                    "    \"/$key\": \"None\"," +
-//                    "    \"/*/f1\": \"NONE\"" +
-//                    "  }" +
-//                    "  typeref unionRefNoAlias = map[string, " +
-//                    "  union[f1:int, f2:string]" +
-//                    "  ]" +
-//                    "}",
-//                "{" +
-//                    "    \"type\": \"record\"," +
-//                    "    \"name\": \"test\"," +
-//                    "    \"fields\": [" +
-//                    "        {" +
-//                    "            \"name\": \"unionTyperef\"," +
-//                    "            \"type\": {" +
-//                    "                \"type\": \"map\"," +
-//                    "                \"values\": {" +
-//                    "                    \"type\": \"record\"," +
-//                    "                    \"name\": \"testUnionTyperef\"," +
-//                    "                    \"fields\": [" +
-//                    "                        {" +
-//                    "                            \"name\": \"f1\"," +
-//                    "                            \"type\": [" +
-//                    "                                \"null\"," +
-//                    "                                \"int\"" +
-//                    "                            ]," +
-//                    "                            \"default\": null" +
-//                    "                        }," +
-//                    "                        {" +
-//                    "                            \"name\": \"f2\"," +
-//                    "                            \"type\": [" +
-//                    "                                \"null\"," +
-//                    "                                \"string\"" +
-//                    "                            ]," +
-//                    "                            \"default\": null" +
-//                    "                        }," +
-//                    "                        {" +
-//                    "                            \"name\": \"fieldDiscriminator\"," +
-//                    "                            \"type\": {" +
-//                    "                                \"type\": \"enum\"," +
-//                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
-//                    "                                \"symbols\": [" +
-//                    "                                    \"f1\"," +
-//                    "                                    \"f2\"" +
-//                    "                                ]" +
-//                    "                            }," +
-//                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
-//                    "                        }" +
-//                    "                    ]" +
-//                    "                }" +
-//                    "            }," +
-//                    "            \"compliance\": {" +
-//                    "                \"/$key\": \"None\"," +
-//                    "                \"/*/f1\": \"NONE\"" +
-//                    "            }" +
-//                    "        }" +
-//                    "    ]" +
-//                    "}"
-//            },
-//            {
-//                "record test {" +
-//                    "  unionTyperef:" +
-//                    "  @compliance = {" +
-//                    "    \"/f1\": \"NONE\"" +
-//                    "  }" +
-//                    "  typeref unionRefWithAlias =" +
-//                    "  union[f1:int, f2:string]" +
-//                    "}",
-//                "{" +
-//                    "    \"type\": \"record\"," +
-//                    "    \"name\": \"test\"," +
-//                    "    \"fields\": [" +
-//                    "        {" +
-//                    "            \"name\": \"unionTyperef\"," +
-//                    "            \"type\": {" +
-//                    "                \"type\": \"record\"," +
-//                    "                \"name\": \"testUnionTyperef\"," +
-//                    "                \"fields\": [" +
-//                    "                    {" +
-//                    "                        \"name\": \"f1\"," +
-//                    "                        \"type\": [" +
-//                    "                            \"null\"," +
-//                    "                            \"int\"" +
-//                    "                        ]," +
-//                    "                        \"default\": null" +
-//                    "                    }," +
-//                    "                    {" +
-//                    "                        \"name\": \"f2\"," +
-//                    "                        \"type\": [" +
-//                    "                            \"null\"," +
-//                    "                            \"string\"" +
-//                    "                        ]," +
-//                    "                        \"default\": null" +
-//                    "                    }," +
-//                    "                    {" +
-//                    "                        \"name\": \"fieldDiscriminator\"," +
-//                    "                        \"type\": {" +
-//                    "                            \"type\": \"enum\"," +
-//                    "                            \"name\": \"testUnionTyperefDiscriminator\"," +
-//                    "                            \"symbols\": [" +
-//                    "                                \"f1\"," +
-//                    "                                \"f2\"" +
-//                    "                            ]" +
-//                    "                        }," +
-//                    "                        \"doc\": \"Contains the name of the field that has its value set.\"" +
-//                    "                    }" +
-//                    "                ]" +
-//                    "            }," +
-//                    "            \"compliance\": {" +
-//                    "                \"/f1\": \"NONE\"" +
-//                    "            }" +
-//                    "        }" +
-//                    "    ]" +
-//                    "}"
-//             },
+            {
+                "record test {" +
+                    "  unionTyperef:" +
+                    "  @compliance = {" +
+                    "    \"/string\": \"NONE\"" +
+                    "  }" +
+                    "  typeref unionRefNoAlias =" +
+                    "  union[int, string]" +
+                    "}",
+                "{" +
+                    "    \"type\": \"record\"," +
+                    "    \"name\": \"test\"," +
+                    "    \"fields\": [" +
+                    "        {" +
+                    "            \"name\": \"unionTyperef\"," +
+                    "            \"type\": [" +
+                    "                \"int\"," +
+                    "                \"string\"" +
+                    "            ]," +
+                    "            \"compliance\": {" +
+                    "                \"/string\": \"NONE\"" +
+                    "            }" +
+                    "        }" +
+                    "    ]" +
+                    "}"
+            },
+            {
+                "record test {" +
+                    "  unionTyperef:" +
+                    "  @compliance = {" +
+                    "    \"/*/f1\": \"NONE\"" +
+                    "  }" +
+                    "  typeref arrayToUnionWithAlias = array[" +
+                    "  union[f1:int, f2:string]" +
+                    "  ]" +
+                    "}",
+                "{" +
+                    "    \"type\": \"record\"," +
+                    "    \"name\": \"test\"," +
+                    "    \"fields\": [" +
+                    "        {" +
+                    "            \"name\": \"unionTyperef\"," +
+                    "            \"type\": {" +
+                    "                \"type\": \"array\"," +
+                    "                \"items\": {" +
+                    "                    \"type\": \"record\"," +
+                    "                    \"name\": \"testUnionTyperef\"," +
+                    "                    \"fields\": [" +
+                    "                        {" +
+                    "                            \"name\": \"f1\"," +
+                    "                            \"type\": [" +
+                    "                                \"null\"," +
+                    "                                \"int\"" +
+                    "                            ]," +
+                    "                            \"default\": null" +
+                    "                        }," +
+                    "                        {" +
+                    "                            \"name\": \"f2\"," +
+                    "                            \"type\": [" +
+                    "                                \"null\"," +
+                    "                                \"string\"" +
+                    "                            ]," +
+                    "                            \"default\": null" +
+                    "                        }," +
+                    "                        {" +
+                    "                            \"name\": \"fieldDiscriminator\"," +
+                    "                            \"type\": {" +
+                    "                                \"type\": \"enum\"," +
+                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
+                    "                                \"symbols\": [" +
+                    "                                    \"f1\"," +
+                    "                                    \"f2\"" +
+                    "                                ]" +
+                    "                            }," +
+                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
+                    "                        }" +
+                    "                    ]" +
+                    "                }" +
+                    "            }," +
+                    "            \"compliance\": {" +
+                    "                \"/*/f1\": \"NONE\"" +
+                    "            }" +
+                    "        }" +
+                    "    ]" +
+                    "}"
+            },
+            {
+                "record test {" +
+                    "  unionTyperef:" +
+                    "  @compliance = {" +
+                    "    \"/$key\": \"None\"," +
+                    "    \"/*/f1\": \"NONE\"" +
+                    "  }" +
+                    "  typeref unionRefNoAlias = map[string, " +
+                    "  union[f1:int, f2:string]" +
+                    "  ]" +
+                    "}",
+                "{" +
+                    "    \"type\": \"record\"," +
+                    "    \"name\": \"test\"," +
+                    "    \"fields\": [" +
+                    "        {" +
+                    "            \"name\": \"unionTyperef\"," +
+                    "            \"type\": {" +
+                    "                \"type\": \"map\"," +
+                    "                \"values\": {" +
+                    "                    \"type\": \"record\"," +
+                    "                    \"name\": \"testUnionTyperef\"," +
+                    "                    \"fields\": [" +
+                    "                        {" +
+                    "                            \"name\": \"f1\"," +
+                    "                            \"type\": [" +
+                    "                                \"null\"," +
+                    "                                \"int\"" +
+                    "                            ]," +
+                    "                            \"default\": null" +
+                    "                        }," +
+                    "                        {" +
+                    "                            \"name\": \"f2\"," +
+                    "                            \"type\": [" +
+                    "                                \"null\"," +
+                    "                                \"string\"" +
+                    "                            ]," +
+                    "                            \"default\": null" +
+                    "                        }," +
+                    "                        {" +
+                    "                            \"name\": \"fieldDiscriminator\"," +
+                    "                            \"type\": {" +
+                    "                                \"type\": \"enum\"," +
+                    "                                \"name\": \"testUnionTyperefDiscriminator\"," +
+                    "                                \"symbols\": [" +
+                    "                                    \"f1\"," +
+                    "                                    \"f2\"" +
+                    "                                ]" +
+                    "                            }," +
+                    "                            \"doc\": \"Contains the name of the field that has its value set.\"" +
+                    "                        }" +
+                    "                    ]" +
+                    "                }" +
+                    "            }," +
+                    "            \"compliance\": {" +
+                    "                \"/$key\": \"None\"," +
+                    "                \"/*/f1\": \"NONE\"" +
+                    "            }" +
+                    "        }" +
+                    "    ]" +
+                    "}"
+            },
+            {
+                "record test {" +
+                    "  unionTyperef:" +
+                    "  @compliance = {" +
+                    "    \"/f1\": \"NONE\"" +
+                    "  }" +
+                    "  typeref unionRefWithAlias =" +
+                    "  union[f1:int, f2:string]" +
+                    "}",
+                "{" +
+                    "    \"type\": \"record\"," +
+                    "    \"name\": \"test\"," +
+                    "    \"fields\": [" +
+                    "        {" +
+                    "            \"name\": \"unionTyperef\"," +
+                    "            \"type\": {" +
+                    "                \"type\": \"record\"," +
+                    "                \"name\": \"testUnionTyperef\"," +
+                    "                \"fields\": [" +
+                    "                    {" +
+                    "                        \"name\": \"f1\"," +
+                    "                        \"type\": [" +
+                    "                            \"null\"," +
+                    "                            \"int\"" +
+                    "                        ]," +
+                    "                        \"default\": null" +
+                    "                    }," +
+                    "                    {" +
+                    "                        \"name\": \"f2\"," +
+                    "                        \"type\": [" +
+                    "                            \"null\"," +
+                    "                            \"string\"" +
+                    "                        ]," +
+                    "                        \"default\": null" +
+                    "                    }," +
+                    "                    {" +
+                    "                        \"name\": \"fieldDiscriminator\"," +
+                    "                        \"type\": {" +
+                    "                            \"type\": \"enum\"," +
+                    "                            \"name\": \"testUnionTyperefDiscriminator\"," +
+                    "                            \"symbols\": [" +
+                    "                                \"f1\"," +
+                    "                                \"f2\"" +
+                    "                            ]" +
+                    "                        }," +
+                    "                        \"doc\": \"Contains the name of the field that has its value set.\"" +
+                    "                    }" +
+                    "                ]" +
+                    "            }," +
+                    "            \"compliance\": {" +
+                    "                \"/f1\": \"NONE\"" +
+                    "            }" +
+                    "        }" +
+                    "    ]" +
+                    "}"
+             },
             {
                 "record test {" +
                     "  unionTyperef:" +

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -69,8 +69,9 @@ public class TestSchemaTranslator
 
     assertSame(DataToAvroSchemaTranslationOptions.DEFAULT_OPTIONAL_DEFAULT_MODE, OptionalDefaultMode.TRANSLATE_DEFAULT);
   }
+
   @DataProvider
-  public Object[][] toAvroSchemaData_testTypeRefAnnotationPropagationUnionWithAlias()
+  public Object[][] toAvroSchemaDataTestTypeRefAnnotationPropagationUnionWithAlias()
   {
     return new Object[][]
         {
@@ -282,7 +283,7 @@ public class TestSchemaTranslator
  }
 
  @DataProvider
- public Object[][] toAvroSchemaData_testTypeRefAnnotationPropagation()
+ public Object[][] toAvroSchemaDataTestTypeRefAnnotationPropagation()
  {
    //These test were specially moved out from "toAvroSchemaData" tests because custom logic needed to validate the correctness
    //of those properties
@@ -519,7 +520,7 @@ public class TestSchemaTranslator
 
  }
 
- @Test(dataProvider = "toAvroSchemaData_testTypeRefAnnotationPropagationUnionWithAlias")
+ @Test(dataProvider = "toAvroSchemaDataTestTypeRefAnnotationPropagationUnionWithAlias")
  public void testToAvroSchema_testTypeRefAnnotationPropagationUnionWithAlias(String schemaBeforeTranslation,
                                                                String expectedAvroSchemaAsString) throws Exception
  {
@@ -533,7 +534,7 @@ public class TestSchemaTranslator
    assertEquals(fieldsPropertiesMap, avroSchemaAsDataMap);
  }
 
-  @Test(dataProvider = "toAvroSchemaData_testTypeRefAnnotationPropagation")
+  @Test(dataProvider = "toAvroSchemaDataTestTypeRefAnnotationPropagation")
   public void testToAvroSchema_testTypeRefAnnotationPropagation(String schemaBeforeTranslation,
       String expectedAvroSchemaAsString) throws Exception
   {

--- a/data/src/main/java/com/linkedin/data/schema/TyperefDataSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/TyperefDataSchema.java
@@ -17,6 +17,7 @@
 package com.linkedin.data.schema;
 
 import com.linkedin.data.DataMap;
+import java.util.HashMap;
 import java.util.Map;
 
 
@@ -110,9 +111,13 @@ public class TyperefDataSchema extends NamedDataSchema
     {
       propertiesToBeMerged = ((TyperefDataSchema) getRef()).getMergedTyperefProperties();
     }
-    else
+    else if (getRef().isPrimitive())
     {
       propertiesToBeMerged = getRef().getProperties();
+    }
+    else
+    {
+      propertiesToBeMerged = new HashMap<>();
     }
     Map<String, Object> mergedMap = new DataMap(getProperties());
     // Merge rule for same name property conflicts:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.11
+version=29.7.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
…pagated during pegasus to avro translation

The typeref property should be brought to Avro schema translation.

It was not previously working with typeref in Union with Alias since typeref in unionwithalias was handled separately in callbacks. 

This change is bring typeref properties to the union with alias.