### PR TITLE
Empty commit to bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.8.0] - 2020-10-29
+- Empty commit to bump pegasus minor version
+
 ## [29.7.15] - 2020-10-23
 Log Streaming Error or Timeout Error in Jetty SyncIOHandler
 
@@ -4727,7 +4730,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.7.15...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.8.0...master
+[29.8.0]: https://github.com/linkedin/rest.li/compare/v29.7.15...v29.8.0
 [29.7.15]: https://github.com/linkedin/rest.li/compare/v29.7.14...v29.7.15
 [29.7.14]: https://github.com/linkedin/rest.li/compare/v29.7.13...v29.7.14
 [29.7.13]: https://github.com/linkedin/rest.li/compare/v29.7.12...v29.7.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.8.0] - 2020-10-29
-- Empty commit to bump pegasus minor version
+- Empty commit to bump pegasus minor version. LinkedIn internal service needs the new minor version to prevent client version downgrade, since the LinkedIn internal services only notice on minor version discrepancy.
 
 ## [29.7.15] - 2020-10-23
 Log Streaming Error or Timeout Error in Jetty SyncIOHandler

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.7.15
+version=29.8.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This PR doesn't do anything, it only bump the minor version of pegasus.
Why do we need this?
I need this for LinkedIn HI preparation. For the HI to onboard to relative load balancer, the prerequisites is to have all the mps using a certain container version and a certain pegasus version. To reduce the effort of asking everyone to bump the pegasus version, we want container to give an error when clients downgrade the pegasus version, and we agreed with SF team that the downgrade error will happen on a minor version downgrade. Therefore, I'm upgrading the minor version and will use this version in the container.