### PR TITLE
Sort properties and defaults when encoding PDLs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
- - Generate fluent client APIs get and create methods of collection resources.
+
+## [29.14.0] - 2021-01-29
+- Generate fluent client APIs get and create methods of collection resources.
+- Encode JSON values in PDLs deterministically:
+  - Annotation maps are now sorted alphabetically (to arbitrary depth).
+  - Default values of fields with record type are sorted by the field order of the record schema.
 
 ## [29.13.12] - 2021-01-29
 Fix a bug of losing HTTP status code when a retriable response goes through ClientRetryFilter
@@ -4826,7 +4831,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.14.0...master
+[29.14.0]: https://github.com/linkedin/rest.li/compare/v29.13.12...v29.14.0
 [29.13.12]: https://github.com/linkedin/rest.li/compare/v29.13.11...v29.13.12
 [29.13.11]: https://github.com/linkedin/rest.li/compare/v29.13.10...v29.13.11
 [29.13.10]: https://github.com/linkedin/rest.li/compare/v29.13.9...v29.13.10

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -67,9 +67,16 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
 
   protected final JsonFactory _factory;
 
+  private boolean _sortKeys;
+
   protected AbstractJacksonDataCodec(JsonFactory factory)
   {
     _factory = factory;
+  }
+
+  public void setSortKeys(boolean sortKeys)
+  {
+    _sortKeys = sortKeys;
   }
 
   @Override
@@ -135,7 +142,7 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
 
   protected Data.TraverseCallback createTraverseCallback(JsonGenerator generator)
   {
-    return createTraverseCallback(generator, false);
+    return createTraverseCallback(generator, _sortKeys);
   }
 
   /**
@@ -167,10 +174,6 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
     {
       return new Parser().parse(jsonParser, expectType);
     }
-    catch (IOException e)
-    {
-      throw e;
-    }
     finally
     {
       DataCodec.closeQuietly(jsonParser);
@@ -196,10 +199,6 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
     try
     {
       return new Parser(true).parse(jsonParser, mesg, locationMap);
-    }
-    catch (IOException e)
-    {
-      throw e;
     }
     finally
     {

--- a/data/src/main/java/com/linkedin/data/schema/CompactPdlBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/CompactPdlBuilder.java
@@ -17,6 +17,7 @@
 package com.linkedin.data.schema;
 
 import com.linkedin.data.codec.JacksonDataCodec;
+import com.linkedin.data.template.JacksonDataTemplateCodec;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.regex.Pattern;
@@ -35,6 +36,13 @@ class CompactPdlBuilder extends PdlBuilder
 {
   private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("[A-Za-z0-9_\\-`]");
   private static final JacksonDataCodec JSON_CODEC = new JacksonDataCodec();
+  private static final JacksonDataTemplateCodec JSON_DATA_TEMPLATE_CODEC = new JacksonDataTemplateCodec();
+
+  static
+  {
+    JSON_CODEC.setSortKeys(true);
+  }
+
   /**
    * See {@link PdlBuilder.Provider}.
    */
@@ -193,9 +201,16 @@ class CompactPdlBuilder extends PdlBuilder
   }
 
   @Override
-  PdlBuilder writeJson(Object value) throws IOException
+  PdlBuilder writeJson(Object value, DataSchema schema) throws IOException
   {
-    write(toJson(value, JSON_CODEC));
+    if (schema != null)
+    {
+      write(toJson(value, JSON_DATA_TEMPLATE_CODEC, schema));
+    }
+    else
+    {
+      write(toJson(value, JSON_CODEC));
+    }
     return this;
   }
 }

--- a/data/src/main/java/com/linkedin/data/schema/IndentedPdlBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/IndentedPdlBuilder.java
@@ -16,9 +16,11 @@
 
 package com.linkedin.data.schema;
 
+import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.linkedin.data.codec.JacksonDataCodec;
+import com.linkedin.data.template.JacksonDataTemplateCodec;
 import java.io.IOException;
 import java.io.Writer;
 import org.apache.commons.lang3.StringUtils;
@@ -122,15 +124,30 @@ class IndentedPdlBuilder extends PdlBuilder
   }
 
   @Override
-  PdlBuilder writeJson(Object value) throws IOException
+  PdlBuilder writeJson(Object value, DataSchema schema) throws IOException
   {
-    JacksonDataCodec jsonCodec = new JacksonDataCodec();
+    if (schema != null)
+    {
+      JacksonDataTemplateCodec jsonCodec = new JacksonDataTemplateCodec();
+      jsonCodec.setPrettyPrinter(getPrettyPrinter());
+      write(toJson(value, jsonCodec, schema));
+    }
+    else
+    {
+      JacksonDataCodec jsonCodec = new JacksonDataCodec();
+      jsonCodec.setPrettyPrinter(getPrettyPrinter());
+      jsonCodec.setSortKeys(true);
+      write(toJson(value, jsonCodec));
+    }
+    return this;
+  }
+
+  private PrettyPrinter getPrettyPrinter()
+  {
     DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
     prettyPrinter.indentObjectsWith(
         new DefaultIndenter(getIndentSpaces(1), DefaultIndenter.SYS_LF + getIndentSpaces(_indentDepth)));
-    jsonCodec.setPrettyPrinter(prettyPrinter);
-    write(toJson(value, jsonCodec));
-    return this;
+    return prettyPrinter;
   }
 
   /**

--- a/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
@@ -350,7 +350,7 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
       _builder.writeSpace()
           .write("=")
           .writeSpace()
-          .writeJson(field.getDefault());
+          .writeJson(field.getDefault(), field.getType());
     }
     _builder.newline();
   }

--- a/data/src/test/java/com/linkedin/data/schema/TestPdlBuilder.java
+++ b/data/src/test/java/com/linkedin/data/schema/TestPdlBuilder.java
@@ -66,12 +66,11 @@ public class TestPdlBuilder
               "@flatten.`array` = [ 1, 2, 3 ]\n",
               "@flatten.`array`=[1,2,3]"
             },
-            /* TODO Add test case for multiple properties in a map level once iteration logic is fixed to be deterministic
             {
               jsonValueProp,
               "@nested = {\n  \"array\" : [ 1, 2, 3 ],\n  \"empty\" : { }\n}\n",
               "@nested={\"array\":[1,2,3],\"empty\":{}}"
-            }*/
+            }
         };
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.13.12
+version=29.14.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The PDL encoder already sorts the top-level properties on a field by
their names. This extends this sorting to nested properties.

An example of a nested property that is sorted is:

    @nested = {
      "a" : "a",
      "b" : "b"
    }

When default values are records, their fields are sorted in the order
that the fields are defined in the schema. For example:

    date: record Date {
      month: int
      day: int
      year: int
    } = {
      "month": 1,
      "day": 1,
      "year": 2021
    }

This enables the PDL encoder to be used for autoformatting PDLs, since
the order of map entries will be deterministic.