### PR TITLE
Fix bug that if the schema is an enum without any symbols, doc gen should handle it rather than throwing exception.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.15.6] - 2021-03-04
+- Fix bug that if a schema is an enum without any symbols, doc gen should handle it instead of throwing exception.
+
 ## [29.15.5] - 2021-03-03
 - Fix content type header not set in case of RestliResponseException from non streaming server
 
@@ -4865,7 +4868,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.6...master
+[29.15.6]: https://github.com/linkedin/rest.li/compare/v29.15.5...v29.15.6
 [29.15.5]: https://github.com/linkedin/rest.li/compare/v29.15.4...v29.15.5
 [29.15.4]: https://github.com/linkedin/rest.li/compare/v29.15.3...v29.15.4
 [29.15.3]: https://github.com/linkedin/rest.li/compare/v29.15.2...v29.15.3

--- a/data/src/main/java/com/linkedin/data/schema/generator/DefaultSampleDataCallback.java
+++ b/data/src/main/java/com/linkedin/data/schema/generator/DefaultSampleDataCallback.java
@@ -135,6 +135,11 @@ public class DefaultSampleDataCallback implements SampleDataCallback
   public String getEnum(String fieldName, EnumDataSchema enumDataSchema)
   {
     List<String> symbols = enumDataSchema.getSymbols();
+    // enum without any symbols is allowed, return "EmptyEnum" as a reference in doc.
+    if (symbols.size() < 1)
+    {
+      return "EmptyEnum";
+    }
     return symbols.get(nonNegative(symbols.size() - 1));
   }
 

--- a/generator-test/src/test/java/com/linkedin/data/schema/generator/TestSchemaSampleDataGenerator.java
+++ b/generator-test/src/test/java/com/linkedin/data/schema/generator/TestSchemaSampleDataGenerator.java
@@ -53,6 +53,7 @@ import com.linkedin.data.template.LongMap;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.pegasus.generator.test.Certification;
+import com.linkedin.pegasus.generator.test.EnumEmpty;
 import com.linkedin.pegasus.generator.test.EnumFruits;
 import com.linkedin.pegasus.generator.test.FixedMD5;
 import com.linkedin.pegasus.generator.test.InvalidSelfReference;
@@ -129,6 +130,15 @@ public class TestSchemaSampleDataGenerator
     final String value = (String) SchemaSampleDataGenerator.buildData(schema, _spec);
     Assert.assertSame(schema.getSymbolDocs().size(), EnumFruits.class.getEnumConstants().length - 1/*The $UNKNOWN value*/);
     EnumFruits.valueOf(value);
+  }
+
+  @Test
+  public void testEmptyEnumSchema()
+  {
+    final EnumDataSchema schema = (EnumDataSchema) DataTemplateUtil.getSchema(EnumEmpty.class);
+    final String value = (String) SchemaSampleDataGenerator.buildData(schema, _spec);
+    Assert.assertSame(schema.getSymbols().size(), EnumEmpty.class.getEnumConstants().length - 1/*The $UNKNOWN value*/);
+    Assert.assertEquals("EmptyEnum", value);
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.15.5
+version=29.15.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Doc gen did not handle the case that if resource key is an enum type without any symbols. Enum without symbols is a valid use case. This PR is fixing this issue.

Test:
Unit test.