### PR TITLE
Reserve symbol table resource name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add a boolean flag as header for symbol table request to avoid conflict with resource requests.
 
 ## [29.11.3] - 2020-11-25
 - Enable cycle check when serializing only when assertions are enabled, to avoid severe performance degradation at high QPS due to ThreadLocal slowdown.

--- a/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
+++ b/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
@@ -48,6 +48,11 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
   private static final String ACCEPT_HEADER = "Accept";
 
   /**
+   * Symbol table request header
+   */
+  private static final String SYMBOL_TABLE_HEADER = "X-Restli-Symbol-Table-Request";
+
+  /**
    * Logger.
    */
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSymbolTableProvider.class.getSimpleName());
@@ -134,6 +139,7 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
       try
       {
         connection.setRequestProperty(ACCEPT_HEADER, ProtobufDataCodec.DEFAULT_HEADER);
+        connection.setRequestProperty(SYMBOL_TABLE_HEADER, Boolean.toString(true));
         int responseCode = connection.getResponseCode();
 
         if (responseCode == HttpURLConnection.HTTP_OK)

--- a/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
+++ b/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
@@ -50,7 +50,7 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
   /**
    * Symbol table request header
    */
-  private static final String SYMBOL_TABLE_HEADER = "X-Restli-Symbol-Table-Request";
+  private static final String SYMBOL_TABLE_HEADER = "x-restli-symbol-table-request";
 
   /**
    * Logger.

--- a/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
@@ -58,6 +58,8 @@ public interface RestConstants
   String HEADER_RESTLI_PROTOCOL_VERSION = "X-RestLi-Protocol-Version";
   String CONTENT_TYPE_PARAM_SYMBOL_TABLE = "symbol-table";
   String HEADER_CONTENT_ID = "Content-ID";
+  String HEADER_SERVICE_SCOPED_PATH = "x-restli-service-scoped-path";
+  String HEADER_FETCH_SYMBOL_TABLE = "X-Restli-Symbol-Table-Request";
 
   // Default supported mime types.
   Set<String> SUPPORTED_MIME_TYPES = new LinkedHashSet<>(

--- a/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
@@ -59,7 +59,7 @@ public interface RestConstants
   String CONTENT_TYPE_PARAM_SYMBOL_TABLE = "symbol-table";
   String HEADER_CONTENT_ID = "Content-ID";
   String HEADER_SERVICE_SCOPED_PATH = "x-restli-service-scoped-path";
-  String HEADER_FETCH_SYMBOL_TABLE = "X-Restli-Symbol-Table-Request";
+  String HEADER_FETCH_SYMBOL_TABLE = "x-restli-symbol-table-request";
 
   // Default supported mime types.
   Set<String> SUPPORTED_MIME_TYPES = new LinkedHashSet<>(

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiApiBuilder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiApiBuilder.java
@@ -17,6 +17,7 @@
 package com.linkedin.restli.internal.server.model;
 
 
+import com.linkedin.data.codec.symbol.DefaultSymbolTableProvider;
 import com.linkedin.restli.server.ResourceConfigException;
 import com.linkedin.restli.server.RestLiConfig;
 
@@ -119,6 +120,12 @@ public class RestLiApiBuilder implements RestApiBuilder
     if (model.isRoot())
     {
       String path = "/" + model.getName();
+      if (model.getName().equals(DefaultSymbolTableProvider.SYMBOL_TABLE_URI_PATH))
+      {
+        String errorMessage = String.format("Resource class \"%s\" API name \"symbolTable\" is reserved for internal use",
+            model.getResourceClass().getCanonicalName());
+        throw new ResourceConfigException(errorMessage);
+      }
       final ResourceModel existingResource = rootResourceModels.get(path);
       if (existingResource != null)
       {

--- a/restli-server/src/main/java/com/linkedin/restli/server/symbol/RestLiSymbolTableRequestHandler.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/symbol/RestLiSymbolTableRequestHandler.java
@@ -90,11 +90,20 @@ public class RestLiSymbolTableRequestHandler implements NonResourceRequestHandle
       return false;
     }
 
-    //
     // When path is service scoped, URI is in the form of /<SERVICE>/symbolTable, else it
     // is in the form of /symbolTable or /symbolTable/<TABLENAME>
-    return pathSegments.get(pathSegments.size() - 1).getPath().equals(SYMBOL_TABLE_URI_PATH)
-        || pathSegments.get(pathSegments.size() - 2).getPath().equals(SYMBOL_TABLE_URI_PATH);
+    boolean isSymbolTableRequest = request.getHeaders().containsKey(RestConstants.HEADER_FETCH_SYMBOL_TABLE);
+    if (isSymbolTableRequest)
+    {
+      return pathSegments.get(pathSegments.size() - 1).getPath().equals(SYMBOL_TABLE_URI_PATH)
+              || pathSegments.get(pathSegments.size() - 2).getPath().equals(SYMBOL_TABLE_URI_PATH);
+    }
+    boolean isServiceScopedPath = request.getHeaders().containsKey(RestConstants.HEADER_SERVICE_SCOPED_PATH);
+    if (isServiceScopedPath)
+    {
+      return (pathSegments.size() == 3) && pathSegments.get(2).getPath().equals(SYMBOL_TABLE_URI_PATH);
+    }
+    return ((pathSegments.size() == 2 || pathSegments.size() == 3) && pathSegments.get(1).getPath().equals(SYMBOL_TABLE_URI_PATH));
   }
 
   @Override

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -162,6 +162,9 @@ class SampleResources
   @RestLiCollection(name = "FOO")
   static class FOOResource extends CollectionResourceTemplate<Long, EmptyRecord> {}
 
+  @RestLiCollection(name = "symbolTable")
+  static class SymbolsResource extends CollectionResourceTemplate<Long, EmptyRecord> {}
+
   @RestLiCollection(
     name = "TestResource",
     namespace = "com.linkedin.restli.internal.server.model",

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -103,20 +103,30 @@ public class TestRestLiApiBuilder
     Assert.assertNotNull(parentResource.getSubResource("TestResource"));
   }
 
-  @Test
-  public void testBadResource()
+  @DataProvider(name = "badResources")
+  public Object[][] badResources()
+  {
+    return new Object[][]
+        {
+            { BadResource.class, "bogusKey not found in path keys"},
+            { SymbolsResource.class, "\"symbolTable\" is reserved for internal use"},
+        };
+  }
+
+  @Test(dataProvider = "badResources")
+  public void testBadResource(Class<?> resourceClass, String errorMsg)
   {
     Set<Class<?>> set = new HashSet<>();
     set.add(ParentResource.class);
-    set.add(BadResource.class);
-
+    set.add(resourceClass);
     try
     {
       RestLiApiBuilder.buildResourceModels(set);
       Assert.fail("Building api with BadResource should throw " + ResourceConfigException.class);
     }
-    catch (ResourceConfigException e)  {
-      Assert.assertTrue(e.getMessage().contains("bogusKey not found in path keys"));
+    catch (ResourceConfigException e)
+    {
+      Assert.assertTrue(e.getMessage().contains(errorMsg));
     }
   }
 

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestRestLiSymbolTableRequestHandler.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestRestLiSymbolTableRequestHandler.java
@@ -68,14 +68,16 @@ public class TestRestLiSymbolTableRequestHandler
   @DataProvider
   public Object[][] uris()
   {
+    Map<String, String> requestHeaders = Collections.singletonMap(RestConstants.HEADER_FETCH_SYMBOL_TABLE, Boolean.TRUE.toString());
     return new Object[][] {
         // do not handle empty path
         { "/", Collections.emptyMap(), false },
         // non symbolTable path
         { "/someResource", Collections.emptyMap(), false },
+        { "/service/someReource/foo", requestHeaders, false },
         { "/symbolTable", Collections.emptyMap(), true },
-        { "/service/symbolTable", Collections.emptyMap(), true },
-        { "/service/foo/symbolTable", Collections.emptyMap(), true },
+        { "/service/symbolTable", requestHeaders, true },
+        { "/service/symbolTable/foo", requestHeaders, true },
     };
   }
 

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/symbol/RestLiSymbolTableProvider.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/symbol/RestLiSymbolTableProvider.java
@@ -226,7 +226,6 @@ public class RestLiSymbolTableProvider implements SymbolTableProvider, ResourceD
     {
       return null;
     }
-
     String serviceName = LoadBalancerUtil.getServiceNameFromUri(requestUri);
 
     // First check the cache.
@@ -238,9 +237,6 @@ public class RestLiSymbolTableProvider implements SymbolTableProvider, ResourceD
       return symbolTable == EmptySymbolTable.SHARED ? null : symbolTable;
     }
 
-    // Ok, we didn't find it in the cache, let's go query the other service using the URI prefix. In this case, we
-    // make sure to set the {@link RestConstants#HEADER_SERVICE_SCOPED_PATH} header to true to indicate that this
-    // path, post resolution must be interpreted as a service scoped path.
     try
     {
       URI symbolTableUri = new URI(_uriPrefix + serviceName + "/" + RestLiSymbolTableRequestHandler.SYMBOL_TABLE_URI_PATH);
@@ -304,7 +300,9 @@ public class RestLiSymbolTableProvider implements SymbolTableProvider, ResourceD
   {
     try
     {
-      Future<RestResponse> future = _client.restRequest(new RestRequestBuilder(symbolTableUri).setHeaders(requestHeaders).build());
+      Map<String, String> headers = new HashMap<>(requestHeaders);
+      headers.put(RestConstants.HEADER_FETCH_SYMBOL_TABLE, Boolean.TRUE.toString());
+      Future<RestResponse> future = _client.restRequest(new RestRequestBuilder(symbolTableUri).setHeaders(headers).build());
       RestResponse restResponse = future.get(DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
       int status = restResponse.getStatus();
 

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/symbol/TestRestLiSymbolTableProvider.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/symbol/TestRestLiSymbolTableProvider.java
@@ -110,8 +110,10 @@ public class TestRestLiSymbolTableProvider
         Collections.unmodifiableList(Arrays.asList("Haha", "Hehe")));
     builder.setEntity(SymbolTableSerializer.toByteString(ContentType.PROTOBUF2.getCodec(), symbolTable));
     builder.setHeader(RestConstants.HEADER_CONTENT_TYPE, ContentType.PROTOBUF2.getHeaderKey());
-    when(_client.restRequest(eq(new RestRequestBuilder(URI.create("https://OtherHost:100/service/symbolTable/Test--332004310")).build())))
-        .thenReturn(CompletableFuture.completedFuture(builder.build()));
+    when(_client.restRequest(eq(new RestRequestBuilder(
+            URI.create("https://OtherHost:100/service/symbolTable/Test--332004310"))
+            .setHeaders(Collections.singletonMap(RestConstants.HEADER_FETCH_SYMBOL_TABLE, Boolean.TRUE.toString()))
+            .build()))).thenReturn(CompletableFuture.completedFuture(builder.build()));
 
     SymbolTable remoteSymbolTable = _provider.getSymbolTable("https://OtherHost:100/service|Test--332004310");
     Assert.assertNotNull(remoteSymbolTable);
@@ -145,7 +147,7 @@ public class TestRestLiSymbolTableProvider
     builder.setEntity(SymbolTableSerializer.toByteString(ContentType.PROTOBUF2.getCodec(), symbolTable));
     builder.setHeader(RestConstants.HEADER_CONTENT_TYPE, ContentType.PROTOBUF2.getHeaderKey());
     when(_client.restRequest(eq(new RestRequestBuilder(URI.create("d2://someservice/symbolTable"))
-        .build())))
+        .setHeaders(Collections.singletonMap(RestConstants.HEADER_FETCH_SYMBOL_TABLE, Boolean.TRUE.toString())).build())))
         .thenReturn(CompletableFuture.completedFuture(builder.build()));
 
     SymbolTable remoteSymbolTable = _provider.getRequestSymbolTable(URI.create("d2://someservice/path"));

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/symbol/TestRestLiSymbolTableProvider.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/symbol/TestRestLiSymbolTableProvider.java
@@ -175,8 +175,6 @@ public class TestRestLiSymbolTableProvider
   {
     RestResponseBuilder builder = new RestResponseBuilder();
     builder.setStatus(404);
-    when(_client.restRequest(eq(new RestRequestBuilder(URI.create("d2://serviceName/symbolTable")).build())))
-        .thenReturn(CompletableFuture.completedFuture(builder.build()));
 
     Assert.assertNull(_provider.getRequestSymbolTable(URI.create("d2://serviceName")));
 
@@ -191,7 +189,9 @@ public class TestRestLiSymbolTableProvider
     AtomicInteger networkCallCount = new AtomicInteger(0);
     RestResponseBuilder builder = new RestResponseBuilder();
     builder.setStatus(500);
-    when(_client.restRequest(eq(new RestRequestBuilder(URI.create("d2://serviceName/symbolTable")).build()))).thenAnswer(
+    when(_client.restRequest(eq(new RestRequestBuilder(URI.create("d2://serviceName/symbolTable"))
+        .setHeaders(Collections.singletonMap(RestConstants.HEADER_FETCH_SYMBOL_TABLE, Boolean.TRUE.toString()))
+        .build()))).thenAnswer(
         invocation -> {
           networkCallCount.incrementAndGet();
           return CompletableFuture.completedFuture(builder.build());


### PR DESCRIPTION
1. Throw error in API builder if Resource name conflicts with "symbolTable"
2. Add symbol-table-request header for requesting symbol table to avoid conflict with resource requests.