### PR TITLE
Detect and resolve naming conflits for unnamed inner types(array, map and union).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Java does not allow inner class names to be same as enclosing classes. Detect and resolve such naming conflits for unnamed inner types(array, map and union).
 
 ## [29.13.6] - 2021-01-07
 - Fix for "pegasus to avro translation of UnionWithAlias RecordFeidls does not have field properties"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.13.7] - 2021-01-08
 - Java does not allow inner class names to be same as enclosing classes. Detect and resolve such naming conflits for unnamed inner types(array, map and union).
 
 ## [29.13.6] - 2021-01-07
@@ -4799,7 +4801,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.7...master
+[29.13.7]: https://github.com/linkedin/rest.li/compare/v29.13.6...v29.13.7
 [29.13.6]: https://github.com/linkedin/rest.li/compare/v29.13.5...v29.13.6
 [29.13.5]: https://github.com/linkedin/rest.li/compare/v29.13.4...v29.13.5
 [29.13.4]: https://github.com/linkedin/rest.li/compare/v29.13.3...v29.13.4

--- a/generator-test/src/test/java/com/linkedin/data/schema/generator/TestPegasusDataTemplateGenerator.java
+++ b/generator-test/src/test/java/com/linkedin/data/schema/generator/TestPegasusDataTemplateGenerator.java
@@ -7,6 +7,7 @@ import com.linkedin.pegasus.generator.test.StringUnionRecord;
 import com.linkedin.pegasus.generator.test.unnamed.UnionNameConflict;
 import com.linkedin.pegasus.generator.test.unnamed.UnionNameConflictArray;
 import com.linkedin.pegasus.generator.test.unnamed.UnionNameConflictMap;
+import com.linkedin.pegasus.generator.test.unnamed.records.SimpleArray;
 import java.io.IOException;
 
 import org.testng.annotations.Test;
@@ -40,5 +41,6 @@ public class TestPegasusDataTemplateGenerator
     UnionNameConflictMap.UnionNameConflictMap$Map unionMap;
     UnionNameConflictMap.UnionNameConflictMap$Union unionMapUnion;
     UnionNameConflictMap.UnionNameConflictMap$UnionMap unionMap2;
+    SimpleArray simpleArray;
   }
 }

--- a/generator-test/src/test/java/com/linkedin/data/schema/generator/TestPegasusDataTemplateGenerator.java
+++ b/generator-test/src/test/java/com/linkedin/data/schema/generator/TestPegasusDataTemplateGenerator.java
@@ -4,6 +4,9 @@ package com.linkedin.data.schema.generator;
 import com.linkedin.pegasus.generator.test.IntUnionRecord;
 import com.linkedin.pegasus.generator.test.StringUnionRecord;
 
+import com.linkedin.pegasus.generator.test.unnamed.UnionNameConflict;
+import com.linkedin.pegasus.generator.test.unnamed.UnionNameConflictArray;
+import com.linkedin.pegasus.generator.test.unnamed.UnionNameConflictMap;
 import java.io.IOException;
 
 import org.testng.annotations.Test;
@@ -23,5 +26,19 @@ public class TestPegasusDataTemplateGenerator
     // add usage to ensure the import will not be automatically trimmed by IDE
     IntUnionRecord.IntUnion intUnion;
     StringUnionRecord.StringUnion stringUnion;
+  }
+
+  @Test
+  public void testIncludeUnionConflictResolution() throws IOException
+  {
+    // add usage to ensure the import will not be automatically trimmed by IDE
+    UnionNameConflict.UnionNameConflict$Union union;
+    UnionNameConflict.UnionNameConflictUnion union2;
+    UnionNameConflictArray.UnionNameConflictArray$Array unionArray;
+    UnionNameConflictArray.UnionNameConflictArray$Union unionArrayUnion;
+    UnionNameConflictArray.UnionNameConflictArray$UnionArray unionArray2;
+    UnionNameConflictMap.UnionNameConflictMap$Map unionMap;
+    UnionNameConflictMap.UnionNameConflictMap$Union unionMapUnion;
+    UnionNameConflictMap.UnionNameConflictMap$UnionMap unionMap2;
   }
 }

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/SimpleArray.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/SimpleArray.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.pegasus.generator.test.unnamed
+
+import com.linkedin.pegasus.generator.test.unnamed.records.Simple
+
+record SimpleArray {
+  // This tests checks that SimpleArray will be created in the same namespace as the Simple record (not inlined here).
+  // So there is no naming conflict for the array type.
+  records: array[Simple]
+}

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/UnionNameConflict.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/UnionNameConflict.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.pegasus.generator.test.unnamed
+
+record UnionNameConflict {
+  // Inner class will be named UnionNameConflict$Union to avoid name conflict with record's class
+  unionNameConflict: union [int, string]
+
+  // Inner class will be named UnionNameConflictUnion
+  unionNameConflictUnion: union [int, string]
+}

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/UnionNameConflictArray.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/UnionNameConflictArray.pdl
@@ -1,0 +1,10 @@
+namespace com.linkedin.pegasus.generator.test.unnamed
+
+record UnionNameConflictArray {
+  // Union's inner class should be UnionNameConflict, the array class will be UnionNameConflictArray$Array to avoid
+  // naming conflict with record class.
+  unionNameConflict: array[union[int, string]]
+  // Union's inner class should be UnionNameConflictArray$Union to avoid naming conflict, and the array class will be
+  // UnionNameConflictArray$UnionArray
+  unionNameConflictArray: array[union[int, string]]
+}

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/UnionNameConflictMap.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/UnionNameConflictMap.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.pegasus.generator.test.unnamed
+
+record UnionNameConflictMap {
+  // Union's inner class should be UnionNameConflict, the map class will be UnionNameConflictMap$Map
+  unionNameConflict: map[string, union[int, string]]
+  // Union's inner class should be UnionNameConflictMap$Union, the map class will be UnionNameConflictMap$UnionMap
+  unionNameConflictMap: map[string, union[int, string]]
+}

--- a/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/records/Simple.pdl
+++ b/generator-test/src/test/pegasus/com/linkedin/pegasus/generator/test/unnamed/records/Simple.pdl
@@ -1,0 +1,11 @@
+namespace com.linkedin.pegasus.generator.test.unnamed.records
+
+/**
+ * A simple record
+ */
+record Simple {
+  /**
+   * A simple field
+   */
+  message: optional string
+}

--- a/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
@@ -924,8 +924,7 @@ public class TemplateSpecGenerator
       if (ancestorClass.getClassName().equals(className))
       {
         className = className + CLASS_NAME_SUFFIX_SEPARATOR + suffix;
-        // Check for name conflict from the immediate enclosing class again.
-        ancestorClass = enclosingClass;
+        break;
       }
       else
       {

--- a/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
@@ -832,7 +832,12 @@ public class TemplateSpecGenerator
           final ClassInfo classInfo = classNameForUnnamedTraverse(enclosingClass, memberName, arraySchema.getItems());
           // Add just the "Array" suffix first. This is to ensure backwards compatibility with the old codegen logic.
           String className = classInfo.name + ARRAY_SUFFIX;
-          className = resolveInnerClassName(enclosingClass, className, ARRAY_SUFFIX);
+          // If this array is for an unnamed inner type (e.g, union) then this will be inner class. So, ensure the Array
+          // class name doesn't conflict with ancestor class names.
+          if (enclosingClass != null && classInfo.namespace.equals(enclosingClass.getFullName()))
+          {
+            className = resolveInnerClassName(enclosingClass, className, ARRAY_SUFFIX);
+          }
           classInfo.name = className;
           return classInfo;
         }
@@ -848,7 +853,12 @@ public class TemplateSpecGenerator
           final ClassInfo classInfo = classNameForUnnamedTraverse(enclosingClass, memberName, mapSchema.getValues());
           // Add just the "Map" suffix first. This is to ensure backwards compatibility with the old codegen logic.
           String className = classInfo.name + MAP_SUFFIX;
-          className = resolveInnerClassName(enclosingClass, className, MAP_SUFFIX);
+          // If this map is for an unnamed inner type (e.g, union), then ensure the Map's class name doesn't conflict
+          // with ancestor class names.
+          if (enclosingClass != null && classInfo.namespace.equals(enclosingClass.getFullName()))
+          {
+            className = resolveInnerClassName(enclosingClass, className, MAP_SUFFIX);
+          }
           classInfo.name = className;
           return classInfo;
         }

--- a/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
@@ -29,7 +29,6 @@ import com.linkedin.data.schema.MapDataSchema;
 import com.linkedin.data.schema.NamedDataSchema;
 import com.linkedin.data.schema.PrimitiveDataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
-import com.linkedin.data.schema.SchemaFormatType;
 import com.linkedin.data.schema.TyperefDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.data.template.DataTemplate;
@@ -70,6 +69,10 @@ public class TemplateSpecGenerator
   private static final Logger _log = LoggerFactory.getLogger(TemplateSpecGenerator.class);
   private static final String ARRAY_SUFFIX = "Array";
   private static final String MAP_SUFFIX = "Map";
+  private static final String UNION_SUFFIX = "Union";
+  // Separator to add with the suffix for unnamed types. This should be a character allowed in java type names but not
+  // allowed in pdl identifiers.
+  private static final String CLASS_NAME_SUFFIX_SEPARATOR = "$";
   private static final String[] SPECIAL_SUFFIXES = {ARRAY_SUFFIX, MAP_SUFFIX};
 
   private final Collection<ClassTemplateSpec> _classTemplateSpecs = new LinkedHashSet<>();
@@ -827,7 +830,10 @@ public class TemplateSpecGenerator
         else
         {
           final ClassInfo classInfo = classNameForUnnamedTraverse(enclosingClass, memberName, arraySchema.getItems());
-          classInfo.name += ARRAY_SUFFIX;
+          // Add just the "Array" suffix first. This is to ensure backwards compatibility with the old codegen logic.
+          String className = classInfo.name + ARRAY_SUFFIX;
+          className = resolveInnerClassName(enclosingClass, className, ARRAY_SUFFIX);
+          classInfo.name = className;
           return classInfo;
         }
       case MAP:
@@ -840,7 +846,10 @@ public class TemplateSpecGenerator
         else
         {
           final ClassInfo classInfo = classNameForUnnamedTraverse(enclosingClass, memberName, mapSchema.getValues());
-          classInfo.name += MAP_SUFFIX;
+          // Add just the "Map" suffix first. This is to ensure backwards compatibility with the old codegen logic.
+          String className = classInfo.name + MAP_SUFFIX;
+          className = resolveInnerClassName(enclosingClass, className, MAP_SUFFIX);
+          classInfo.name = className;
           return classInfo;
         }
 
@@ -857,7 +866,8 @@ public class TemplateSpecGenerator
         }
         else
         {
-          return new ClassInfo(enclosingClass.getFullName(), CodeUtil.capitalize(memberName));
+          String className = resolveInnerClassName(enclosingClass, CodeUtil.capitalize(memberName), UNION_SUFFIX);
+          return new ClassInfo(enclosingClass.getFullName(), className);
         }
 
       case FIXED:
@@ -894,6 +904,35 @@ public class TemplateSpecGenerator
       default:
         throw unrecognizedSchemaType(enclosingClass, memberName, dereferencedDataSchema);
     }
+  }
+
+  /**
+   * Java doesn't allow inner-classnames to be same as the enclosing or ancestor class. This method takes a candidate
+   * class name for an inner class and its enclosing class and resolves to a name that doesn't conflict. It does this
+   * by adding a special separator {@link #CLASS_NAME_SUFFIX_SEPARATOR} and the provided suffix to the classname
+   * whenever a conflict is detected.
+   * The special separator is needed to ensure the new name does not conflict with classes generated from other fields.
+   * @param enclosingClass Class enclosing the inner class.
+   * @param className Candidate name for the innerclass
+   * @param suffix Suffix to add to the className if a conflict is found.
+   * @return a class name that doesn't conflict with any of the ancestor classes.
+   */
+  private String resolveInnerClassName(ClassTemplateSpec enclosingClass, String className, String suffix) {
+    ClassTemplateSpec ancestorClass = enclosingClass;
+    while (ancestorClass != null)
+    {
+      if (ancestorClass.getClassName().equals(className))
+      {
+        className = className + CLASS_NAME_SUFFIX_SEPARATOR + suffix;
+        // Check for name conflict from the immediate enclosing class again.
+        ancestorClass = enclosingClass;
+      }
+      else
+      {
+        ancestorClass = ancestorClass.getEnclosingClass();
+      }
+    }
+    return className;
   }
 
   private static class CustomClasses

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.13.6
+version=29.13.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Java doesn't allow inner class names to be same as enclosing classes. Detect and resolve such naming conflicts for unnamed inner types(array, map and union).