### PR TITLE
Compression filter changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.15.0] - 2021-02-17
+- Always enable client compression filter so that responses can be decompressed. If the request already has an accept encoding header set do not overwrite it.
+
 ## [29.14.5] - 2021-02-11
 - Shortcircuit already serialized projection params
 
@@ -4846,7 +4849,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.14.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.0...master
+[29.15.0]: https://github.com/linkedin/rest.li/compare/v29.14.5...v29.15.0
 [29.14.5]: https://github.com/linkedin/rest.li/compare/v29.14.4...v29.14.5
 [29.14.4]: https://github.com/linkedin/rest.li/compare/v29.14.3...v29.14.4
 [29.14.3]: https://github.com/linkedin/rest.li/compare/v29.14.2...v29.14.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.14.5
+version=29.15.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/ClientStreamCompressionFilter.java
+++ b/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/ClientStreamCompressionFilter.java
@@ -144,16 +144,16 @@ public class ClientStreamCompressionFilter implements StreamFilter
   public String buildAcceptEncodingHeader()
   {
     //Essentially, we want to assign nonzero quality values to all those specified;
-    float delta = 1.0f/(_acceptedEncodings.length+1);
+    float delta = 1.0f/(_acceptedEncodings.length + 1);
     float currentQuality = 1.0f;
 
     //Special case so we don't end with an unnecessary delimiter
     StringBuilder acceptEncodingValue = new StringBuilder();
-    for(int i=0; i < _acceptedEncodings.length; i++)
+    for (int i = 0; i < _acceptedEncodings.length; i++)
     {
       StreamEncodingType t = _acceptedEncodings[i];
 
-      if(i > 0)
+      if (i > 0)
       {
         acceptEncodingValue.append(CompressionConstants.ENCODING_DELIMITER);
       }
@@ -299,7 +299,7 @@ public class ClientStreamCompressionFilter implements StreamFilter
 
   private Map<String, String> stripHeaders(Map<String, String> headerMap, String...headers)
   {
-    Map<String, String> newMap = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+    Map<String, String> newMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     newMap.putAll(headerMap);
     for (String header : headers)
     {
@@ -309,7 +309,8 @@ public class ClientStreamCompressionFilter implements StreamFilter
   }
 
   /**
-   * Builds HTTP headers related to response compression and creates a RestRequest with those headers added.
+   * Builds HTTP headers related to response compression and creates a RestRequest with those headers added. If the
+   * request already has a {@link HttpConstants#ACCEPT_ENCODING} set, then it returns the input request as is.
    *
    * @param responseCompressionOverride compression force on/off override from the request context.
    * @param req current request.
@@ -317,6 +318,12 @@ public class ClientStreamCompressionFilter implements StreamFilter
    */
   public StreamRequest addResponseCompressionHeaders(CompressionOption responseCompressionOverride, StreamRequest req)
   {
+    // If the client manually set an accept encoding header, don't override and short circuit.
+    if (req.getHeader(HttpConstants.ACCEPT_ENCODING) != null)
+    {
+      return req;
+    }
+
     StreamRequestBuilder builder = req.builder();
     if (responseCompressionOverride == null)
     {

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamResponseCompression.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamResponseCompression.java
@@ -22,13 +22,7 @@ import com.linkedin.common.util.None;
 import com.linkedin.r2.filter.FilterChain;
 import com.linkedin.r2.filter.FilterChains;
 import com.linkedin.r2.filter.compression.ServerStreamCompressionFilter;
-import com.linkedin.r2.filter.compression.streaming.Bzip2Compressor;
-import com.linkedin.r2.filter.compression.streaming.DeflateCompressor;
-import com.linkedin.r2.filter.compression.streaming.GzipCompressor;
-import com.linkedin.r2.filter.compression.streaming.NoopCompressor;
-import com.linkedin.r2.filter.compression.streaming.SnappyCompressor;
 import com.linkedin.r2.filter.compression.streaming.StreamEncodingType;
-import com.linkedin.r2.filter.compression.streaming.StreamingCompressor;
 import com.linkedin.r2.filter.message.stream.StreamFilter;
 import com.linkedin.r2.message.RequestContext;
 import com.linkedin.r2.message.rest.RestStatus;
@@ -64,6 +58,7 @@ import test.r2.integ.clientserver.providers.client.ClientProvider;
 import test.r2.integ.clientserver.providers.server.ServerProvider;
 import test.r2.integ.helper.BytesReader;
 import test.r2.integ.helper.TimedBytesWriter;
+
 
 /**
  * @author Ang Xu
@@ -117,28 +112,28 @@ public class TestStreamResponseCompression extends AbstractServiceTest
   public void testDeflateCompression()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "deflate", new DeflateCompressor(_executor));
+    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "deflate");
   }
 
   @Test
   public void testGzipCompression()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "gzip", new GzipCompressor(_executor));
+    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "gzip");
   }
 
   @Test
   public void testBzip2Compression()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "bzip2", new Bzip2Compressor(_executor));
+    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "bzip2");
   }
 
   @Test
   public void testSnappyCompression()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "x-snappy-framed", new SnappyCompressor(_executor));
+    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "x-snappy-framed");
   }
 
   @Test
@@ -146,44 +141,42 @@ public class TestStreamResponseCompression extends AbstractServiceTest
       throws InterruptedException, ExecutionException, TimeoutException
   {
     testResponseCompression(SMALL_URI, SMALL_BYTES_NUM,
-                            "x-snappy-framed;q=1, bzip2;q=0.75, gzip;q=0.5, defalte;q=0",
-                            new SnappyCompressor(_executor));
+                            "x-snappy-framed;q=1, bzip2;q=0.75, gzip;q=0.5, defalte;q=0");
   }
 
   @Test
   public void testSnappyCompression3()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "x-snappy-framed, *;q=0",
-                            new SnappyCompressor(_executor));
+    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "x-snappy-framed, *;q=0");
   }
 
   @Test
   public void testNoCompression()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "identity", new NoopCompressor());
+    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "identity");
   }
 
   @Test
   public void testNoCompression2()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "", new NoopCompressor());
+    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "");
   }
 
   @Test
   public void testNoCompression3()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "foobar", new NoopCompressor());
+    testResponseCompression(SMALL_URI, SMALL_BYTES_NUM, "foobar");
   }
 
   @Test
   public void testCompressionThreshold()
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    testResponseCompression(TINY_URI, TINY_BYTES_NUM, "x-snappy-framed", new NoopCompressor());
+    testResponseCompression(TINY_URI, TINY_BYTES_NUM, "x-snappy-framed");
   }
 
   @Test
@@ -193,7 +186,7 @@ public class TestStreamResponseCompression extends AbstractServiceTest
     testEncodingNotAcceptable("foobar, identity;q=0");
   }
 
-  private void testResponseCompression(URI uri, long bytes, String acceptEncoding, final StreamingCompressor compressor)
+  private void testResponseCompression(URI uri, long bytes, String acceptEncoding)
       throws InterruptedException, TimeoutException, ExecutionException
   {
     StreamRequestBuilder builder = new StreamRequestBuilder((_clientProvider.createHttpURI(_port, uri)));
@@ -208,7 +201,7 @@ public class TestStreamResponseCompression extends AbstractServiceTest
 
     final FutureCallback<None> readerCallback = new FutureCallback<None>();
     final BytesReader reader = new BytesReader(BYTE, readerCallback);
-    final EntityStream decompressedStream = compressor.inflate(response.getEntityStream());
+    final EntityStream decompressedStream = response.getEntityStream();
     decompressedStream.setReader(reader);
 
     readerCallback.get(60, TimeUnit.SECONDS);

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
@@ -1080,6 +1080,14 @@ public class HttpClientFactory implements TransportClientFactory
             _responseCompressionConfigs.get(httpServiceName),
             httpResponseCompressionOperations));
       }
+      else
+      {
+        filters = filters.addLastRest(new ClientCompressionFilter(EncodingType.IDENTITY,
+            _defaultRequestCompressionConfig,
+            null,
+            null,
+            Collections.emptyList()));
+      }
 
       if (streamRequestContentEncoding != StreamEncodingType.IDENTITY || !httpResponseCompressionOperations.isEmpty())
       {
@@ -1089,6 +1097,15 @@ public class HttpClientFactory implements TransportClientFactory
             buildStreamAcceptEncodingSchemas(responseEncodings),
             _responseCompressionConfigs.get(httpServiceName),
             httpResponseCompressionOperations,
+            _compressionExecutor));
+      }
+      else
+      {
+        filters = filters.addLast(new ClientStreamCompressionFilter(StreamEncodingType.IDENTITY,
+            _defaultRequestCompressionConfig,
+            null,
+            null,
+            Collections.emptyList(),
             _compressionExecutor));
       }
     }


### PR DESCRIPTION
Always enable client compression filter so that responses can be decompressed. If the request already has an accept encoding header set do not overwrite it