### PR TITLE
Add UnionTemplate.memberKeyName()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.15.2] - 2021-02-19
 - Add UnionTemplate.memberKeyName() to directly return the key name for a union member
 
 ## [29.15.1] - 2021-02-18
@@ -4853,7 +4855,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.2...master
+[29.15.2]: https://github.com/linkedin/rest.li/compare/v29.15.1...v29.15.2
 [29.15.1]: https://github.com/linkedin/rest.li/compare/v29.15.0...v29.15.1
 [29.15.0]: https://github.com/linkedin/rest.li/compare/v29.14.5...v29.15.0
 [29.14.5]: https://github.com/linkedin/rest.li/compare/v29.14.4...v29.14.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add UnionTemplate.memberKeyName() to directly return the key name for a union member
 
 ## [29.15.1] - 2021-02-18
 - Cleanup compression code to reduce duplication and minimize memcopies 

--- a/data/src/main/java/com/linkedin/data/template/UnionTemplate.java
+++ b/data/src/main/java/com/linkedin/data/template/UnionTemplate.java
@@ -137,6 +137,18 @@ public class UnionTemplate implements DataTemplate<Object>
   }
 
   /**
+   * Name of the key that identifies the contained member in the Union.
+   *
+   * @return the name of the key that identifies the contained member.
+   * @throws NullUnionUnsupportedOperationException if the union is a null union.
+   */
+  public String memberKeyName()
+  {
+    checkNotNull();
+    return _map.keySet().iterator().next();
+  }
+
+  /**
    * Returns whether the contained member in the Union is identified by the specified key.
    *
    * If the underlying {@link DataMap} has a single entry and the entry's key equals the

--- a/data/src/test/java/com/linkedin/data/template/TestRecordAndUnionTemplate.java
+++ b/data/src/test/java/com/linkedin/data/template/TestRecordAndUnionTemplate.java
@@ -2614,6 +2614,7 @@ public class TestRecordAndUnionTemplate
     Foo.Union union2 = foo.getUnion();
     assertFalse(union2.isNull());
     assertTrue(union2.isInt());
+    assertEquals(union2.memberKeyName(), "int");
     assertEquals(union2.getInt(), value);
     assertSame(union2.memberType(), Foo.Union.MEMBER_int);
     assertNull(union2.getBar());
@@ -2627,6 +2628,7 @@ public class TestRecordAndUnionTemplate
     union2.setBar(bar);
     assertFalse(union2.isNull());
     assertTrue(union2.isBar());
+    assertEquals(union2.memberKeyName(), "Bar");
     assertEquals(union2.getBar().getInt(), value);
     assertSame(union2.memberType(), Foo.Union.MEMBER_Bar);
     assertNull(union2.getInt());
@@ -2645,6 +2647,7 @@ public class TestRecordAndUnionTemplate
       assertFalse(unionClone.isNull());
       assertFalse(unionClone.isInt());
       assertTrue(unionClone.isBar());
+      assertEquals(union2.memberKeyName(), "Bar");
       assertEquals(unionClone.getBar().getInt(), value);
       assertSame(unionClone.getBar(), union2.getBar());
       assertEquals(unionClone.getBar(), union2.getBar());
@@ -2674,8 +2677,10 @@ public class TestRecordAndUnionTemplate
       unionCopy = union2.copy();
       unionCopy.setEnumType(EnumType.APPLE);
       assertTrue(union2.isBar());
+      assertEquals(union2.memberKeyName(), "Bar");
       assertEquals(union2.getBar().getInt(), origValue);
       assertTrue(unionCopy.isEnumType());
+      assertEquals(unionCopy.memberKeyName(), "EnumType");
       assertSame(unionCopy.getEnumType(), EnumType.APPLE);
     }
     catch (CloneNotSupportedException e)
@@ -2848,6 +2853,19 @@ public class TestRecordAndUnionTemplate
     assertTrue(exc != null);
     assertTrue(exc instanceof NullUnionUnsupportedOperationException);
 
+    // memberKeyName cannot be used with null union
+    try
+    {
+      exc = null;
+      union.memberKeyName();
+    }
+    catch (Exception e)
+    {
+      exc = e;
+    }
+    assertTrue(exc != null);
+    assertTrue(exc instanceof NullUnionUnsupportedOperationException);
+
     // test legacy
     union = new Foo.Union(new DataMap());
     Integer i = 43;
@@ -2909,6 +2927,7 @@ public class TestRecordAndUnionTemplate
     assertFalse(unionWithAliases.isFruit());
     assertFalse(unionWithAliases.isNull());
 
+    assertEquals(unionWithAliases.memberKeyName(), "label");
     assertTrue(unionWithAliases.memberIs("label"));
     assertEquals(unionWithAliases.memberType(), Foo.UnionWithAliases.MEMBER_Label);
 
@@ -2928,6 +2947,7 @@ public class TestRecordAndUnionTemplate
     assertFalse(unionWithAliases.isFruit());
     assertFalse(unionWithAliases.isNull());
 
+    assertEquals(unionWithAliases.memberKeyName(), "count");
     assertTrue(unionWithAliases.memberIs("count"));
     assertEquals(unionWithAliases.memberType(), Foo.UnionWithAliases.MEMBER_Count);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.15.1
+version=29.15.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
New function for UnionTemplate to directly reeturn the key name for a
given union member.


./gradlew :data:build

BUILD SUCCESSFUL in 47s
21 actionable tasks: 21 executed