### PR TITLE
[bugfix] Prevent eager resolution of UNUSED_CONFIGURATIONS values

### DIFF
--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -655,7 +655,7 @@ public class PegasusPlugin implements Plugin<Project>
           gradle.getRootProject().subprojects(subproject ->
             UNUSED_CONFIGURATIONS.forEach(configurationName -> {
               Configuration conf = subproject.getConfigurations().findByName(configurationName);
-              if (conf != null && !conf.isEmpty()) {
+              if (conf != null && !conf.getDependencies().isEmpty()) {
                 subproject.getLogger().warn("*** Project {} declares dependency to unused configuration \"{}\". "
                     + "This configuration is deprecated and you can safely remove the dependency. ***",
                     subproject.getPath(), configurationName);


### PR DESCRIPTION
 - Invoking Configuration#isEmpty() will force the underlying Configuration to resolve all files - this is bad and can break native IDEA project import
 - Rather, we can see if the Configuration has any first-order dependencies associated with it, which is probably the author's original intent
 - If the Configuration exists and contains any first-order dependencies, only then should we warn.