### PR TITLE
Bump javax.mail:mail to 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Bump `javax.mail:mail` dependency from `1.4.1` to `1.4.4` to avoid classloader issues in `javax.activation` code with Java 11.
 
 ## [29.12.0] - 2020-12-02
 - Add a boolean flag as header for symbol table request to avoid conflict with resource requests.

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ project.ext.externalDependency = [
   'log4j2Api': 'org.apache.logging.log4j:log4j-api:2.0.2',
   'log4j2Core': 'org.apache.logging.log4j:log4j-core:2.0.2',
   'log4jLog4j2': 'org.apache.logging.log4j:log4j-1.2-api:2.0.2',
-  'mail': 'javax.mail:mail:1.4.1',
+  'mail': 'javax.mail:mail:1.4.4',
   'netty': 'io.netty:netty-all:4.1.41.Final',
   'objenesis': 'org.objenesis:objenesis:1.2',
   'parseq': 'com.linkedin.parseq:parseq:4.1.6',


### PR DESCRIPTION
This should resolve some classloader issues introduced in
javax.activation code with java 11.