### PR TITLE
Adding required record field is allowed and should be considered as backward compatible change in extension schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.8.4] - 2020-11-09
+- Adding required record field is allowed and should be considered as backward compatible change in extension schemas. 
+
 ## [29.8.3] - 2020-11-09
 - Support symbolTable requests with suffixes
 
@@ -4739,7 +4742,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.8.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.8.4...master
+[29.8.4]: https://github.com/linkedin/rest.li/compare/v29.8.3...v29.8.4
 [29.8.3]: https://github.com/linkedin/rest.li/compare/v29.8.2...v29.8.3
 [29.8.2]: https://github.com/linkedin/rest.li/compare/v29.8.1...v29.8.2
 [29.8.1]: https://github.com/linkedin/rest.li/compare/v29.8.0...v29.8.1

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityChecker.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityChecker.java
@@ -111,7 +111,7 @@ public class CompatibilityChecker
     }
 
     int pathCount = 1;
-    if (_options.getMode() == CompatibilityOptions.Mode.DATA)
+    if (_options.getMode() == CompatibilityOptions.Mode.DATA || _options.getMode() == CompatibilityOptions.Mode.EXTENSION )
     {
       older = older.getDereferencedDataSchema();
       while (newer.getType() == DataSchema.Type.TYPEREF)
@@ -370,7 +370,7 @@ public class CompatibilityChecker
       }
     }
 
-    if (newerRequiredAdded.isEmpty() == false)
+    if (newerRequiredAdded.isEmpty() == false && _options.getMode() != CompatibilityOptions.Mode.EXTENSION)
     {
       appendMessage(CompatibilityMessage.Impact.BREAKS_NEW_READER,
                     "new record added required fields %s",

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityOptions.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityOptions.java
@@ -79,7 +79,12 @@ public class CompatibilityOptions
      * Check whether the schema is compatible, includes checking
      * typeref compatibility.
      */
-    SCHEMA
+    SCHEMA,
+
+    /**
+     * Check whether the schema is compatible for extension schemas, allowing adding required record field.
+     */
+    EXTENSION
   }
 
   /**

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -601,7 +601,7 @@ public class PegasusPlugin implements Plugin<Project>
 
   private static final String SCHEMA_ANNOTATION_HANDLER_CONFIGURATION = "schemaAnnotationHandler";
 
-  private static final String COMPATIBILITY_OPTIONS_MODE_DATA = "DATA";
+  private static final String COMPATIBILITY_OPTIONS_MODE_EXTENSION = "EXTENSION";
 
   private static final String COMPATIBILITY_LEVEL_BACKWARDS = "BACKWARDS";
 
@@ -1452,7 +1452,7 @@ public class PegasusPlugin implements Plugin<Project>
               .plus(project.getConfigurations().getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME)));
           task.setCompatibilityLevel(isExtensionSchema ? COMPATIBILITY_LEVEL_BACKWARDS
               :PropertyUtil.findCompatLevel(project, FileCompatibilityType.PEGASUS_SCHEMA_SNAPSHOT));
-          task.setCompatibilityMode(isExtensionSchema ? COMPATIBILITY_OPTIONS_MODE_DATA :
+          task.setCompatibilityMode(isExtensionSchema ? COMPATIBILITY_OPTIONS_MODE_EXTENSION :
               PropertyUtil.findCompatMode(project, PEGASUS_COMPATIBILITY_MODE));
           task.setExtensionSchema(isExtensionSchema);
           task.setHandlerJarPath(project.getConfigurations() .getByName(SCHEMA_ANNOTATION_HANDLER_CONFIGURATION));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.8.3
+version=29.8.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/check/TestPegasusSchemaSnapshotCompatibilityChecker.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/check/TestPegasusSchemaSnapshotCompatibilityChecker.java
@@ -38,12 +38,12 @@ public class TestPegasusSchemaSnapshotCompatibilityChecker
   private String snapshotDir = testDir + FS + "pegasusSchemaSnapshot";
 
   @Test(dataProvider = "compatibleInputFiles")
-  public void testCompatiblePegasusSchemaSnapshot(String prevSchema, String currSchema)
+  public void testCompatiblePegasusSchemaSnapshot(String prevSchema, String currSchema, CompatibilityLevel compatLevel, CompatibilityOptions.Mode mode)
   {
     PegasusSchemaSnapshotCompatibilityChecker checker = new PegasusSchemaSnapshotCompatibilityChecker();
     CompatibilityInfoMap infoMap = checker.checkPegasusSchemaCompatibility(snapshotDir + FS + prevSchema, snapshotDir + FS + currSchema,
-        CompatibilityOptions.Mode.DATA);
-    Assert.assertTrue(infoMap.isModelCompatible(CompatibilityLevel.EQUIVALENT));
+        mode);
+    Assert.assertTrue(infoMap.isModelCompatible(compatLevel));
   }
 
   @Test(dataProvider = "incompatibleInputFiles")
@@ -145,7 +145,8 @@ public class TestPegasusSchemaSnapshotCompatibilityChecker
   {
     return new Object[][]
         {
-            { "BirthInfo.pdl", "compatibleSchemaSnapshot/BirthInfo.pdl"},
+            { "BirthInfo.pdl", "compatibleSchemaSnapshot/BirthInfo.pdl", CompatibilityLevel.EQUIVALENT, CompatibilityOptions.Mode.DATA },
+            { "Foo.pdl", "compatibleSchemaSnapshot/Foo.pdl", CompatibilityLevel.BACKWARDS, CompatibilityOptions.Mode.EXTENSION },
         };
   }
 

--- a/restli-tools/src/test/pegasusSchemaSnapshot/Foo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/Foo.pdl
@@ -1,0 +1,3 @@
+record Foo {
+  bar: typeref BarUrn = string
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/Foo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/Foo.pdl
@@ -1,0 +1,4 @@
+record Foo {
+  bar: typeref BarUrn = string
+  baz: typeref BazUrn = string
+}


### PR DESCRIPTION
Adding an enum in CompatibilityOptions.Mode - EXTENSION to allow adding required record field in extension schemas.

The previous PR was closed accidentally, since I forced to update the branch it does not allow me to reopen the PR. Therefore create a new PR.