### PR TITLE
Performance optimization in TimingContextUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Check if debug logging is enabled before calling debug log message in TimingContextUtil to avoid unnecessary exception instantiation.
 
 ## [29.7.9] - 2020-10-15
 - Add partition validation when getting relative load balancer metrics.

--- a/r2-core/src/main/java/com/linkedin/r2/message/timing/TimingContextUtil.java
+++ b/r2-core/src/main/java/com/linkedin/r2/message/timing/TimingContextUtil.java
@@ -205,7 +205,10 @@ public class TimingContextUtil
    */
   private static void logWarning(String message)
   {
-    LOG.debug(message, new RuntimeException(message));
+    if (LOG.isDebugEnabled())
+    {
+      LOG.debug(message, new RuntimeException(message));
+    }
   }
 
   /**


### PR DESCRIPTION
Check if debug logging is enabled before calling debug log method in TimingContextUtil to avoid unnecessary exception instantiation.