### PR TITLE
Prevent RetriableRequestException from cascading to the indirect caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.15.3] - 2021-02-24
 - Add support for update, partial_update, delete and get_all methods in fluent API bindings.
+- Prevent RetriableRequestException from cascading to the indirect caller.
 
 ## [29.15.2] - 2021-02-19
 - Add UnionTemplate.memberKeyName() to directly return the key name for a union member
@@ -4856,7 +4859,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.3...master
+[29.15.3]: https://github.com/linkedin/rest.li/compare/v29.15.2...v29.15.3
 [29.15.2]: https://github.com/linkedin/rest.li/compare/v29.15.1...v29.15.2
 [29.15.1]: https://github.com/linkedin/rest.li/compare/v29.15.0...v29.15.1
 [29.15.0]: https://github.com/linkedin/rest.li/compare/v29.14.5...v29.15.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/RetryClient.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/RetryClient.java
@@ -309,6 +309,7 @@ public class RetryClient extends D2ClientDelegator
                 else
                 {
                   LOG.warn("Client retry ratio exceeded. This request will fail.");
+                  disableRetryException(e);
                   doRetry = false;
                 }
                 if (!doRetry)
@@ -321,6 +322,7 @@ public class RetryClient extends D2ClientDelegator
             else
             {
               LOG.warn("Retry limit exceeded. This request will fail.");
+              disableRetryException(e);
             }
           }
         }
@@ -345,6 +347,20 @@ public class RetryClient extends D2ClientDelegator
       }
 
       return false;
+    }
+
+    private void disableRetryException(Throwable e)
+    {
+      Throwable[] throwables = ExceptionUtils.getThrowables(e);
+
+      for (Throwable throwable: throwables)
+      {
+        if (throwable instanceof RetriableRequestException)
+        {
+          ((RetriableRequestException) throwable).setDoNotRetryOverride(true);
+          return;
+        }
+      }
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.15.2
+version=29.15.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/filter/transport/ServerRetryFilter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/filter/transport/ServerRetryFilter.java
@@ -115,16 +115,18 @@ public class ServerRetryFilter implements RestFilter, StreamFilter
     {
       if (cause instanceof RetriableRequestException)
       {
-        String message = cause.getMessage();
-        if (_serverRetryTracker.isBelowRetryRatio())
+        if (!((RetriableRequestException) cause).getDoNotRetryOverride())
         {
-          LOG.debug("RetriableRequestException caught! Do retry. Error message: {}", message);
-          wireAttrs.put(R2Constants.RETRY_MESSAGE_ATTRIBUTE_KEY, message);
-        }
-        else
-        {
-          LOG.debug("Max request retry ratio exceeded! Will not retry. Error message: {}", message);
-          wireAttrs.remove(R2Constants.RETRY_MESSAGE_ATTRIBUTE_KEY);
+          String message = cause.getMessage();
+          if (_serverRetryTracker.isBelowRetryRatio())
+          {
+            LOG.debug("RetriableRequestException caught! Do retry. Error message: {}", message);
+            wireAttrs.put(R2Constants.RETRY_MESSAGE_ATTRIBUTE_KEY, message);
+          }
+          else
+          {
+            LOG.debug("Max request retry ratio exceeded! Will not retry. Error message: {}", message);
+          }
         }
         break;
       }


### PR DESCRIPTION
Suppose A sends request to B, and B sends request to C. When C is overloaded, B will retry its requests on C. If all of the retry attempts failed, the error will be propagated back to A. But we would like to prevent the RetriableRequestException from C from cascading to the indirect caller A, and therefore, we need to disable retry at B in this case.