### PR TITLE
Fix validation for ActionResult return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Fix build-time validation of Action methods that return custom typerefs (e.g. `CustomLong`) yet don't indicate the
+  corresponding typeref class (e.g. `CustomLongRef.class`) in the `@Action` annotation.
+  - Clearly state that the `returnTyperef` annotation element is required for custom tyeprefs.
+  - Catch previously-unhandled reflection exception for `ActionResult`-wrapped return types (e.g. `ActionResult<CustomLong>`).
 
 ## [29.22.14] - 2021-11-24
 - Fix bug where content type was not set for stream requests

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestModelConstants.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestModelConstants.java
@@ -148,6 +148,9 @@ public interface RestModelConstants
       AbstractMapTemplate[].class
   };
 
+  /*
+   * This doesn't include ActionResult because the enclosed type parameter of ActionResult is what's validated.
+   */
   Class<?>[] VALID_ACTION_RETURN_TYPES = new Class<?>[] {
       Void.TYPE,
       boolean.class,
@@ -167,7 +170,6 @@ public interface RestModelConstants
       FixedTemplate.class,
       AbstractArrayTemplate.class,
       AbstractMapTemplate.class,
-      ActionResult.class,
 
       boolean[].class,
       Boolean[].class,


### PR DESCRIPTION
Validate the type parameter of `ActionResult`, not `ActionResult` itself. Also improve the build error message for cases where an Action method's return type is a custom typeref but the `@Action` parameter doesn't specify a `returnTyperef` attribute.

Context:

For an Action method that has a custom typeref return type (e.g. `CustomLong`) yet doesn't indicate in the `@Action` parameter that it has a typeref class (e.g. `CustomLongRef.class`), the error will show up as the following:
- If the return type is `CustomLong`: `com.linkedin.restli.server.ResourceConfigException: @Action method 'doAction' on class 'com.example.impl.ExampleResource' has an invalid return type 'com.example.CustomLong'. Expected a DataTemplate or a primitive`
- If the return type is `ActionResult<CustomLong>`: an unhandled reflection exception.

After this change, the error message will be this for both `CustomLong` and `ActionResult<CustomLong>`: `com.linkedin.restli.server.ResourceConfigException: @Action method 'doAction' on class 'com.example.impl.ExampleResource' has an invalid return type 'com.example.CustomLong'. Expected a DataTemplate or a primitive, or expected returnTyperef to be specified in the @Action annotation.`

A couple notes:
- I'm not sure if `getLogicalReturnClass(method)` was used instead of the `returnClass` parameter (which is more accurate because it also unwraps `ActionResult`) on purpose, but using `returnClass` would be accurate as it would make validation consistent between return types `T` and `ActionResult<T>`.
- I just added more text to the existing exception, but would it make sense to check if the custom coercer exists and to display a more specific error message?
- This is backward-incompatible because it removes `ActionResult` from the set of acceptable Action return types (it shouldn't be there if we're checking the logical return type).