### PR TITLE
Fix empty union validation to only allow validation pass when projection in union is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4783,9 +4783,8 @@ patch operations can re-use these classes for generating patch messages.
 ## [0.14.1]
 
 [Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.1...master
-[29.13.1]: https://github.com/linkedin/rest.li/compare/v29.12.1...v29.13.1
-[29.13.0]: https://github.com/linkedin/rest.li/compare/v29.12.1...v29.13.0
-[29.12.1]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.12.1
+[29.13.1]: https://github.com/linkedin/rest.li/compare/v29.13.0...v29.13.1
+[29.13.0]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.13.0
 [29.12.0]: https://github.com/linkedin/rest.li/compare/v29.11.3...v29.12.0
 [29.11.3]: https://github.com/linkedin/rest.li/compare/v29.11.2...v29.11.3
 [29.11.2]: https://github.com/linkedin/rest.li/compare/v29.11.1...v29.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and what APIs have changed, if applicable.
 - Bump `javax.mail:mail` dependency from `1.4.1` to `1.4.4` to avoid classloader issues in `javax.activation` code with Java 11.
 - Bump arvo compatibility layer `avroutil` dependency from `0.1.11` to `0.2.17` for Arvo Upgrade HI.
 - Setup the base infra for generating new fluent api client bindings.
+- Fix the restriction of empty union validation from wide open to only allow when there is a projection in the union
 
 ## [29.12.0] - 2020-12-02
 - Add a boolean flag as header for symbol table request to avoid conflict with resource requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.13.1] - 2020-12-14
 - Fix the restriction of empty union validation from wide open to only allow when there is a projection in the union
 
 ## [29.13.0] - 2020-12-12
@@ -4784,7 +4786,8 @@ patch operations can re-use these classes for generating patch messages.
 [Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.0...master
 [29.13.0]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.13.0
 =======
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.12.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.1...master
+[29.13.1]: https://github.com/linkedin/rest.li/compare/v29.12.1...v29.13.1
 [29.12.1]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.12.1
 >>>>>>> bd549e7ff (bump version)
 [29.12.0]: https://github.com/linkedin/rest.li/compare/v29.11.3...v29.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4782,14 +4782,10 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-<<<<<<< HEAD
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.0...master
-[29.13.0]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.13.0
-=======
 [Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.1...master
 [29.13.1]: https://github.com/linkedin/rest.li/compare/v29.12.1...v29.13.1
+[29.13.0]: https://github.com/linkedin/rest.li/compare/v29.12.1...v29.13.0
 [29.12.1]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.12.1
->>>>>>> bd549e7ff (bump version)
 [29.12.0]: https://github.com/linkedin/rest.li/compare/v29.11.3...v29.12.0
 [29.11.3]: https://github.com/linkedin/rest.li/compare/v29.11.2...v29.11.3
 [29.11.2]: https://github.com/linkedin/rest.li/compare/v29.11.1...v29.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Fix the restriction of empty union validation from wide open to only allow when there is a projection in the union
 
 ## [29.13.0] - 2020-12-12
 - Change AvroUtil to use newCompatibleJsonDecoder from avro-util
 - Bump `javax.mail:mail` dependency from `1.4.1` to `1.4.4` to avoid classloader issues in `javax.activation` code with Java 11.
 - Bump arvo compatibility layer `avroutil` dependency from `0.1.11` to `0.2.17` for Arvo Upgrade HI.
 - Setup the base infra for generating new fluent api client bindings.
-- Fix the restriction of empty union validation from wide open to only allow when there is a projection in the union
 
 ## [29.12.0] - 2020-12-02
 - Add a boolean flag as header for symbol table request to avoid conflict with resource requests.
@@ -28,8 +28,8 @@ and what APIs have changed, if applicable.
 - Enable cycle check when serializing only when assertions are enabled, to avoid severe performance degradation at high QPS due to ThreadLocal slowdown.
 
 ## [29.11.2] - 2020-11-23
-- Enhance request symbol table fetch. 
-  - Return null if uri prefix doesn't match. 
+- Enhance request symbol table fetch.
+  - Return null if uri prefix doesn't match.
   - If the fetch call 404s internally store an empty symbol table and return null. This will avoid repeated invocations to services that are not yet ready to support symbol tables
 
 ## [29.11.1] - 2020-11-20
@@ -38,7 +38,7 @@ and what APIs have changed, if applicable.
   - Also, if there are projection, the projection will apply to empty union if it is projected.
 
 ## [29.10.1] - 2020-11-19
-- Fix bug where records wrapping the same map were not updated when setter was invoked on one record. 
+- Fix bug where records wrapping the same map were not updated when setter was invoked on one record.
 
 ## [29.10.0] - 2020-11-18
 - Fix relative load balancer log. Bumping the minor version so that it can be picked up by LinkedIn internal services.
@@ -53,7 +53,7 @@ and what APIs have changed, if applicable.
 - By default, Pegasus Plugin's generated files (for GenerateDataTemplateTask and GenerateRestClientTask Gradle Tasks) are created with lower case file system paths. (There is an optional flag at the Gradle task level to change this behavior.)
 
 ## [29.8.4] - 2020-11-09
-- Adding required record field is allowed and should be considered as backward compatible change in extension schemas. 
+- Adding required record field is allowed and should be considered as backward compatible change in extension schemas.
 
 ## [29.8.3] - 2020-11-09
 - Support symbolTable requests with suffixes
@@ -116,7 +116,7 @@ Log Streaming Error or Timeout Error in Jetty SyncIOHandler
 
 ## [29.7.3] - 2020-10-02
 - Bump `parseq` dependency from `2.6.31` to `4.1.6`.
-- Add `checkPegasusSchemaSnapshot` task. 
+- Add `checkPegasusSchemaSnapshot` task.
    - The task will be used to check any pegasus schema compatible and incompatible changes.
    - The pegasus schema may or may not be part of a Rest.li resource.
    - The task will be triggered at build time, if user provides gradle property: `pegasusPlugin.enablePegasusSchemaCompatibilityCheck=true`.
@@ -4780,8 +4780,13 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
+<<<<<<< HEAD
 [Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.0...master
 [29.13.0]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.13.0
+=======
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.12.1...master
+[29.12.1]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.12.1
+>>>>>>> bd549e7ff (bump version)
 [29.12.0]: https://github.com/linkedin/rest.li/compare/v29.11.3...v29.12.0
 [29.11.3]: https://github.com/linkedin/rest.li/compare/v29.11.2...v29.11.3
 [29.11.2]: https://github.com/linkedin/rest.li/compare/v29.11.1...v29.11.2

--- a/data/src/main/java/com/linkedin/data/schema/UnionDataSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/UnionDataSchema.java
@@ -37,9 +37,11 @@ import static com.linkedin.data.schema.DataSchemaConstants.RESTRICTED_UNION_ALIA
 public final class UnionDataSchema extends ComplexDataSchema
 {
   /**
-   *
+   * If this is set to true, this is schema will be  a partial schema
+   * created from projection. It is internal use only to represent a
+   * subset of members in the union.
    */
-  private boolean allowEmptyUnionResponse = false;
+  private boolean isPartialSchema = false;
 
   /**
    * Class for representing a member inside a Union
@@ -463,13 +465,18 @@ public final class UnionDataSchema extends ComplexDataSchema
 
   private static final Map<String, Integer> _emptyTypesToIndexMap = Collections.emptyMap();
 
-  public void setAllowEmptyUnionResponse(boolean allowEmptyUnionResponse)
+  /**
+   * This set/get pair methods are used internal only to specify a boolean flag
+   * for partial union schema.
+   * @param partialSchema
+   */
+  public void setPartialSchema(boolean partialSchema)
   {
-    this.allowEmptyUnionResponse = allowEmptyUnionResponse;
+    this.isPartialSchema = partialSchema;
   }
 
-  public boolean isAllowEmptyUnionResponse()
+  public boolean isPartialSchema()
   {
-    return this.allowEmptyUnionResponse;
+    return this.isPartialSchema;
   }
 }

--- a/data/src/main/java/com/linkedin/data/schema/UnionDataSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/UnionDataSchema.java
@@ -37,6 +37,11 @@ import static com.linkedin.data.schema.DataSchemaConstants.RESTRICTED_UNION_ALIA
 public final class UnionDataSchema extends ComplexDataSchema
 {
   /**
+   *
+   */
+  private boolean allowEmptyUnionResponse = false;
+
+  /**
    * Class for representing a member inside a Union
    */
   public static class Member implements Cloneable
@@ -457,4 +462,14 @@ public final class UnionDataSchema extends ComplexDataSchema
   private boolean _membersAliased = false;
 
   private static final Map<String, Integer> _emptyTypesToIndexMap = Collections.emptyMap();
+
+  public void setAllowEmptyUnionResponse(boolean allowEmptyUnionResponse)
+  {
+    this.allowEmptyUnionResponse = allowEmptyUnionResponse;
+  }
+
+  public boolean isAllowEmptyUnionResponse()
+  {
+    return this.allowEmptyUnionResponse;
+  }
 }

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -526,6 +526,10 @@ public final class ValidateDataAgainstSchema
             validate(memberElement, memberSchema, value);
           }
         }
+        else if (!schema.isAllowEmptyUnionResponse())
+        {
+          addMessage(element, "DataMap should have at least one entry for a union type or specify the member in projection");
+        }
       }
       else
       {

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -23,7 +23,6 @@ import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.Null;
 import com.linkedin.data.element.DataElement;
-import com.linkedin.data.element.DataElementUtil;
 import com.linkedin.data.element.MutableDataElement;
 import com.linkedin.data.element.SimpleDataElement;
 import com.linkedin.data.it.IterationOrder;
@@ -526,7 +525,7 @@ public final class ValidateDataAgainstSchema
             validate(memberElement, memberSchema, value);
           }
         }
-        else if (!schema.isAllowEmptyUnionResponse())
+        else if (!schema.isPartialSchema())
         {
           addMessage(element, "DataMap should have at least one entry for a union type or specify the member in projection");
         }

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -527,7 +527,7 @@ public final class ValidateDataAgainstSchema
         }
         else if (!schema.isPartialSchema())
         {
-          addMessage(element, "DataMap should have at least one entry for a union type or specify the member in projection");
+          addMessage(element, "DataMap should have at least one entry for a union type");
         }
       }
       else

--- a/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
+++ b/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
@@ -1096,7 +1096,6 @@ public class TestValidation
     Object goodObjects[] =
     {
         Data.NULL,
-        new DataMap(),
         new DataMap(asMap("int", new Integer(1))),
         new DataMap(asMap("string", "x")),
         new DataMap(asMap("Fruits", "APPLE")),
@@ -1112,6 +1111,7 @@ public class TestValidation
         new Double(1),
         new String(),
         new DataList(),
+        new DataMap(),
         new DataMap(asMap("int", new Boolean(true))),
         new DataMap(asMap("int", new String("1"))),
         new DataMap(asMap("int", new Long(1L))),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.13.0
+version=29.13.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/java/com/linkedin/restli/common/util/ProjectionMaskApplier.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/util/ProjectionMaskApplier.java
@@ -215,7 +215,7 @@ public class ProjectionMaskApplier
 
     UnionDataSchema newUnionDataSchema = new UnionDataSchema();
     newUnionDataSchema.setMembers(newUnionMembers, errorMessageBuilder);
-    if (newUnionMembers.size() > 0 && unionDataSchema.getMembers().size() > newUnionMembers.size())
+    if (unionDataSchema.getMembers().size() > newUnionMembers.size())
     {
       newUnionDataSchema.setPartialSchema(true);
     }

--- a/restli-common/src/main/java/com/linkedin/restli/common/util/ProjectionMaskApplier.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/util/ProjectionMaskApplier.java
@@ -215,9 +215,9 @@ public class ProjectionMaskApplier
 
     UnionDataSchema newUnionDataSchema = new UnionDataSchema();
     newUnionDataSchema.setMembers(newUnionMembers, errorMessageBuilder);
-    if (newUnionMembers.size() > 0)
+    if (newUnionMembers.size() > 0 && unionDataSchema.getMembers().size() > newUnionMembers.size())
     {
-      newUnionDataSchema.setAllowEmptyUnionResponse(true);
+      newUnionDataSchema.setPartialSchema(true);
     }
 
     if (unionDataSchema.getProperties() != null)

--- a/restli-common/src/main/java/com/linkedin/restli/common/util/ProjectionMaskApplier.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/util/ProjectionMaskApplier.java
@@ -215,6 +215,11 @@ public class ProjectionMaskApplier
 
     UnionDataSchema newUnionDataSchema = new UnionDataSchema();
     newUnionDataSchema.setMembers(newUnionMembers, errorMessageBuilder);
+    if (newUnionMembers.size() > 0)
+    {
+      newUnionDataSchema.setAllowEmptyUnionResponse(true);
+    }
+
     if (unionDataSchema.getProperties() != null)
     {
       newUnionDataSchema.setProperties(unionDataSchema.getProperties());

--- a/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.emptyUnion.restspec.json
+++ b/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.emptyUnion.restspec.json
@@ -1,0 +1,20 @@
+{
+  "name" : "emptyUnion",
+  "namespace" : "com.linkedin.restli.examples.greetings.client",
+  "path" : "/emptyUnion",
+  "schema" : "com.linkedin.restli.examples.greetings.api.ValidateEmptyUnion",
+  "doc" : "Resource for testing Rest.li empty union data validation.\n\ngenerated from: com.linkedin.restli.examples.greetings.server.ValidateEmptyUnionResource",
+  "collection" : {
+    "identifier" : {
+      "name" : "emptyUnionId",
+      "type" : "long"
+    },
+    "supports" : [ "get" ],
+    "methods" : [ {
+      "method" : "get"
+    } ],
+    "entity" : {
+      "path" : "/emptyUnion/{emptyUnionId}"
+    }
+  }
+}

--- a/restli-int-test-api/src/main/pegasus/com/linkedin/restli/examples/greetings/api/ValidateEmptyUnion.pdl
+++ b/restli-int-test-api/src/main/pegasus/com/linkedin/restli/examples/greetings/api/ValidateEmptyUnion.pdl
@@ -1,0 +1,5 @@
+namespace com.linkedin.restli.examples.greetings.api
+
+record ValidateEmptyUnion {
+  foo: union[bar: string, fuzz: int]
+}

--- a/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.emptyUnion.snapshot.json
+++ b/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.emptyUnion.snapshot.json
@@ -1,0 +1,37 @@
+{
+  "models" : [ {
+    "type" : "record",
+    "name" : "ValidateEmptyUnion",
+    "namespace" : "com.linkedin.restli.examples.greetings.api",
+    "fields" : [ {
+      "name" : "foo",
+      "type" : [ {
+        "alias" : "bar",
+        "type" : "string"
+      }, {
+        "alias" : "fuzz",
+        "type" : "int"
+      } ]
+    } ]
+  } ],
+  "schema" : {
+    "name" : "emptyUnion",
+    "namespace" : "com.linkedin.restli.examples.greetings.client",
+    "path" : "/emptyUnion",
+    "schema" : "com.linkedin.restli.examples.greetings.api.ValidateEmptyUnion",
+    "doc" : "Resource for testing Rest.li empty union data validation.\n\ngenerated from: com.linkedin.restli.examples.greetings.server.ValidateEmptyUnionResource",
+    "collection" : {
+      "identifier" : {
+        "name" : "emptyUnionId",
+        "type" : "long"
+      },
+      "supports" : [ "get" ],
+      "methods" : [ {
+        "method" : "get"
+      } ],
+      "entity" : {
+        "path" : "/emptyUnion/{emptyUnionId}"
+      }
+    }
+  }
+}

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/ValidateEmptyUnionResource.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/ValidateEmptyUnionResource.java
@@ -1,0 +1,41 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.restli.examples.greetings.server;
+
+import com.linkedin.restli.examples.greetings.api.ValidateEmptyUnion;
+import com.linkedin.restli.internal.server.util.DataMapUtils;
+import com.linkedin.restli.server.annotations.RestLiCollection;
+import com.linkedin.restli.server.resources.CollectionResourceTemplate;
+
+
+/**
+ * Resource for testing Rest.li empty union data validation.
+ * @author Brian Pin
+ */
+@RestLiCollection(name = "emptyUnion", namespace = "com.linkedin.restli.examples.greetings.client")
+public class ValidateEmptyUnionResource extends CollectionResourceTemplate<Long, ValidateEmptyUnion>
+{
+  // write some resource method to provide the data of the ValidateEmptyUnion record
+  @Override
+  public ValidateEmptyUnion get(Long keyId)
+  {
+    ValidateEmptyUnion union = new ValidateEmptyUnion();
+    ValidateEmptyUnion.Foo foo = new ValidateEmptyUnion.Foo();
+    union.setFoo(foo);
+    return union;
+  }
+}

--- a/restli-int-test-server/src/test/java/com/linkedin/restli/docgen/TestResourceSchemaCollection.java
+++ b/restli-int-test-server/src/test/java/com/linkedin/restli/docgen/TestResourceSchemaCollection.java
@@ -136,6 +136,7 @@ public class TestResourceSchemaCollection
     expectedTypes.put("com.linkedin.restli.examples.greetings.client.complexKeyAltKey", ResourceType.COLLECTION);
     expectedTypes.put("com.linkedin.restli.examples.greetings.client.altKey.altKeySub", ResourceType.COLLECTION);
     expectedTypes.put("com.linkedin.restli.examples.defaults.api.fillInDefaults", ResourceType.COLLECTION);
+    expectedTypes.put("com.linkedin.restli.examples.greetings.client.emptyUnion", ResourceType.COLLECTION);
 
     for (Map.Entry<String, ResourceSchema> entry: _schemas.getResources().entrySet())
     {

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestEmptyUnionValidation.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestEmptyUnionValidation.java
@@ -1,0 +1,78 @@
+/*
+   Copyright (c) 2018 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.restli.examples;
+
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.client.GetRequest;
+import com.linkedin.restli.client.Request;
+import com.linkedin.restli.client.Response;
+import com.linkedin.restli.client.RestLiResponseException;
+import com.linkedin.restli.common.BatchCollectionResponse;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.examples.greetings.api.ValidateEmptyUnion;
+import com.linkedin.restli.examples.greetings.api.ValidationDemo;
+import com.linkedin.restli.examples.greetings.api.ValidationDemoCriteria;
+import com.linkedin.restli.examples.greetings.client.EmptyUnionRequestBuilders;
+import com.linkedin.restli.examples.greetings.client.GreetingsBuilders;
+import com.linkedin.restli.examples.greetings.client.ValidationDemosRequestBuilders;
+import com.linkedin.restli.server.validation.RestLiValidationFilter;
+import com.linkedin.restli.test.util.RootBuilderWrapper;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TestEmptyUnionValidation extends RestLiIntegrationTest
+{
+  @BeforeClass
+  public void initClass() throws Exception
+  {
+    super.init(Collections.singletonList(new RestLiValidationFilter()));
+  }
+
+  @AfterClass
+  public void shutDown() throws Exception
+  {
+    super.shutdown();
+  }
+
+  @Test
+  public void testUnionEmptyWithProjection() throws RemoteInvocationException
+  {
+    ValidateEmptyUnion expected = new ValidateEmptyUnion();
+    expected.setFoo(new ValidateEmptyUnion.Foo());
+    List<PathSpec> spec = Collections.singletonList(ValidateEmptyUnion.fields().foo().Fuzz());
+    EmptyUnionRequestBuilders requestBuilders = new EmptyUnionRequestBuilders();
+    GetRequest<ValidateEmptyUnion> req = requestBuilders.get().id(1L).fields(spec.toArray(new PathSpec[spec.size()])).build();
+    ValidateEmptyUnion actual = getClient().sendRequest(req).getResponse().getEntity();
+    Assert.assertEquals(actual, expected);
+  }
+
+  @Test(expectedExceptions = RestLiResponseException.class)
+  public void testUnionEmptyWithoutProjection() throws RemoteInvocationException {
+    String expectedSuffix = "projection";
+    EmptyUnionRequestBuilders requestBuilders = new EmptyUnionRequestBuilders();
+    GetRequest<ValidateEmptyUnion> req = requestBuilders.get().id(1L).build();
+    ValidateEmptyUnion res = getClient().sendRequest(req).getResponse().getEntity();
+  }
+}

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestEmptyUnionValidation.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestEmptyUnionValidation.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2018 LinkedIn Corp.
+   Copyright (c) 2020 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,26 +19,16 @@ package com.linkedin.restli.examples;
 import com.linkedin.data.schema.PathSpec;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.restli.client.GetRequest;
-import com.linkedin.restli.client.Request;
-import com.linkedin.restli.client.Response;
 import com.linkedin.restli.client.RestLiResponseException;
-import com.linkedin.restli.common.BatchCollectionResponse;
-import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.examples.greetings.api.ValidateEmptyUnion;
-import com.linkedin.restli.examples.greetings.api.ValidationDemo;
-import com.linkedin.restli.examples.greetings.api.ValidationDemoCriteria;
 import com.linkedin.restli.examples.greetings.client.EmptyUnionRequestBuilders;
-import com.linkedin.restli.examples.greetings.client.GreetingsBuilders;
-import com.linkedin.restli.examples.greetings.client.ValidationDemosRequestBuilders;
 import com.linkedin.restli.server.validation.RestLiValidationFilter;
-import com.linkedin.restli.test.util.RootBuilderWrapper;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestEmptyUnionValidation.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestEmptyUnionValidation.java
@@ -69,10 +69,23 @@ public class TestEmptyUnionValidation extends RestLiIntegrationTest
   }
 
   @Test(expectedExceptions = RestLiResponseException.class)
-  public void testUnionEmptyWithoutProjection() throws RemoteInvocationException {
+  public void testUnionEmptyWithoutProjection() throws RemoteInvocationException
+  {
     String expectedSuffix = "projection";
     EmptyUnionRequestBuilders requestBuilders = new EmptyUnionRequestBuilders();
     GetRequest<ValidateEmptyUnion> req = requestBuilders.get().id(1L).build();
     ValidateEmptyUnion res = getClient().sendRequest(req).getResponse().getEntity();
+  }
+
+  @Test(expectedExceptions = RestLiResponseException.class)
+  public void testFailValidationWithFullUnionMemberProjection() throws RemoteInvocationException {
+    ValidateEmptyUnion expected = new ValidateEmptyUnion();
+    expected.setFoo(new ValidateEmptyUnion.Foo());
+    List<PathSpec> spec = Arrays.asList(
+        ValidateEmptyUnion.fields().foo().Fuzz(),
+        ValidateEmptyUnion.fields().foo().Bar());
+    EmptyUnionRequestBuilders requestBuilders = new EmptyUnionRequestBuilders();
+    GetRequest<ValidateEmptyUnion> req = requestBuilders.get().id(1L).fields(spec.toArray(new PathSpec[spec.size()])).build();
+    ValidateEmptyUnion actual = getClient().sendRequest(req).getResponse().getEntity();
   }
 }


### PR DESCRIPTION
Before this fix, the RestLiValidationFilter will allow empty union to pass, i.e if there is a union that is an empty map, when doing the validation. 
That is too wide open and risky. So this fix, change it  restricted only when a projection is specified in the union.