### PR TITLE
Expose resource method parameters in FilterRequestContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 - Fix bug which prevented using the `@PathKeyParam` resource method parameter annotation for a non-parent path key (i.e. path key defined in the same resource).
   - Users will no longer have to rely on `@PathKeysParam` as a workaround.
+- Expose resource method parameters in the `FilterRequestContext` interface.
 
 ## [29.13.9] - 2021-01-13
 - Add max batch size support on Rest.li server.

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/filter/FilterRequestContextInternalImpl.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/filter/FilterRequestContextInternalImpl.java
@@ -24,6 +24,7 @@ import com.linkedin.data.transform.filter.request.MaskTree;
 import com.linkedin.restli.common.ProtocolVersion;
 import com.linkedin.restli.common.ResourceMethod;
 import com.linkedin.restli.internal.server.ServerResourceContext;
+import com.linkedin.restli.internal.server.model.Parameter;
 import com.linkedin.restli.internal.server.model.ResourceMethodDescriptor;
 import com.linkedin.restli.server.PathKeys;
 import com.linkedin.restli.server.ProjectionMode;
@@ -258,6 +259,12 @@ public class FilterRequestContextInternalImpl implements FilterRequestContextInt
   public Method getMethod()
   {
     return _resourceMethod.getMethod();
+  }
+
+  @Override
+  public List<Parameter<?>> getMethodParameters()
+  {
+    return Collections.unmodifiableList(_resourceMethod.getParameters());
   }
 
   @Override

--- a/restli-server/src/main/java/com/linkedin/restli/server/filter/FilterRequestContext.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/filter/FilterRequestContext.java
@@ -19,10 +19,12 @@ package com.linkedin.restli.server.filter;
 
 import com.linkedin.data.DataMap;
 import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.transform.ImmutableList;
 import com.linkedin.data.transform.filter.request.MaskTree;
 import com.linkedin.r2.message.RequestContext;
 import com.linkedin.restli.common.ProtocolVersion;
 import com.linkedin.restli.common.ResourceMethod;
+import com.linkedin.restli.internal.server.model.Parameter;
 import com.linkedin.restli.server.CustomRequestContext;
 import com.linkedin.restli.server.PathKeys;
 import com.linkedin.restli.server.ProjectionMode;
@@ -31,6 +33,7 @@ import com.linkedin.restli.server.errors.ServiceError;
 
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -251,6 +254,17 @@ public interface FilterRequestContext extends CustomRequestContext
    * @return {@link Method}
    */
   Method getMethod();
+
+  /**
+   * Gets an immutable view of the parameters defined for the target resource method.
+   * TODO: Remove the "default" implementation in the next major version.
+   *
+   * @return list of method parameters
+   */
+  default List<Parameter<?>> getMethodParameters()
+  {
+    return Collections.unmodifiableList(Collections.emptyList());
+  }
 
   /**
    * Return the attributes from R2 RequestContext.

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/filter/TestFilterRequestContextInternalImpl.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/filter/TestFilterRequestContextInternalImpl.java
@@ -25,6 +25,7 @@ import com.linkedin.restli.internal.common.AllProtocolVersions;
 import com.linkedin.restli.internal.server.MutablePathKeys;
 import com.linkedin.restli.internal.server.PathKeysImpl;
 import com.linkedin.restli.internal.server.ServerResourceContext;
+import com.linkedin.restli.internal.server.model.Parameter;
 import com.linkedin.restli.internal.server.model.ResourceMethodDescriptor;
 import com.linkedin.restli.internal.server.model.ResourceModel;
 import com.linkedin.restli.server.ProjectionMode;
@@ -53,6 +54,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertNotSame;
 
 
 public class TestFilterRequestContextInternalImpl
@@ -79,6 +81,7 @@ public class TestFilterRequestContextInternalImpl
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testFilterRequestContextAdapter() throws Exception
   {
     final String resourceName = "resourceName";
@@ -108,6 +111,7 @@ public class TestFilterRequestContextInternalImpl
 
     final List<ServiceError> methodServiceErrors = Collections.singletonList(TestServiceError.METHOD_LEVEL_ERROR);
     final List<ServiceError> resourceServiceErrors = Collections.singletonList(TestServiceError.RESOURCE_LEVEL_ERROR);
+    final List<Parameter<?>> methodParameters = Collections.singletonList(Mockito.mock(Parameter.class));
 
     when(resourceModel.getName()).thenReturn(resourceName);
     when(resourceModel.getNamespace()).thenReturn(resourceNamespace);
@@ -119,6 +123,7 @@ public class TestFilterRequestContextInternalImpl
     when(resourceMethod.getActionName()).thenReturn(actionName);
     when(resourceMethod.getCustomAnnotationData()).thenReturn(customAnnotations);
     when(resourceMethod.getMethod()).thenReturn(null);
+    when(resourceMethod.getParameters()).thenReturn(methodParameters);
     when(resourceMethod.getServiceErrors()).thenReturn(methodServiceErrors);
 
     when(context.getProjectionMode()).thenReturn(projectionMode);
@@ -156,6 +161,8 @@ public class TestFilterRequestContextInternalImpl
     assertEquals(filterContext.getBatchFinderName(), batchFinderName);
     assertEquals(filterContext.getRequestContextLocalAttrs(), localAttrs);
     assertNull(filterContext.getMethod());
+    assertEquals(filterContext.getMethodParameters(), methodParameters);
+    assertNotSame(filterContext.getMethodParameters(), methodParameters);
     assertEquals(filterContext.getMethodServiceErrors(), methodServiceErrors);
     filterContext.getRequestHeaders().put("header2", "value2");
     assertEquals(requestHeaders.get("header2"), "value2");
@@ -169,6 +176,7 @@ public class TestFilterRequestContextInternalImpl
     verify(resourceMethod).getBatchFinderName();
     verify(resourceMethod).getActionName();
     verify(resourceMethod).getMethod();
+    verify(resourceMethod, times(2)).getParameters();
     verify(resourceMethod).getServiceErrors();
     verify(context).getProjectionMode();
     verify(context).setProjectionMask(maskTree);


### PR DESCRIPTION
The interface has a default implementation for now to keep it
compatible, but that should be removed in the next major version.