### PR TITLE
Fix extra whitespace at the end of the line in the pegasus schema snapshot files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.13.3] - 2021-01-06
 - Add support for accessing schema statically from generated template classes and for getting symbol properties from enum schema properties.
+- Fix extra whitespaces at the end of the line in the pegasus snapshot files.
 
 ## [29.13.2] - 2020-12-23
 - Implement overload failure client-side retry.
@@ -4786,7 +4789,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.3...master
+[29.13.3]: https://github.com/linkedin/rest.li/compare/v29.13.2...v29.13.3
 [29.13.2]: https://github.com/linkedin/rest.li/compare/v29.13.1...v29.13.2
 [29.13.1]: https://github.com/linkedin/rest.li/compare/v29.13.0...v29.13.1
 [29.13.0]: https://github.com/linkedin/rest.li/compare/v29.12.0...v29.13.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.13.2
+version=29.13.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/gen/PegasusSchemaSnapshotExporter.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/snapshot/gen/PegasusSchemaSnapshotExporter.java
@@ -115,9 +115,12 @@ public class PegasusSchemaSnapshotExporter
     schemaToPdlEncoder.setTypeReferenceFormat(AbstractSchemaEncoder.TypeReferenceFormat.DENORMALIZE);
     schemaToPdlEncoder.encode(dataSchema);
 
+    // Remove extra whitespace at the end of each line
+    String fileString = stringWriter.toString().replaceAll(" " + System.lineSeparator(), System.lineSeparator());
+
     File generatedSnapshotFile = new File(outputDir, fileName + PDL);
 
-    Files.write(generatedSnapshotFile.toPath(), stringWriter.toString().getBytes(StandardCharsets.UTF_8));
+    Files.write(generatedSnapshotFile.toPath(), fileString.getBytes(StandardCharsets.UTF_8));
   }
 
   private static String getFileExtension(String fileName)


### PR DESCRIPTION
This PR is a fix to remove extra whitespace at the end of the line in the pegasus schema snapshot files.

Test: generated snapshot and tested against dr-restaurants mp.
