### PR TITLE
Include mime type params when setting the response content-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.15.7] - 2021-03-05
+- Include accept header params when setting the response content type.
+
 ## [29.15.6] - 2021-03-04
 - Fix bug that if a schema is an enum without any symbols, doc gen should handle it instead of throwing exception.
 
@@ -4868,7 +4871,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.7...master
+[29.15.7]: https://github.com/linkedin/rest.li/compare/v29.15.6...v29.15.7
 [29.15.6]: https://github.com/linkedin/rest.li/compare/v29.15.5...v29.15.6
 [29.15.5]: https://github.com/linkedin/rest.li/compare/v29.15.4...v29.15.5
 [29.15.4]: https://github.com/linkedin/rest.li/compare/v29.15.3...v29.15.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.15.6
+version=29.15.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/util/TestMIMEParse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/util/TestMIMEParse.java
@@ -33,6 +33,8 @@ import org.testng.annotations.Test;
 public class TestMIMEParse
 {
   private static final String JSON_TYPE = "application/json";
+  private static final String JSON_TYPE_WITH_VALID_PARAMS = "application/json; foo=bar";
+  private static final String JSON_TYPE_WITH_Q_PARAM = "application/json; q=.9";
   private static final String PSON_TYPE = "application/x-pson";
   private static final String EMPTY_TYPE = "";
   private static final String HTML_HEADER = "text/html";
@@ -57,6 +59,8 @@ public class TestMIMEParse
     return new Object[][]
     {
         { Arrays.asList(new String[] { JSON_TYPE }), JSON_HEADER, JSON_TYPE },
+        { Arrays.asList(new String[] { JSON_TYPE }), JSON_TYPE_WITH_VALID_PARAMS, JSON_TYPE_WITH_VALID_PARAMS },
+        { Arrays.asList(new String[] { JSON_TYPE }), JSON_TYPE_WITH_Q_PARAM, JSON_TYPE },
         { Arrays.asList(new String[] { PSON_TYPE }), JSON_HEADER, EMPTY_TYPE },
         { Arrays.asList(new String[] { JSON_TYPE, PSON_TYPE }), JSON_HEADER, JSON_TYPE },
         { Arrays.asList(new String[] { JSON_TYPE, PSON_TYPE }), HTML_HEADER, EMPTY_TYPE },

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/util/TestRestUtils.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/util/TestRestUtils.java
@@ -51,6 +51,8 @@ import org.testng.annotations.Test;
 public class TestRestUtils
 {
   private static final String JSON_TYPE = "application/json";
+  private static final String JSON_TYPE_WITH_VALID_PARAMS = "application/json; foo=bar";
+  private static final String JSON_TYPE_WITH_Q_PARAM = "application/json; q=.9";
   private static final String PSON_TYPE = "application/x-pson";
   private static final String EMPTY_TYPE = "";
   private static final String HTML_HEADER = "text/html";
@@ -77,6 +79,8 @@ public class TestRestUtils
     {
         { JSON_HEADER, JSON_TYPE },
         { PSON_HEADER, PSON_TYPE },
+        { JSON_TYPE_WITH_VALID_PARAMS, JSON_TYPE_WITH_VALID_PARAMS },
+        { JSON_TYPE_WITH_Q_PARAM, JSON_TYPE },
         { HTML_HEADER, EMPTY_TYPE },
         { UNKNOWN_TYPE_HEADER, EMPTY_TYPE },
         { UNKNOWN_TYPE_HEADER_WITH_INVALID_PARAMS, EMPTY_TYPE },


### PR DESCRIPTION
Rest.li is setting the response `content-type` based on the best matching `accept` mime type. However it only sets the base mime type while ignoring any mime type parameters. If a mime type parameter is malformed, it is silently ignored.

Changes:
* Include mime type params when setting the response content type
* Throw an InvalidMimeTypeException when there are invalid params in the accept header.