### PR TITLE
[Relative Load Balancer] Add parity of do not slow start in Dyno test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.9.2] - 2020-11-16
+- Implemented doNotSlowStart in relative load balancer.
+
 ## [29.9.1] - 2020-11-12
-Performance improved: add lazy instantiation of Throwable objects for timeout errors
+- Performance improved: add lazy instantiation of Throwable objects for timeout errors
 
 ## [29.9.0] - 2020-11-10
 - By default, Pegasus Plugin's generated files (for GenerateDataTemplateTask and GenerateRestClientTask Gradle Tasks) are created with lower case file system paths. (There is an optional flag at the Gradle task level to change this behavior.)
@@ -4748,7 +4751,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.9.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.9.2...master
+[29.9.2]: https://github.com/linkedin/rest.li/compare/v29.9.1...v29.9.2
 [29.9.1]: https://github.com/linkedin/rest.li/compare/v29.9.0...v29.9.1
 [29.9.0]: https://github.com/linkedin/rest.li/compare/v29.8.5...v29.9.0
 [29.8.5]: https://github.com/linkedin/rest.li/compare/v29.8.4...v29.8.5

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/DegraderTrackerClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/DegraderTrackerClientImpl.java
@@ -49,21 +49,21 @@ public class DegraderTrackerClientImpl extends TrackerClientImpl implements Degr
                                Clock clock, DegraderImpl.Config config)
   {
     this(uri, partitionDataMap, wrappedClient, clock, config, TrackerClientImpl.DEFAULT_CALL_TRACKER_INTERVAL,
-         TrackerClientImpl.DEFAULT_ERROR_STATUS_PATTERN, Collections.emptyMap());
+         TrackerClientImpl.DEFAULT_ERROR_STATUS_PATTERN, false);
   }
 
   public DegraderTrackerClientImpl(URI uri, Map<Integer, PartitionData> partitionDataMap, TransportClient wrappedClient,
                                Clock clock, DegraderImpl.Config config, long interval, Pattern errorStatusPattern)
   {
-    this(uri, partitionDataMap, wrappedClient, clock, config, interval, errorStatusPattern, null);
+    this(uri, partitionDataMap, wrappedClient, clock, config, interval, errorStatusPattern, false);
   }
 
   public DegraderTrackerClientImpl(URI uri, Map<Integer, PartitionData> partitionDataMap, TransportClient wrappedClient,
                                Clock clock, DegraderImpl.Config config, long interval, Pattern errorStatusPattern,
-                               Map<String, Object> uriSpecificProperties)
+                               boolean doNotSlowStart)
   {
     super(uri, partitionDataMap, wrappedClient, clock, interval,
-        (status) -> errorStatusPattern.matcher(Integer.toString(status)).matches());
+        (status) -> errorStatusPattern.matcher(Integer.toString(status)).matches(), true, doNotSlowStart);
 
     if (config == null)
     {
@@ -75,12 +75,7 @@ public class DegraderTrackerClientImpl extends TrackerClientImpl implements Degr
     // The overrideDropRate will be globally determined by the DegraderLoadBalancerStrategy.
     config.setOverrideDropRate(0.0);
 
-    if (uriSpecificProperties == null)
-    {
-      uriSpecificProperties = new HashMap<>();
-    }
-    if (uriSpecificProperties.containsKey(PropertyKeys.DO_NOT_SLOW_START)
-      && Boolean.parseBoolean(uriSpecificProperties.get(PropertyKeys.DO_NOT_SLOW_START).toString()))
+    if (doNotSlowStart)
     {
       config.setInitialDropRate(DegraderImpl.DEFAULT_DO_NOT_SLOW_START_INITIAL_DROP_RATE);
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClient.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClient.java
@@ -46,6 +46,11 @@ public interface TrackerClient extends LoadBalancerClient
   TransportClient getTransportClient();
 
   /**
+   * @return is the host should not perform slow start
+   */
+  boolean doNotSlowStart();
+
+  /**
    * @param partitionId Partition ID key.
    * @return Weight of specified partition or null if no partition with the ID exists.
    */

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClient.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClient.java
@@ -46,7 +46,7 @@ public interface TrackerClient extends LoadBalancerClient
   TransportClient getTransportClient();
 
   /**
-   * @return is the host should not perform slow start
+   * @return Should the host skip performing slow start
    */
   boolean doNotSlowStart();
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
@@ -72,6 +72,7 @@ public class TrackerClientImpl implements TrackerClient
   private final Map<Integer, PartitionData> _partitionData;
   private final URI _uri;
   private final Predicate<Integer> _isErrorStatus;
+  private final boolean _doNotSlowStart;
   final CallTracker _callTracker;
 
   private volatile CallTracker.CallStats _latestCallStats;
@@ -79,11 +80,11 @@ public class TrackerClientImpl implements TrackerClient
   public TrackerClientImpl(URI uri, Map<Integer, PartitionData> partitionDataMap, TransportClient transportClient,
       Clock clock, long interval, Predicate<Integer> isErrorStatus)
   {
-    this(uri, partitionDataMap, transportClient, clock, interval, isErrorStatus, true);
+    this(uri, partitionDataMap, transportClient, clock, interval, isErrorStatus, true, false);
   }
 
   public TrackerClientImpl(URI uri, Map<Integer, PartitionData> partitionDataMap, TransportClient transportClient,
-      Clock clock, long interval, Predicate<Integer> isErrorStatus, boolean percentileTrackingEnabled)
+      Clock clock, long interval, Predicate<Integer> isErrorStatus, boolean percentileTrackingEnabled, boolean doNotSlowStart)
   {
     _uri = uri;
     _transportClient = transportClient;
@@ -91,6 +92,7 @@ public class TrackerClientImpl implements TrackerClient
     _isErrorStatus = isErrorStatus;
     _partitionData = Collections.unmodifiableMap(partitionDataMap);
     _latestCallStats = _callTracker.getCallStats();
+    _doNotSlowStart = doNotSlowStart;
 
     _callTracker.addStatsRolloverEventListener(event -> _latestCallStats = event.getCallStats());
 
@@ -184,6 +186,12 @@ public class TrackerClientImpl implements TrackerClient
 
       _wrappedCallback.onResponse(response);
     }
+  }
+
+  @Override
+  public boolean doNotSlowStart()
+  {
+    return _doNotSlowStart;
   }
 
   private class TrackerClientStreamCallback implements TransportCallback<StreamResponse>

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -313,9 +313,16 @@ public class StateUpdater
       }
       else
       {
-        // If it is a new client, we directly set health score as the initial health score to initialize
-        trackerClientStateMap.put(trackerClient, new TrackerClientState(_relativeStrategyProperties.getInitialHealthScore(),
-            _relativeStrategyProperties.getMinCallCount()));
+        // Initializing a new client score
+        if (trackerClient.doNotSlowStart())
+        {
+          trackerClientStateMap.put(trackerClient, new TrackerClientState(MAX_HEALTH_SCORE,
+              _relativeStrategyProperties.getMinCallCount()));
+        }
+        else {
+          trackerClientStateMap.put(trackerClient,
+              new TrackerClientState(_relativeStrategyProperties.getInitialHealthScore(), _relativeStrategyProperties.getMinCallCount()));
+        }
       }
     }
     partitionState.setPartitionStats(avgClusterLatency, clusterCallCount, clusterErrorCount);

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -319,7 +319,8 @@ public class StateUpdater
           trackerClientStateMap.put(trackerClient, new TrackerClientState(MAX_HEALTH_SCORE,
               _relativeStrategyProperties.getMinCallCount()));
         }
-        else {
+        else
+        {
           trackerClientStateMap.put(trackerClient,
               new TrackerClientState(_relativeStrategyProperties.getInitialHealthScore(), _relativeStrategyProperties.getMinCallCount()));
         }

--- a/d2/src/test/java/com/linkedin/d2/balancer/clients/TrackerClientTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clients/TrackerClientTest.java
@@ -297,9 +297,6 @@ public class TrackerClientTest
   @Test
   public void testDoNotSlowStartWhenTrue()
   {
-    Map<String, Object> uriSpecificProperties = new HashMap<>();
-    uriSpecificProperties.put(PropertyKeys.DO_NOT_SLOW_START, true);
-
     Map<Integer, PartitionData> partitionDataMap = createDefaultPartitionData(1d);
 
     DegraderImpl.Config config = new DegraderImpl.Config();
@@ -308,7 +305,7 @@ public class TrackerClientTest
 
     DegraderTrackerClient client = new DegraderTrackerClientImpl(URI.create("http://test.qa.com:1234/foo"), partitionDataMap,
                                                              new TestClient(), new SettableClock(), config, DegraderLoadBalancerStrategyConfig.DEFAULT_UPDATE_INTERVAL_MS,
-                                                             TrackerClientImpl.DEFAULT_ERROR_STATUS_PATTERN, uriSpecificProperties);
+                                                             TrackerClientImpl.DEFAULT_ERROR_STATUS_PATTERN, true);
     DegraderControl degraderControl = client.getDegraderControl(DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
     Assert.assertEquals(degraderControl.getInitialDropRate(), DegraderImpl.DEFAULT_DO_NOT_SLOW_START_INITIAL_DROP_RATE,
         "Initial drop rate in config should have been overridden by doNotSlowStart uri property.");
@@ -317,9 +314,6 @@ public class TrackerClientTest
   @Test
   public void testDoNotSlowStartWhenFalse()
   {
-    Map<String, Object> uriSpecificProperties = new HashMap<>();
-    uriSpecificProperties.put(PropertyKeys.DO_NOT_SLOW_START, false);
-
     Map<Integer, PartitionData> partitionDataMap = createDefaultPartitionData(1d);
 
     DegraderImpl.Config config = new DegraderImpl.Config();
@@ -328,7 +322,7 @@ public class TrackerClientTest
 
     DegraderTrackerClient client = new DegraderTrackerClientImpl(URI.create("http://test.qa.com:1234/foo"), partitionDataMap,
                                                              new TestClient(), new SettableClock(), config, DegraderLoadBalancerStrategyConfig.DEFAULT_UPDATE_INTERVAL_MS,
-                                                             TrackerClientImpl.DEFAULT_ERROR_STATUS_PATTERN, uriSpecificProperties);
+                                                             TrackerClientImpl.DEFAULT_ERROR_STATUS_PATTERN, false);
     DegraderControl degraderControl = client.getDegraderControl(DefaultPartitionAccessor.DEFAULT_PARTITION_ID);
     Assert.assertEquals(degraderControl.getInitialDropRate(), initialDropRate,
         "Initial drop rate in config should not have been overridden by doNotSlowStart uri property.");

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -97,8 +97,8 @@ public class StateUpdaterTest
         };
   }
 
-  @Test
-  public void testInitializePartitionWithSlowStartInitialHealthScore()
+  @Test(dataProvider = "doNotSlowStart")
+  public void testInitializePartitionWithSlowStartInitialHealthScore(boolean doNotSlowStart)
   {
     double initialHealthScore = 0.01;
     D2RelativeStrategyProperties relativeStrategyProperties = new D2RelativeStrategyProperties()
@@ -106,16 +106,34 @@ public class StateUpdaterTest
     setup(relativeStrategyProperties, new ConcurrentHashMap<>());
 
     List<TrackerClient> trackerClients = TrackerClientMockHelper.mockTrackerClients(2,
-        Arrays.asList(20, 20), Arrays.asList(10, 10), Arrays.asList(200L, 500L), Arrays.asList(100L, 200L), Arrays.asList(0, 0));
+        Arrays.asList(20, 20), Arrays.asList(10, 10), Arrays.asList(200L, 500L), Arrays.asList(100L, 200L), Arrays.asList(0, 0), doNotSlowStart);
 
     assertTrue(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).isEmpty(), "There should be no state before initialization");
 
     _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, DEFAULT_CLUSTER_GENERATION_ID);
 
-    assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(0).getUri()).intValue(),
-        (int) (initialHealthScore * RelativeLoadBalancerStrategyFactory.DEFAULT_POINTS_PER_WEIGHT));
-    assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(1).getUri()).intValue(),
-        (int) (initialHealthScore * RelativeLoadBalancerStrategyFactory.DEFAULT_POINTS_PER_WEIGHT));
+    if (!doNotSlowStart)
+    {
+      assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(0).getUri()).intValue(),
+          (int) (initialHealthScore * RelativeLoadBalancerStrategyFactory.DEFAULT_POINTS_PER_WEIGHT));
+      assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(1).getUri()).intValue(),
+          (int) (initialHealthScore * RelativeLoadBalancerStrategyFactory.DEFAULT_POINTS_PER_WEIGHT));
+    }
+    else {
+      assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(0).getUri()).intValue(), HEALTHY_POINTS);
+      assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(1).getUri()).intValue(), HEALTHY_POINTS);
+    }
+
+  }
+
+  @DataProvider(name = "doNotSlowStart")
+  public Object[][] doNotSlowStart()
+  {
+    return new Object[][]
+        {
+            {true},
+            {false}
+        };
   }
 
   @Test

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -119,7 +119,8 @@ public class StateUpdaterTest
       assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(1).getUri()).intValue(),
           (int) (initialHealthScore * RelativeLoadBalancerStrategyFactory.DEFAULT_POINTS_PER_WEIGHT));
     }
-    else {
+    else
+    {
       assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(0).getUri()).intValue(), HEALTHY_POINTS);
       assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(1).getUri()).intValue(), HEALTHY_POINTS);
     }

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/TrackerClientMockHelper.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/TrackerClientMockHelper.java
@@ -57,6 +57,13 @@ public class TrackerClientMockHelper
     return trackerClients;
   }
 
+  public static List<TrackerClient> mockTrackerClients(int numTrackerClients, List<Integer> callCountList,
+      List<Integer> outstandingCallCountList, List<Long> latencyList, List<Long> outstandingLatencyList,
+      List<Integer> errorCountList)
+  {
+    return mockTrackerClients(numTrackerClients, callCountList, outstandingCallCountList, latencyList, outstandingLatencyList, errorCountList, false);
+  }
+
   /**
    * Mock a list of {@link TrackerClient} for testing
    *
@@ -70,7 +77,7 @@ public class TrackerClientMockHelper
    */
   public static List<TrackerClient> mockTrackerClients(int numTrackerClients, List<Integer> callCountList,
       List<Integer> outstandingCallCountList, List<Long> latencyList, List<Long> outstandingLatencyList,
-      List<Integer> errorCountList)
+      List<Integer> errorCountList, boolean doNotSlowStart)
   {
     List<TrackerClient> trackerClients = new ArrayList<>();
     for (int index = 0; index < numTrackerClients; index ++)
@@ -102,6 +109,7 @@ public class TrackerClientMockHelper
       Mockito.when(callTracker.getCallStats()).thenReturn(callStats);
       Mockito.when(trackerClient.getUri()).thenReturn(uri);
       Mockito.when(trackerClient.getPartitionWeight(anyInt())).thenReturn(1.0);
+      Mockito.when(trackerClient.doNotSlowStart()).thenReturn(doNotSlowStart);
       trackerClients.add(trackerClient);
     }
     return trackerClients;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.9.1
+version=29.9.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
**Background**
In the existing degrader load balancer, we have one special logic about Dyno tests: When a dyno test is started, they will explicitly indicate uriProperties "doNotSlowStart" for the uri, so that when a host's weight is adjusted in Zookeeper, it does not perform any slow start. However, I just realized the same feature is not added to relative load balancer. Hence this PR will add the parity.