### PR TITLE
Update generators to generate files with lower case path.

### DIFF
--- a/generator/src/main/java/com/linkedin/pegasus/generator/JavaCodeUtil.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/JavaCodeUtil.java
@@ -146,7 +146,12 @@ public class JavaCodeUtil
         }
         else if (definedClass.outer() == null)
         {
-          final File file = new File(targetDirectory, definedClass.fullName().replace('.', File.separatorChar) + ".java");
+          // This seems like the safer approach to create path since fullName() has a recursive call.
+          String fullName = definedClass.fullName();
+          String name = definedClass.name();
+          String packageName = fullName.substring(0, fullName.length() - name.length());
+          String path = packageName.toLowerCase() + name;
+          final File file = new File(targetDirectory, path.replace('.', File.separatorChar) + ".java");
           generatedFiles.add(file);
         }
       }

--- a/generator/src/main/java/com/linkedin/pegasus/generator/LowercasePathFileCodeWriter.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/LowercasePathFileCodeWriter.java
@@ -1,0 +1,82 @@
+package com.linkedin.pegasus.generator;
+
+import com.sun.codemodel.CodeWriter;
+import com.sun.codemodel.JPackage;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Similar to {@link com.sun.codemodel.FileCodeWriter} but has ability to create directories in lower case.
+ */
+public class LowercasePathFileCodeWriter extends CodeWriter {
+    /**
+     * The target directory to put source code.
+     */
+    private final File target;
+
+    /**
+     * specify whether or not to mark the generated files read-only.
+     */
+    private final boolean readOnly;
+
+    /**
+     * Files that shall be marked as read only.
+     */
+    private final Set<File> readonlyFiles = new HashSet<File>();
+
+    public LowercasePathFileCodeWriter(File target, boolean readOnly) throws IOException {
+        this.target = target;
+        this.readOnly = readOnly;
+        if (!target.exists() || !target.isDirectory()) {
+            throw new IOException(target + ": non-existent directory");
+        }
+    }
+
+    public OutputStream openBinary(JPackage pkg, String fileName) throws IOException {
+        return new FileOutputStream(getFile(pkg, fileName));
+    }
+
+    protected File getFile(JPackage pkg, String fileName) throws IOException {
+        File dir;
+        if (pkg.isUnnamed()) {
+            dir = target;
+        } else {
+            dir = new File(target, toDirName(pkg));
+        }
+
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        File fn = new File(dir, fileName);
+
+        if (fn.exists()) {
+            if (!fn.delete())
+                throw new IOException(fn + ": Can't delete previous version");
+        }
+
+        if (readOnly) {
+            readonlyFiles.add(fn);
+        }
+        return fn;
+    }
+
+    public void close() throws IOException {
+        // mark files as read-only if necessary
+        for (File f : readonlyFiles) {
+            f.setReadOnly();
+        }
+    }
+
+    /**
+     * Converts a package name to the directory name lower case.
+     */
+    private String toDirName(JPackage pkg) {
+        return pkg.name().toLowerCase().replace('.', File.separatorChar);
+    }
+}

--- a/generator/src/main/java/com/linkedin/pegasus/generator/PegasusDataTemplateGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/PegasusDataTemplateGenerator.java
@@ -25,7 +25,6 @@ import com.linkedin.util.FileUtil;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JPackage;
-import com.sun.codemodel.writer.FileCodeWriter;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -156,7 +155,7 @@ public class PegasusDataTemplateGenerator
       _log.debug("Files: "+ targetFiles);
       validateDefinedClassRegistration(dataTemplateGenerator.getCodeModel(), dataTemplateGenerator.getGeneratedClasses().keySet());
       targetDirectory.mkdirs();
-      dataTemplateGenerator.getCodeModel().build(new FileCodeWriter(targetDirectory, true));
+      dataTemplateGenerator.getCodeModel().build(new LowercasePathFileCodeWriter(targetDirectory, true));
     }
 
     return new DefaultGeneratorResult(parseResult.getSourceFiles(), targetFiles, modifiedFiles);

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/RestRequestBuilderGenerator.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/RestRequestBuilderGenerator.java
@@ -18,8 +18,8 @@ package com.linkedin.restli.tools.clientgen;
 
 
 import com.linkedin.common.Version;
-import com.linkedin.data.schema.generator.AbstractGenerator;
 import com.linkedin.internal.tools.ArgumentFileProcessor;
+import com.linkedin.pegasus.generator.LowercasePathFileCodeWriter;
 import com.linkedin.pegasus.generator.CodeUtil;
 import com.linkedin.pegasus.generator.DefaultGeneratorResult;
 import com.linkedin.pegasus.generator.GeneratorResult;
@@ -40,7 +40,6 @@ import java.util.List;
 
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
-import com.sun.codemodel.writer.FileCodeWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -235,8 +234,8 @@ public class RestRequestBuilderGenerator
       modifiedFiles = targetFiles;
       _log.info("Generating " + targetFiles.size() + " files");
       _log.debug("Files: " + targetFiles);
-      requestBuilderCodeModel.build(new FileCodeWriter(targetDirectory, true));
-      dataTemplateCodeModel.build(new FileCodeWriter(targetDirectory, true));
+      requestBuilderCodeModel.build(new LowercasePathFileCodeWriter(targetDirectory, true));
+      dataTemplateCodeModel.build(new LowercasePathFileCodeWriter(targetDirectory, true));
     }
     return new DefaultGeneratorResult(parseResult.getSourceFiles(), targetFiles, modifiedFiles);
   }

--- a/restli-tools/src/test/resources/idls/namespace-case.restspec.json
+++ b/restli-tools/src/test/resources/idls/namespace-case.restspec.json
@@ -1,0 +1,24 @@
+{
+  "name" : "namespaceCase",
+  "path" : "/namespaceCase",
+  "schema" : "com.linkedin.greetings.api.Greeting",
+  "doc" : "This idl is for testing array and items fields.",
+  "namespace": "com.LINKEDIN.greetings.API.builders",
+  "collection" : {
+    "identifier" : {
+      "name" : "id",
+      "type" : "string"
+    },
+    "supports" : [ ],
+    "finders" : [ {
+      "name" : "test",
+      "parameters" : [ {
+        "name" : "param",
+        "type" : "{ \"type\" : \"array\", \"items\" : \"com.linkedin.greetings.api.Tone\" }"
+      } ]
+    } ],
+    "entity" : {
+      "path" : "/namespaceCase/{id}"
+    }
+  }
+}


### PR DESCRIPTION
Issue:
Was working on two different file systems and noticed that after a rync,
I was getting a "DuplicateClassException" on my Linux system - there
were duplicate files in similar paths.

Typically a Mac/Windows system will have a case insensitive file system,
whereas a Linux system will have a case sensitive file system. For a
case insensitive file system, "~/com/astro" and "~/com/ASTRO" point to
the same folder. For a case sensitive file system, "~/com/astro" and
"~/com/ASTRO" will be different folders.

 Example:
   File1: namespace = com.astro.file1
   File2: namespace = com.aSTRo.file2

   The following files would be generated with the path specified.
   1) Case insensitive (if file1 is generated first):
       com/astro/file1
                /file2
   2) Case insensitive (if file2 is generated first):
       com/aSTRo/file1
                /file2
   3) Case sensitive:
       com/astro/file1
           aSTRo/file2

Resolution:
Force generators to generate paths with lowercase path. Updated the
PegasusDataTemplateGenerator and RestRequestBuilderGenerator.

Testing:
Created unit tests to validate path's on both linux and mac systems
where the file system were case sensitive and case insensitive
respectively.