### PR TITLE
Update generators to optionally generate files with lower case path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.8.5] - 2020-11-10
+- By default, Pegasus Plugin's generated files (for GenerateDataTemplateTask and GenerateRestClientTask Gradle Tasks) are created with lower case file system paths. (There is an optional flag at the Gradle task level to change this behavior.)
+
 ## [29.8.4] - 2020-11-09
 - Adding required record field is allowed and should be considered as backward compatible change in extension schemas. 
 
@@ -4742,7 +4745,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.8.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.8.5...master
+[29.8.5]: https://github.com/linkedin/rest.li/compare/v29.8.4...v29.8.5
 [29.8.4]: https://github.com/linkedin/rest.li/compare/v29.8.3...v29.8.4
 [29.8.3]: https://github.com/linkedin/rest.li/compare/v29.8.2...v29.8.3
 [29.8.2]: https://github.com/linkedin/rest.li/compare/v29.8.1...v29.8.2

--- a/generator/src/main/java/com/linkedin/pegasus/generator/CaseSensitiveFileCodeWriter.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/CaseSensitiveFileCodeWriter.java
@@ -26,7 +26,8 @@ public class CaseSensitiveFileCodeWriter extends CodeWriter {
     /** True, generated directories to be created in lower case; False, otherwise. */
     private boolean generateLowercasePath;
 
-    public CaseSensitiveFileCodeWriter(File target, boolean readOnly, boolean generateLowercasePath) throws IOException {
+    public CaseSensitiveFileCodeWriter(File target, boolean readOnly, boolean generateLowercasePath) throws IOException
+    {
         this.target = target;
         this.readOnly = readOnly;
         if (!target.exists() || !target.isDirectory()) {
@@ -35,11 +36,13 @@ public class CaseSensitiveFileCodeWriter extends CodeWriter {
         this.generateLowercasePath = generateLowercasePath;
     }
 
-    public OutputStream openBinary(JPackage pkg, String fileName) throws IOException {
+    public OutputStream openBinary(JPackage pkg, String fileName) throws IOException
+    {
         return new FileOutputStream(getFile(pkg, fileName));
     }
 
-    protected File getFile(JPackage pkg, String fileName) throws IOException {
+    protected File getFile(JPackage pkg, String fileName) throws IOException
+    {
         File dir;
         if (pkg.isUnnamed()) {
             dir = target;
@@ -64,7 +67,8 @@ public class CaseSensitiveFileCodeWriter extends CodeWriter {
         return fn;
     }
 
-    public void close() throws IOException {
+    public void close() throws IOException
+    {
         // mark files as read-only if necessary
         for (File f : readonlyFiles) {
             f.setReadOnly();
@@ -72,7 +76,8 @@ public class CaseSensitiveFileCodeWriter extends CodeWriter {
     }
 
     /** Converts a package name to the directory name. */
-    private String toDirName(JPackage pkg) {
+    private String toDirName(JPackage pkg)
+    {
         String packageName = generateLowercasePath ? pkg.name().toLowerCase() : pkg.name();
         return packageName.replace('.', File.separatorChar);
     }

--- a/generator/src/main/java/com/linkedin/pegasus/generator/CaseSensitiveFileCodeWriter.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/CaseSensitiveFileCodeWriter.java
@@ -1,0 +1,79 @@
+package com.linkedin.pegasus.generator;
+
+import com.sun.codemodel.CodeWriter;
+import com.sun.codemodel.JPackage;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Similar to {@link com.sun.codemodel.FileCodeWriter} but has ability to create directories in lower case.
+ */
+public class CaseSensitiveFileCodeWriter extends CodeWriter {
+    /** The target directory to put source code. */
+    private final File target;
+
+    /** specify whether or not to mark the generated files read-only. */
+    private final boolean readOnly;
+
+    /** Files that shall be marked as read only. */
+    private final Set<File> readonlyFiles = new HashSet<File>();
+
+    /** True, generated directories to be created in lower case; False, otherwise. */
+    private boolean generateLowercasePath;
+
+    public CaseSensitiveFileCodeWriter(File target, boolean readOnly, boolean generateLowercasePath) throws IOException {
+        this.target = target;
+        this.readOnly = readOnly;
+        if (!target.exists() || !target.isDirectory()) {
+            throw new IOException(target + ": non-existent directory");
+        }
+        this.generateLowercasePath = generateLowercasePath;
+    }
+
+    public OutputStream openBinary(JPackage pkg, String fileName) throws IOException {
+        return new FileOutputStream(getFile(pkg, fileName));
+    }
+
+    protected File getFile(JPackage pkg, String fileName) throws IOException {
+        File dir;
+        if (pkg.isUnnamed()) {
+            dir = target;
+        } else {
+            dir = new File(target, toDirName(pkg));
+        }
+
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        File fn = new File(dir, fileName);
+
+        if (fn.exists()) {
+            if (!fn.delete())
+                throw new IOException(fn + ": Can't delete previous version");
+        }
+
+        if (readOnly) {
+            readonlyFiles.add(fn);
+        }
+        return fn;
+    }
+
+    public void close() throws IOException {
+        // mark files as read-only if necessary
+        for (File f : readonlyFiles) {
+            f.setReadOnly();
+        }
+    }
+
+    /** Converts a package name to the directory name. */
+    private String toDirName(JPackage pkg) {
+        String packageName = generateLowercasePath ? pkg.name().toLowerCase() : pkg.name();
+        return packageName.replace('.', File.separatorChar);
+    }
+}

--- a/generator/src/main/java/com/linkedin/pegasus/generator/JavaCodeUtil.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/JavaCodeUtil.java
@@ -118,6 +118,21 @@ public class JavaCodeUtil
    */
   public static List<File> targetFiles(File targetDirectory, JCodeModel codeModel, ClassLoader classLoader, PersistentClassChecker checker)
   {
+    return targetFiles(targetDirectory, codeModel, classLoader, checker, true);
+  }
+
+  /**
+   * Build the list of files need to be written from CodeModel, with the targetDirectory as base directory.
+   *
+   * @param targetDirectory directory for the target files
+   * @param codeModel {@link JCodeModel} instance
+   * @param classLoader Java {@link ClassLoader} to check if a class for the potential target file already exist
+   * @param checker custom closure to check if a class should be persistent
+   * @param generateLowercasePath true, files are generated with a lower case path; false, files are generated as spec specifies.
+   * @return target files to be written
+   */
+  public static List<File> targetFiles(File targetDirectory, JCodeModel codeModel, ClassLoader classLoader, PersistentClassChecker checker, boolean generateLowercasePath)
+  {
     final List<File> generatedFiles = new ArrayList<File>();
 
     for (Iterator<JPackage> packageIterator = codeModel.packages(); packageIterator.hasNext(); )
@@ -146,7 +161,17 @@ public class JavaCodeUtil
         }
         else if (definedClass.outer() == null)
         {
-          final File file = new File(targetDirectory, definedClass.fullName().replace('.', File.separatorChar) + ".java");
+          String path;
+          if (generateLowercasePath) {
+            // Create path this way since fullName() has a recursive call.
+            String fullName = definedClass.fullName();
+            String name = definedClass.name();
+            String packageName = fullName.substring(0, fullName.length() - name.length());
+            path = packageName.toLowerCase() + name;
+          } else {
+            path = definedClass.fullName();
+          }
+          final File file = new File(targetDirectory, path.replace('.', File.separatorChar) + ".java");
           generatedFiles.add(file);
         }
       }

--- a/generator/src/main/java/com/linkedin/pegasus/generator/JavaCodeUtil.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/JavaCodeUtil.java
@@ -162,13 +162,16 @@ public class JavaCodeUtil
         else if (definedClass.outer() == null)
         {
           String path;
-          if (generateLowercasePath) {
+          if (generateLowercasePath)
+          {
             // Create path this way since fullName() has a recursive call.
             String fullName = definedClass.fullName();
             String name = definedClass.name();
             String packageName = fullName.substring(0, fullName.length() - name.length());
             path = packageName.toLowerCase() + name;
-          } else {
+          }
+          else
+          {
             path = definedClass.fullName();
           }
           final File file = new File(targetDirectory, path.replace('.', File.separatorChar) + ".java");

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
@@ -128,11 +128,13 @@ public class GenerateDataTemplateTask extends DefaultTask
 
   @Optional
   @Input
-  public Boolean generateLowercasePath() {
+  public Boolean generateLowercasePath()
+  {
     return _generateLowercasePath;
   }
 
-  public void setGenerateLowercasePath(Boolean enable) {
+  public void setGenerateLowercasePath(Boolean enable)
+  {
     _generateLowercasePath = enable;
   }
 
@@ -182,7 +184,8 @@ public class GenerateDataTemplateTask extends DefaultTask
       javaExecSpec.setMain("com.linkedin.pegasus.generator.PegasusDataTemplateGenerator");
       javaExecSpec.setClasspath(_pathedCodegenClasspath);
       javaExecSpec.jvmArgs("-Dgenerator.resolver.path=" + resolverPathArg);
-      if (_generateLowercasePath != null) {
+      if (_generateLowercasePath != null)
+      {
         javaExecSpec.jvmArgs("-Dgenerator.generate.lowercase.path=" + _generateLowercasePath); //.run(generateLowercasePath)
       }
       javaExecSpec.jvmArgs("-Droot.path=" + getProject().getRootDir().getPath());

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
@@ -17,6 +17,7 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -40,11 +41,15 @@ import static com.linkedin.pegasus.gradle.SharedFileUtils.getSuffixedFiles;
 @CacheableTask
 public class GenerateDataTemplateTask extends DefaultTask
 {
-  private File _destinationDir;
+  // Input Task Property
   private File _inputDir;
   private FileCollection _resolverPath;
   private FileCollection _codegenClasspath;
   private boolean _enableArgFile;
+  private Boolean _generateLowercasePath;
+
+  // Output Task Property
+  private File _destinationDir;
 
   public GenerateDataTemplateTask()
   {
@@ -121,6 +126,16 @@ public class GenerateDataTemplateTask extends DefaultTask
     _enableArgFile = enable;
   }
 
+  @Optional
+  @Input
+  public Boolean generateLowercasePath() {
+    return _generateLowercasePath;
+  }
+
+  public void setGenerateLowercasePath(Boolean enable) {
+    _generateLowercasePath = enable;
+  }
+
   @TaskAction
   public void generate()
   {
@@ -167,6 +182,9 @@ public class GenerateDataTemplateTask extends DefaultTask
       javaExecSpec.setMain("com.linkedin.pegasus.generator.PegasusDataTemplateGenerator");
       javaExecSpec.setClasspath(_pathedCodegenClasspath);
       javaExecSpec.jvmArgs("-Dgenerator.resolver.path=" + resolverPathArg);
+      if (_generateLowercasePath != null) {
+        javaExecSpec.jvmArgs("-Dgenerator.generate.lowercase.path=" + _generateLowercasePath); //.run(generateLowercasePath)
+      }
       javaExecSpec.jvmArgs("-Droot.path=" + getProject().getRootDir().getPath());
       javaExecSpec.args(_destinationDir.getPath());
       javaExecSpec.args(_inputDir);

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateRestClientTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateRestClientTask.java
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -47,15 +48,21 @@ import static com.linkedin.pegasus.gradle.internal.ArgumentFileGenerator.getArgF
 @CacheableTask
 public class GenerateRestClientTask extends DefaultTask
 {
+  // Input Task Property
   private File _inputDir;
   private FileCollection _resolverPath;
   private FileCollection _runtimeClasspath;
   private FileCollection _codegenClasspath;
+  private boolean _enableArgFile;
+  private Boolean _generateLowercasePath;
+
+  // Output Task Property
   private File _destinationDir;
+
+  // Internal Task Properties
   private boolean _restli1FormatSuppressed;
   private boolean _restli2FormatSuppressed;
   private boolean _restli1BuildersDeprecated = true;
-  private boolean _enableArgFile;
 
   @TaskAction
   public void generate()
@@ -153,6 +160,9 @@ public class GenerateRestClientTask extends DefaultTask
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.datatemplates=false"); //RestRequestBuilderGenerator.run(generateDataTemplates)
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.version=1.0.0"); //RestRequestBuilderGenerator.run(version)
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.deprecated.version=" + deprecatedVersion); //RestRequestBuilderGenerator.run(deprecatedByVersion)
+        if (_generateLowercasePath != null) {
+          javaExecSpec.jvmArgs("-Dgenerator.rest.generate.lowercase.path=" + _generateLowercasePath); //RestRequestBuilderGenerator.run(generateLowercasePath)
+        }
         javaExecSpec.jvmArgs("-Droot.path=" + getProject().getRootDir().getPath());
         javaExecSpec.args(_destinationDir.getAbsolutePath());
         javaExecSpec.args(sources);
@@ -177,6 +187,9 @@ public class GenerateRestClientTask extends DefaultTask
         javaExecSpec.jvmArgs("-Dgenerator.generate.imported=false"); //RestRequestBuilderGenerator.run(generateImported)
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.datatemplates=false"); //RestRequestBuilderGenerator.run(generateDataTemplates)
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.version=2.0.0"); //RestRequestBuilderGenerator.run(version)
+        if (_generateLowercasePath != null) {
+          javaExecSpec.jvmArgs("-Dgenerator.rest.generate.lowercase.path=" + _generateLowercasePath); //RestRequestBuilderGenerator.run(generateLowercasePath)
+        }
         javaExecSpec.jvmArgs("-Droot.path=" + getProject().getRootDir().getPath());
         javaExecSpec.args(_destinationDir.getAbsolutePath());
         javaExecSpec.args(sources);
@@ -240,6 +253,16 @@ public class GenerateRestClientTask extends DefaultTask
   public void setEnableArgFile(boolean enable)
   {
     _enableArgFile = enable;
+  }
+
+  @Optional
+  @Input
+  public Boolean generateLowercasePath() {
+    return _generateLowercasePath;
+  }
+
+  public void setGenerateLowercasePath(Boolean enable) {
+    _generateLowercasePath = enable;
   }
 
   @OutputDirectory

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateRestClientTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateRestClientTask.java
@@ -160,7 +160,8 @@ public class GenerateRestClientTask extends DefaultTask
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.datatemplates=false"); //RestRequestBuilderGenerator.run(generateDataTemplates)
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.version=1.0.0"); //RestRequestBuilderGenerator.run(version)
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.deprecated.version=" + deprecatedVersion); //RestRequestBuilderGenerator.run(deprecatedByVersion)
-        if (_generateLowercasePath != null) {
+        if (_generateLowercasePath != null)
+        {
           javaExecSpec.jvmArgs("-Dgenerator.rest.generate.lowercase.path=" + _generateLowercasePath); //RestRequestBuilderGenerator.run(generateLowercasePath)
         }
         javaExecSpec.jvmArgs("-Droot.path=" + getProject().getRootDir().getPath());
@@ -187,7 +188,8 @@ public class GenerateRestClientTask extends DefaultTask
         javaExecSpec.jvmArgs("-Dgenerator.generate.imported=false"); //RestRequestBuilderGenerator.run(generateImported)
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.datatemplates=false"); //RestRequestBuilderGenerator.run(generateDataTemplates)
         javaExecSpec.jvmArgs("-Dgenerator.rest.generate.version=2.0.0"); //RestRequestBuilderGenerator.run(version)
-        if (_generateLowercasePath != null) {
+        if (_generateLowercasePath != null)
+        {
           javaExecSpec.jvmArgs("-Dgenerator.rest.generate.lowercase.path=" + _generateLowercasePath); //RestRequestBuilderGenerator.run(generateLowercasePath)
         }
         javaExecSpec.jvmArgs("-Droot.path=" + getProject().getRootDir().getPath());
@@ -257,11 +259,13 @@ public class GenerateRestClientTask extends DefaultTask
 
   @Optional
   @Input
-  public Boolean generateLowercasePath() {
+  public Boolean generateLowercasePath()
+  {
     return _generateLowercasePath;
   }
 
-  public void setGenerateLowercasePath(Boolean enable) {
+  public void setGenerateLowercasePath(Boolean enable)
+  {
     _generateLowercasePath = enable;
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.8.4
+version=29.8.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/RestRequestBuilderGenerator.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/RestRequestBuilderGenerator.java
@@ -170,7 +170,7 @@ public class RestRequestBuilderGenerator
                deprecatedByVersion,
                targetDirectoryPath,
                sources,
-               false);
+               true);
   }
 
   /**

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/RestRequestBuilderGenerator.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/RestRequestBuilderGenerator.java
@@ -18,8 +18,8 @@ package com.linkedin.restli.tools.clientgen;
 
 
 import com.linkedin.common.Version;
-import com.linkedin.data.schema.generator.AbstractGenerator;
 import com.linkedin.internal.tools.ArgumentFileProcessor;
+import com.linkedin.pegasus.generator.CaseSensitiveFileCodeWriter;
 import com.linkedin.pegasus.generator.CodeUtil;
 import com.linkedin.pegasus.generator.DefaultGeneratorResult;
 import com.linkedin.pegasus.generator.GeneratorResult;
@@ -40,7 +40,6 @@ import java.util.List;
 
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
-import com.sun.codemodel.writer.FileCodeWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +53,7 @@ public class RestRequestBuilderGenerator
 {
   static final String GENERATOR_REST_GENERATE_DATATEMPLATES = "generator.rest.generate.datatemplates";
   static final String GENERATOR_REST_GENERATE_VERSION = "generator.rest.generate.version";
+  public static final String GENERATOR_REST_GENERATE_LOWERCASE_PATH = "generator.rest.generate.lowercase.path";
   private static final String GENERATOR_REST_GENERATE_DEPRECATED_VERSION = "generator.rest.generate.deprecated.version";
   private static final Logger _log = LoggerFactory.getLogger(RestRequestBuilderGenerator.class);
 
@@ -89,6 +89,7 @@ public class RestRequestBuilderGenerator
     final String generateImported = System.getProperty(PegasusDataTemplateGenerator.GENERATOR_GENERATE_IMPORTED);
     final String generateDataTemplates = System.getProperty(GENERATOR_REST_GENERATE_DATATEMPLATES);
     final String versionString = System.getProperty(GENERATOR_REST_GENERATE_VERSION);
+    final String generateLowercasePath = System.getProperty(GENERATOR_REST_GENERATE_LOWERCASE_PATH);
     final RestliVersion version = RestliVersion.lookUpRestliVersion(new Version(versionString));
     if (version == null)
     {
@@ -106,7 +107,8 @@ public class RestRequestBuilderGenerator
                                     version,
                                     deprecatedByVersion,
                                     args[0],
-                                    sources);
+                                    sources,
+                                    generateLowercasePath == null ? true : Boolean.parseBoolean(generateLowercasePath));
   }
 
   public static RestliVersion findDeprecatedVersion()
@@ -157,6 +159,32 @@ public class RestRequestBuilderGenerator
                                     RestliVersion deprecatedByVersion,
                                     String targetDirectoryPath,
                                     String[] sources)
+          throws IOException {
+    return run(resolverPath,
+               defaultPackage,
+               rootPath,
+               generateImported,
+               generateDataTemplates,
+               version,
+               deprecatedByVersion,
+               targetDirectoryPath,
+               sources,
+               false);
+  }
+
+  /**
+   * @param generateLowercasePath true, files are generated with a lower case path; false, files are generated as spec specifies.
+   */
+  public static GeneratorResult run(String resolverPath,
+                                    String defaultPackage,
+                                    String rootPath,
+                                    final boolean generateImported,
+                                    final boolean generateDataTemplates,
+                                    RestliVersion version,
+                                    RestliVersion deprecatedByVersion,
+                                    String targetDirectoryPath,
+                                    String[] sources,
+                                    boolean generateLowercasePath)
       throws IOException
   {
     final RestSpecParser parser = new RestSpecParser();
@@ -221,8 +249,8 @@ public class RestRequestBuilderGenerator
     final JCodeModel dataTemplateCodeModel = generator.getJavaDataTemplateGenerator().getCodeModel();
 
     final File targetDirectory = new File(targetDirectoryPath);
-    final List<File> targetFiles = JavaCodeUtil.targetFiles(targetDirectory, requestBuilderCodeModel, classLoader, checker);
-    targetFiles.addAll(JavaCodeUtil.targetFiles(targetDirectory, dataTemplateCodeModel, classLoader, checker));
+    final List<File> targetFiles = JavaCodeUtil.targetFiles(targetDirectory, requestBuilderCodeModel, classLoader, checker, generateLowercasePath);
+    targetFiles.addAll(JavaCodeUtil.targetFiles(targetDirectory, dataTemplateCodeModel, classLoader, checker, generateLowercasePath));
 
     final List<File> modifiedFiles;
     if (FileUtil.upToDate(parseResult.getSourceFiles(), targetFiles))
@@ -235,8 +263,8 @@ public class RestRequestBuilderGenerator
       modifiedFiles = targetFiles;
       _log.info("Generating " + targetFiles.size() + " files");
       _log.debug("Files: " + targetFiles);
-      requestBuilderCodeModel.build(new FileCodeWriter(targetDirectory, true));
-      dataTemplateCodeModel.build(new FileCodeWriter(targetDirectory, true));
+      requestBuilderCodeModel.build(new CaseSensitiveFileCodeWriter(targetDirectory, true, generateLowercasePath));
+      dataTemplateCodeModel.build(new CaseSensitiveFileCodeWriter(targetDirectory, true, generateLowercasePath));
     }
     return new DefaultGeneratorResult(parseResult.getSourceFiles(), targetFiles, modifiedFiles);
   }

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/RestRequestBuilderGenerator.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/RestRequestBuilderGenerator.java
@@ -159,7 +159,8 @@ public class RestRequestBuilderGenerator
                                     RestliVersion deprecatedByVersion,
                                     String targetDirectoryPath,
                                     String[] sources)
-          throws IOException {
+      throws IOException
+  {
     return run(resolverPath,
                defaultPackage,
                rootPath,

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/clientgen/TestRestRequestBuilderGenerator.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/clientgen/TestRestRequestBuilderGenerator.java
@@ -3,6 +3,7 @@ package com.linkedin.restli.tools.clientgen;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.linkedin.pegasus.generator.GeneratorResult;
 import com.linkedin.restli.internal.common.RestliVersion;
 import com.linkedin.restli.tools.ExporterTestUtils;
 
@@ -11,7 +12,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -28,12 +31,22 @@ import org.testng.collections.Lists;
  */
 public class TestRestRequestBuilderGenerator
 {
+  private static final String FS = File.separator;
+  private static final String RESOURCES_DIR = "src" + FS + "test" + FS + "resources";
+  private static final Pattern LOWERCASE_PATH_PATTERN = Pattern.compile("^[a-z/]*$");
+
+  private File outdir;
+  private File outdir2;
+  private String moduleDir;
+  private boolean isFileSystemCaseSensitive;
+
   @BeforeClass
   public void setUp() throws IOException
   {
     outdir = ExporterTestUtils.createTmpDir();
     outdir2 = ExporterTestUtils.createTmpDir();
     moduleDir = System.getProperty("user.dir");
+    isFileSystemCaseSensitive = isFileSystemCaseSensitive();
   }
 
   @AfterClass
@@ -119,6 +132,89 @@ public class TestRestRequestBuilderGenerator
     Assert.assertTrue(aBuilderFileContent.contains("Generated from " + RESOURCES_DIR + FS + "idls" + FS + "arrayDuplicateA.restspec.json"));
     final String bBuilderFileContent = IOUtils.toString(new FileInputStream(bBuilderFile));
     Assert.assertTrue(bBuilderFileContent.contains("Generated from " + RESOURCES_DIR + FS + "idls" + FS + "arrayDuplicateB.restspec.json"));
+  }
+
+  /**
+   * Testing case sensitivity of generated files. Typically a Mac/Windows system will have a case insensitive file
+   * system, whereas a Linux system will have a case sensitive file system. For a case insensitive file system,
+   * "~/com/astro" and "~/com/ASTRO" point to the same folder. For a case sensitive file system, "~/com/astro" and "~/com/ASTRO"
+   * will be different folders.
+   *
+   * Example:
+   *   File1: namespace = com.astro.file1
+   *   File2: namespace = com.aSTRo.file2
+   *
+   *   The following files would be generated with the path specified.
+   *   1) Case insensitive (if file1 is generated first):
+   *       com/astro/file1
+   *                /file2
+   *   2) Case insensitive (if file2 is generated first):
+   *       com/aSTRo/file1
+   *                /file2
+   *   3) Case sensitive:
+   *       com/astro/file1
+   *           aSTRo/file2
+   *
+   * @param version RestLi version
+   * @param restspec1 First restli spec to generate
+   * @param restspec2 Second restli spec to generate
+   * @param generateLowercasePath True, generate path lowercase; False, generate path as spec specifies.
+   */
+  @Test(dataProvider = "arrayDuplicateDataProvider2")
+  public void testGenerationPathOrder(RestliVersion version, String restspec1, String restspec2, boolean generateLowercasePath) throws Exception
+  {
+    // Given: RestLi version and spec files.
+    File tmpDir = ExporterTestUtils.createTmpDir();
+    final String pegasusDir = moduleDir + FS + RESOURCES_DIR + FS + "pegasus";
+    final String tmpPath = tmpDir.getPath();
+    final String file1 = moduleDir + FS + RESOURCES_DIR + FS + "idls" + FS + restspec1;
+    final String file2 = moduleDir + FS + RESOURCES_DIR + FS + "idls" + FS + restspec2;
+
+    // When: Generate the files defined by spec.
+    GeneratorResult r = RestRequestBuilderGenerator.run(pegasusDir,
+            null,
+            moduleDir,
+            true,
+            false,
+            version,
+            null,
+            tmpPath,
+            new String[] { file1 },
+            generateLowercasePath);
+    GeneratorResult r2 = RestRequestBuilderGenerator.run(pegasusDir,
+            null,
+            moduleDir,
+            true,
+            false,
+            version,
+            null,
+            tmpPath,
+            new String[] { file2 },
+            generateLowercasePath);
+
+    int c = tmpDir.getCanonicalPath().length();
+
+    // Then: Validate the Builder files were created with the correct paths.
+    ArrayList<File> files = new ArrayList<>(r.getModifiedFiles());
+    files.addAll(r2.getModifiedFiles());
+    for (File f : files) {
+      Assert.assertTrue(f.exists());
+      if (!isFileSystemCaseSensitive && !generateLowercasePath) {
+        // Do not validate path case since we would need to read paths from files.
+        continue;
+      } else if (generateLowercasePath) {
+        // Validate path is lowercase.
+        String path = f.getCanonicalPath().substring(c);
+        int idx = path.lastIndexOf("/") + 1;
+        path = path.substring(0, idx);
+        Matcher matcher = LOWERCASE_PATH_PATTERN.matcher(path);
+        Assert.assertTrue(matcher.find());
+      }
+      Assert.assertTrue(f.getCanonicalPath().endsWith(f.getAbsolutePath()));
+    }
+
+    // Clean up.
+    ExporterTestUtils.rmdir(tmpDir);
   }
 
   @Test(dataProvider = "deprecatedByVersionDataProvider")
@@ -216,6 +312,20 @@ public class TestRestRequestBuilderGenerator
   }
 
   @DataProvider
+  private static Object[][] arrayDuplicateDataProvider2() {
+    return new Object[][] {
+      { RestliVersion.RESTLI_1_0_0, "arrayDuplicateA.namespace.restspec.json", "arrayDuplicateB.namespace.restspec.json", true},
+      { RestliVersion.RESTLI_1_0_0, "arrayDuplicateA.namespace.restspec.json", "arrayDuplicateB.namespace.restspec.json", false},
+      { RestliVersion.RESTLI_1_0_0, "arrayDuplicateB.namespace.restspec.json", "arrayDuplicateA.namespace.restspec.json", true},
+      { RestliVersion.RESTLI_1_0_0, "arrayDuplicateB.namespace.restspec.json", "arrayDuplicateA.namespace.restspec.json", false},
+      { RestliVersion.RESTLI_2_0_0, "arrayDuplicateA.namespace.restspec.json", "arrayDuplicateB.namespace.restspec.json", true},
+      { RestliVersion.RESTLI_2_0_0, "arrayDuplicateA.namespace.restspec.json", "arrayDuplicateB.namespace.restspec.json", false},
+      { RestliVersion.RESTLI_2_0_0, "arrayDuplicateB.namespace.restspec.json", "arrayDuplicateA.namespace.restspec.json", true},
+      { RestliVersion.RESTLI_2_0_0, "arrayDuplicateB.namespace.restspec.json", "arrayDuplicateA.namespace.restspec.json", false},
+    };
+  }
+
+  @DataProvider
   private static Object[][] deprecatedByVersionDataProvider()
   {
     return new Object[][] {
@@ -233,10 +343,15 @@ public class TestRestRequestBuilderGenerator
     };
   }
 
-  private static final String FS = File.separator;
-  private static final String RESOURCES_DIR = "src" + FS + "test" + FS + "resources";
-
-  private File outdir;
-  private File outdir2;
-  private String moduleDir;
+  /**
+   * @return typically false for mac/windows; true for linux
+   */
+  private static boolean isFileSystemCaseSensitive() throws IOException {
+    File tmpDir = ExporterTestUtils.createTmpDir();
+    File caseSensitiveTestFile = new File(tmpDir + FS + "random_file");
+    caseSensitiveTestFile.createNewFile();
+    boolean caseSensitive = !new File(tmpDir + FS + "RANDOM_FILE" ).exists();
+    caseSensitiveTestFile.delete();
+    return caseSensitive;
+  }
 }

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/clientgen/TestRestRequestBuilderGenerator.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/clientgen/TestRestRequestBuilderGenerator.java
@@ -346,7 +346,8 @@ public class TestRestRequestBuilderGenerator
   /**
    * @return typically false for mac/windows; true for linux
    */
-  private static boolean isFileSystemCaseSensitive() throws IOException {
+  private static boolean isFileSystemCaseSensitive() throws IOException
+  {
     File tmpDir = ExporterTestUtils.createTmpDir();
     File caseSensitiveTestFile = new File(tmpDir + FS + "random_file");
     caseSensitiveTestFile.createNewFile();

--- a/restli-tools/src/test/resources/idls/arrayDuplicateA.namespace.restspec.json
+++ b/restli-tools/src/test/resources/idls/arrayDuplicateA.namespace.restspec.json
@@ -1,0 +1,24 @@
+{
+  "name" : "arrayDuplicateA",
+  "path" : "/arrayDuplicateA",
+  "schema" : "com.linkedin.greetings.api.Greeting",
+  "doc" : "This idl is for testing array and items fields.",
+  "namespace": "com.linkedin.greetings.api.builders",
+  "collection" : {
+    "identifier" : {
+      "name" : "id",
+      "type" : "string"
+    },
+    "supports" : [ ],
+    "finders" : [ {
+      "name" : "test",
+      "parameters" : [ {
+        "name" : "param",
+        "type" : "{ \"type\" : \"array\", \"items\" : \"com.linkedin.greetings.api.ArrayTestRecord\" }"
+      } ]
+    } ],
+    "entity" : {
+      "path" : "/arrayDuplicateA/{id}"
+    }
+  }
+}

--- a/restli-tools/src/test/resources/idls/arrayDuplicateB.namespace.restspec.json
+++ b/restli-tools/src/test/resources/idls/arrayDuplicateB.namespace.restspec.json
@@ -1,0 +1,24 @@
+{
+  "name" : "arrayDuplicateB",
+  "path" : "/arrayDuplicateB",
+  "schema" : "com.linkedin.greetings.api.Greeting",
+  "doc" : "This idl is for testing array and items fields.",
+  "namespace": "com.LINKedin.greetings.api.builders",
+  "collection" : {
+    "identifier" : {
+      "name" : "id",
+      "type" : "string"
+    },
+    "supports" : [ ],
+    "finders" : [ {
+      "name" : "test",
+      "parameters" : [ {
+        "name" : "param",
+        "type" : "{ \"type\" : \"array\", \"items\" : \"com.linkedin.greetings.api.Tone\" }"
+      } ]
+    } ],
+    "entity" : {
+      "path" : "/arrayDuplicateB/{id}"
+    }
+  }
+}


### PR DESCRIPTION
Issue:
Was working on two different file systems and noticed that after a rync,
I was getting a "DuplicateClassException" on my Linux system - there
were duplicate files in similar paths.

Typically a Mac/Windows system will have a case insensitive file system,
whereas a Linux system will have a case sensitive file system. For a
case insensitive file system, "~/com/astro" and "~/com/ASTRO" point to
the same folder. For a case sensitive file system, "~/com/astro" and
"~/com/ASTRO" will be different folders.

 Example:
   File1: namespace = com.astro.file1
   File2: namespace = com.aSTRo.file2

   The following files would be generated with the path specified.
   1) Case insensitive (if file1 is generated first):
       com/astro/file1
                /file2
   2) Case insensitive (if file2 is generated first):
       com/aSTRo/file1
                /file2
   3) Case sensitive:
       com/astro/file1
           aSTRo/file2

Resolution:
Add abililty for generators to generate paths with lower
case path. Updated the TempalteSpecGenerator,
PegasusDataTemplateGenerator, RestRequestBuilderGenerator, and
JavaRequestBuilderGenerator.

The Gradle Tasks of GenerateDataTemplateTask and
GenerateRestClientTask have been modified to have an optional input property
to generate teh lower case path.

Testing:
Created unit tests to validate path's on both linux and mac systems
where the file system were case sensitive and case insensitive
respectively.