### PR TITLE
Fix bug in SchemaFormatTranslator that caused files to be skipped on a Mac system.

### DIFF
--- a/restli-tools/src/main/java/com/linkedin/restli/tools/data/SchemaFormatTranslator.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/data/SchemaFormatTranslator.java
@@ -220,7 +220,7 @@ public class SchemaFormatTranslator
       //   - Schemas not loaded from the source dir provided as input.
       //   - Nested schemas.
       if (!location.getSourceFile().getAbsolutePath().endsWith(_sourceFormat) ||
-          !location.toString().startsWith(_sourceDir.getAbsolutePath()) ||
+          !location.toString().startsWith(_sourceDir.getCanonicalPath()) ||
           !isTopLevelSchema(schema, location))
       {
         continue;


### PR DESCRIPTION
**Issue**:
Unit tests do not pass when I run unit tests on my mac system.

**Repro**:
Run the following command off the "master" branch on both Mac and Linux
systems.
./gradlew :restli-tools:test --tests com.linkedin.restli.tools.data.TestSchemaFormatTranslator --rerun-tasks

Running the test will pass on the Linux system but will fail on the
LinkedIn Mac system.
different canonical and absolute paths.

The 2 element in the if stmt below is the culprit.

In SchemaFormatTranslator#getTopLevelSchemaToTranslatedSchemaMap,
if (!location.getSourceFile().getAbsolutePath().endsWith(_sourceFormat) ||
    !location.toString().startsWith(_sourceDir.getAbsolutePath()) ||
          !isTopLevelSchema(schema, location))

On my mac system, I get the following values at if stmt above.
location.toString:             /private/var/folders/y_/538q1mm54938q917tl1xrz9h001647/T/restli749618466199352564/com/linkedin/greetings/api/ArrayTestRecord.pdl
_sourceDir.getAbsolutePath():  /var/folders/y_/538q1mm54938q917tl1xrz9h001647/T/restli749618466199352564
_sourceDir.getCanonicalPath(): /private/var/folders/y_/538q1mm54938q917tl1xrz9h001647/T/restli749618466199352564

**Resolution**:
change !location.toString().startsWith(_sourceDir.getAbsoutePath() to
either of the following:
location.toString().startsWith(_sourceDir.getCanonicalPath())
OR
location.toString().contains(_sourceDir.getAbsolutePath())

**Testing**:
Unit tests pass on both Linux and Mac systems.