### PR TITLE
Update Netty and depend on individual artifacts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ File getEnvironmentScript()
 apply from: environmentScript
 apply from: "${buildScriptDirPath}/configBuildScript.gradle"
 
+def versions = [
+  'netty': '4.1.58.Final'
+]
+
 project.ext.externalDependency = [
   'antlr': 'org.antlr:antlr4:4.5',
   'antlrRuntime': 'org.antlr:antlr4-runtime:4.5',
@@ -86,7 +90,13 @@ project.ext.externalDependency = [
   'log4j2Core': 'org.apache.logging.log4j:log4j-core:2.0.2',
   'log4jLog4j2': 'org.apache.logging.log4j:log4j-1.2-api:2.0.2',
   'mail': 'javax.mail:mail:1.4.4',
-  'netty': 'io.netty:netty-all:4.1.41.Final',
+  'nettyBuffer': "io.netty:netty-buffer:${versions['netty']}",
+  'nettyCodec': "io.netty:netty-codec:${versions['netty']}",
+  'nettyCodecHttp': "io.netty:netty-codec-http:${versions['netty']}",
+  'nettyCodecHttp2': "io.netty:netty-codec-http2:${versions['netty']}",
+  'nettyCommon': "io.netty:netty-common:${versions['netty']}",
+  'nettyHandler': "io.netty:netty-handler:${versions['netty']}",
+  'nettyTransport': "io.netty:netty-transport:${versions['netty']}",
   'objenesis': 'org.objenesis:objenesis:1.2',
   'parseq': 'com.linkedin.parseq:parseq:4.1.6',
   'parseq_tracevis': 'com.linkedin.parseq:parseq-tracevis:4.1.6',

--- a/d2-int-test/build.gradle
+++ b/d2-int-test/build.gradle
@@ -12,7 +12,6 @@ dependencies {
   compile externalDependency.commonsHttpClient
   compile externalDependency.zookeeper
   compile externalDependency.jdkTools
-  compile externalDependency.netty
   testCompile externalDependency.testng
   testCompile externalDependency.commonsIo
   testCompile project(path: ':d2', configuration: 'testArtifacts')
@@ -20,4 +19,3 @@ dependencies {
   testRuntime project(':r2-jetty')
   testCompile project(':test-util')
 }
-

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/TestServer.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/TestServer.java
@@ -229,7 +229,17 @@ public class TestServer
       {
         final String headerName = "X-Long-Header:";
         int size = Integer.parseInt(q.replace("headerSize=", ""));
-        int valueSize = size - headerName.length();
+
+        // We need to subtract 1 from the length of the header content
+        // we should generate, because Netty counts the trailing "\r\n"
+        // as a single character toward the header size.
+        //
+        // This appears to have been a change in Netty 4.1.46.Final in
+        // this commit:
+        //
+        //   https://github.com/netty/netty/commit/9ae782d632ff18f7c9e645c58458b3180d257ff3
+        //
+        int valueSize = size - headerName.length() - 1;
 
         char[] headerValue = new char[valueSize];
         Arrays.fill(headerValue, 'a');

--- a/r2-int-test/build.gradle
+++ b/r2-int-test/build.gradle
@@ -3,6 +3,9 @@ dependencies {
     compile project (':r2-sample')
     compile project (':test-util')
     testCompile project(path: ':r2-core', configuration: 'testArtifacts')
+    testCompile externalDependency.nettyCommon
+    testCompile externalDependency.nettyHandler
+    testCompile externalDependency.nettyTransport
     testCompile externalDependency.testng
     testCompile externalDependency.junit
     compile externalDependency.commonsLang

--- a/r2-netty/build.gradle
+++ b/r2-netty/build.gradle
@@ -6,7 +6,13 @@ dependencies {
   compile project(':r2-filter-compression')
 
   compile externalDependency.commonsLang
-  compile externalDependency.netty
+  compile externalDependency.nettyBuffer
+  compile externalDependency.nettyCodec
+  compile externalDependency.nettyCodecHttp
+  compile externalDependency.nettyCodecHttp2
+  compile externalDependency.nettyCommon
+  compile externalDependency.nettyHandler
+  compile externalDependency.nettyTransport
 
   testCompile project(path: ':r2-core', configuration: 'testArtifacts')
   testCompile externalDependency.mockito

--- a/r2-perf-test/build.gradle
+++ b/r2-perf-test/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   compile project (':r2-sample')
   compile project (':pegasus-common')
   compile project (':test-util')
+  testCompile externalDependency.nettyTransport
   testRuntime externalDependency.disruptor
 }
 

--- a/r2-sample/build.gradle
+++ b/r2-sample/build.gradle
@@ -4,6 +4,6 @@ dependencies {
   compile project(':pegasus-common')
   compile project(':data')
   compile project(':r2-jetty')
-  compile externalDependency.netty
+  compile externalDependency.nettyTransport
   compile externalDependency.servletApi
 }

--- a/restli-int-test/build.gradle
+++ b/restli-int-test/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   testCompile externalDependency.junit
   testCompile externalDependency.mockito
   testCompile externalDependency.httpclient
+  testCompile externalDependency.nettyTransport
   testCompile externalDependency.parseq_restClient
   testCompile externalDependency.parseq_testApi
   testDataModel project(path: ':restli-int-test-api', configuration: 'dataTemplate')


### PR DESCRIPTION
The main objective of this patch is to stop depending on the netty-all
uberjar in favor of the individual netty-* artifacts. This reduces the
weight of the dependencies that rest.li needs (as netty-all weighs in
at a hefty 4.1 MB).

More importantly, this plays much more nicely with other dependencies
that use the individual artifacts. Currently, there are issues inside
LinkedIn where the netty-all artifact shades some but not all of the
netty-* artifacts on the classpath, leading to runtime errors.

For discussion about this problem on the Netty Github, see:

  https://github.com/netty/netty/issues/4671

Since this is a backwards incompatible change, this patch also goes
ahead and updates the Netty version too, cause why not.