### PR TITLE
Fix memory leak in CheckedMap when one map is used to create multiple record templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.13.11] - 2021-01-27
+- Fix memory leak in `CheckedMap` when one map is used to create multiple record templates.
+  - Change listener list now clears finalized weak references when it detects any change listener was finalized or when listeners are notified.
+
 ## [29.13.10] - 2021-01-20
 - Fix bug which prevented using the `@PathKeyParam` resource method parameter annotation for a non-parent path key (i.e. path key defined in the same resource).
   - Users will no longer have to rely on `@PathKeysParam` as a workaround.
@@ -4817,7 +4821,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.13.11...master
+[29.13.11]: https://github.com/linkedin/rest.li/compare/v29.13.10...v29.13.11
 [29.13.10]: https://github.com/linkedin/rest.li/compare/v29.13.9...v29.13.10
 [29.13.9]: https://github.com/linkedin/rest.li/compare/v29.13.8...v29.13.9
 [29.13.8]: https://github.com/linkedin/rest.li/compare/v29.13.7...v29.13.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-- Update 'CreateOnly' and 'ReadOnly' javadocs to be more accurate that the validation is performed by 'RestLiValidationFilter'.
 
 ## [29.13.11] - 2021-01-27
+- Update 'CreateOnly' and 'ReadOnly' javadocs to be more accurate that the validation is performed by 'RestLiValidationFilter'.
 - Fix memory leak in `CheckedMap` when one map is used to create multiple record templates.
   - Change listener list now clears finalized weak references when it detects any change listener was finalized or when listeners are notified.
 

--- a/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
+++ b/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
@@ -23,9 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -166,7 +163,7 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
   {
     checkMutability();
     Set<K> keys = null;
-    if (_changeListeners != null)
+    if (_changeListenerHead != null)
     {
       keys = new HashSet<>(keySet());
     }
@@ -184,7 +181,7 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
     CheckedMap<K,V> o = (CheckedMap<K,V>) super.clone();
     o._map = (HashMap<K,V>) _map.clone();
     o._readOnly = false;
-    o._changeListeners = null;
+    o._changeListenerHead = null;
     o._changeListenerReferenceQueue = null;
     return o;
   }
@@ -353,26 +350,18 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
       return;
     }
 
-    if (_changeListeners == null)
+    if (_changeListenerReferenceQueue == null)
     {
-      // Change listeners are mostly used by map wrappers, and we always iterate through them
-      // linearly, so use a linked list.
-      _changeListeners = new LinkedList<>();
       _changeListenerReferenceQueue = new ReferenceQueue<>();
     }
-
+    else
+    {
+      purgeStaleChangeListeners();
+    }
     // Maintain a weak reference to to the listener to avoid leaking the wrapper beyond its
     // lifetime.
-    _changeListeners.add(new WeakReference<>(listener, _changeListenerReferenceQueue));
-    // Clear finalized weak references.
-    if (_changeListenerReferenceQueue.poll() != null)
-    {
-      while (_changeListenerReferenceQueue.poll() != null)
-      {
-        // Do nothing, as we are just clearing the reference queue.
-      }
-      _changeListeners.removeIf(weakReference -> weakReference.get() == null);
-    }
+    _changeListenerHead = new  WeakListNode<>(
+        new WeakReference<>(listener, _changeListenerReferenceQueue), _changeListenerHead);
   }
 
   final private void checkKeyValue(K key, V value)
@@ -493,70 +482,63 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
 
   private void notifyChangeListenersOnPut(K key, V value)
   {
-    if (_changeListeners == null)
+    purgeStaleChangeListeners();
+    if (_changeListenerHead == null)
     {
       return;
     }
-
-    Iterator<WeakReference<ChangeListener<K, V>>> itr = _changeListeners.iterator();
-    while (itr.hasNext())
+    WeakListNode<ChangeListener<K, V>> node = _changeListenerHead;
+    while (node != null)
     {
-      WeakReference<ChangeListener<K, V>> listenerRef = itr.next();
+      WeakReference<ChangeListener<K, V>> listenerRef = node._object;
       ChangeListener<K, V> listener = listenerRef.get();
       if (listener != null)
       {
         listener.onUnderlyingMapChanged(key, value);
       }
-      else
-      {
-        itr.remove();
-      }
+      node = node._next;
     }
   }
 
   private void notifyChangeListenersOnPutAll(Map<? extends K, ? extends V> map)
   {
-    if (_changeListeners == null)
+    purgeStaleChangeListeners();
+    if (_changeListenerHead == null)
     {
       return;
     }
 
-    Iterator<WeakReference<ChangeListener<K, V>>> itr = _changeListeners.iterator();
-    while (itr.hasNext())
+    WeakListNode<ChangeListener<K, V>> node = _changeListenerHead;
+    while (node != null)
     {
-      WeakReference<ChangeListener<K, V>> listenerRef = itr.next();
+      WeakReference<ChangeListener<K, V>> listenerRef = node._object;
       ChangeListener<K, V> listener = listenerRef.get();
       if (listener != null)
       {
         map.forEach(listener::onUnderlyingMapChanged);
       }
-      else
-      {
-        itr.remove();
-      }
+      node = node._next;
     }
   }
 
   private void notifyChangeListenersOnClear(Set<? extends K> keys)
   {
-    if (_changeListeners == null)
+    purgeStaleChangeListeners();
+    if (_changeListenerHead == null)
     {
       return;
     }
 
-    Iterator<WeakReference<ChangeListener<K, V>>> itr = _changeListeners.iterator();
-    while (itr.hasNext())
+    WeakListNode<ChangeListener<K, V>> node = _changeListenerHead;
+    while (node != null)
     {
-      WeakReference<ChangeListener<K, V>> listenerRef = itr.next();
+      WeakReference<ChangeListener<K, V>> listenerRef = node._object;
       ChangeListener<K, V> listener = listenerRef.get();
       if (listener != null)
       {
         keys.forEach(key -> listener.onUnderlyingMapChanged(key, null));
       }
-      else
-      {
-        itr.remove();
-      }
+      node = node._next;
     }
   }
 
@@ -574,11 +556,60 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
     void onUnderlyingMapChanged(K key, V value);
   }
 
+  private void purgeStaleChangeListeners()
+  {
+    if (_changeListenerReferenceQueue != null && _changeListenerReferenceQueue.poll() != null)
+    {
+      // Clear finalized weak references.
+      while (_changeListenerReferenceQueue.poll() != null)
+      {
+        // Do nothing, as we are just clearing the reference queue.
+      }
+      // Now iterate over change listeners and purge stale references.
+      WeakListNode<ChangeListener<K, V>> node = _changeListenerHead,  prev = null;
+      while (node != null)
+      {
+        if (node._object.get() == null)
+        {
+          if (prev == null)
+          {
+            _changeListenerHead = node._next;
+          }
+          else
+          {
+            prev._next = node._next;
+          }
+        }
+        else
+        {
+          prev = node;
+        }
+        node = node._next;
+      }
+    }
+  }
+
   private boolean _readOnly = false;
   protected MapChecker<K,V> _checker;
-  protected List<WeakReference<ChangeListener<K, V>>> _changeListeners;
+  // Change listeners are mostly used by map wrappers, and we always iterate through them
+  // linearly, so use a linked list.
+  protected WeakListNode<ChangeListener<K, V>> _changeListenerHead;
   // Reference queue holds any change listener weak references finalized by GC. It being non-empty is a signal
   // to purge change listeners of stale entries.
   private ReferenceQueue<ChangeListener<K, V>> _changeListenerReferenceQueue;
   private HashMap<K,V> _map;
+
+  /**
+   * A singly-linked list node that holds weak references to objects.
+   */
+  static class WeakListNode<T> {
+    final WeakReference<T> _object;
+    WeakListNode<T> _next;
+
+    WeakListNode(WeakReference<T> object, WeakListNode<T> next)
+    {
+      this._object = object;
+      this._next = next;
+    }
+  }
 }

--- a/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
+++ b/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 
 /**
@@ -487,17 +488,7 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
     {
       return;
     }
-    WeakListNode<ChangeListener<K, V>> node = _changeListenerHead;
-    while (node != null)
-    {
-      WeakReference<ChangeListener<K, V>> listenerRef = node._object;
-      ChangeListener<K, V> listener = listenerRef.get();
-      if (listener != null)
-      {
-        listener.onUnderlyingMapChanged(key, value);
-      }
-      node = node._next;
-    }
+    forEachChangeListener(listener -> listener.onUnderlyingMapChanged(key, value));
   }
 
   private void notifyChangeListenersOnPutAll(Map<? extends K, ? extends V> map)
@@ -507,18 +498,7 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
     {
       return;
     }
-
-    WeakListNode<ChangeListener<K, V>> node = _changeListenerHead;
-    while (node != null)
-    {
-      WeakReference<ChangeListener<K, V>> listenerRef = node._object;
-      ChangeListener<K, V> listener = listenerRef.get();
-      if (listener != null)
-      {
-        map.forEach(listener::onUnderlyingMapChanged);
-      }
-      node = node._next;
-    }
+    forEachChangeListener(listener -> map.forEach(listener::onUnderlyingMapChanged));
   }
 
   private void notifyChangeListenersOnClear(Set<? extends K> keys)
@@ -529,17 +509,7 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
       return;
     }
 
-    WeakListNode<ChangeListener<K, V>> node = _changeListenerHead;
-    while (node != null)
-    {
-      WeakReference<ChangeListener<K, V>> listenerRef = node._object;
-      ChangeListener<K, V> listener = listenerRef.get();
-      if (listener != null)
-      {
-        keys.forEach(key -> listener.onUnderlyingMapChanged(key, null));
-      }
-      node = node._next;
-    }
+    forEachChangeListener(listener -> keys.forEach(key -> listener.onUnderlyingMapChanged(key, null)));
   }
 
   /**
@@ -586,6 +556,21 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
         }
         node = node._next;
       }
+    }
+  }
+
+  private void forEachChangeListener(Consumer<ChangeListener<K, V>> listenerConsumer)
+  {
+    WeakListNode<ChangeListener<K, V>> node = _changeListenerHead;
+    while (node != null)
+    {
+      WeakReference<ChangeListener<K, V>> listenerRef = node._object;
+      ChangeListener<K, V> listener = listenerRef.get();
+      if (listener != null)
+      {
+        listenerConsumer.accept(listener);
+      }
+      node = node._next;
     }
   }
 

--- a/data/src/main/java/com/linkedin/data/schema/validator/DataSchemaAnnotationValidator.java
+++ b/data/src/main/java/com/linkedin/data/schema/validator/DataSchemaAnnotationValidator.java
@@ -424,6 +424,7 @@ public class DataSchemaAnnotationValidator implements Validator
         {
           Constructor<? extends Validator> ctor = clazz.getConstructor(DataMap.class);
           DataMap configDataMap = (DataMap) config;
+          configDataMap.makeReadOnly();
           Integer priority = configDataMap.getInteger(VALIDATOR_PRIORITY);
           Validator validator = ctor.newInstance(configDataMap);
           validatorInfoList.add(new ValidatorInfo(priority, validator));

--- a/data/src/main/java/com/linkedin/data/schema/validator/DataSchemaAnnotationValidator.java
+++ b/data/src/main/java/com/linkedin/data/schema/validator/DataSchemaAnnotationValidator.java
@@ -424,6 +424,8 @@ public class DataSchemaAnnotationValidator implements Validator
         {
           Constructor<? extends Validator> ctor = clazz.getConstructor(DataMap.class);
           DataMap configDataMap = (DataMap) config;
+          // Marking the config read-only as this is being shared by all validators (across multiple threads).
+          // This also ensures change listeners on the map are not created everytime a validator warps it in a record.
           configDataMap.makeReadOnly();
           Integer priority = configDataMap.getInteger(VALIDATOR_PRIORITY);
           Validator validator = ctor.newInstance(configDataMap);

--- a/data/src/test/java/com/linkedin/data/collections/TestCheckedMap.java
+++ b/data/src/test/java/com/linkedin/data/collections/TestCheckedMap.java
@@ -1,0 +1,72 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.data.collections;
+
+import com.linkedin.data.DataMap;
+import java.lang.ref.WeakReference;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * @author kbalasub
+ */
+public class TestCheckedMap
+{
+  @Test(timeOut = 3000)
+  public void testPurgingStaleChangeListeners() throws InterruptedException
+  {
+    CheckedMap<String, Object> checkedMap = new CheckedMap<>();
+    for (int i = 0; i < 1000; i++)
+    {
+      CheckedMap.ChangeListener<String, Object> listener = new CheckedMap.ChangeListener<String, Object>()
+      {
+        @Override
+        public void onUnderlyingMapChanged(String key, Object value)
+        {
+          // Do nothing.
+        }
+      };
+      checkedMap.addChangeListener(listener);
+    }
+    // Run gc to finalize weak references.
+    while(checkedMap._changeListeners.get(0).get() != null)
+    {
+      System.gc();
+    }
+    // Sleep needed to ensure the reference queue is filled
+    Thread.sleep(100);
+    // Add one more to trigger and purge the change listeners list.
+    checkedMap.addChangeListener((key, value) ->
+    {
+      // Do nothing.
+    });
+    Assert.assertTrue(checkedMap._changeListeners.size() < 1000);
+  }
+
+  @Test
+  public void testNoChangeListenerOnReadOnlyMap()
+  {
+    final DataMap map = new DataMap();
+    map.setReadOnly();
+    map.addChangeListener((key, value) ->
+    {
+      // Do nothing.
+    });
+    Assert.assertNull(map._changeListeners);
+  }
+}

--- a/data/src/test/java/com/linkedin/data/collections/TestCheckedMap.java
+++ b/data/src/test/java/com/linkedin/data/collections/TestCheckedMap.java
@@ -44,7 +44,7 @@ public class TestCheckedMap
       checkedMap.addChangeListener(listener);
     }
     // Run gc to finalize weak references.
-    while(checkedMap._changeListeners.get(0).get() != null)
+    while(checkedMap._changeListenerHead._object.get() != null)
     {
       System.gc();
     }
@@ -55,7 +55,18 @@ public class TestCheckedMap
     {
       // Do nothing.
     });
-    Assert.assertTrue(checkedMap._changeListeners.size() < 1000);
+    Assert.assertTrue(sizeOf(checkedMap._changeListenerHead) < 1000);
+  }
+
+  private static int sizeOf(CheckedMap.WeakListNode<CheckedMap.ChangeListener<String, Object>> node)
+  {
+    int count = 0;
+    while (node != null)
+    {
+      count++;
+      node = node._next;
+    }
+    return count;
   }
 
   @Test
@@ -67,6 +78,6 @@ public class TestCheckedMap
     {
       // Do nothing.
     });
-    Assert.assertNull(map._changeListeners);
+    Assert.assertNull(map._changeListenerHead);
   }
 }

--- a/data/src/test/java/com/linkedin/data/collections/TestCheckedUtil.java
+++ b/data/src/test/java/com/linkedin/data/collections/TestCheckedUtil.java
@@ -151,17 +151,6 @@ public class TestCheckedUtil
     testPutAllCycleWithAssertChecking();
   }
 
-  @Test
-  public void testNoChangeListenerOnReadOnlyMap()
-  {
-    final DataMap map = new DataMap();
-    map.setReadOnly();
-    map.addChangeListener((key, value) -> {
-      // Do nothing.
-    });
-    Assert.assertNull(map._changeListeners);
-  }
-
   private void mutateMap(Map<String, String> map)
   {
     map.put("key", "value");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.13.10
+version=29.13.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Change listener list now clears finalized weak references when it detects any change listener was finalized or when listeners are notified.