### PR TITLE
Adding new required record field is considering as backward compatible change in extension schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Adding required record field is allowed and should be considered as backward compatible change in extension schemas. 
 
 ## [29.8.2] - 2020-11-06
 - Fix bug: if there is no input schema, do not run pegasusSchemaSnapshotCheck. The check statement was wrong.

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -603,7 +603,7 @@ public class PegasusPlugin implements Plugin<Project>
 
   private static final String COMPATIBILITY_OPTIONS_MODE_DATA = "DATA";
 
-  private static final String COMPATIBILITY_LEVEL_BACKWARDS = "BACKWARDS";
+  private static final String COMPATIBILITY_LEVEL_EXTENSION = "EXTENSION";
 
   @SuppressWarnings("unchecked")
   private Class<? extends Plugin<Project>> _thisPluginType = (Class<? extends Plugin<Project>>)
@@ -1450,7 +1450,7 @@ public class PegasusPlugin implements Plugin<Project>
           task.setCodegenClasspath(project.getConfigurations().getByName(PEGASUS_PLUGIN_CONFIGURATION)
               .plus(project.getConfigurations().getByName(SCHEMA_ANNOTATION_HANDLER_CONFIGURATION))
               .plus(project.getConfigurations().getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME)));
-          task.setCompatibilityLevel(isExtensionSchema ? COMPATIBILITY_LEVEL_BACKWARDS
+          task.setCompatibilityLevel(isExtensionSchema ? COMPATIBILITY_LEVEL_EXTENSION
               :PropertyUtil.findCompatLevel(project, FileCompatibilityType.PEGASUS_SCHEMA_SNAPSHOT));
           task.setCompatibilityMode(isExtensionSchema ? COMPATIBILITY_OPTIONS_MODE_DATA :
               PropertyUtil.findCompatMode(project, PEGASUS_COMPATIBILITY_MODE));

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityInfoMap.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityInfoMap.java
@@ -101,9 +101,28 @@ public class CompatibilityInfoMap
    */
   public void addModelInfo(CompatibilityMessage message)
   {
+    addModelInfo(message, CompatibilityLevel.DEFAULT);
+  }
+
+  /**
+   * Add info used for adding errors related to {@link com.linkedin.data.schema.NamedDataSchema} compatibility.
+   * The path will be the path to the relevant field within the NamedDataSchema.
+   * @param message {@link CompatibilityMessage}
+   * @param level {@link CompatibilityLevel}
+   * if level is EXTENSION, adding required record field is allowed, this message will not be written into info map.
+   */
+  public void addModelInfo(CompatibilityMessage message, CompatibilityLevel level)
+  {
     final CompatibilityInfo.Type infoType;
     CompatibilityInfo info;
     String infoMessage = String.format(message.getFormat(), message.getArgs());
+
+    // Adding required record field is allowed in the pegasus extension schemas and considered as backward compatible change.
+    // If compatibilityLevel is EXTENSION, filter it out from CompatibilityMessage.
+    if (level == CompatibilityLevel.EXTENSION && infoMessage.contains("new record added required fields"))
+    {
+      return;
+    }
 
     if (message.isError())
     {

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityLevel.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityLevel.java
@@ -28,6 +28,7 @@ public enum CompatibilityLevel
 {
   OFF,
   IGNORE,
+  EXTENSION,
   BACKWARDS,
   EQUIVALENT;
 

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/check/PegasusSchemaSnapshotCompatibilityChecker.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/check/PegasusSchemaSnapshotCompatibilityChecker.java
@@ -197,7 +197,7 @@ public class PegasusSchemaSnapshotCompatibilityChecker
     {
       String prevSnapshot = prevSnapshotAndCurrSnapshotPairs.get(i-1);
       String currentSnapshot = prevSnapshotAndCurrSnapshotPairs.get(i);
-      compatibilityChecker.checkPegasusSchemaCompatibility(prevSnapshot, currentSnapshot, compatMode);
+      compatibilityChecker.checkPegasusSchemaCompatibility(prevSnapshot, currentSnapshot, compatMode, compatLevel);
     }
 
     if (cl.hasOption("report"))
@@ -220,7 +220,7 @@ public class PegasusSchemaSnapshotCompatibilityChecker
    * @return CompatibilityInfoMap which contains information whether the given two files are compatible or not.
    */
   public CompatibilityInfoMap checkPegasusSchemaCompatibility(String prevPegasusSchemaPath, String currentPegasusSchemaPath,
-      CompatibilityOptions.Mode compatMode)
+      CompatibilityOptions.Mode compatMode, CompatibilityLevel compatLevel)
   {
     boolean newSchemaCreated = false;
     boolean preSchemaRemoved = false;
@@ -266,7 +266,7 @@ public class PegasusSchemaSnapshotCompatibilityChecker
 
     if (!result.getMessages().isEmpty())
     {
-      result.getMessages().forEach(message -> _infoMap.addModelInfo(message));
+      result.getMessages().forEach(message -> _infoMap.addModelInfo(message, compatLevel));
     }
 
     if (!_handlers.isEmpty())

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/check/TestPegasusSchemaSnapshotCompatibilityChecker.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/check/TestPegasusSchemaSnapshotCompatibilityChecker.java
@@ -38,12 +38,12 @@ public class TestPegasusSchemaSnapshotCompatibilityChecker
   private String snapshotDir = testDir + FS + "pegasusSchemaSnapshot";
 
   @Test(dataProvider = "compatibleInputFiles")
-  public void testCompatiblePegasusSchemaSnapshot(String prevSchema, String currSchema)
+  public void testCompatiblePegasusSchemaSnapshot(String prevSchema, String currSchema, CompatibilityLevel compatLevel)
   {
     PegasusSchemaSnapshotCompatibilityChecker checker = new PegasusSchemaSnapshotCompatibilityChecker();
     CompatibilityInfoMap infoMap = checker.checkPegasusSchemaCompatibility(snapshotDir + FS + prevSchema, snapshotDir + FS + currSchema,
-        CompatibilityOptions.Mode.DATA);
-    Assert.assertTrue(infoMap.isModelCompatible(CompatibilityLevel.EQUIVALENT));
+        CompatibilityOptions.Mode.DATA, compatLevel);
+    Assert.assertTrue(infoMap.isModelCompatible(compatLevel));
   }
 
   @Test(dataProvider = "incompatibleInputFiles")
@@ -52,7 +52,7 @@ public class TestPegasusSchemaSnapshotCompatibilityChecker
   {
     PegasusSchemaSnapshotCompatibilityChecker checker = new PegasusSchemaSnapshotCompatibilityChecker();
     CompatibilityInfoMap infoMap = checker.checkPegasusSchemaCompatibility(snapshotDir + FS + prevSchema, snapshotDir + FS + currSchema,
-        CompatibilityOptions.Mode.DATA);
+        CompatibilityOptions.Mode.DATA, CompatibilityLevel.BACKWARDS);
     Assert.assertFalse(infoMap.isModelCompatible(CompatibilityLevel.BACKWARDS));
     Assert.assertFalse(infoMap.isModelCompatible(CompatibilityLevel.EQUIVALENT));
     Assert.assertTrue(infoMap.isModelCompatible(CompatibilityLevel.IGNORE));
@@ -145,7 +145,8 @@ public class TestPegasusSchemaSnapshotCompatibilityChecker
   {
     return new Object[][]
         {
-            { "BirthInfo.pdl", "compatibleSchemaSnapshot/BirthInfo.pdl"},
+            { "BirthInfo.pdl", "compatibleSchemaSnapshot/BirthInfo.pdl", CompatibilityLevel.EQUIVALENT },
+            { "Foo.pdl", "compatibleSchemaSnapshot/Foo.pdl", CompatibilityLevel.EXTENSION },
         };
   }
 

--- a/restli-tools/src/test/pegasusSchemaSnapshot/Foo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/Foo.pdl
@@ -1,0 +1,3 @@
+record Foo {
+  bar: typeref BarUrn = string
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/Foo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/Foo.pdl
@@ -1,0 +1,4 @@
+record Foo {
+  bar: typeref BarUrn = string
+  baz: typeref BazUrn = string
+}


### PR DESCRIPTION
The CompatibilityChecker treats adding new required record field as backward incompatible changes. 
For entity relationship - extension schema, adding new required record field is allowed and it should be considered as backward compatible change. 

Update PegasusSchemaSnapshotCompatibilityChecker to allow such change for extension schemas.