### PR TITLE
Improve wrapped array/map template performance. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.7.16] - 2020-10-23
+- Improve array and map template performance by caching the wrapped types when they are added.
+
 ## [29.7.15] - 2020-10-23
-Log Streaming Error or Timeout Error in Jetty SyncIOHandler
+- Log Streaming Error or Timeout Error in Jetty SyncIOHandler
 
 ## [29.7.14] - 2020-10-22
 - Improve performance of schema format translator.
@@ -4727,7 +4730,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.15...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.16...master
+[29.7.16]: https://github.com/linkedin/rest.li/compare/v29.7.15...v29.7.16
 [29.7.15]: https://github.com/linkedin/rest.li/compare/v29.7.14...v29.7.15
 [29.7.14]: https://github.com/linkedin/rest.li/compare/v29.7.13...v29.7.14
 [29.7.13]: https://github.com/linkedin/rest.li/compare/v29.7.12...v29.7.13

--- a/data/src/main/java/com/linkedin/data/template/WrappingArrayTemplate.java
+++ b/data/src/main/java/com/linkedin/data/template/WrappingArrayTemplate.java
@@ -49,7 +49,9 @@ public class WrappingArrayTemplate<E extends DataTemplate<?>> extends AbstractAr
   @Override
   public boolean add(E element) throws ClassCastException
   {
-    boolean result = CheckedUtil.addWithoutChecking(_list, unwrap(element));
+    Object unwrapped = unwrap(element);
+    boolean result = CheckedUtil.addWithoutChecking(_list, unwrapped);
+    _cache.put(unwrapped, element);
     modCount++;
     return result;
   }
@@ -57,7 +59,9 @@ public class WrappingArrayTemplate<E extends DataTemplate<?>> extends AbstractAr
   @Override
   public void add(int index, E element) throws ClassCastException
   {
-    CheckedUtil.addWithoutChecking(_list, index, unwrap(element));
+    Object unwrapped = unwrap(element);
+    CheckedUtil.addWithoutChecking(_list, index, unwrapped);
+    _cache.put(unwrapped, element);
     modCount++;
   }
 
@@ -85,7 +89,9 @@ public class WrappingArrayTemplate<E extends DataTemplate<?>> extends AbstractAr
   @Override
   public E set(int index, E element) throws ClassCastException, TemplateOutputCastException
   {
-    Object replaced = CheckedUtil.setWithoutChecking(_list, index, unwrap(element));
+    Object unwrapped = unwrap(element);
+    Object replaced = CheckedUtil.setWithoutChecking(_list, index, unwrapped);
+    _cache.put(unwrapped, element);
     modCount++;
     return cacheLookup(replaced, -1);
   }

--- a/data/src/main/java/com/linkedin/data/template/WrappingMapTemplate.java
+++ b/data/src/main/java/com/linkedin/data/template/WrappingMapTemplate.java
@@ -16,13 +16,11 @@
 
 package com.linkedin.data.template;
 
-
 import com.linkedin.data.DataMap;
 import com.linkedin.data.DataMapBuilder;
 import com.linkedin.data.collections.CheckedUtil;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.MapDataSchema;
-import com.linkedin.data.template.DataObjectToObjectCache;
 import com.linkedin.util.ArgumentUtil;
 import java.lang.reflect.Constructor;
 import java.util.AbstractMap;
@@ -95,7 +93,9 @@ public abstract class WrappingMapTemplate<V extends DataTemplate<?>> extends Abs
   @Override
   public V put(String key, V value) throws ClassCastException, TemplateOutputCastException
   {
-    Object found = CheckedUtil.putWithoutChecking(_map, key, unwrap(value));
+    Object unwrapped = unwrap(value);
+    Object found = CheckedUtil.putWithoutChecking(_map, key, unwrapped);
+    _cache.put(unwrapped, value);
     return cacheLookup(found, null);
   }
 

--- a/data/src/test/java/com/linkedin/data/template/TestArrayTemplate.java
+++ b/data/src/test/java/com/linkedin/data/template/TestArrayTemplate.java
@@ -140,7 +140,7 @@ public class TestArrayTemplate
         E value = adds.get(i);
         assertTrue(array3.add(value));
         Object getValue = array3.get(i);
-        assertEquals(array3.get(i), value);
+        assertSame(array3.get(i), value);
         assertSame(array3.get(i), getValue);
         assertTrue(array3.toString().contains(value.toString()));
       }
@@ -153,7 +153,7 @@ public class TestArrayTemplate
         E value = adds.get(adds.size() - i - 1);
         array4.add(0, value);
         Object getValue = array4.get(0);
-        assertEquals(array4.get(0), value);
+        assertSame(array4.get(0), value);
         assertSame(array4.get(0), getValue);
       }
       assertEquals(array4, adds);
@@ -258,8 +258,8 @@ public class TestArrayTemplate
         E refLoPrev = reference9.set(i, hi);
         assertEquals(hiPrev, refHiPrev);
         assertEquals(loPrev, refLoPrev);
-        assertEquals(array9.get(i), reference9.get(i));
-        assertEquals(array9.get(k), reference9.get(k));
+        assertSame(array9.get(i), reference9.get(i));
+        assertSame(array9.get(k), reference9.get(k));
       }
 
       // clone and copy return types

--- a/data/src/test/java/com/linkedin/data/template/TestMapTemplate.java
+++ b/data/src/test/java/com/linkedin/data/template/TestMapTemplate.java
@@ -205,7 +205,7 @@ public class TestMapTemplate
         assertTrue(replaced == null);
         E got = map3.get(key);
         assertTrue(got != null);
-        assertEquals(value, got);
+        assertSame(value, got);
         assertSame(map3.get(key), got);
         assertTrue(map3.containsKey(key));
         assertTrue(map3.containsValue(value));
@@ -229,7 +229,7 @@ public class TestMapTemplate
         assertTrue(map3.containsValue(value));
         E replaced = map3.put(key, newValue);
         assertTrue(replaced != null);
-        assertEquals(replaced, value);
+        assertSame(replaced, value);
         E got = map3.get(key);
         assertSame(map3.get(key), got);
         assertTrue(map3.containsKey(key));
@@ -247,7 +247,7 @@ public class TestMapTemplate
         E putResult = map3.put(testKey, e.getValue());
         if (lastValue != null)
         {
-          assertEquals(putResult, lastValue);
+          assertSame(putResult, lastValue);
         }
         lastValue = e.getValue();
       }
@@ -264,7 +264,7 @@ public class TestMapTemplate
         assertTrue(map4.containsValue(value));
         E removed = map4.remove(key);
         assertTrue(removed != null);
-        assertEquals(value, removed);
+        assertSame(value, removed);
         assertFalse(map4.containsKey(key));
         assertFalse(map4.containsValue(value));
         map4Size--;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.15
+version=29.7.16
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
When wrapped objects are added/put in the templates, only the underlying DataComplex is stored before. This forces them to be wrapped again when they are read, nullifying performance improvements made by generating member variables for fields. 

This PR fixes that by caching the wrapped objects when they are added.