### PR TITLE
[rest.li] Fix content type header not set in case of StreamException from rest.li server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Fix content type header not set in case of StreamException from rest.li server
 
 ## [29.15.3] - 2021-02-24
 - Add support for update, partial_update, delete and get_all methods in fluent API bindings.

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/response/ResponseUtils.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/response/ResponseUtils.java
@@ -252,16 +252,17 @@ public class ResponseUtils
     return new RestException(restResponse, cause==null ? null : cause.toString(), cause, writableStackTrace);
   }
 
-  public static StreamException buildStreamException(RestLiResponseException restLiResponseException, StreamDataCodec codec)
+  public static StreamException buildStreamException(RestLiResponseException restLiResponseException, ContentType contentType)
   {
     RestLiResponse restLiResponse = restLiResponseException.getRestLiResponse();
     StreamResponseBuilder responseBuilder = new StreamResponseBuilder()
         .setHeaders(restLiResponse.getHeaders())
+        .setHeader(RestConstants.HEADER_CONTENT_TYPE, contentType.getHeaderKey())
         .setCookies(CookieUtil.encodeSetCookies(restLiResponse.getCookies()))
         .setStatus(restLiResponse.getStatus() == null ? HttpStatus.S_500_INTERNAL_SERVER_ERROR.getCode()
             : restLiResponse.getStatus().getCode());
 
-    EntityStream<ByteString> entityStream = codec.encodeMap(restLiResponse.getDataMap());
+    EntityStream<ByteString> entityStream = contentType.getStreamCodec().encodeMap(restLiResponse.getDataMap());
     StreamResponse response = responseBuilder.build(EntityStreamAdapters.fromGenericEntityStream(entityStream));
     return new StreamException(response, restLiResponseException.getCause());
   }

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/response/ResponseUtils.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/response/ResponseUtils.java
@@ -252,6 +252,24 @@ public class ResponseUtils
     return new RestException(restResponse, cause==null ? null : cause.toString(), cause, writableStackTrace);
   }
 
+  /**
+   * @Deprecated: Use buildStreamException(RestLiResponseException, ContentType) method instead
+   */
+  @Deprecated
+  public static StreamException buildStreamException(RestLiResponseException restLiResponseException, StreamDataCodec codec)
+  {
+    RestLiResponse restLiResponse = restLiResponseException.getRestLiResponse();
+    StreamResponseBuilder responseBuilder = new StreamResponseBuilder()
+        .setHeaders(restLiResponse.getHeaders())
+        .setCookies(CookieUtil.encodeSetCookies(restLiResponse.getCookies()))
+        .setStatus(restLiResponse.getStatus() == null ? HttpStatus.S_500_INTERNAL_SERVER_ERROR.getCode()
+            : restLiResponse.getStatus().getCode());
+
+    EntityStream<ByteString> entityStream = codec.encodeMap(restLiResponse.getDataMap());
+    StreamResponse response = responseBuilder.build(EntityStreamAdapters.fromGenericEntityStream(entityStream));
+    return new StreamException(response, restLiResponseException.getCause());
+  }
+
   public static StreamException buildStreamException(RestLiResponseException restLiResponseException, ContentType contentType)
   {
     RestLiResponse restLiResponse = restLiResponseException.getRestLiResponse();

--- a/restli-server/src/main/java/com/linkedin/restli/server/StreamRestLiServer.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/StreamRestLiServer.java
@@ -369,7 +369,7 @@ class StreamRestLiServer extends BaseRestLiServer implements StreamRequestHandle
         TimingContextUtil.beginTiming(requestContext, FrameworkTimingKeys.SERVER_RESPONSE_RESTLI_ERROR_SERIALIZATION.key());
 
         RestLiResponseException responseException = (RestLiResponseException) e;
-        final Throwable throwable = ResponseUtils.buildStreamException(responseException, _contentType.getStreamCodec());
+        final Throwable throwable = ResponseUtils.buildStreamException(responseException, _contentType);
 
         TimingContextUtil.endTiming(requestContext, FrameworkTimingKeys.SERVER_RESPONSE_RESTLI_ERROR_SERIALIZATION.key());
         return throwable;

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/response/TestResponseUtils.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/response/TestResponseUtils.java
@@ -21,7 +21,12 @@ import com.linkedin.data.schema.SchemaFormatType;
 import com.linkedin.data.schema.generator.AbstractGenerator;
 import com.linkedin.data.schema.resolver.MultiFormatDataSchemaResolver;
 import com.linkedin.data.template.DataTemplateUtil;
+import com.linkedin.r2.message.stream.StreamException;
+import com.linkedin.restli.common.ContentType;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.common.RestConstants;
 import com.linkedin.restli.internal.server.util.DataMapUtils;
+import com.linkedin.restli.server.TestRecord;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.Collections;
@@ -83,6 +88,24 @@ public class TestResponseUtils
     {
       Assert.fail("Test failed with exception: \n" + e.toString());
     }
+  }
+
+  @Test
+  public void testContentTypeHeaderForStreamException()
+  {
+    RestLiResponseException restLiResponseException = new RestLiResponseException(
+        new RuntimeException("this is a test"),
+        new RestLiResponse.Builder()
+            .status(HttpStatus.S_500_INTERNAL_SERVER_ERROR)
+            .entity(new TestRecord())
+            .headers(Collections.emptyMap())
+            .cookies(Collections.emptyList())
+            .build());
+
+    StreamException streamException = ResponseUtils.buildStreamException(restLiResponseException, ContentType.PROTOBUF2);
+
+    Assert.assertEquals(streamException.getResponse().getHeader(RestConstants.HEADER_CONTENT_TYPE),
+        ContentType.PROTOBUF2.getHeaderKey());
   }
 
   @AfterTest


### PR DESCRIPTION
This PR is to fix restli-client side decoding of error response data map failure, when restli server returns error data for stream requests.