### PR TITLE
Add Java 11 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
     - GRAVIS="$HOME/gravis"
     # Select the versions of Java 8 and Java 11 that is to be used. A list of available versions can be seen with "jabba ls-remote"
     - JDK8="adopt@1.8.0-232"
+    - JDK=$JDK8
     - JDK11="adopt@1.11.0-9"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  # JDKs will be maintained by jabba so this entry doesn't do anything
   - oraclejdk8
 
 # Anything after trusty doesn't have Java 8
@@ -10,7 +11,14 @@ dist: trusty
 install: true
 
 # Build commits to master, PRs to master, and release tags
-script: ./scripts/travis/build.sh
+script:
+  # This variable is used by the build script in order to run tests with Java 11
+  - export JAVA11_HOME=$HOME/.jabba/jdk/$JDK11
+  - echo "Java 11 version used for tests:"
+  - $JAVA11_HOME/bin/java -version
+  - echo "Java 8 version used for compilation and tests:"
+  - java -version
+  - ./scripts/travis/build.sh
 branches:
   only:
     - master
@@ -21,6 +29,21 @@ env:
   global:
     - secure: "nWfVV8tA9njefTyPrQc03XCdE83Ep3XvQYvx+ABmoS9NwUrbHf0koKtchgrmATVELTXCrdmoFSh8CfXdwlYz26XMzho+jdXyLv5aR1SeRHgN+uR+l3MvnNaOm1xQUapXF5E2M0X9dgBfGdiYJBSgpW3iceWKs2Jb0/U7wdVtVbaNX5icLAaegaelzsF54QxI37g9SpImpnMZP0YwrD2Kt+eVwqIlCiBfYvjbxnKd/h+zZCYwH1hdtBG8Ce/e95/CcMg9/YwMWDCLkUBnFHZBiGR5WsN9i6d7lwZ/KjsXlwVSnFFFR98mXuWjCTjgqsbgT5GTKtUHuyoC6gMIAifajr+y7Zhf1f9HTHPNFgxSXDSM/rIIYcx88gwbfCDkV8VPKpojSJZwfO/gunHSS0bEnKBKNyD8sz6ObAjH+TYvYZulOcec59KBhQ1hLMnTlaWumFdxxFWNvp8tcqnYM4UcIZrX/shEYKtkqBvgWXwP80g+u9EyHYW2z682cd8ynRt5xP9X0M5LJTHlfmWb3Hv18sn4vkLBXkpUokzfZzxff/63j+FdYNbG4jsJEeAxqa46NtkZcjIMddfp0GobKMgfj+CfWJoHueYucGPkaD1FQ5r4SrtSgnrShRZjvgF2sbSosbanbrmdAQtYfSqPV/H16iezSUMn9EDSfkuOp/a0maU="
     - secure: "k0njGMbUMDbAmZjp+wWKkQXfENmpLqS86xPP5PRcLty6sG6Y3L9wGy9krGTKuny+vVVxtNmbEweyHLv8k1aoN3fDJc+ixQEHcjYGwdNoJlHaxRax3JDb8yNclzTrArob5gTJGlV3zbbaY+a81qrJ0LAfWNrLQSEgtrrBRh44lQwx3ZZ0g84jGC0m+uHwixI3G2rqERJ+Gkngp0yq+zcERv46k3xAbmh/0vtDlrbgVqVN+FtiAkQjqK3MPSj+zkAQ433D31f1nShPGch8iUFa562ghmnH3HJMSm99aEyo25jVl+vzajxzdp9HBwyT+tbFtQ/Vz36PqwRkEHP4bsa1zTdKHrqIdVWDD2525vruuWz8VavSaxGSlyeTHCKzh+i5zlhQIYc474y1Zr5bDBMWZRHHKKf649dgItWN4u8p+ays0KIuClTXjzrobHEZ2iN7lAa3kT0o4guL2z8wh73GFVdBImXwL8lqadsq54kNu9B6oLYsMnD4K+xpWebel5WvVjklczY5OXIVLPBmal3GGo0/rW0YQzO8tT5D90lO4UJvGyO+fMlOSt8jR0jTk3ox0HT80qWegYv6MvrGG/6L0dO7/GaWYTpj41JvWC/k9A0mUUiUTqEGZzTM8VbDgusUBR5SrEPwm1K5DrLzBoTEqxAS4aHgniFz39tVMMmak2k="
+    - GRAVIS_REPO="https://github.com/DanySK/Gravis-CI.git"
+    - GRAVIS="$HOME/gravis"
+    # Select the versions of Java 8 and Java 11 that is to be used. A list of available versions can be seen with "jabba ls-remote"
+    - JDK8="adopt@1.8.0-232"
+    - JDK11="adopt@1.11.0-9"
+
+before_install:
+  # Check out the gravis script set
+  - travis_retry git clone --depth 1 $GRAVIS_REPO $GRAVIS
+  # Install the JDK you configured in the $JDK environment variable
+  # Never use travis_retry: hides failures. travis_retry is used internally where possible.
+  - source $GRAVIS/install-jdk
+  # Install Java 8 and Java 11
+  - jabba install $JDK11
+  - jabba install $JDK8
 
 # Publish a new version on tag push
 deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,7 @@ idea {
 
 subprojects {
   apply plugin: 'java'
+  apply plugin: 'alternateJvmTest'
   apply plugin: 'eclipse'
   apply from: "${buildScriptDirPath}/cleanGenerated.gradle"
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,22 @@
+plugins {
+  id 'java-gradle-plugin'
+}
+
 // add gradle-plugins to the source of buildSrc
 // this allows buildSrc to use the up-to-date pegasus plugin code without duplication
 project.sourceSets.main.java {
   srcDir '../gradle-plugins/src/main/java'
+}
+
+gradlePlugin {
+  plugins {
+    myPlugins {
+      id = 'alternateJvmTest'
+      implementationClass = 'com.linkedin.pegasus.gradle.AlternateJvmTestPlugin'
+    }
+  }
+}
+
+dependencies {
+  compileOnly gradleApi()
 }

--- a/buildSrc/src/main/java/com/linkedin/pegasus/gradle/AlternateJvmTestPlugin.java
+++ b/buildSrc/src/main/java/com/linkedin/pegasus/gradle/AlternateJvmTestPlugin.java
@@ -1,0 +1,50 @@
+package com.linkedin.pegasus.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.testing.Test;
+
+/**
+ * This plugin configures the alternateJvmTest task. This allows users to run their tests with a different JVM.
+ * This will allow users to support multiple JVMs if their libraries have upstreams in multiple JVM versions.
+ * This task will only run if and only if the alternateJvm project property is set.
+ * You can use it manually like this: "ligradle -PalternateJvm=/export/apps/jdk/JDK-11_0_5-zulu/bin/java check".
+ *
+ * The alternateJvm property takes either a jvm_version (can be found in ~/jdk-versions.json) or a direct path to a
+ * java executable.
+ *
+ * You can also add this command to whatever mint command you wish to.
+ *
+ *
+ * WARNING: Please do not set this in gradle.properties because this would set that JVM for ALL your tests.
+ **/
+public class AlternateJvmTestPlugin implements Plugin<Project> {
+  public static final String ALTERNATE_JVM_TEST_PROPERTY_NAME = "alternateJvm";
+
+  private final static Logger LOG = Logging.getLogger(AlternateJvmTestPlugin.class);
+
+  @Override
+  public void apply(Project project) {
+    configureAlternateJVMForTests(project);
+  }
+
+  /**
+   * This method configures the alternateJVM for all tests.
+   *
+   * @param project The project property "alternateJvm" must be provided in order for the task to be configured
+   */
+  private void configureAlternateJVMForTests(Project project) {
+    if (!project.hasProperty(ALTERNATE_JVM_TEST_PROPERTY_NAME) || project.property(ALTERNATE_JVM_TEST_PROPERTY_NAME) == null) {
+      return;
+    }
+
+    String alternateJvmProperty = project.property(ALTERNATE_JVM_TEST_PROPERTY_NAME).toString();
+
+    LOG.lifecycle("Setting Test tasks to run with {} jvm.", alternateJvmProperty);
+
+    // We set the java version for tests to the property passed in
+    project.getTasks().withType(Test.class).forEach(task -> task.setExecutable(alternateJvmProperty));
+  }
+}

--- a/buildSrc/src/main/java/com/linkedin/pegasus/gradle/AlternateJvmTestPlugin.java
+++ b/buildSrc/src/main/java/com/linkedin/pegasus/gradle/AlternateJvmTestPlugin.java
@@ -10,7 +10,7 @@ import org.gradle.api.tasks.testing.Test;
  * This plugin configures the alternateJvmTest task. This allows users to run their tests with a different JVM.
  * This will allow users to support multiple JVMs if their libraries have upstreams in multiple JVM versions.
  * This task will only run if and only if the alternateJvm project property is set.
- * You can use it manually like this: "ligradle -PalternateJvm=/export/apps/jdk/JDK-11_0_5-zulu/bin/java check".
+ * You can use it manually like this: "./gradlew -PalternateJvm=/export/apps/jdk/JDK-11_0_5-zulu/bin/java check".
  *
  * WARNING: Please do not set this in gradle.properties because this would set that JVM for ALL your tests.
  **/

--- a/buildSrc/src/main/java/com/linkedin/pegasus/gradle/AlternateJvmTestPlugin.java
+++ b/buildSrc/src/main/java/com/linkedin/pegasus/gradle/AlternateJvmTestPlugin.java
@@ -12,12 +12,6 @@ import org.gradle.api.tasks.testing.Test;
  * This task will only run if and only if the alternateJvm project property is set.
  * You can use it manually like this: "ligradle -PalternateJvm=/export/apps/jdk/JDK-11_0_5-zulu/bin/java check".
  *
- * The alternateJvm property takes either a jvm_version (can be found in ~/jdk-versions.json) or a direct path to a
- * java executable.
- *
- * You can also add this command to whatever mint command you wish to.
- *
- *
  * WARNING: Please do not set this in gradle.properties because this would set that JVM for ALL your tests.
  **/
 public class AlternateJvmTestPlugin implements Plugin<Project> {

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/RetryZooKeeperTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/RetryZooKeeperTest.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.discovery.stores.zk;
 
 
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -529,7 +530,7 @@ public class RetryZooKeeperTest {
     EasyMock.verify(rzkPartialMock);
   }
 
-  @Test
+  @Test(retryAnalyzer = ThreeRetries.class)
   public void testRetryBackoff() throws NoSuchMethodException, InterruptedException
   {
     final RetryZooKeeper rzkPartialMock = EasyMock.createMockBuilder(RetryZooKeeper.class)

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/SharedZkConnectionProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/SharedZkConnectionProviderTest.java
@@ -47,6 +47,7 @@ import com.linkedin.r2.transport.common.TransportClientFactory;
 import com.linkedin.r2.transport.common.bridge.client.TransportClient;
 import com.linkedin.r2.transport.common.bridge.common.TransportCallback;
 import com.linkedin.r2.transport.common.bridge.common.TransportResponse;
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -336,7 +337,7 @@ public class SharedZkConnectionProviderTest {
   /**
    * Test announcing many hosts using one connection concurrently
    */
-  @Test(groups = "needZk")
+  @Test(groups = "needZk", retryAnalyzer = ThreeRetries.class)
   public void testManyHostsAnnouncementSharingConnections() throws Exception {
     List<URI> hostNames = prepareHostNames(100, "testManyHostsAnnouncementSharingConnections");
     List<ZooKeeperConnectionManager> connectionManagers = prepareConnectionManagers(hostNames);
@@ -354,7 +355,7 @@ public class SharedZkConnectionProviderTest {
    * Testing sharing connections between announcers and d2client
    * @throws Exception
    */
-  @Test(groups = "needZk")
+  @Test(groups = "needZk", retryAnalyzer = ThreeRetries.class)
   public void testAnnouncerAndClientSharing() throws Exception {
     //connection shared to announcers
     List<URI> hostNames = prepareHostNames(20, "testAnnouncerAndClientSharing");

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamingTimeout.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamingTimeout.java
@@ -36,6 +36,7 @@ import com.linkedin.r2.transport.common.StreamRequestHandler;
 import com.linkedin.r2.transport.common.bridge.server.TransportDispatcher;
 import com.linkedin.r2.transport.common.bridge.server.TransportDispatcherBuilder;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.test.util.retry.ThreeRetries;
 import com.linkedin.util.clock.SystemClock;
 import java.net.URI;
 import java.util.HashMap;
@@ -120,7 +121,7 @@ public class TestStreamingTimeout extends AbstractServiceTest
     Assert.assertTrue(reader.allBytesCorrect());
   }
 
-  @Test
+  @Test(retryAnalyzer = ThreeRetries.class)
   public void testStreamTimeoutWithStreamingTimeoutInServerStream() throws Exception
   {
     final EntityStream entityStream = EntityStreams.newEntityStream(new BytesWriter(SMALL_BYTES_NUM, BYTE));

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -53,9 +53,29 @@ fi
 ./gradlew build $EXTRA_ARGS
 EXIT_CODE=$?
 
+if [ $EXIT_CODE != 0 ]; then
+  # Kill the waiter job
+  echo "[Ping] Killing the waiter job"
+  kill $WAITER_PID
+
+  echo "Java 8 build and test failed"
+  exit 1
+fi
+
+# Run tests with Java 11
+# .travis.yml provides this environment variable
+EXIT_CODE_JAVA11=0
+if [ ! -z "$JAVA11_HOME" ]; then
+  echo "Running tests with Java 11"
+  ./gradlew check -PalternateJvm=$JAVA11_HOME/bin/java
+  EXIT_CODE_JAVA11=$?
+fi
+
 # Kill the waiter job
+echo "[Ping] Killing the waiter job"
 kill $WAITER_PID
 
-if [ $EXIT_CODE != 0 ]; then
+if [ $EXIT_CODE_JAVA11 != 0 ]; then
+  echo "Java 11 tests failed"
   exit 1
 fi

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -65,7 +65,7 @@ fi
 # Run tests with Java 11
 # .travis.yml provides this environment variable
 EXIT_CODE_JAVA11=0
-if [ ! -z "$JAVA11_HOME" ]; then
+if [ ! -z "$JAVA11_HOME" ] && [ -z $EXTRA_ARGS ]; then
   echo "Running tests with Java 11"
   ./gradlew check -PalternateJvm=$JAVA11_HOME/bin/java
   EXIT_CODE_JAVA11=$?


### PR DESCRIPTION
This PR configures rest.li's CI builds to run additional tests using Java 11. This is meant to be in addition to the Java 8 build and tests. As in the workflow should go: 

1. Java 8 build
2. Java 8 tests 
3. Java 11 tests

The tests run by Java 8 and Java 11 are the same but they are just run by different jvms.

Using adopt openjdk for both builds. 1.8.0_232 for Java 8 and 11.0.9 for Java 11.

We add the alternateJvmPlugin which allows us to run Tests with a different jvm by specifying the alternateJvm gradle property. These properties can be specified by the -P parameter. 

The recommended way of using this is to run `./gradlew check -PalternateJvm=$JAVA11_HOME/bin/java`. 

Please do not specify this property in the gradle.properties file as it would then make all tests (including the Java 8 build) run with Java 11.
