### PR TITLE
Update translate schemas task to look in the input folder first when resolving schemas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.13.5] - 2021-01-06
+- Improve logging when conflicts are detected during parsing. Update translate schemas task to look in the input folder first when resolving schemas.
+
 ## [29.13.4] - 2021-01-07
 - Change listeners should not be added to readonly maps.
 
@@ -4792,7 +4795,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.5...master
+[29.13.5]: https://github.com/linkedin/rest.li/compare/v29.13.4...v29.13.5
 [29.13.4]: https://github.com/linkedin/rest.li/compare/v29.13.3...v29.13.4
 [29.13.3]: https://github.com/linkedin/rest.li/compare/v29.13.2...v29.13.3
 [29.13.2]: https://github.com/linkedin/rest.li/compare/v29.13.1...v29.13.2

--- a/data/src/main/java/com/linkedin/data/schema/AbstractSchemaParser.java
+++ b/data/src/main/java/com/linkedin/data/schema/AbstractSchemaParser.java
@@ -157,10 +157,18 @@ abstract public class AbstractSchemaParser implements PegasusSchemaParser
     }
     if (ok)
     {
-      DataSchema found = getResolver().existingDataSchema(name.getFullName());
+      DataSchemaLocation found = getResolver().existingSchemaLocation(name.getFullName());
       if (found != null)
       {
-        startErrorMessage(name).append("\"").append(name.getFullName()).append("\" already defined as " + found + ".\n");
+        if (found == DataSchemaLocation.NO_LOCATION)
+        {
+          startErrorMessage(name).append("\"").append(name.getFullName())
+                  .append("\" already defined as " + getResolver().existingDataSchema(name.getFullName()) + ".\n");
+        }
+        else
+        {
+          startErrorMessage(name).append("\"").append(name.getFullName()).append("\" already defined at " + found + ".\n");
+        }
         ok = false;
       }
       else

--- a/data/src/main/java/com/linkedin/data/schema/DataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/DataSchemaResolver.java
@@ -97,6 +97,21 @@ public interface DataSchemaResolver
   NamedDataSchema existingDataSchema(String name);
 
   /**
+   * Lookup existing {@link NamedDataSchema}'s location with the specified name.
+   *
+   * This is a pure lookup operation. If a {@link NamedDataSchema} with the specified
+   * name does not already exist, then this method will return null, else it
+   * returns the location of the existing {@link NamedDataSchema}.
+   *
+   * @param name of the schema to find.
+   * @return the {@link DataSchemaLocation} if the schema already exists, else return null.
+   */
+  default DataSchemaLocation existingSchemaLocation(String name)
+  {
+    return nameToDataSchemaLocations().get(name);
+  }
+
+  /**
    * Return whether the specified {@link DataSchemaLocation} has been associated with a name.
    *
    * @param location provides the {@link DataSchemaLocation} to check.

--- a/data/src/main/java/com/linkedin/data/schema/resolver/AbstractMultiFormatDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/AbstractMultiFormatDataSchemaResolver.java
@@ -131,6 +131,20 @@ public abstract class AbstractMultiFormatDataSchemaResolver implements DataSchem
   }
 
   @Override
+  public DataSchemaLocation existingSchemaLocation(String name)
+  {
+    for (DataSchemaResolver resolver: _resolvers)
+    {
+      DataSchemaLocation result = resolver.existingSchemaLocation(name);
+      if (result != null)
+      {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  @Override
   public boolean locationResolved(DataSchemaLocation location)
   {
     for (DataSchemaResolver resolver: _resolvers)

--- a/data/src/test/java/com/linkedin/data/schema/generator/TestAbstractGenerator.java
+++ b/data/src/test/java/com/linkedin/data/schema/generator/TestAbstractGenerator.java
@@ -191,7 +191,7 @@ public class TestAbstractGenerator
 
   Map<String, String> _badPegasusSchemas = asMap(
     "/error/b/c/error.pdsc", "size must not be negative",
-    "/error/b/c/redefine1.pdsc", "already defined as",
+    "/error/b/c/redefine1.pdsc", "already defined at",
     "/error/b/c/enumValueDocError.pdsc", "symbol has an invalid documentation value"
   );
 

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
@@ -245,7 +245,7 @@ public class TestDataSchemaResolver
       {
         "redefine1",
         ERROR,
-        "already defined as"
+        "\"redefine1\" already defined at"
       },
   };
 

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/TranslateSchemasTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/TranslateSchemasTask.java
@@ -44,7 +44,7 @@ public class TranslateSchemasTask extends DefaultTask {
     getProject().getLogger().info("Translating data schemas ...");
     _destinationDir.mkdirs();
 
-    String resolverPathStr = _resolverPath.plus(getProject().files(_inputDir)).getAsPath();
+    String resolverPathStr = getProject().files(_inputDir).plus(_resolverPath).getAsPath();
 
     FileCollection _pathedCodegenClasspath;
     try

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/TranslateSchemasTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/TranslateSchemasTask.java
@@ -44,6 +44,8 @@ public class TranslateSchemasTask extends DefaultTask {
     getProject().getLogger().info("Translating data schemas ...");
     _destinationDir.mkdirs();
 
+    // Adding the input dir first in resolver path as some usecases keep overridden schemas locally.
+    // Resolving to pick them first ensures the override logic works correctly.
     String resolverPathStr = getProject().files(_inputDir).plus(_resolverPath).getAsPath();
 
     FileCollection _pathedCodegenClasspath;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.13.4
+version=29.13.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Improve logging when conflicts are detected during parsing. Message now specifies the location of the conflict instead of printing the schema. Having the location is more useful to resolve conflict errors.