### PR TITLE
D2 Cluster Subsetting Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.17.0] - 2021-03-23
+- Implement D2 cluster subsetting.
+
 ## [29.16.2] - 2021-03-22
 - Fix an issue where in collection response, we did not fill in the default values in the metadata and paging metadata.
 
@@ -4889,7 +4892,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.16.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.17.0...master
+[29.17.0]: https://github.com/linkedin/rest.li/compare/v29.16.2...v29.17.0
 [29.16.2]: https://github.com/linkedin/rest.li/compare/v29.16.1...v29.16.2
 [29.16.1]: https://github.com/linkedin/rest.li/compare/v29.16.0...v29.16.1
 [29.16.0]: https://github.com/linkedin/rest.li/compare/v29.15.9...v29.16.0

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Service.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Service.pdl
@@ -98,7 +98,12 @@ record D2Service includes D2ChangeTimeStamps {
   backupRequests: optional array[BackupRequestsConfiguration]
 
   /**
-   * The minimum cluster subset size for this service. With a value greater than 0, each client will only send requests to a subset of the hosts in the cluster. A value of -1 disables the feature.
+   * When enabled, client will only send requests to a subset of the hosts in the cluster. Used together with minClusterSubsetSize.
+   */
+  enableClusterSubsetting: optional boolean
+
+  /**
+   * The minimum cluster subset size for this service. Will only take effect when enableClusterSubsetting is set to true.
    */
   minClusterSubsetSize: optional int
 }

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Service.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Service.pdl
@@ -96,4 +96,9 @@ record D2Service includes D2ChangeTimeStamps {
    * Configuration of backup requests. Each element describes backup requests configuration for specific operation.
    */
   backupRequests: optional array[BackupRequestsConfiguration]
+
+  /**
+   * The minimum cluster subset size for this service. With a value greater than 0, each client will only send requests to a subset of the hosts in the cluster. A value of -1 disables the feature.
+   */
+  minClusterSubsetSize: optional int
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -33,6 +33,7 @@ import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategy
 import com.linkedin.d2.balancer.strategies.random.RandomLoadBalancerStrategyFactory;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
 import com.linkedin.d2.balancer.util.downstreams.DownstreamServicesFetcher;
 import com.linkedin.d2.balancer.util.downstreams.FSBasedDownstreamServicesFetcher;
 import com.linkedin.d2.balancer.util.healthcheck.HealthCheckOperations;
@@ -173,7 +174,8 @@ public class D2ClientBuilder
                   _config.jmxManager,
                   _config.d2JmxManagerPrefix,
                   _config.zookeeperReadWindowMs,
-                  _config.enableRelativeLoadBalancer);
+                  _config.enableRelativeLoadBalancer,
+                  _config.subsettingStrategyFactory);
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() :
@@ -527,6 +529,12 @@ public class D2ClientBuilder
   public D2ClientBuilder setEnableRelativeLoadBalancer(boolean enableRelativeLoadBalancer)
   {
     _config.enableRelativeLoadBalancer = enableRelativeLoadBalancer;
+    return this;
+  }
+
+  public D2ClientBuilder setSubsettingStrategyFactory(SubsettingStrategyFactory subsettingStrategyFactory)
+  {
+    _config.subsettingStrategyFactory = subsettingStrategyFactory;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -34,7 +34,6 @@ import com.linkedin.d2.balancer.strategies.random.RandomLoadBalancerStrategyFact
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategyFactory;
 import com.linkedin.d2.balancer.subsetting.DeterministicSubsettingMetadataProvider;
-import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
 import com.linkedin.d2.balancer.util.downstreams.DownstreamServicesFetcher;
 import com.linkedin.d2.balancer.util.downstreams.FSBasedDownstreamServicesFetcher;
 import com.linkedin.d2.balancer.util.healthcheck.HealthCheckOperations;

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -33,6 +33,7 @@ import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategy
 import com.linkedin.d2.balancer.strategies.random.RandomLoadBalancerStrategyFactory;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.subsetting.DeterministicSubsettingMetadataProvider;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
 import com.linkedin.d2.balancer.util.downstreams.DownstreamServicesFetcher;
 import com.linkedin.d2.balancer.util.downstreams.FSBasedDownstreamServicesFetcher;
@@ -175,7 +176,7 @@ public class D2ClientBuilder
                   _config.d2JmxManagerPrefix,
                   _config.zookeeperReadWindowMs,
                   _config.enableRelativeLoadBalancer,
-                  _config.subsettingStrategyFactory);
+                  _config.deterministicSubsettingMetadataProvider);
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() :
@@ -532,9 +533,9 @@ public class D2ClientBuilder
     return this;
   }
 
-  public D2ClientBuilder setSubsettingStrategyFactory(SubsettingStrategyFactory subsettingStrategyFactory)
+  public D2ClientBuilder setDeterministicSubsettingMetadataProvider(DeterministicSubsettingMetadataProvider provider)
   {
-    _config.subsettingStrategyFactory = subsettingStrategyFactory;
+    _config.deterministicSubsettingMetadataProvider = provider;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -21,6 +21,8 @@ import com.linkedin.d2.balancer.event.EventEmitter;
 import com.linkedin.d2.balancer.simple.SslSessionValidatorFactory;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
+import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactoryImpl;
 import com.linkedin.d2.balancer.util.WarmUpLoadBalancer;
 import com.linkedin.d2.balancer.util.downstreams.DownstreamServicesFetcher;
 import com.linkedin.d2.balancer.util.healthcheck.HealthCheckOperations;
@@ -103,7 +105,7 @@ public class D2ClientConfig
   JmxManager jmxManager = new NoOpJmxManager();
   String d2JmxManagerPrefix = "UnknownPrefix";
   boolean enableRelativeLoadBalancer = false;
-
+  SubsettingStrategyFactory subsettingStrategyFactory = SubsettingStrategyFactory.NO_OP_SUBSETTING_STRATEGY_FACTORY;
   public static final int DEAULT_RETRY_LIMIT = 3;
 
   public D2ClientConfig()
@@ -159,7 +161,8 @@ public class D2ClientConfig
                  JmxManager jmxManager,
                  String d2JmxManagerPrefix,
                  int zookeeperReadWindowMs,
-                 boolean enableRelativeLoadBalancer)
+                 boolean enableRelativeLoadBalancer,
+                 SubsettingStrategyFactory subsettingStrategyFactory)
   {
     this.zkHosts = zkHosts;
     this.zkSessionTimeoutInMs = zkSessionTimeoutInMs;
@@ -211,5 +214,6 @@ public class D2ClientConfig
     this.d2JmxManagerPrefix = d2JmxManagerPrefix;
     this.zookeeperReadWindowMs = zookeeperReadWindowMs;
     this.enableRelativeLoadBalancer = enableRelativeLoadBalancer;
+    this.subsettingStrategyFactory = subsettingStrategyFactory;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -21,6 +21,7 @@ import com.linkedin.d2.balancer.event.EventEmitter;
 import com.linkedin.d2.balancer.simple.SslSessionValidatorFactory;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.subsetting.DeterministicSubsettingMetadataProvider;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactoryImpl;
 import com.linkedin.d2.balancer.util.WarmUpLoadBalancer;
@@ -105,7 +106,7 @@ public class D2ClientConfig
   JmxManager jmxManager = new NoOpJmxManager();
   String d2JmxManagerPrefix = "UnknownPrefix";
   boolean enableRelativeLoadBalancer = false;
-  SubsettingStrategyFactory subsettingStrategyFactory = SubsettingStrategyFactory.NO_OP_SUBSETTING_STRATEGY_FACTORY;
+  DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider = null;
   public static final int DEAULT_RETRY_LIMIT = 3;
 
   public D2ClientConfig()
@@ -162,7 +163,7 @@ public class D2ClientConfig
                  String d2JmxManagerPrefix,
                  int zookeeperReadWindowMs,
                  boolean enableRelativeLoadBalancer,
-                 SubsettingStrategyFactory subsettingStrategyFactory)
+                 DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider)
   {
     this.zkHosts = zkHosts;
     this.zkSessionTimeoutInMs = zkSessionTimeoutInMs;
@@ -214,6 +215,6 @@ public class D2ClientConfig
     this.d2JmxManagerPrefix = d2JmxManagerPrefix;
     this.zookeeperReadWindowMs = zookeeperReadWindowMs;
     this.enableRelativeLoadBalancer = enableRelativeLoadBalancer;
-    this.subsettingStrategyFactory = subsettingStrategyFactory;
+    this.deterministicSubsettingMetadataProvider = deterministicSubsettingMetadataProvider;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -22,8 +22,6 @@ import com.linkedin.d2.balancer.simple.SslSessionValidatorFactory;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
 import com.linkedin.d2.balancer.subsetting.DeterministicSubsettingMetadataProvider;
-import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
-import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactoryImpl;
 import com.linkedin.d2.balancer.util.WarmUpLoadBalancer;
 import com.linkedin.d2.balancer.util.downstreams.DownstreamServicesFetcher;
 import com.linkedin.d2.balancer.util.healthcheck.HealthCheckOperations;

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -99,7 +99,7 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     SimpleLoadBalancerState state = new SimpleLoadBalancerState(
       config._executorService, uriBus, clusterBus, serviceBus, config.clientFactories, config.loadBalancerStrategyFactories,
       config.sslContext, config.sslParameters, config.isSSLEnabled, config.partitionAccessorRegistry,
-      config.sslSessionValidatorFactory, config.subsettingStrategyFactory);
+      config.sslSessionValidatorFactory, config.deterministicSubsettingMetadataProvider);
     d2ClientJmxManager.setSimpleLoadBalancerState(state);
 
     SimpleLoadBalancer simpleLoadBalancer = new SimpleLoadBalancer(state, config.lbWaitTimeout, config.lbWaitUnit, config._executorService);

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -99,7 +99,7 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     SimpleLoadBalancerState state = new SimpleLoadBalancerState(
       config._executorService, uriBus, clusterBus, serviceBus, config.clientFactories, config.loadBalancerStrategyFactories,
       config.sslContext, config.sslParameters, config.isSSLEnabled, config.partitionAccessorRegistry,
-      config.sslSessionValidatorFactory);
+      config.sslSessionValidatorFactory, config.subsettingStrategyFactory);
     d2ClientJmxManager.setSimpleLoadBalancerState(state);
 
     SimpleLoadBalancer simpleLoadBalancer = new SimpleLoadBalancer(state, config.lbWaitTimeout, config.lbWaitUnit, config._executorService);

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
@@ -29,6 +29,7 @@ import com.linkedin.r2.transport.common.bridge.client.TransportClient;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -89,6 +90,14 @@ public interface LoadBalancerState
 
   List<SchemeStrategyPair> getStrategiesForService(String serviceName,
                                                     List<String> prioritizedSchemes);
+
+  default Map<URI, TrackerClient> getClientsSubset(String serviceName,
+                                                   ServiceProperties serviceProperties,
+                                                   int partitionId,
+                                                   Map<URI, TrackerClient> potentialClients)
+  {
+    return potentialClients;
+  }
 
   /**
    * This registers the LoadBalancerClusterListener with the LoadBalancerState, so that

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
@@ -92,7 +92,7 @@ public interface LoadBalancerState
                                                     List<String> prioritizedSchemes);
 
   default Map<URI, TrackerClient> getClientsSubset(String serviceName,
-                                                   ServiceProperties serviceProperties,
+                                                   int minClusterSubsetSize,
                                                    int partitionId,
                                                    Map<URI, TrackerClient> potentialClients)
   {

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -93,7 +93,7 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    config.sslSessionValidatorFactory,
                                                    d2ClientJmxManager,
                                                    config.zookeeperReadWindowMs,
-                                                   config.subsettingStrategyFactory
+                                                   config.deterministicSubsettingMetadataProvider
     );
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -92,7 +92,8 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    config.enableSaveUriDataOnDisk,
                                                    config.sslSessionValidatorFactory,
                                                    d2ClientJmxManager,
-                                                   config.zookeeperReadWindowMs
+                                                   config.zookeeperReadWindowMs,
+                                                   config.subsettingStrategyFactory
     );
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClient.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClient.java
@@ -62,6 +62,19 @@ public interface TrackerClient extends LoadBalancerClient
   }
 
   /**
+   * @param partitionId Partition ID key.
+   * @param subsetWeight Weight of the tracker client in the subset
+   */
+  default void setSubsetWeight(int partitionId, double subsetWeight)
+  {
+  }
+
+  default double getSubsetWeight(int partitionId)
+  {
+    return 1D;
+  }
+
+  /**
    * @return CallTracker.
    */
   CallTracker getCallTracker();

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -74,7 +75,7 @@ public class TrackerClientImpl implements TrackerClient
   private final URI _uri;
   private final Predicate<Integer> _isErrorStatus;
   private final boolean _doNotSlowStart;
-  private final Map<Integer, Double> _subsetWeightMap;
+  private final ConcurrentMap<Integer, Double> _subsetWeightMap;
   final CallTracker _callTracker;
 
   private volatile CallTracker.CallStats _latestCallStats;

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
@@ -48,6 +48,7 @@ import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
 import java.util.Map;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -73,6 +74,7 @@ public class TrackerClientImpl implements TrackerClient
   private final URI _uri;
   private final Predicate<Integer> _isErrorStatus;
   private final boolean _doNotSlowStart;
+  private final Map<Integer, Double> _subsetWeightMap;
   final CallTracker _callTracker;
 
   private volatile CallTracker.CallStats _latestCallStats;
@@ -93,6 +95,7 @@ public class TrackerClientImpl implements TrackerClient
     _partitionData = Collections.unmodifiableMap(partitionDataMap);
     _latestCallStats = _callTracker.getCallStats();
     _doNotSlowStart = doNotSlowStart;
+    _subsetWeightMap = new ConcurrentHashMap<>();
 
     _callTracker.addStatsRolloverEventListener(event -> _latestCallStats = event.getCallStats());
 
@@ -121,6 +124,17 @@ public class TrackerClientImpl implements TrackerClient
   public Map<Integer, PartitionData> getPartitionDataMap()
   {
     return _partitionData;
+  }
+
+  @Override
+  public void setSubsetWeight(int partitionId, double partitionWeight)
+  {
+    _subsetWeightMap.put(partitionId, partitionWeight);
+  }
+
+  @Override
+  public double getSubsetWeight(int partitionId) {
+    return _subsetWeightMap.getOrDefault(partitionId, 1D);
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/balancer/event/D2MonitorEventEmitter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/event/D2MonitorEventEmitter.java
@@ -113,7 +113,7 @@ public class D2MonitorEventEmitter
 
   private boolean isClientHealthy(TrackerClient trackerClient, final Map<URI, Integer> pointsMap)
   {
-    int perfectHealth = (int) (trackerClient.getPartitionWeight(_partitionId) * _pointsPerWeight);
+    int perfectHealth = (int) (trackerClient.getPartitionWeight(_partitionId) * trackerClient.getSubsetWeight(_partitionId) * _pointsPerWeight);
     return pointsMap.get(trackerClient.getUri()) >= perfectHealth;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -72,6 +72,7 @@ public class PropertyKeys
   public static final String ALLOWED_CLIENT_OVERRIDE_KEYS = "allowedClientOverrideKeys";
   public static final String SERVICE_METADATA_PROPERTIES = "serviceMetadataProperties";
   public static final String RELATIVE_STRATEGY_PROPERTIES = "relativeStrategyProperties";
+  public static final String ENABLE_CLUSTER_SUBSETTING = "enableClusterSubsetting";
   public static final String MIN_CLUSTER_SUBSET_SIZE = "minClusterSubsetSize";
 
   //load balancer specific properties

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -72,6 +72,7 @@ public class PropertyKeys
   public static final String ALLOWED_CLIENT_OVERRIDE_KEYS = "allowedClientOverrideKeys";
   public static final String SERVICE_METADATA_PROPERTIES = "serviceMetadataProperties";
   public static final String RELATIVE_STRATEGY_PROPERTIES = "relativeStrategyProperties";
+  public static final String MIN_CLUSTER_SUBSET_SIZE = "minClusterSubsetSize";
 
   //load balancer specific properties
   public static final String LB_STRATEGY_LIST = "loadBalancerStrategyList";

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceProperties.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.balancer.properties;
 
+import com.linkedin.d2.balancer.subsetting.SubsettingStrategy;
 import com.linkedin.util.ArgumentUtil;
 
 import java.net.URI;
@@ -39,6 +40,7 @@ public class ServiceProperties
   private final List<String> _prioritizedSchemes;
   private final Set<URI> _banned;
   private final Map<String, Object> _serviceMetadataProperties;
+  private final int _minClusterSubsetSize;
 
   public ServiceProperties(String serviceName,
                            String clusterName,
@@ -125,6 +127,25 @@ public class ServiceProperties
                            List<Map<String,Object>> backupRequests,
                            Map<String, Object> relativeStrategyProperties)
   {
+    this(serviceName, clusterName, path, prioritizedStrategyList, loadBalancerStrategyProperties, transportClientProperties, degraderProperties,
+        prioritizedSchemes, banned, serviceMetadataProperties, backupRequests, relativeStrategyProperties,
+        SubsettingStrategy.DEFAULT_CLUSTER_SUBSET_SIZE);
+  }
+
+  public ServiceProperties(String serviceName,
+      String clusterName,
+      String path,
+      List<String> prioritizedStrategyList,
+      Map<String,Object> loadBalancerStrategyProperties,
+      Map<String,Object> transportClientProperties,
+      Map<String,String> degraderProperties,
+      List<String> prioritizedSchemes,
+      Set<URI> banned,
+      Map<String,Object> serviceMetadataProperties,
+      List<Map<String,Object>> backupRequests,
+      Map<String, Object> relativeStrategyProperties,
+      int minClusterSubsetSize)
+  {
     ArgumentUtil.notNull(serviceName, PropertyKeys.SERVICE_NAME);
     ArgumentUtil.notNull(clusterName, PropertyKeys.CLUSTER_NAME);
     ArgumentUtil.notNull(path, PropertyKeys.PATH);
@@ -153,6 +174,7 @@ public class ServiceProperties
         Collections.<String,Object>emptyMap();
     _relativeStrategyProperties = relativeStrategyProperties != null
         ? relativeStrategyProperties : Collections.emptyMap();
+    _minClusterSubsetSize = minClusterSubsetSize;
   }
 
   public String getClusterName()
@@ -232,6 +254,11 @@ public class ServiceProperties
     return _serviceMetadataProperties;
   }
 
+  public int getMinClusterSubsetSize()
+  {
+    return _minClusterSubsetSize;
+  }
+
   @Override
   public String toString()
   {
@@ -254,8 +281,8 @@ public class ServiceProperties
         + _serviceMetadataProperties
         + ", backupRequests="
         + _backupRequests
-        + ", relativeStrategyProperties="
-        + _relativeStrategyProperties
+        + ", minimumClusterSubsetSize="
+        + _minClusterSubsetSize
         + "]";
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceProperties.java
@@ -40,6 +40,7 @@ public class ServiceProperties
   private final List<String> _prioritizedSchemes;
   private final Set<URI> _banned;
   private final Map<String, Object> _serviceMetadataProperties;
+  private final boolean _enableClusterSubsetting;
   private final int _minClusterSubsetSize;
 
   public ServiceProperties(String serviceName,
@@ -129,7 +130,7 @@ public class ServiceProperties
   {
     this(serviceName, clusterName, path, prioritizedStrategyList, loadBalancerStrategyProperties, transportClientProperties, degraderProperties,
         prioritizedSchemes, banned, serviceMetadataProperties, backupRequests, relativeStrategyProperties,
-        SubsettingStrategy.DEFAULT_CLUSTER_SUBSET_SIZE);
+        SubsettingStrategy.DEFAULT_ENABLE_CLUSTER_SUBSETTING, SubsettingStrategy.DEFAULT_CLUSTER_SUBSET_SIZE);
   }
 
   public ServiceProperties(String serviceName,
@@ -144,6 +145,7 @@ public class ServiceProperties
       Map<String,Object> serviceMetadataProperties,
       List<Map<String,Object>> backupRequests,
       Map<String, Object> relativeStrategyProperties,
+      boolean enableClusterSubsetting,
       int minClusterSubsetSize)
   {
     ArgumentUtil.notNull(serviceName, PropertyKeys.SERVICE_NAME);
@@ -174,6 +176,7 @@ public class ServiceProperties
         Collections.<String,Object>emptyMap();
     _relativeStrategyProperties = relativeStrategyProperties != null
         ? relativeStrategyProperties : Collections.emptyMap();
+    _enableClusterSubsetting = enableClusterSubsetting;
     _minClusterSubsetSize = minClusterSubsetSize;
   }
 
@@ -252,6 +255,11 @@ public class ServiceProperties
   public Map<String,Object> getServiceMetadataProperties()
   {
     return _serviceMetadataProperties;
+  }
+
+  public boolean isEnableClusterSubsetting()
+  {
+    return _enableClusterSubsetting;
   }
 
   public int getMinClusterSubsetSize()

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.balancer.properties;
 
 
+import com.linkedin.d2.balancer.subsetting.SubsettingStrategy;
 import com.linkedin.d2.balancer.util.JacksonUtil;
 import com.linkedin.d2.discovery.PropertyBuilder;
 import com.linkedin.d2.discovery.PropertySerializationException;
@@ -202,6 +203,7 @@ public class ServicePropertiesJsonSerializer implements
     Map<String, Object> transportClientProperties = mapGetOrDefault(map, PropertyKeys.TRANSPORT_CLIENT_PROPERTIES, Collections.emptyMap());
     Map<String, String> degraderProperties = mapGetOrDefault(map, PropertyKeys.DEGRADER_PROPERTIES, Collections.emptyMap());
     Map<String, Object> relativeStrategyProperties = mapGetOrDefault(map, PropertyKeys.RELATIVE_STRATEGY_PROPERTIES, Collections.emptyMap());
+    int minClusterSubsetSize = mapGetOrDefault(map, PropertyKeys.MIN_CLUSTER_SUBSET_SIZE, SubsettingStrategy.DEFAULT_CLUSTER_SUBSET_SIZE);
 
     List<URI> bannedList = mapGetOrDefault(map, PropertyKeys.BANNED_URIS, Collections.emptyList());
     Set<URI> banned = new HashSet<>(bannedList);
@@ -238,6 +240,7 @@ public class ServicePropertiesJsonSerializer implements
                                  banned,
                                  metadataProperties,
                                  backupRequests,
-                                 relativeStrategyProperties);
+                                 relativeStrategyProperties,
+                                 minClusterSubsetSize);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
@@ -203,6 +203,7 @@ public class ServicePropertiesJsonSerializer implements
     Map<String, Object> transportClientProperties = mapGetOrDefault(map, PropertyKeys.TRANSPORT_CLIENT_PROPERTIES, Collections.emptyMap());
     Map<String, String> degraderProperties = mapGetOrDefault(map, PropertyKeys.DEGRADER_PROPERTIES, Collections.emptyMap());
     Map<String, Object> relativeStrategyProperties = mapGetOrDefault(map, PropertyKeys.RELATIVE_STRATEGY_PROPERTIES, Collections.emptyMap());
+    boolean enableClusterSubsetting = mapGetOrDefault(map, PropertyKeys.ENABLE_CLUSTER_SUBSETTING, SubsettingStrategy.DEFAULT_ENABLE_CLUSTER_SUBSETTING);
     int minClusterSubsetSize = mapGetOrDefault(map, PropertyKeys.MIN_CLUSTER_SUBSET_SIZE, SubsettingStrategy.DEFAULT_CLUSTER_SUBSET_SIZE);
 
     List<URI> bannedList = mapGetOrDefault(map, PropertyKeys.BANNED_URIS, Collections.emptyList());
@@ -241,6 +242,7 @@ public class ServicePropertiesJsonSerializer implements
                                  metadataProperties,
                                  backupRequests,
                                  relativeStrategyProperties,
+                                 enableClusterSubsetting,
                                  minClusterSubsetSize);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -719,8 +719,9 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     Set<URI> possibleUris = uris.getUriBySchemeAndPartition(scheme, partitionId);
 
     Map<URI, TrackerClient> clientsToBalance = getPotentialClients(serviceName, serviceProperties, clusterProperties, possibleUris);
-    Map<URI, TrackerClient> clientsSubset = _state.getClientsSubset(serviceName,
-        serviceProperties.getMinClusterSubsetSize(), partitionId, clientsToBalance);
+    Map<URI, TrackerClient> clientsSubset = serviceProperties.isEnableClusterSubsetting() ?
+        _state.getClientsSubset(serviceName, serviceProperties.getMinClusterSubsetSize(),
+            partitionId, clientsToBalance) : clientsToBalance;
 
     if (clientsSubset.isEmpty())
     {

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -719,7 +719,8 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     Set<URI> possibleUris = uris.getUriBySchemeAndPartition(scheme, partitionId);
 
     Map<URI, TrackerClient> clientsToBalance = getPotentialClients(serviceName, serviceProperties, clusterProperties, possibleUris);
-    Map<URI, TrackerClient> clientsSubset = _state.getClientsSubset(serviceName, serviceProperties, partitionId, clientsToBalance);
+    Map<URI, TrackerClient> clientsSubset = _state.getClientsSubset(serviceName,
+        serviceProperties.getMinClusterSubsetSize(), partitionId, clientsToBalance);
 
     if (clientsSubset.isEmpty())
     {

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -719,11 +719,13 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     Set<URI> possibleUris = uris.getUriBySchemeAndPartition(scheme, partitionId);
 
     Map<URI, TrackerClient> clientsToBalance = getPotentialClients(serviceName, serviceProperties, clusterProperties, possibleUris);
-    if (clientsToBalance.isEmpty())
+    Map<URI, TrackerClient> clientsSubset = _state.getClientsSubset(serviceName, serviceProperties, partitionId, clientsToBalance);
+
+    if (clientsSubset.isEmpty())
     {
       info(_log, "Can not find a host for service: ", serviceName, ", scheme: ", scheme, ", partition: ", partitionId);
     }
-    return clientsToBalance;
+    return clientsSubset;
   }
 
   private Map<URI, TrackerClient> getPotentialClients(String serviceName,

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -673,11 +673,11 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
 
   @Override
   public Map<URI, TrackerClient> getClientsSubset(String serviceName,
-                                                  ServiceProperties serviceProperties,
+                                                  int minClusterSubsetSize,
                                                   int partitionId,
                                                   Map<URI, TrackerClient> potentialClients)
   {
-    SubsettingStrategy<URI> subsettingStrategy = _subsettingStrategyFactory.get(serviceName, serviceProperties, partitionId);
+    SubsettingStrategy<URI> subsettingStrategy = _subsettingStrategyFactory.get(serviceName, minClusterSubsetSize, partitionId);
     if (subsettingStrategy != null)
     {
       if (subsettingStrategy.isSubsetChanged(_version.get()) ||

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -144,7 +145,7 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
   private final SslSessionValidatorFactory _sslSessionValidatorFactory;
 
   private final SubsettingStrategyFactory _subsettingStrategyFactory;
-  private final Map<String, Map<Integer, Map<URI, TrackerClient>>>                      _weightedSubsetsCache;
+  private final ConcurrentMap<String, ConcurrentMap<Integer, Map<URI, TrackerClient>>> _weightedSubsetsCache;
 
   /*
    * Concurrency considerations:

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/degrader/DegraderLoadBalancerStrategyV3.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/degrader/DegraderLoadBalancerStrategyV3.java
@@ -513,7 +513,7 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
   {
     DegraderControl degraderControl = client.getDegraderControl(partitionId);
     return client.getUri() + ":" + pointsMap.get(client.getUri()) + "/" +
-        String.valueOf(client.getPartitionWeight(partitionId) * config.getPointsPerWeight())
+        String.valueOf(client.getPartitionWeight(partitionId) * client.getSubsetWeight(partitionId) * config.getPointsPerWeight())
         + "(" + degraderControl.getCallTimeStats().getAverage() + "ms)";
   }
 
@@ -527,7 +527,7 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
     for (DegraderTrackerClientUpdater clientUpdater : degraderTrackerClientUpdaters)
     {
       DegraderTrackerClient client = clientUpdater.getTrackerClient();
-      int perfectHealth = (int) (client.getPartitionWeight(partitionId) * config.getPointsPerWeight());
+      int perfectHealth = (int) (client.getPartitionWeight(partitionId) * client.getSubsetWeight(partitionId) * config.getPointsPerWeight());
       URI uri = client.getUri();
       if (!pointsMap.containsKey(uri))
       {
@@ -735,7 +735,7 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
       // calculate the weight as the probability of successful transmission to this
       // node divided by the probability of successful transmission to the entire
       // cluster
-      double clientWeight = client.getPartitionWeight(partitionId);
+      double clientWeight = client.getPartitionWeight(partitionId) * client.getSubsetWeight(partitionId);
       double successfulTransmissionWeight = clientWeight * (1.0 - dropRate);
 
       // calculate the weight as the probability of a successful transmission to this node

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
@@ -167,7 +167,10 @@ public class PartitionState
         .collect(Collectors.toMap(TrackerClient::getUri, TrackerClient::getCallTracker)));
     _pointsMap = _trackerClientStateMap.entrySet().stream()
         .collect(Collectors.toMap(entry -> entry.getKey().getUri(),
-            entry -> (int) Math.round(entry.getValue().getHealthScore() * entry.getKey().getPartitionWeight(_partitionId) * _pointsPerWeight)));
+            entry -> (int) Math.round(entry.getValue().getHealthScore()
+                * entry.getKey().getPartitionWeight(_partitionId)
+                * entry.getKey().getSubsetWeight(_partitionId)
+                * _pointsPerWeight)));
     _ring = _ringFactory.createRing(_pointsMap, callTrackerMap);
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadata.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadata.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 import java.util.Objects;

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadata.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadata.java
@@ -1,0 +1,61 @@
+package com.linkedin.d2.balancer.subsetting;
+
+import java.util.Objects;
+
+
+/**
+ * The metadata required by the deterministic subsetting strategy.
+ */
+public final class DeterministicSubsettingMetadata
+{
+  private final int _instanceId;
+  private final int _totalInstanceCount;
+
+  public DeterministicSubsettingMetadata(int instanceId, int totalInstanceCount)
+  {
+    _instanceId = instanceId;
+    _totalInstanceCount = totalInstanceCount;
+  }
+
+  /**
+   * Get the ID of current client instance. In the peer cluster, the IDs should start from 0 and be contiguous
+   */
+  public int getInstanceId()
+  {
+    return _instanceId;
+  }
+
+  /**
+   * Get the total number of instances in the peer client cluster.
+   */
+  public int getTotalInstanceCount()
+  {
+    return _totalInstanceCount;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeterministicSubsettingMetadata that = (DeterministicSubsettingMetadata) o;
+    return _instanceId == that._instanceId && _totalInstanceCount == that._totalInstanceCount;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(_instanceId, _totalInstanceCount);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "DeterministicSubsettingMetadata{" + "_instanceId=" + _instanceId + ", _totalInstanceCount="
+        + _totalInstanceCount + '}';
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadataProvider.java
@@ -1,0 +1,9 @@
+package com.linkedin.d2.balancer.subsetting;
+
+/**
+ * Provides deterministic subsetting strategy with the peer cluster metadata needed
+ */
+public interface DeterministicSubsettingMetadataProvider
+{
+  DeterministicSubsettingMetadata getSubsettingMetadata();
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadataProvider.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadataProvider.java
@@ -16,10 +16,16 @@
 
 package com.linkedin.d2.balancer.subsetting;
 
+import com.linkedin.d2.balancer.LoadBalancerState;
+
+
 /**
  * Provides deterministic subsetting strategy with the peer cluster metadata needed
  */
 public interface DeterministicSubsettingMetadataProvider
 {
-  DeterministicSubsettingMetadata getSubsettingMetadata();
+  /**
+   * Retrieve subsetting metadata of peer cluster given the load balancer state
+   */
+  DeterministicSubsettingMetadata getSubsettingMetadata(LoadBalancerState state);
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategy.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 import com.linkedin.d2.balancer.util.hashing.MD5Hash;

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategy.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
-import org.apache.http.annotation.GuardedBy;
+import javax.annotation.concurrent.GuardedBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,9 @@ public class DeterministicSubsettingStrategy<T extends Comparable<T>> implements
 
   @GuardedBy("_lock")
   private DeterministicSubsettingMetadata _currentMetadata;
+  @GuardedBy("_lock")
   private long _currentVersion = -1;
+  @GuardedBy("_lock")
   private Map<T, Double> _currentWeightedSubset;
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategy.java
@@ -1,0 +1,299 @@
+package com.linkedin.d2.balancer.subsetting;
+
+import com.linkedin.d2.balancer.util.hashing.MD5Hash;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This strategy picks a subset from a collection of items with deterministic assignment based
+ * on the following article:
+ * <a href="https://blog.twitter.com/engineering/en_us/topics/infrastructure/2019/daperture-load-balancer.html">
+ *   Deterministic Aperture: A distributed, load balancing algorithm</a>
+ *
+ * The items are placed on a destination ring in a distance proportional to their weights. Each client is also
+ * placed on a peer ring in equidistant intervals. Overlaying the destination ring and the peer ring, each client
+ * will select a subset of items in an order defined by walking the ring clockwise. The overlap can be fractional
+ * to ensure that the overload item distribution is fair.
+ */
+public class DeterministicSubsettingStrategy<T> implements SubsettingStrategy<T>
+{
+  public static final int WEIGHT_DECIMAL_PLACE = 5;
+  public static final double POINTS_MAP_CHANGED_DELTA = 0.1;
+  private final Logger _log = LoggerFactory.getLogger(DeterministicSubsettingStrategy.class);
+
+  private final DeterministicSubsettingMetadataProvider _metadataProvider;
+  private final Random _randomSeed;
+  private final int _minSubsetSize;
+
+  private DeterministicSubsettingMetadata _currentMetadata;
+  private Map<T, Double> _currentPointsMap;
+  private Map<T, Double> _currentWeightedSubset;
+
+  /**
+   * Builds deterministic subsetting strategy
+   *
+   * @param metadataProvider  Provides peer cluster metadata information
+   * @param clusterName The name of the peer cluster
+   * @param minSubsetSize The minimum subset size to satisfy
+   */
+  public DeterministicSubsettingStrategy(DeterministicSubsettingMetadataProvider metadataProvider,
+                                         String clusterName,
+                                         int minSubsetSize)
+  {
+    _metadataProvider = metadataProvider;
+    MD5Hash hashFunction = new MD5Hash();
+    String[] keyTokens = {clusterName};
+    _randomSeed = new Random(hashFunction.hashLong(keyTokens));
+    _minSubsetSize = minSubsetSize;
+  }
+
+  @Override
+  public Map<T, Double> getWeightedSubset(Map<T, Double> pointsMap)
+  {
+    DeterministicSubsettingMetadata metadata = _metadataProvider.getSubsettingMetadata();
+    if (metadata != null)
+    {
+      if (metadata.equals(_currentMetadata))
+      {
+        if (_currentPointsMap != null && _currentWeightedSubset != null && !isPointsMapChanged(pointsMap))
+        {
+          return _currentWeightedSubset;
+        }
+        else
+        {
+          _currentPointsMap = pointsMap;
+        }
+      }
+      else
+      {
+        _currentMetadata = metadata;
+        _currentPointsMap = pointsMap;
+      }
+
+      List<T> points = new ArrayList<>(pointsMap.keySet());
+      Collections.shuffle(points, _randomSeed);
+      List<Double> weights = points.stream().map(pointsMap::get).collect(Collectors.toList());
+      Ring ring = new Ring(weights);
+
+      double offset = metadata.getInstanceId() / (double) metadata.getTotalInstanceCount();
+      double subsetSliceWidth = getSubsetSliceWidth(metadata.getTotalInstanceCount(), points.size());
+      List<Integer> indices = ring.getIndices(offset, subsetSliceWidth);
+
+      _currentWeightedSubset = indices.stream().collect(
+          Collectors.toMap(points::get, i -> round(ring.getWeight(i, offset, subsetSliceWidth), WEIGHT_DECIMAL_PLACE)));
+      return _currentWeightedSubset;
+    }
+    else
+    {
+      _log.warn("Cannot retrieve metadata required for D2 subsetting. Revert to use all available hosts.");
+      return null;
+    }
+  }
+
+  private static double round(double value, int places)
+  {
+    BigDecimal bd = new BigDecimal(Double.toString(value));
+    bd = bd.setScale(places, RoundingMode.HALF_UP);
+    return bd.doubleValue();
+  }
+
+  private static boolean isEqual(double a, double b, double delta)
+  {
+    return Math.abs(a - b) <= delta;
+  }
+
+  private boolean isPointsMapChanged(Map<T, Double> pointsMap)
+  {
+    if (pointsMap.size() != _currentPointsMap.size())
+    {
+      return true;
+    }
+
+    for (Map.Entry<T, Double> entry: pointsMap.entrySet())
+    {
+      if (!_currentPointsMap.containsKey(entry.getKey()) ||
+          !isEqual(_currentPointsMap.get(entry.getKey()), entry.getValue(), POINTS_MAP_CHANGED_DELTA))
+      {
+       return true;
+      }
+    }
+    return false;
+  }
+
+  private double getSubsetSliceWidth(int totalClientCount, int totalHostCount)
+  {
+    double clientUnitWidth = 1.0 / totalClientCount;
+    double hostUnitWidth = 1.0 / totalHostCount;
+
+    // Adjust the subset slice width as a multiple of client's unit width
+    double adjustedSubsetSliceWidth = (int) Math.ceil(_minSubsetSize * hostUnitWidth / clientUnitWidth) * clientUnitWidth;
+
+    return Double.min(1, adjustedSubsetSliceWidth);
+  }
+
+  private static class Ring
+  {
+    private static final double DELTA = 1e-5;
+
+    private final int _totalPoints;
+    private final List<Double> _weights;
+    private final double _totalWeight;
+
+    Ring(List<Double> weights)
+    {
+      _weights = weights;
+      _totalPoints = weights.size();
+      _totalWeight = weights.stream().mapToDouble(Double::doubleValue).sum();
+    }
+
+    /**
+     * Get the indices of the slices that intersect with [offset, offset + width)
+     */
+    public List<Integer> getIndices(double offset, double width)
+    {
+      List<Integer> indices = new ArrayList<>();
+      int begin = getIndex(offset);
+      int range = getRange(offset, width);
+
+      while (range > 0)
+      {
+        int index = begin % _totalPoints;
+        indices.add(index);
+        begin += 1;
+        range -= 1;
+      }
+
+      return indices;
+    }
+
+    /**
+     * Get the fractional width (0.0 - 1.0) of the slice at given index
+     */
+    private double getUnitWidth(int index)
+    {
+      return _weights.get(index) / _totalWeight;
+    }
+
+    /**
+     * Get the total fractional width (0.0 - 1.0) from the slice at index 0 to the slice at given index
+     */
+    private double getWidthUntil(int index)
+    {
+      double weightsSum = 0;
+
+      for (int i = 0; i < index; i++)
+      {
+        weightsSum += _weights.get(i);
+      }
+
+      return weightsSum / _totalWeight;
+    }
+
+    /**
+     * Get the index of the slice at given offset (0.0 - 1.0)
+     */
+    public int getIndex(double offset)
+    {
+      double length = 0;
+      int index = 0;
+      while (index < _totalPoints)
+      {
+        length += getUnitWidth(index);
+        // At slice boundary, return the next index
+        if (isEqual(length, offset, Ring.DELTA))
+        {
+          return (index + 1) % _totalPoints;
+        }
+        else if (length > offset)
+        {
+          return index;
+        }
+        index++;
+      }
+      return 0;
+    }
+
+    /**
+     * Get the number of slices included from offset to (offset + width)
+     */
+    private int getRange(double offset, double width)
+    {
+      if (width == 1.0)
+      {
+        return _totalPoints;
+      }
+      else
+      {
+        int begin = getIndex(offset);
+        int end = getIndex((offset + width) % 1.0);
+
+        if (begin == end)
+        {
+          // Wrap around the entire ring, so return all the points
+          if (width > getUnitWidth(begin))
+          {
+            return _totalPoints;
+          }
+          // Only one index is included
+          else
+          {
+            return 1;
+          }
+        }
+        else
+        {
+          // If the slice at index end does not overlap with [offset, offset + width), it should not be included
+          int adjustedEnd = isEqual(getWeight(end, offset, width), 0, Ring.DELTA) ? end : end + 1;
+          int diff = adjustedEnd - begin;
+          return diff <= 0 ? diff + _totalPoints : diff;
+        }
+      }
+    }
+
+    /**
+     * Get the ratio of the intersection between slice at the given index and [offset, offset + width)
+     */
+    private double getWeight(int index, double offset, double width)
+    {
+      double unitWidth = getUnitWidth(index);
+      if (unitWidth == 0.0)
+      {
+        return 0.0;
+      }
+
+      double ringSegmentStart = getWidthUntil(index);
+      double ringSegmentEnd = ringSegmentStart + unitWidth;
+
+      // If cases where [offset, offset + width) wraps around the ring, we take the compliment of it to
+      // calculate the inverse intersection ratio, and subtract that from 1 to get the actual ratio
+      if (offset + width > 1.0)
+      {
+        double start = (offset + width) % 1.0;
+        double end = offset;
+        return 1D - (intersect(ringSegmentStart, ringSegmentEnd, start, end) / unitWidth);
+      }
+      else
+      {
+        return intersect(ringSegmentStart, ringSegmentEnd, offset, offset + width) / unitWidth;
+      }
+    }
+
+    /**
+     * Get the fractional width (0.0 - 1.0) where [start0, end0) and [start1, end1) overlaps
+     */
+    private double intersect(double start0, double end0, double start1, double end1)
+    {
+      double length = Double.min(end0, end1) - Double.max(start0, start1);
+      return Double.min(Double.max(0, length), 1.0);
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
@@ -25,7 +25,19 @@ import java.util.Map;
  */
 public interface SubsettingStrategy<T>
 {
-  public static final int DEFAULT_CLUSTER_SUBSET_SIZE = -1;
+  int DEFAULT_CLUSTER_SUBSET_SIZE = -1;
 
-  Map<T, Double> getWeightedSubset(Map<T, Double> pointsMap);
+  /**
+   * Checks whether the subset is changed given the version number
+   */
+  boolean isSubsetChanged(long version);
+
+  /**
+   * Picks a subset from a collection of items
+   *
+   * @param weightMap Maps each item to its weight on a scale of 0.0 to 1.0.
+   * @param version The version of the weightMap. Subsequent calls with the same version number will return the cached subset.
+   * @return A subset that maps each item to its weight on a scale of 0.0 to 1.0.
+   */
+  Map<T, Double> getWeightedSubset(Map<T, Double> weightMap, long version);
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
@@ -1,0 +1,15 @@
+package com.linkedin.d2.balancer.subsetting;
+
+import java.util.Map;
+
+
+/**
+ * Picks a subset from a collection of items. Items in the subset can be picked with
+ * different probabilities, proportional to their weights.
+ */
+public interface SubsettingStrategy<T>
+{
+  public static final int DEFAULT_CLUSTER_SUBSET_SIZE = -1;
+
+  Map<T, Double> getWeightedSubset(Map<T, Double> pointsMap);
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 import java.util.Map;

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
@@ -25,6 +25,7 @@ import java.util.Map;
  */
 public interface SubsettingStrategy<T>
 {
+  boolean DEFAULT_ENABLE_CLUSTER_SUBSETTING = false;
   int DEFAULT_CLUSTER_SUBSET_SIZE = -1;
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
@@ -22,11 +22,11 @@ import java.net.URI;
 
 public interface SubsettingStrategyFactory
 {
-  SubsettingStrategyFactory NO_OP_SUBSETTING_STRATEGY_FACTORY = (serviceName, serviceProperties, partitionId) -> null;
+  SubsettingStrategyFactory NO_OP_SUBSETTING_STRATEGY_FACTORY = (serviceName, minClusterSubsetSize, partitionId) -> null;
 
   /**
    * get retrieves the {@link SubsettingStrategy} corresponding to the serviceName and partition Id
    * @return {@link SubsettingStrategy}
    */
-   SubsettingStrategy<URI> get(String serviceName, ServiceProperties serviceProperties, int partitionId);
+   SubsettingStrategy<URI> get(String serviceName, int minClusterSubsetSize, int partitionId);
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 import com.linkedin.d2.balancer.properties.ServiceProperties;

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
@@ -1,0 +1,16 @@
+package com.linkedin.d2.balancer.subsetting;
+
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import java.net.URI;
+
+
+public interface SubsettingStrategyFactory
+{
+  SubsettingStrategyFactory NO_OP_SUBSETTING_STRATEGY_FACTORY = (serviceName, serviceProperties, partitionId) -> null;
+
+  /**
+   * get retrieves the {@link SubsettingStrategy} corresponding to the serviceName and partition Id
+   * @return {@link SubsettingStrategy}
+   */
+   SubsettingStrategy<URI> get(String serviceName, ServiceProperties serviceProperties, int partitionId);
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
@@ -25,8 +25,8 @@ public interface SubsettingStrategyFactory
   SubsettingStrategyFactory NO_OP_SUBSETTING_STRATEGY_FACTORY = (serviceName, minClusterSubsetSize, partitionId) -> null;
 
   /**
-   * get retrieves the {@link SubsettingStrategy} corresponding to the serviceName and partition Id
-   * @return {@link SubsettingStrategy}
+   * get retrieves the {@link SubsettingStrategy} corresponding to the serviceName and partition Id.
+   * @return {@link SubsettingStrategy} or {@code null} if minClusterSubsetSize is less than or equal to 0.
    */
    SubsettingStrategy<URI> get(String serviceName, int minClusterSubsetSize, int partitionId);
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactoryImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactoryImpl.java
@@ -38,10 +38,8 @@ public class SubsettingStrategyFactoryImpl implements SubsettingStrategyFactory
   }
 
   @Override
-  public SubsettingStrategy<URI> get(String serviceName, ServiceProperties serviceProperties, int partitionId)
+  public SubsettingStrategy<URI> get(String serviceName, int minClusterSubsetSize, int partitionId)
   {
-    int minClusterSubsetSize = serviceProperties.getMinClusterSubsetSize();
-
     if (minClusterSubsetSize > 0)
     {
       if (_subsettingStrategyMap.containsKey(serviceName))

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactoryImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactoryImpl.java
@@ -1,0 +1,49 @@
+package com.linkedin.d2.balancer.subsetting;
+
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public class SubsettingStrategyFactoryImpl implements SubsettingStrategyFactory
+{
+  private final Map<String, Map<Integer, SubsettingStrategy<URI>>> _subsettingStrategyMap;
+  private final DeterministicSubsettingMetadataProvider _deterministicSubsettingMetadataProvider;
+
+  public SubsettingStrategyFactoryImpl(DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider)
+  {
+    _subsettingStrategyMap = new ConcurrentHashMap<>();
+    _deterministicSubsettingMetadataProvider = deterministicSubsettingMetadataProvider;
+  }
+
+  @Override
+  public SubsettingStrategy<URI> get(String serviceName, ServiceProperties serviceProperties, int partitionId)
+  {
+    int minClusterSubsetSize = serviceProperties.getMinClusterSubsetSize();
+
+    if (minClusterSubsetSize > 0)
+    {
+      if (_subsettingStrategyMap.containsKey(serviceName))
+      {
+        Map<Integer, SubsettingStrategy<URI>> strategyMap = _subsettingStrategyMap.get(serviceName);
+        if (strategyMap.containsKey(partitionId))
+        {
+          return strategyMap.get(partitionId);
+        }
+        else
+        {
+          strategyMap.put(partitionId, new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider, serviceName, minClusterSubsetSize));
+        }
+      }
+      else
+      {
+        Map<Integer, SubsettingStrategy<URI>> strategyMap = new ConcurrentHashMap<>();
+        strategyMap.put(partitionId, new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider, serviceName, minClusterSubsetSize));
+        _subsettingStrategyMap.put(serviceName, strategyMap);
+      }
+    }
+
+    return null;
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactoryImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactoryImpl.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 import com.linkedin.d2.balancer.properties.ServiceProperties;

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -1,0 +1,75 @@
+package com.linkedin.d2.balancer.subsetting;
+
+import com.linkedin.common.callback.FutureCallback;
+import com.linkedin.d2.balancer.LoadBalancerState;
+import com.linkedin.d2.balancer.properties.PropertyKeys;
+import com.linkedin.d2.balancer.properties.UriProperties;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+
+/**
+ * Listens to the peer cluster in ZooKeeper and provides deterministic subsetting strategy with
+ * the metadata needed
+ */
+public class ZKDeterministicSubsettingMetadataProvider implements DeterministicSubsettingMetadataProvider
+{
+  private final String _clusterName;
+  private final URI _nodeUri;
+  private final LoadBalancerState _loadBalancerState;
+  private final long _timeout;
+  private final TimeUnit _unit;
+
+  public ZKDeterministicSubsettingMetadataProvider(String clusterName,
+                                      URI nodeUri,
+                                      LoadBalancerState loadBalancerState,
+                                      long timeout,
+                                      TimeUnit unit)
+  {
+    _clusterName = clusterName;
+    _nodeUri = nodeUri;
+    _loadBalancerState = loadBalancerState;
+    _timeout = timeout;
+    _unit = unit;
+  }
+
+  @Override
+  public DeterministicSubsettingMetadata getSubsettingMetadata()
+  {
+    FutureCallback<DeterministicSubsettingMetadata> metadataFutureCallback = new FutureCallback<>();
+
+    _loadBalancerState.listenToCluster(_clusterName, (type, name) ->
+    {
+      UriProperties uriProperties = _loadBalancerState.getUriProperties(_clusterName).getProperty();
+      if (uriProperties != null)
+      {
+        // Sort the URIs so each client sees the same ordering
+        List<URI> sortedUris = uriProperties.getPartitionDesc().keySet().stream()
+            .filter(uri -> uri.getScheme().equals(_nodeUri.getScheme()))
+            .sorted()
+            .collect(Collectors.toList());
+
+        int instanceId = sortedUris.indexOf(_nodeUri);
+
+        if (instanceId >= 0)
+        {
+          metadataFutureCallback.onSuccess(new DeterministicSubsettingMetadata(instanceId, sortedUris.size()));
+          return;
+        }
+      }
+      metadataFutureCallback.onSuccess(null);
+    });
+
+    try
+    {
+      return metadataFutureCallback.get(_timeout, _unit);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      return null;
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 import com.linkedin.common.callback.FutureCallback;

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -37,8 +37,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ZKDeterministicSubsettingMetadataProvider implements DeterministicSubsettingMetadataProvider
 {
-  private final Logger _log = LoggerFactory.getLogger(ZKDeterministicSubsettingMetadataProvider.class);
-
   private final String _clusterName;
   private final URI _nodeUri;
   private final long _timeout;

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ZKDeterministicSubsettingMetadataProvider implements DeterministicSubsettingMetadataProvider
 {
+  private static final Logger _log = LoggerFactory.getLogger(ZKDeterministicSubsettingMetadataProvider.class);
   private final String _clusterName;
   private final URI _nodeUri;
   private final long _timeout;
@@ -46,6 +47,7 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
 
   @GuardedBy("_lock")
   private long _clusterGenerationId = -1;
+  @GuardedBy("_lock")
   private DeterministicSubsettingMetadata _subsettingMetadata;
 
   public ZKDeterministicSubsettingMetadataProvider(String clusterName,
@@ -106,6 +108,7 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
     {
       return metadataFutureCallback.get(_timeout, _unit);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      _log.warn("Failed to fetch deterministic subsetting metadata from ZooKeeper", e);
       return null;
     }
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
@@ -35,8 +35,6 @@ import com.linkedin.d2.balancer.simple.SslSessionValidatorFactory;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
 import com.linkedin.d2.balancer.subsetting.DeterministicSubsettingMetadataProvider;
-import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
-import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactoryImpl;
 import com.linkedin.d2.balancer.util.FileSystemDirectory;
 import com.linkedin.d2.balancer.util.TogglingLoadBalancer;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessorRegistry;

--- a/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
@@ -34,6 +34,7 @@ import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
 import com.linkedin.d2.balancer.simple.SslSessionValidatorFactory;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.subsetting.DeterministicSubsettingMetadataProvider;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactoryImpl;
 import com.linkedin.d2.balancer.util.FileSystemDirectory;
@@ -89,7 +90,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
   private final boolean _useNewEphemeralStoreWatcher;
   private final PartitionAccessorRegistry _partitionAccessorRegistry;
   private final SslSessionValidatorFactory _sslSessionValidatorFactory;
-  private final SubsettingStrategyFactory _subsettingStrategyFactory;
+  private final DeterministicSubsettingMetadataProvider _deterministicSubsettingMetadataProvider;
 
   private static final Logger _log = LoggerFactory.getLogger(ZKFSTogglingLoadBalancerFactoryImpl.class);
 
@@ -196,7 +197,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
         sslSessionValidatorFactory,
         d2ClientJmxManager,
         zookeeperReadWindowMs,
-        SubsettingStrategyFactory.NO_OP_SUBSETTING_STRATEGY_FACTORY);
+        null);
   }
 
   public ZKFSTogglingLoadBalancerFactoryImpl(ComponentFactory factory,
@@ -217,7 +218,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
       SslSessionValidatorFactory sslSessionValidatorFactory,
       D2ClientJmxManager d2ClientJmxManager,
       int zookeeperReadWindowMs,
-      SubsettingStrategyFactory subsettingStrategyFactory)
+      DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider)
   {
     _factory = factory;
     _lbTimeout = timeout;
@@ -237,7 +238,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
     _sslSessionValidatorFactory = sslSessionValidatorFactory;
     _d2ClientJmxManager = d2ClientJmxManager;
     _zookeeperReadWindowMs = zookeeperReadWindowMs;
-    _subsettingStrategyFactory = subsettingStrategyFactory;
+    _deterministicSubsettingMetadataProvider = deterministicSubsettingMetadataProvider;
   }
 
   @Override
@@ -295,7 +296,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
     SimpleLoadBalancerState state = new SimpleLoadBalancerState(
             executorService, uriBus, clusterBus, serviceBus, _clientFactories, _loadBalancerStrategyFactories,
             _sslContext, _sslParameters, _isSSLEnabled, _partitionAccessorRegistry,
-            _sslSessionValidatorFactory, _subsettingStrategyFactory);
+            _sslSessionValidatorFactory, _deterministicSubsettingMetadataProvider);
     _d2ClientJmxManager.setSimpleLoadBalancerState(state);
 
     SimpleLoadBalancer balancer = new SimpleLoadBalancer(state, _lbTimeout, _lbTimeoutUnit, executorService);

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -18,7 +18,6 @@ package com.linkedin.d2.balancer.strategies.relative;
 
 import com.linkedin.d2.D2RelativeStrategyProperties;
 import com.linkedin.d2.balancer.clients.TrackerClient;
-import com.linkedin.test.util.retry.SingleRetry;
 import com.linkedin.test.util.retry.ThreeRetries;
 import java.net.URI;
 import java.util.Arrays;

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/TrackerClientMockHelper.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/TrackerClientMockHelper.java
@@ -52,6 +52,7 @@ public class TrackerClientMockHelper
       Mockito.when(trackerClient.getCallTracker()).thenReturn(new CallTrackerImpl(RelativeLoadBalancerStrategyFactory.DEFAULT_UPDATE_INTERVAL_MS));
       Mockito.when(trackerClient.getUri()).thenReturn(uri);
       Mockito.when(trackerClient.getPartitionWeight(anyInt())).thenReturn(1.0);
+      Mockito.when(trackerClient.getSubsetWeight(anyInt())).thenReturn(1.0);
       trackerClients.add(trackerClient);
     }
     return trackerClients;
@@ -109,6 +110,7 @@ public class TrackerClientMockHelper
       Mockito.when(callTracker.getCallStats()).thenReturn(callStats);
       Mockito.when(trackerClient.getUri()).thenReturn(uri);
       Mockito.when(trackerClient.getPartitionWeight(anyInt())).thenReturn(1.0);
+      Mockito.when(trackerClient.getSubsetWeight(anyInt())).thenReturn(1.0);
       Mockito.when(trackerClient.doNotSlowStart()).thenReturn(doNotSlowStart);
       trackerClients.add(trackerClient);
     }

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
@@ -189,9 +189,9 @@ public class DeterministicSubsettingStrategyTest
         };
   }
 
-  private static double[] generateRandomWeights(int size)
+  private static double[] generateRandomWeights(int size, double bound)
   {
-    return new Random().doubles(size, 0D, 1D).toArray();
+    return new Random().doubles(size, 0D, bound).toArray();
   }
 
   @DataProvider
@@ -203,11 +203,11 @@ public class DeterministicSubsettingStrategyTest
             {1, new double[]{1.0, 1.0, 1.0, 1.0, 1.0}, 10},
             {1, new double[]{1.0, 0.0, 0.0, 0.0, 0.0}, 10},
             {5, new double[]{1.0, 1.0, 0.0, 0.0, 0.0}, 10},
-            {10, generateRandomWeights(100), 10},
-            {7, generateRandomWeights(40), 13},
-            {47, generateRandomWeights(40), 13},
-            {13, generateRandomWeights(200), 11},
-            {83, generateRandomWeights(359), 23}
+            {10, generateRandomWeights(100, 1D), 10},
+            {7, generateRandomWeights(40, 1D), 13},
+            {47, generateRandomWeights(40, 10D), 13},
+            {13, generateRandomWeights(200, 20D), 11},
+            {83, generateRandomWeights(359, 20D), 23}
         };
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
@@ -1,0 +1,171 @@
+package com.linkedin.d2.balancer.subsetting;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+public class DeterministicSubsettingStrategyTest
+{
+  public static final double DELTA_DIFF = 1e-5;
+
+  @Mock
+  private DeterministicSubsettingMetadataProvider _deterministicSubsettingMetadataProvider;
+
+  private DeterministicSubsettingStrategy<String> _deterministicSubsettingStrategy;
+
+  private Map<String, Double> constructPointsMap(double[] weights)
+  {
+    Map<String, Double> pointsMap = new HashMap<>();
+    int id = 0;
+
+    for (double weight: weights)
+    {
+      pointsMap.put("host" + id, weight);
+      id += 1;
+    }
+    return pointsMap;
+  }
+
+  @BeforeMethod
+  public void setUp()
+  {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testCaching()
+  {
+    Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata())
+        .thenReturn(new DeterministicSubsettingMetadata(0, 20));
+    _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
+        "test", 10);
+
+    double[] weights = new double[100];
+    Arrays.fill(weights, 1D);
+    Map<String, Double> pointsMap = constructPointsMap(weights);
+
+    Map<String, Double> weightedSubset1 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap);
+
+    pointsMap = constructPointsMap(weights);
+    Map<String, Double> weightedSubset2 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap);
+
+    assertSame(weightedSubset1, weightedSubset2);
+  }
+
+  @Test(dataProvider = "uniformWeightData")
+  public void testDistributionWithUniformWeight(int clientNum, int hostNum, int minSubsetSize)
+  {
+    double[] weights = new double[hostNum];
+    Arrays.fill(weights, 1D);
+    Map<String, Double> pointsMap = constructPointsMap(weights);
+
+    Map<String, Double> distributionMap = new HashMap<>();
+
+    for (int i = 0; i < clientNum; i++)
+    {
+      Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata())
+          .thenReturn(new DeterministicSubsettingMetadata(i, clientNum));
+      _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
+          "test", minSubsetSize);
+      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap);
+      assertTrue(weightedSubset.size() >= Math.min(minSubsetSize, hostNum));
+
+      for (Map.Entry<String, Double> entry: weightedSubset.entrySet())
+      {
+        distributionMap.put(entry.getKey(), distributionMap.getOrDefault(entry.getKey(), 0D) + entry.getValue());
+      }
+    }
+
+    double host0WeightSum = distributionMap.getOrDefault("host0", 0D);
+    for (double weightSum: distributionMap.values())
+    {
+      assertEquals(weightSum, host0WeightSum, DELTA_DIFF);
+    }
+  }
+
+  @Test(dataProvider = "differentWeightsData")
+  public void testDistributionWithDifferentWeights(int clientNum, double[] weights, int minSubsetSize)
+  {
+    Map<String, Double> pointsMap = constructPointsMap(weights);
+    Map<String, Double> distributionMap = new HashMap<>();
+
+    for (int i = 0; i < clientNum; i++)
+    {
+      Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata())
+          .thenReturn(new DeterministicSubsettingMetadata(i, clientNum));
+      _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
+          "test", minSubsetSize);
+      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap);
+
+      for (Map.Entry<String, Double> entry: weightedSubset.entrySet())
+      {
+        distributionMap.put(entry.getKey(),
+            distributionMap.getOrDefault(entry.getKey(), 0D) + entry.getValue() * pointsMap.get(entry.getKey()));
+      }
+    }
+
+    double totalWeights = distributionMap.values().stream().mapToDouble(Double::doubleValue).sum();
+    double totalHostWeights = Arrays.stream(weights).sum();
+    for (Map.Entry<String, Double> entry: distributionMap.entrySet())
+    {
+      String hostName = entry.getKey();
+      double hostWeight = weights[Integer.parseInt(hostName.substring("test".length()))];
+      assertEquals(entry.getValue() / totalWeights, hostWeight / totalHostWeights, DELTA_DIFF);
+    }
+  }
+
+  @DataProvider
+  public Object[][] uniformWeightData()
+  {
+    return new Object[][]
+        {
+            {5, 0, 10},
+            {1, 1, 10},
+            {1, 5, 10},
+            {5, 1, 10},
+            {5, 5, 10},
+            {5, 5, 1},
+            {3, 6, 2},
+            {5, 40, 10},
+            {10, 100, 10},
+            {7, 47, 13},
+            {47, 40, 13},
+            {13, 200, 11},
+            {83, 359, 23}
+        };
+  }
+
+  private static double[] generateRandomWeights(int size)
+  {
+    return new Random().doubles(size, 0D, 1D).toArray();
+  }
+
+  @DataProvider
+  public Object[][] differentWeightsData()
+  {
+    return new Object[][]
+        {
+            {1, new double[]{1.0}, 10},
+            {1, new double[]{1.0, 1.0, 1.0, 1.0, 1.0}, 10},
+            {1, new double[]{1.0, 0.0, 0.0, 0.0, 0.0}, 10},
+            {5, new double[]{1.0, 1.0, 0.0, 0.0, 0.0}, 10},
+            {10, generateRandomWeights(100), 10},
+            {7, generateRandomWeights(40), 13},
+            {47, generateRandomWeights(40), 13},
+            {13, generateRandomWeights(200), 11},
+            {83, generateRandomWeights(359), 23}
+        };
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.balancer.subsetting;
 
+import com.linkedin.d2.balancer.LoadBalancerState;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,6 +37,9 @@ public class DeterministicSubsettingStrategyTest
 
   @Mock
   private DeterministicSubsettingMetadataProvider _deterministicSubsettingMetadataProvider;
+
+  @Mock
+  private LoadBalancerState _state;
 
   private DeterministicSubsettingStrategy<String> _deterministicSubsettingStrategy;
 
@@ -61,10 +65,10 @@ public class DeterministicSubsettingStrategyTest
   @Test
   public void testCaching()
   {
-    Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata())
+    Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata(_state))
         .thenReturn(new DeterministicSubsettingMetadata(0, 20));
     _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
-        "test", 10);
+        "test", 10, _state);
 
     double[] weights = new double[100];
     Arrays.fill(weights, 1D);
@@ -92,7 +96,7 @@ public class DeterministicSubsettingStrategyTest
 
     assertSame(weightedSubset3, weightedSubset4);
 
-    Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata())
+    Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata(_state))
         .thenReturn(new DeterministicSubsettingMetadata(0, 19));
     assertTrue(_deterministicSubsettingStrategy.isSubsetChanged(1));
   }
@@ -108,10 +112,10 @@ public class DeterministicSubsettingStrategyTest
 
     for (int i = 0; i < clientNum; i++)
     {
-      Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata())
+      Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata(_state))
           .thenReturn(new DeterministicSubsettingMetadata(i, clientNum));
       _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
-          "test", minSubsetSize);
+          "test", minSubsetSize, _state);
       Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
       assertTrue(weightedSubset.size() >= Math.min(minSubsetSize, hostNum));
 
@@ -136,10 +140,10 @@ public class DeterministicSubsettingStrategyTest
 
     for (int i = 0; i < clientNum; i++)
     {
-      Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata())
+      Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata(_state))
           .thenReturn(new DeterministicSubsettingMetadata(i, clientNum));
       _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
-          "test", minSubsetSize);
+          "test", minSubsetSize, _state);
       Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
 
       for (Map.Entry<String, Double> entry: weightedSubset.entrySet())

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
@@ -27,9 +27,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 
 public class DeterministicSubsettingStrategyTest
@@ -70,14 +68,33 @@ public class DeterministicSubsettingStrategyTest
 
     double[] weights = new double[100];
     Arrays.fill(weights, 1D);
+
+    assertTrue(_deterministicSubsettingStrategy.isSubsetChanged(0));
     Map<String, Double> pointsMap = constructPointsMap(weights);
+    Map<String, Double> weightedSubset1 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
 
-    Map<String, Double> weightedSubset1 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap);
-
+    assertFalse(_deterministicSubsettingStrategy.isSubsetChanged(0));
     pointsMap = constructPointsMap(weights);
-    Map<String, Double> weightedSubset2 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap);
+    Map<String, Double> weightedSubset2 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
 
     assertSame(weightedSubset1, weightedSubset2);
+
+    assertTrue(_deterministicSubsettingStrategy.isSubsetChanged(1));
+    pointsMap = constructPointsMap(weights);
+    Map<String, Double> weightedSubset3 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 1);
+
+    assertEquals(weightedSubset1, weightedSubset3);
+    assertNotSame(weightedSubset1, weightedSubset3);
+
+    assertFalse(_deterministicSubsettingStrategy.isSubsetChanged(1));
+    pointsMap = constructPointsMap(weights);
+    Map<String, Double> weightedSubset4 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 1);
+
+    assertSame(weightedSubset3, weightedSubset4);
+
+    Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata())
+        .thenReturn(new DeterministicSubsettingMetadata(0, 19));
+    assertTrue(_deterministicSubsettingStrategy.isSubsetChanged(1));
   }
 
   @Test(dataProvider = "uniformWeightData")
@@ -95,7 +112,7 @@ public class DeterministicSubsettingStrategyTest
           .thenReturn(new DeterministicSubsettingMetadata(i, clientNum));
       _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
           "test", minSubsetSize);
-      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap);
+      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
       assertTrue(weightedSubset.size() >= Math.min(minSubsetSize, hostNum));
 
       for (Map.Entry<String, Double> entry: weightedSubset.entrySet())
@@ -123,7 +140,7 @@ public class DeterministicSubsettingStrategyTest
           .thenReturn(new DeterministicSubsettingMetadata(i, clientNum));
       _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
           "test", minSubsetSize);
-      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap);
+      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
 
       for (Map.Entry<String, Double> entry: weightedSubset.entrySet())
       {

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 import java.util.Arrays;

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.d2.balancer.subsetting;
 
 import com.linkedin.d2.balancer.LoadBalancerState;

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
@@ -1,0 +1,138 @@
+package com.linkedin.d2.balancer.subsetting;
+
+import com.linkedin.d2.balancer.LoadBalancerState;
+import com.linkedin.d2.balancer.properties.ClusterProperties;
+import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.properties.UriProperties;
+import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
+import com.linkedin.d2.balancer.simple.SimpleLoadBalancerTest;
+import com.linkedin.d2.balancer.simple.SslSessionValidatorFactory;
+import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
+import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.strategies.random.RandomLoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
+import com.linkedin.d2.discovery.event.PropertyEventBusImpl;
+import com.linkedin.d2.discovery.event.SynchronousExecutorService;
+import com.linkedin.d2.discovery.stores.mock.MockStore;
+import com.linkedin.r2.transport.common.TransportClientFactory;
+import com.linkedin.r2.transport.http.client.common.ssl.SslSessionNotTrustedException;
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class ZKDeterministicSubsettingMetadataProviderTest
+{
+  private static final String CLUSTER_NAME = "cluster-1";
+  private static final URI NODE_URI = URI.create("http://cluster-1/test2");
+
+  private ScheduledExecutorService _executorService;
+  private MockStore<UriProperties> _uriRegistry;
+  private MockStore<ClusterProperties>                                             _clusterRegistry;
+  private MockStore<ServiceProperties>                                             _serviceRegistry;
+  private Map<String, TransportClientFactory>                                      _clientFactories;
+  private Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> _loadBalancerStrategyFactories;
+  private SimpleLoadBalancerState _state;
+  private SSLContext _sslContext;
+  private SSLParameters _sslParameters;
+
+  private ZKDeterministicSubsettingMetadataProvider _metadataProvider;
+
+  private static final SslSessionValidatorFactory SSL_SESSION_VALIDATOR_FACTORY =
+      validationStrings -> sslSession -> {
+        if (validationStrings == null || validationStrings.isEmpty())
+        {
+          throw new SslSessionNotTrustedException("no validation string");
+        }
+      };
+
+  @BeforeMethod
+  public void setUp()
+  {
+    _executorService = new SynchronousExecutorService();
+    _uriRegistry = new MockStore<>();
+    _clusterRegistry = new MockStore<>();
+    _serviceRegistry = new MockStore<>();
+    _clientFactories = new HashMap<>();
+    _loadBalancerStrategyFactories = new HashMap<>();
+    _loadBalancerStrategyFactories.put("random", new RandomLoadBalancerStrategyFactory());
+
+    try {
+      _sslContext = SSLContext.getDefault();
+    }
+    catch (NoSuchAlgorithmException e)
+    {
+      throw new RuntimeException(e);
+    }
+
+    _sslParameters = new SSLParameters();
+    _clientFactories.put("https", new SimpleLoadBalancerTest.DoNothingClientFactory());
+    _state =
+        new SimpleLoadBalancerState(_executorService,
+            new PropertyEventBusImpl<>(_executorService, _uriRegistry),
+            new PropertyEventBusImpl<>(_executorService, _clusterRegistry),
+            new PropertyEventBusImpl<>(_executorService, _serviceRegistry),
+            _clientFactories,
+            _loadBalancerStrategyFactories,
+            _sslContext,
+            _sslParameters,
+            true, null,
+            SSL_SESSION_VALIDATOR_FACTORY);
+
+    _metadataProvider = new ZKDeterministicSubsettingMetadataProvider(CLUSTER_NAME, NODE_URI, _state, 1000, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void testGetSubsettingMetadata()
+  {
+    List<String> schemes = new ArrayList<String>();
+    Map<Integer, PartitionData> partitionData = new HashMap<Integer, PartitionData>(1);
+    partitionData.put(DefaultPartitionAccessor.DEFAULT_PARTITION_ID, new PartitionData(1d));
+    Map<URI, Map<Integer, PartitionData>> uriData = new HashMap<URI, Map<Integer, PartitionData>>();
+    for (int i = 0; i < 10; i++)
+    {
+      uriData.put(URI.create("http://cluster-1/test" + i), partitionData);
+    }
+    schemes.add("http");
+
+    _state.listenToCluster("cluster-1", new LoadBalancerState.NullStateListenerCallback());
+    _state.listenToService("service-1", new LoadBalancerState.NullStateListenerCallback());
+    _clusterRegistry.put("cluster-1", new ClusterProperties("cluster-1", schemes));
+    _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
+    _serviceRegistry.put("service-1", new ServiceProperties("service-1",
+        "cluster-1",
+        "/test", Collections.singletonList("random")));
+
+    DeterministicSubsettingMetadata metadata = _metadataProvider.getSubsettingMetadata();
+
+    assertEquals(metadata.getInstanceId(), 2);
+    assertEquals(metadata.getTotalInstanceCount(), 10);
+
+    uriData.remove(URI.create("http://cluster-1/test0"));
+    _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
+
+    metadata = _metadataProvider.getSubsettingMetadata();
+    assertEquals(metadata.getInstanceId(), 1);
+    assertEquals(metadata.getTotalInstanceCount(), 9);
+
+    uriData.remove(URI.create("http://cluster-1/test2"));
+    _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
+
+    metadata = _metadataProvider.getSubsettingMetadata();
+    assertNull(metadata);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
@@ -109,7 +109,7 @@ public class ZKDeterministicSubsettingMetadataProviderTest
             true, null,
             SSL_SESSION_VALIDATOR_FACTORY);
 
-    _metadataProvider = new ZKDeterministicSubsettingMetadataProvider(CLUSTER_NAME, NODE_URI, _state, 1000, TimeUnit.MILLISECONDS);
+    _metadataProvider = new ZKDeterministicSubsettingMetadataProvider(CLUSTER_NAME, NODE_URI, 1000, TimeUnit.MILLISECONDS);
   }
 
   @Test
@@ -133,7 +133,7 @@ public class ZKDeterministicSubsettingMetadataProviderTest
         "cluster-1",
         "/test", Collections.singletonList("random")));
 
-    DeterministicSubsettingMetadata metadata = _metadataProvider.getSubsettingMetadata();
+    DeterministicSubsettingMetadata metadata = _metadataProvider.getSubsettingMetadata(_state);
 
     assertEquals(metadata.getInstanceId(), 2);
     assertEquals(metadata.getTotalInstanceCount(), 10);
@@ -141,14 +141,14 @@ public class ZKDeterministicSubsettingMetadataProviderTest
     uriData.remove(URI.create("http://cluster-1/test0"));
     _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
 
-    metadata = _metadataProvider.getSubsettingMetadata();
+    metadata = _metadataProvider.getSubsettingMetadata(_state);
     assertEquals(metadata.getInstanceId(), 1);
     assertEquals(metadata.getTotalInstanceCount(), 9);
 
     uriData.remove(URI.create("http://cluster-1/test2"));
     _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
 
-    metadata = _metadataProvider.getSubsettingMetadata();
+    metadata = _metadataProvider.getSubsettingMetadata(_state);
     assertNull(metadata);
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.16.2
+version=29.17.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Low QPS is a long-standing problem with the D2 client-side non-cooperative load balancing library. When QPS is low to a server host, its load balancing signals are weak, e.g., its average latency might be volatile when comparing with the average cluster latency, resulting in ineffective degradations and recoveries. 

D2 Subsetting approaches this problem by limiting a single client to only access a subset of the downstream hosts, resulting in higher QPS and stronger signals of a downstream host with the same amount of requests from the client.

The key of D2 Subsetting is to maintain an overall balanced traffic distribution to the downstream, even though the clients are picking different subsets from the downstream hosts.