### PR TITLE
Support symbolTable requests with suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.8.3] - 2020-11-09
+- Support symbolTable requests with suffixes
+
 ## [29.8.2] - 2020-11-06
 - Fix bug: if there is no input schema, do not run pegasusSchemaSnapshotCheck. The check statement was wrong.
 
@@ -4736,7 +4739,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.8.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.8.3...master
+[29.8.3]: https://github.com/linkedin/rest.li/compare/v29.8.2...v29.8.3
 [29.8.2]: https://github.com/linkedin/rest.li/compare/v29.8.1...v29.8.2
 [29.8.1]: https://github.com/linkedin/rest.li/compare/v29.8.0...v29.8.1
 [29.8.0]: https://github.com/linkedin/rest.li/compare/v29.7.15...v29.8.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.8.2
+version=29.8.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
@@ -58,7 +58,6 @@ public interface RestConstants
   String HEADER_RESTLI_PROTOCOL_VERSION = "X-RestLi-Protocol-Version";
   String CONTENT_TYPE_PARAM_SYMBOL_TABLE = "symbol-table";
   String HEADER_CONTENT_ID = "Content-ID";
-  String HEADER_SERVICE_SCOPED_PATH = "x-restli-service-scoped-path";
 
   // Default supported mime types.
   Set<String> SUPPORTED_MIME_TYPES = new LinkedHashSet<>(

--- a/restli-server/src/main/java/com/linkedin/restli/server/symbol/RestLiSymbolTableRequestHandler.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/symbol/RestLiSymbolTableRequestHandler.java
@@ -93,16 +93,8 @@ public class RestLiSymbolTableRequestHandler implements NonResourceRequestHandle
     //
     // When path is service scoped, URI is in the form of /<SERVICE>/symbolTable, else it
     // is in the form of /symbolTable or /symbolTable/<TABLENAME>
-    //
-    boolean isServiceScopedPath = request.getHeaders().containsKey(RestConstants.HEADER_SERVICE_SCOPED_PATH);
-    if (isServiceScopedPath)
-    {
-      return (pathSegments.size() == 3 && pathSegments.get(2).getPath().equals(SYMBOL_TABLE_URI_PATH));
-    }
-    else
-    {
-      return ((pathSegments.size() == 2 || pathSegments.size() == 3) && pathSegments.get(1).getPath().equals(SYMBOL_TABLE_URI_PATH));
-    }
+    return pathSegments.get(pathSegments.size() - 1).getPath().equals(SYMBOL_TABLE_URI_PATH)
+        || pathSegments.get(pathSegments.size() - 2).getPath().equals(SYMBOL_TABLE_URI_PATH);
   }
 
   @Override
@@ -141,27 +133,29 @@ public class RestLiSymbolTableRequestHandler implements NonResourceRequestHandle
 
     final SymbolTableProvider provider = SymbolTableProviderHolder.INSTANCE.getSymbolTableProvider();
     SymbolTable symbolTable = null;
-    try
-    {
-      boolean isServiceScopedPath = request.getHeaders().containsKey(RestConstants.HEADER_SERVICE_SCOPED_PATH);
-      if (isServiceScopedPath)
+
+    // at this point, `handleRequest` has verified that the incoming request is a symbolTable request.
+    // The URL can be one of two options:
+    // .../symbolTable/tableName
+    // .../symbolTable
+    // We check if the last path segments is "symbolTable", and if it is, we call provider.getResponseSymbolTable
+    // because we do not know the table name.
+    // Otherwise, we call provider.getSymbolTable
+    int pathSize = pathSegments.size();
+    try {
+      if (pathSegments.get(pathSize - 1).getPath().equals(SYMBOL_TABLE_URI_PATH))
       {
         symbolTable = provider.getResponseSymbolTable(request.getURI(), request.getHeaders());
       }
+      else if (pathSegments.get(pathSize - 2).getPath().equals(SYMBOL_TABLE_URI_PATH))
+      {
+        symbolTable = provider.getSymbolTable(pathSegments.get(pathSize - 1).getPath());
+      }
       else
       {
-        if (pathSegments.size() == 2)
-        {
-          symbolTable = provider.getResponseSymbolTable(request.getURI(), request.getHeaders());
-        }
-        else if (pathSegments.size() == 3)
-        {
-          symbolTable = provider.getSymbolTable(pathSegments.get(2).getPath());
-        }
+        LOGGER.error("request is malformed for handling symbolTable" + request.getURI());
       }
-    }
-    catch (IllegalStateException e)
-    {
+    } catch (IllegalStateException e) {
       LOGGER.error("Exception retrieving symbol table for URI " + request.getURI());
       symbolTable = null;
     }

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestRestLiSymbolTableRequestHandler.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestRestLiSymbolTableRequestHandler.java
@@ -35,10 +35,12 @@ import com.linkedin.restli.common.RestConstants;
 import com.linkedin.restli.server.symbol.RestLiSymbolTableRequestHandler;
 import java.net.URI;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.*;
@@ -63,40 +65,28 @@ public class TestRestLiSymbolTableRequestHandler
     SymbolTableProviderHolder.INSTANCE.setSymbolTableProvider(new SymbolTableProvider() {});
   }
 
-  @Test
-  public void testShouldNotHandleEmptyPath()
+  @DataProvider
+  public Object[][] uris()
   {
-    RestRequest request = new RestRequestBuilder(URI.create("/")).build();
-    Assert.assertFalse(_requestHandler.shouldHandle(request));
+    return new Object[][] {
+        // do not handle empty path
+        { "/", Collections.emptyMap(), false },
+        // non symbolTable path
+        { "/someResource", Collections.emptyMap(), false },
+        { "/symbolTable", Collections.emptyMap(), true },
+        { "/service/symbolTable", Collections.emptyMap(), true },
+        { "/service/foo/symbolTable", Collections.emptyMap(), true },
+    };
   }
 
-  @Test
-  public void testShouldNotHandleNonSymbolTablePath()
+  @Test(dataProvider = "uris")
+  public void testCorrectlyHandlesURIsWithHeader(String path, Map<String, String> headers, boolean expected)
   {
-    RestRequest request = new RestRequestBuilder(URI.create("/someResource")).build();
-    Assert.assertFalse(_requestHandler.shouldHandle(request));
-  }
+    RestRequest request = new RestRequestBuilder(URI.create(path))
+        .setHeaders(headers)
+        .build();
 
-  @Test
-  public void testShouldHandleSymbolTablePath()
-  {
-    RestRequest request = new RestRequestBuilder(URI.create("/symbolTable")).build();
-    Assert.assertTrue(_requestHandler.shouldHandle(request));
-  }
-
-  @Test
-  public void testShouldHandleServiceScopedSymbolTablePathWhenHeaderSet()
-  {
-    RestRequest request = new RestRequestBuilder(URI.create("/service/symbolTable"))
-        .setHeaders(Collections.singletonMap(RestConstants.HEADER_SERVICE_SCOPED_PATH, "true")).build();
-    Assert.assertTrue(_requestHandler.shouldHandle(request));
-  }
-
-  @Test
-  public void testShouldNotHandleServiceScopedSymbolTablePathWhenNoHeaderSet()
-  {
-    RestRequest request = new RestRequestBuilder(URI.create("/service/symbolTable")).build();
-    Assert.assertFalse(_requestHandler.shouldHandle(request));
+    Assert.assertEquals(_requestHandler.shouldHandle(request), expected);
   }
 
   @Test
@@ -227,8 +217,8 @@ public class TestRestLiSymbolTableRequestHandler
     SymbolTable symbolTable =
         new InMemorySymbolTable("TestName", ImmutableList.of("Haha", "Hehe", "Hoho"));
     URI uri = URI.create("/service/symbolTable");
-    RestRequest request = new RestRequestBuilder(uri).setHeader(RestConstants.HEADER_SERVICE_SCOPED_PATH, "true").build();
-    when(_symbolTableProvider.getResponseSymbolTable(eq(uri), eq(Collections.singletonMap(RestConstants.HEADER_SERVICE_SCOPED_PATH, "true")))).thenReturn(symbolTable);
+    RestRequest request = new RestRequestBuilder(uri).build();
+    when(_symbolTableProvider.getResponseSymbolTable(eq(uri), eq(Collections.emptyMap()))).thenReturn(symbolTable);
 
     CompletableFuture<RestResponse> future = new CompletableFuture<>();
     _requestHandler.handleRequest(request, mock(RequestContext.class), new Callback<RestResponse>() {

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/symbol/RestLiSymbolTableProvider.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/symbol/RestLiSymbolTableProvider.java
@@ -26,7 +26,6 @@ import com.linkedin.data.codec.symbol.SymbolTableMetadata;
 import com.linkedin.data.codec.symbol.SymbolTableProvider;
 import com.linkedin.data.codec.symbol.SymbolTableSerializer;
 import com.linkedin.data.schema.DataSchema;
-import com.linkedin.parseq.function.Tuple3;
 import com.linkedin.r2.message.rest.RestRequestBuilder;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.transport.common.Client;
@@ -40,6 +39,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +85,6 @@ public class RestLiSymbolTableProvider implements SymbolTableProvider, ResourceD
    * Default timeout in milliseconds to use when fetching symbols from other services.
    */
   private static final long DEFAULT_TIMEOUT_MILLIS = 1000;
-
   private final Client _client;
   private final String _uriPrefix;
   private final SymbolTableNameHandler _symbolTableNameHandler;
@@ -236,8 +235,7 @@ public class RestLiSymbolTableProvider implements SymbolTableProvider, ResourceD
     try
     {
       URI symbolTableUri = new URI(_uriPrefix + serviceName + "/" + RestLiSymbolTableRequestHandler.SYMBOL_TABLE_URI_PATH);
-      symbolTable = fetchRemoteSymbolTable(symbolTableUri,
-          Collections.singletonMap(RestConstants.HEADER_SERVICE_SCOPED_PATH, Boolean.TRUE.toString()));
+      symbolTable = fetchRemoteSymbolTable(symbolTableUri, Collections.emptyMap());
 
       if (symbolTable != null)
       {

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/symbol/TestRestLiSymbolTableProvider.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/symbol/TestRestLiSymbolTableProvider.java
@@ -29,6 +29,7 @@ import com.linkedin.r2.transport.common.Client;
 import com.linkedin.restli.common.ContentType;
 import com.linkedin.restli.common.RestConstants;
 import com.linkedin.restli.server.ResourceDefinition;
+import com.linkedin.restli.server.symbol.RestLiSymbolTableRequestHandler;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
@@ -141,7 +142,7 @@ public class TestRestLiSymbolTableProvider
     builder.setEntity(SymbolTableSerializer.toByteString(ContentType.PROTOBUF2.getCodec(), symbolTable));
     builder.setHeader(RestConstants.HEADER_CONTENT_TYPE, ContentType.PROTOBUF2.getHeaderKey());
     when(_client.restRequest(eq(new RestRequestBuilder(URI.create("d2://someservice/symbolTable"))
-        .setHeaders(Collections.singletonMap(RestConstants.HEADER_SERVICE_SCOPED_PATH, "true")).build())))
+        .build())))
         .thenReturn(CompletableFuture.completedFuture(builder.build()));
 
     SymbolTable remoteSymbolTable = _provider.getRequestSymbolTable(URI.create("d2://someservice/path"));


### PR DESCRIPTION
We have a client who adds suffix to the request path.

Given an application named `foo` and a resource with `bar`

```
@RestLiCollection(name = "bar", namespace = "com.foo")
```

they want to support a d2 URL such as

```
d2://foo?action=...
```

the resolved url becomes

```
some-host.com/foo/bar?action=...
```

When we enable protobuf for them, the `RestLiSymbolTableRequestHandler` sees

```
some-host.com/foo/bar/symbolTable
some-host.com/foo/bar/symbolTable/<tableName>
```

In this PR, we are adding support to check the last 2 arguments given a path.

To prevent naming collision and backwards compatibility, we are guarding the
logic behind a header