### PR TITLE
Fix bug in DataComplexTable that breaks Data::copy if there are hash collisions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.13.10] - 2021-01-20
 - Fix bug which prevented using the `@PathKeyParam` resource method parameter annotation for a non-parent path key (i.e. path key defined in the same resource).
   - Users will no longer have to rely on `@PathKeysParam` as a workaround.
 - Expose resource method parameters in the `FilterRequestContext` interface.
+- Fix bug in `DataComplexTable` that breaks `Data::copy` if there are hash collisions.
+  - Hashcodes for `DataComplex` objects are generated using a thread local, and there can be collisions if multiple threads are used to construct a `DataComplex` object.
 
 ## [29.13.9] - 2021-01-13
 - Add max batch size support on Rest.li server.
@@ -4813,7 +4817,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.10...master
+[29.13.10]: https://github.com/linkedin/rest.li/compare/v29.13.9...v29.13.10
 [29.13.9]: https://github.com/linkedin/rest.li/compare/v29.13.8...v29.13.9
 [29.13.8]: https://github.com/linkedin/rest.li/compare/v29.13.7...v29.13.8
 [29.13.7]: https://github.com/linkedin/rest.li/compare/v29.13.6...v29.13.7

--- a/data/src/main/java/com/linkedin/data/DataComplexTable.java
+++ b/data/src/main/java/com/linkedin/data/DataComplexTable.java
@@ -18,6 +18,11 @@ package com.linkedin.data;
 
 import java.util.HashMap;
 
+
+/**
+ * Custom hash table when {@link DataComplex} objects are used as keys. This utilizes the custom
+ * {@link DataComplex#dataComplexHashCode()} as the hash for improved performance.
+ */
 class DataComplexTable
 {
   private final HashMap<DataComplexKey, DataComplex> _map;
@@ -57,6 +62,8 @@ class DataComplexTable
     @Override
     public boolean equals(Object other)
     {
+      // "other" is guaranteed to be DataComplex as this class is "private" scoped within DataComplexTable, which only
+      // supports DataComplex objects.
       return _dataObject == ((DataComplexKey) other)._dataObject;
     }
   }

--- a/data/src/main/java/com/linkedin/data/DataComplexTable.java
+++ b/data/src/main/java/com/linkedin/data/DataComplexTable.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 
 class DataComplexTable
 {
-  private final HashMap<Integer, DataComplex> _map;
+  private final HashMap<DataComplexKey, DataComplex> _map;
 
   DataComplexTable()
   {
@@ -29,11 +29,36 @@ class DataComplexTable
 
   public DataComplex get(DataComplex index)
   {
-    return _map.get(index.dataComplexHashCode());
+    return _map.get(new DataComplexKey(index));
   }
 
   public void put(DataComplex src, DataComplex clone)
   {
-    _map.put(src.dataComplexHashCode(), clone);
+    _map.put(new DataComplexKey(src), clone);
   }
+
+  private static class DataComplexKey
+  {
+    private final DataComplex _dataObject;
+    private final int _hashCode;
+
+    DataComplexKey(DataComplex dataObject)
+    {
+      _hashCode = dataObject.dataComplexHashCode();
+      _dataObject = dataObject;
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return _hashCode;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+      return _dataObject == ((DataComplexKey) other)._dataObject;
+    }
+  }
+
 }

--- a/data/src/test/java/com/linkedin/data/TestData.java
+++ b/data/src/test/java/com/linkedin/data/TestData.java
@@ -866,6 +866,23 @@ public class TestData
     }
   }
 
+  // Tests copy method in the presence of hash collisions in the data objects
+  @Test
+  public void testCopyHashCollisions() throws Exception
+  {
+    DataMap a = new DataMap();
+    a.put("b", new DataMap());
+    a.put("c", new DataMap());
+
+    // Use the next hashcode to cause collision.
+    a.getDataMap("c")._dataComplexHashCode = DataComplexHashCode.nextHashCode() + 1;
+    DataMap copy = a.copy();
+    assertNotNull(copy.get("b"));
+    assertNotNull(copy.get("c"));
+    assertNotSame(copy.get("b"), copy);
+    assertNotSame(copy.get("c"), copy);
+  }
+
   @Test
   public void mapClonesHaveDifferentHashValues() throws CloneNotSupportedException
   {

--- a/data/src/test/java/com/linkedin/data/TestDataComplexTable.java
+++ b/data/src/test/java/com/linkedin/data/TestDataComplexTable.java
@@ -1,0 +1,111 @@
+package com.linkedin.data;
+
+import java.util.Collection;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TestDataComplexTable
+{
+  @Test
+  public void testKeysWithSameHash() throws Exception
+  {
+    DataComplexTable table = new DataComplexTable();
+    MockDataComplex item1 = new MockDataComplex();
+    item1.setHashCode(1);
+    DataComplex item1Clone = item1.clone();
+    MockDataComplex item2 = new MockDataComplex();
+    item2.setHashCode(1);
+    DataComplex item2Clone = item2.clone();
+
+    table.put(item1, item1Clone);
+    table.put(item2, item2Clone);
+
+    Assert.assertNotNull(table.get(item1));
+    Assert.assertNotNull(table.get(item2));
+    Assert.assertSame(item1Clone, table.get(item1));
+    Assert.assertSame(item2Clone, table.get(item2));
+  }
+
+  private static class MockDataComplex implements DataComplex
+  {
+    private int _hashCode = 0;
+    @Override
+    public int dataComplexHashCode()
+    {
+      return _hashCode;
+    }
+
+    public void setHashCode(int hashCode)
+    {
+      this._hashCode = hashCode;
+    }
+
+    @Override
+    public void makeReadOnly()
+    {
+    }
+
+    @Override
+    public boolean isMadeReadOnly()
+    {
+      return false;
+    }
+
+    @Override
+    public Collection<Object> values()
+    {
+      return null;
+    }
+
+    @Override
+    public DataComplex clone() throws CloneNotSupportedException
+    {
+      return (DataComplex) super.clone();
+    }
+
+    @Override
+    public void setReadOnly()
+    {
+    }
+
+    @Override
+    public boolean isReadOnly()
+    {
+      return false;
+    }
+
+    @Override
+    public void invalidate()
+    {
+    }
+
+    @Override
+    public DataComplex copy() throws CloneNotSupportedException
+    {
+      return this.clone();
+    }
+
+    @Override
+    public void startInstrumentingAccess()
+    {
+    }
+
+    @Override
+    public void stopInstrumentingAccess()
+    {
+    }
+
+    @Override
+    public void clearInstrumentedData()
+    {
+    }
+
+    @Override
+    public void collectInstrumentedData(StringBuilder keyPrefix, Map<String, Map<String, Object>> instrumentedData,
+        boolean collectAllData)
+    {
+    }
+  }
+}

--- a/data/src/test/java/com/linkedin/data/TestDataComplexTable.java
+++ b/data/src/test/java/com/linkedin/data/TestDataComplexTable.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.data;
 
 import java.util.Collection;
@@ -43,42 +59,9 @@ public class TestDataComplexTable
     }
 
     @Override
-    public void makeReadOnly()
-    {
-    }
-
-    @Override
-    public boolean isMadeReadOnly()
-    {
-      return false;
-    }
-
-    @Override
-    public Collection<Object> values()
-    {
-      return null;
-    }
-
-    @Override
     public DataComplex clone() throws CloneNotSupportedException
     {
       return (DataComplex) super.clone();
-    }
-
-    @Override
-    public void setReadOnly()
-    {
-    }
-
-    @Override
-    public boolean isReadOnly()
-    {
-      return false;
-    }
-
-    @Override
-    public void invalidate()
-    {
     }
 
     @Override
@@ -88,24 +71,64 @@ public class TestDataComplexTable
     }
 
     @Override
+    public void makeReadOnly()
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isMadeReadOnly()
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Object> values()
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setReadOnly()
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isReadOnly()
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void invalidate()
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void startInstrumentingAccess()
     {
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void stopInstrumentingAccess()
     {
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void clearInstrumentedData()
     {
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public void collectInstrumentedData(StringBuilder keyPrefix, Map<String, Map<String, Object>> instrumentedData,
         boolean collectAllData)
     {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.13.9
+version=29.13.10
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Hashcodes for DataComplex objects are generated using a thread local,
and there can be collisions if multiple threads are used to construct a
DataComplex object.