### PR TITLE
Allow using PathKeyParam for non-parent path keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,23 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Fix bug which prevented using the `@PathKeyParam` resource method parameter annotation for a non-parent path key (i.e. path key defined in the same resource).
+  - Users will no longer have to rely on `@PathKeysParam` as a workaround.
 
 ## [29.13.9] - 2021-01-13
-- Add max batch size support on rest.li server.
-  - Introduce MaxBatchSize annotation, which can be added on batch methods.
+- Add max batch size support on Rest.li server.
+  - Introduce the `@MaxBatchSize` annotation, which can be added on batch methods.
   - Add batch size validation based on the allowed max batch size.
   - Add resource compatibility check rules for the max batch size.
 
 ## [29.13.8] - 2021-01-13
-- Fix a critical bug in RetryClient to set retry header instead of adding a value to retry header
+- Fix a critical bug in `RetryClient` to set retry header instead of adding a value to retry header
 
 ## [29.13.7] - 2021-01-08
-- Java does not allow inner class names to be same as enclosing classes. Detect and resolve such naming conflits for unnamed inner types(array, map and union).
+- Java does not allow inner class names to be same as enclosing classes. Detect and resolve such naming conflits for unnamed inner types (array, map and union).
 
 ## [29.13.6] - 2021-01-07
-- Fix for "pegasus to avro translation of UnionWithAlias RecordFeidls does not have field properties"
+- Fix for "pegasus to avro translation of UnionWithAlias RecordFields does not have field properties"
 
 ## [29.13.5] - 2021-01-06
 - Improve logging when conflicts are detected during parsing. Update translate schemas task to look in the input folder first when resolving schemas.

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -1493,9 +1493,13 @@ public final class RestLiAnnotationReader
     return param;
   }
 
-  private static void checkIfKeyIsValid(String paramName, final Class<?> paramType, ResourceModel model)
+  /**
+   * For a given path key name and resource model, returns true if the path key exists in the resource,
+   * its parent, or any of its super-parents (if applicable).
+   */
+  private static void checkIfKeyIsValid(String keyName, ResourceModel model)
   {
-    ResourceModel nextModel = model.getParentResourceModel();
+    ResourceModel nextModel = model;
 
     while (nextModel != null)
     {
@@ -1503,7 +1507,7 @@ public final class RestLiAnnotationReader
 
       for (Key key : keys)
       {
-        if (key.getName().equals(paramName))
+        if (key.getName().equals(keyName))
         {
           return;
         }
@@ -1512,7 +1516,7 @@ public final class RestLiAnnotationReader
       nextModel = nextModel.getParentResourceModel();
     }
 
-    throw new ResourceConfigException("Parameter " + paramName + " not found in path keys of class " + model.getResourceClass());
+    throw new ResourceConfigException("Parameter " + keyName + " not found in path keys of class " + model.getResourceClass());
   }
 
   private static Parameter<?> buildPathKeyParam(final ResourceModel model,
@@ -1522,7 +1526,7 @@ public final class RestLiAnnotationReader
   {
     String paramName = annotations.get(PathKeyParam.class).value();
 
-    checkIfKeyIsValid(paramName, paramType, model);
+    checkIfKeyIsValid(paramName, model);
 
     Parameter<?> param = new Parameter<>(paramName,
                                         paramType,

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -32,6 +32,7 @@ import com.linkedin.restli.server.CreateResponse;
 import com.linkedin.restli.server.PagingContext;
 import com.linkedin.restli.server.PathKeys;
 import com.linkedin.restli.server.ResourceContext;
+import com.linkedin.restli.server.ResourceLevel;
 import com.linkedin.restli.server.UnstructuredDataReactiveReader;
 import com.linkedin.restli.server.UnstructuredDataReactiveResult;
 import com.linkedin.restli.server.UpdateResponse;
@@ -368,6 +369,27 @@ class SampleResources
   {
     @Action(name = "void")
     public void doVoid() {}
+  }
+
+  /**
+   * The following resource is used by {@link TestRestLiApiBuilder#testPathKeyParamAnnotations()}.
+   */
+
+  @RestLiCollection(name = "pathKeyParamAnnotations")
+  class PathKeyParamAnnotationsResource implements KeyValueResource<Long, EmptyRecord>
+  {
+    @Action(name = "withPathKeyParam", resourceLevel = ResourceLevel.ENTITY)
+    public void withPathKeyParam(@PathKeyParam("pathKeyParamAnnotationsId") Long id) {}
+
+    @Action(name = "withPathKeysParam", resourceLevel = ResourceLevel.ENTITY)
+    public void withPathKeysParam(@PathKeysParam PathKeys pathKeys) {}
+  }
+
+  @RestLiCollection(name = "badPathKeyParamAnnotations")
+  class BadPathKeyParamAnnotationsResource implements KeyValueResource<Long, EmptyRecord>
+  {
+    @Action(name = "withPathKeyParam", resourceLevel = ResourceLevel.ENTITY)
+    public void withPathKeyParam(@PathKeyParam("unknownId") Long id) {}
   }
 
   /**

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiApiBuilder.java
@@ -20,6 +20,7 @@ import com.linkedin.restli.common.EmptyRecord;
 import com.linkedin.restli.server.ResourceConfigException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -255,6 +256,42 @@ public class TestRestLiApiBuilder
     {
       Assert.fail(String.format("Unexpected exception:  class: %s, message: \"%s\"",
               resourceClass.getSimpleName(), exception.getMessage()));
+    }
+  }
+
+  /**
+   * Tests usage of {@link com.linkedin.restli.server.annotations.PathKeysParam} and
+   * {@link com.linkedin.restli.server.annotations.PathKeyParam} when processing the resource implementation.
+   */
+  @Test
+  public void testPathKeyParamAnnotations()
+  {
+    // Test correct use of both @PathKeyParam and @PathKeysParam
+    final Map<String, ResourceModel> resourceModels = new HashMap<>();
+    try
+    {
+      resourceModels.putAll(RestLiApiBuilder.buildResourceModels(Collections.singleton(SampleResources.PathKeyParamAnnotationsResource.class)));
+    }
+    catch (Exception exception)
+    {
+      Assert.fail(String.format("Unexpected exception: class: %s, message: \"%s\"",
+          SampleResources.PathKeyParamAnnotationsResource.class.getSimpleName(), exception.getMessage()));
+    }
+    Assert.assertEquals(1, resourceModels.size());
+    Assert.assertTrue(resourceModels.containsKey("/pathKeyParamAnnotations"));
+
+    // Test incorrect usage of @PathKeyParam (unrecognized path key name)
+    try
+    {
+      RestLiApiBuilder.buildResourceModels(Collections.singleton(SampleResources.BadPathKeyParamAnnotationsResource.class));
+      Assert.fail("Expected a ResourceConfigException due to unrecognized path key names.");
+    }
+    catch (Exception exception)
+    {
+      Assert.assertTrue(exception instanceof ResourceConfigException);
+      Assert.assertEquals("Parameter unknownId not found in path keys of class class "
+          + "com.linkedin.restli.internal.server.model.SampleResources$BadPathKeyParamAnnotationsResource",
+          exception.getMessage());
     }
   }
 }


### PR DESCRIPTION
Fix incorrect behavior for validating the `@PathKeyParam` method parameter annotation. This resulted in a build failure if specifying a path key from the current resource (rather than a parent resource). This makes the behavior consistent with the `@PathKeysParam` annotation.

For example, without this bug fix the following fails:

```
@RestLiCollection(name = "foo")
class FooResource implements KeyValueResource<Long, EmptyRecord>
{
  @Action(name = "doSomething", resourceLevel = ResourceLevel.ENTITY)
  public void doSomething(@PathKeyParam("fooId") Long id) {}
}
```

...Because the logic to validate the key name attribute inside `@PathKeyParam` iterates over the resource up through all its parents and super-parents, starting with the _first parent_ rather than _the resource itself_.