### PR TITLE
Add Travis CI link to output of release job script

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -127,4 +127,4 @@ if [ $? != 0 ]; then
   exit 1
 fi
 
-echo "Tag push complete. Please check the deployment status on GitHub."
+echo "Tag push complete. You can view the $TAG_NAME publish job here: https://travis-ci.com/github/linkedin/rest.li/builds"


### PR DESCRIPTION
Simple improvement for Rest.li maintainers.