### PR TITLE
Enable cycle check when serializing only when assertions are enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.11.3] - 2020-11-25
+- Enable cycle check when serializing only when assertions are enabled, to avoid severe performance degradation at high QPS due to ThreadLocal slowdown.
+
 ## [29.11.2] - 2020-11-23
 - Enhance request symbol table fetch. 
   - Return null if uri prefix doesn't match. 
@@ -4767,7 +4770,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.11.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.11.3...master
+[29.11.3]: https://github.com/linkedin/rest.li/compare/v29.11.2...v29.11.3
 [29.11.2]: https://github.com/linkedin/rest.li/compare/v29.11.1...v29.11.2
 [29.11.1]: https://github.com/linkedin/rest.li/compare/v29.10.1...v29.11.1
 [29.10.1]: https://github.com/linkedin/rest.li/compare/v29.10.0...v29.10.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.11.2
+version=29.11.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This is to avoid severe performance degradation at high QPS due to ThreadLocal slowdown.
See: https://jira.atlassian.com/browse/JRASERVER-71058 for a similar issue.