### PR TITLE
[Relative Load Balancer] Improve log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.7.13] - 2020-10-22
+- Improve relative load balancer logging.
+
 ## [29.7.12] - 2020-10-20
-Fix the bug of not propagating schema properties in typeref with UnionWithAlias during pegasus to avro translation
+- Fix the bug of not propagating schema properties in typeref with UnionWithAlias during pegasus to avro translation
 
 ## [29.7.11] - 2020-10-19
 - Clear the destination directory for generateRestClientTask before the task runs.
@@ -4717,7 +4720,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.13...master
+[29.7.13]: https://github.com/linkedin/rest.li/compare/v29.7.12...v29.7.13
 [29.7.12]: https://github.com/linkedin/rest.li/compare/v29.7.11...v29.7.12
 [29.7.11]: https://github.com/linkedin/rest.li/compare/v29.7.10...v29.7.11
 [29.7.10]: https://github.com/linkedin/rest.li/compare/v29.7.9...v29.7.10

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 public class PartitionState
 {
   private static final long INITIAL_CLUSTER_GENERATION_ID = -1;
+  private static final int LOG_SIZE_LIMIT = 10;
   private int _partitionId;
   private int _pointsPerWeight;
   private RingFactory<URI> _ringFactory;
@@ -202,14 +203,16 @@ public class PartitionState
   @Override
   public String toString()
   {
-    return "PartitionRelativeLoadBalancerState{" + "_partitionId=" + _partitionId
+    return "PartitionRelativeLoadBalancerState={" + "_partitionId=" + _partitionId
         + ", _clusterGenerationId=" + _clusterGenerationId
         + ", _numHostsInCluster=" + (getTrackerClients().size())
-        + ", _recoveryTrackerClients=" + _recoveryTrackerClients
-        + ", _quarantineMap=" + _quarantineMap.keySet().stream().map(TrackerClient::getUri).collect(Collectors.toList())
-        + ", _pointsMap=" + _pointsMap
-        + ", _trackerClientStateMap=" + _trackerClientStateMap
-        + ", _partitionStats={" + _partitionStats + "}}";
+        + ", _partitionStats={" + _partitionStats + "}}"
+        + ", _recoveryTrackerClients={" + _recoveryTrackerClients
+            .stream().limit(LOG_SIZE_LIMIT).map(client -> client.getUri().toString()).collect(Collectors.joining(","))
+        + (_recoveryTrackerClients.size() > LOG_SIZE_LIMIT ? "...(total " + _recoveryTrackerClients.size() + ")" : "") + "}"
+        + ", _quarantineMap={" + _quarantineMap.keySet()
+            .stream().limit(LOG_SIZE_LIMIT).map(client -> client.getUri().toString()).collect(Collectors.joining(","))
+        + (_quarantineMap.size() > LOG_SIZE_LIMIT ? "...(total " + _quarantineMap.size() + ")" : "") + "}}";
   }
 
   class PartitionStats
@@ -244,7 +247,7 @@ public class PartitionState
     {
       return "_avgClusterLatency=" + _avgClusterLatency
           +", _clusterCallCount=" + _clusterCallCount
-          +", _clusterErrorCount= " + _clusterCallCount;
+          +", _clusterErrorCount= " + _clusterErrorCount;
     }
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
@@ -206,7 +206,7 @@ public class PartitionState
     return "PartitionRelativeLoadBalancerState={" + "_partitionId=" + _partitionId
         + ", _clusterGenerationId=" + _clusterGenerationId
         + ", _numHostsInCluster=" + (getTrackerClients().size())
-        + ", _partitionStats={" + _partitionStats + "}}"
+        + ", _partitionStats={" + _partitionStats + "}"
         + ", _recoveryTrackerClients={" + _recoveryTrackerClients
             .stream().limit(LOG_SIZE_LIMIT).map(client -> client.getUri().toString()).collect(Collectors.joining(","))
         + (_recoveryTrackerClients.size() > LOG_SIZE_LIMIT ? "...(total " + _recoveryTrackerClients.size() + ")" : "") + "}"

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategyFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategyFactory.java
@@ -112,7 +112,7 @@ public class RelativeLoadBalancerStrategyFactory implements LoadBalancerStrategy
     {
       listenerFactories.addAll(_stateListenerFactories);
     }
-    return new StateUpdater(relativeStrategyProperties, quarantineManager, _executorService, listenerFactories);
+    return new StateUpdater(relativeStrategyProperties, quarantineManager, _executorService, listenerFactories, serviceName);
   }
 
   private ClientSelector getClientSelector(D2RelativeStrategyProperties relativeStrategyProperties)

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -432,25 +432,25 @@ public class StateUpdater
 
     if (LOG.isDebugEnabled())
     {
-      LOG.debug("Strategy updated: service=" + _serviceName + ", partitionId=" + partitionId
-          + "unhealthyClientNumber=" + newUnhealthyClients.size()
-          + "newState=" + newState
-          +", unhealthyClients={" + (newUnhealthyClients.stream().limit(LOG_UNHEALTHY_CLIENT_NUMBERS)
+      LOG.debug("Strategy updated: service=" + _serviceName
+          + ", unhealthyClientNumber=" + newUnhealthyClients.size()
+          + ", newState=" + newState
+          + ", unhealthyClients={" + (newUnhealthyClients.stream().limit(LOG_UNHEALTHY_CLIENT_NUMBERS)
           .map(client -> getClientStats(client, newTrackerClientStateMap)).collect(Collectors.joining(",")))
           + (newUnhealthyClients.size() > LOG_UNHEALTHY_CLIENT_NUMBERS ? "...(total "
           + newUnhealthyClients.size() + ")" : "") + "},"
-          + "oldState=" + oldState);
+          + ", oldState=" + oldState);
     }
     else if (allowToLog(oldState, newState, newUnhealthyClients, oldUnhealthyClients))
     {
-      LOG.info("Strategy updated: service=" + _serviceName + ", partitionId=" + partitionId
-          + "unhealthyClientNumber=" + newUnhealthyClients.size()
-          + "newState=" + newState
-          +", unhealthyClients={" + (newUnhealthyClients.stream().limit(LOG_UNHEALTHY_CLIENT_NUMBERS)
-              .map(client -> getClientStats(client, newTrackerClientStateMap)).collect(Collectors.joining(",")))
+      LOG.debug("Strategy updated: service=" + _serviceName
+          + ", unhealthyClientNumber=" + newUnhealthyClients.size()
+          + ", newState=" + newState
+          + ", unhealthyClients={" + (newUnhealthyClients.stream().limit(LOG_UNHEALTHY_CLIENT_NUMBERS)
+          .map(client -> getClientStats(client, newTrackerClientStateMap)).collect(Collectors.joining(",")))
           + (newUnhealthyClients.size() > LOG_UNHEALTHY_CLIENT_NUMBERS ? "...(total "
           + newUnhealthyClients.size() + ")" : "") + "},"
-          + "oldState=" + oldState);
+          + ", oldState=" + oldState);
     }
   }
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -56,6 +56,7 @@ public class StateUpdaterTest
   private static final long DEFAULT_CLUSTER_GENERATION_ID = 0;
   private static final int HEALTHY_POINTS = 100;
   private static final int INITIAL_RECOVERY_POINTS = 1;
+  private static final String SERVICE_NAME = "DUMMY_SERVICE";
 
   private StateUpdater _stateUpdater;
   private ScheduledExecutorService _executorService = Mockito.mock(ScheduledExecutorService.class);
@@ -66,7 +67,7 @@ public class StateUpdaterTest
   {
     RelativeLoadBalancerStrategyFactory.putDefaultValues(relativeStrategyProperties);
     _stateUpdater = new StateUpdater(relativeStrategyProperties, _quarantineManager, _executorService,
-        partitionLoadBalancerStateMap, Collections.emptyList());
+        partitionLoadBalancerStateMap, Collections.emptyList(), SERVICE_NAME);
   }
 
   @Test(dataProvider = "partitionId")
@@ -170,7 +171,7 @@ public class StateUpdaterTest
     ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     D2RelativeStrategyProperties relativeStrategyProperties = RelativeLoadBalancerStrategyFactory.putDefaultValues(new D2RelativeStrategyProperties());
     _stateUpdater = new StateUpdater(relativeStrategyProperties, _quarantineManager, executorService,
-        partitionLoadBalancerStateMap, Collections.emptyList());
+        partitionLoadBalancerStateMap, Collections.emptyList(), SERVICE_NAME);
 
     // update will be scheduled twice, once from interval update, once from cluster change
     CountDownLatch countDownLatch = new CountDownLatch(2);
@@ -471,7 +472,7 @@ public class StateUpdaterTest
 
     ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     D2RelativeStrategyProperties relativeStrategyProperties = RelativeLoadBalancerStrategyFactory.putDefaultValues(new D2RelativeStrategyProperties());
-    _stateUpdater = new StateUpdater(relativeStrategyProperties, _quarantineManager, executorService, stateMap, Collections.emptyList());
+    _stateUpdater = new StateUpdater(relativeStrategyProperties, _quarantineManager, executorService, stateMap, Collections.emptyList(), SERVICE_NAME);
 
     // In 6 seconds, the update should be executed twice
     CountDownLatch countDownLatch = new CountDownLatch(2);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.12
+version=29.7.13
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Improve the relative load balancer log:
1. Adding service name, otherwise we do not know which service has changed the degrader score
2. Limiting the size of the recovery map and quarantine map, removed points map. Otherwise for a cluster of hundreds of machines, one entry of log will be too big.