### PR TITLE
Add separate configuration control for retrying RestRequest and StreamRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.15.9] - 2021-03-06
+- Add separate configuration control for retrying RestRequest and StreamRequest.
+
 ## [29.15.8] - 2021-03-05
 - Exclude 3XX http status from adding error logs during build error response from restli server.
 
@@ -4874,7 +4877,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.9...master
+[29.15.9]: https://github.com/linkedin/rest.li/compare/v29.15.8...v29.15.9
 [29.15.8]: https://github.com/linkedin/rest.li/compare/v29.15.7...v29.15.8
 [29.15.7]: https://github.com/linkedin/rest.li/compare/v29.15.6...v29.15.7
 [29.15.6]: https://github.com/linkedin/rest.li/compare/v29.15.5...v29.15.6

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -69,6 +69,7 @@ import org.slf4j.LoggerFactory;
  * Build a {@link D2Client} with basic ZooKeeper setup to connect D2 protocol.
  * The client could be further wrapped by other client classes.
  */
+@SuppressWarnings("deprecation")
 public class D2ClientBuilder
 {
   private static final Logger LOG = LoggerFactory.getLogger(D2ClientBuilder.class);
@@ -145,6 +146,8 @@ public class D2ClientBuilder
                   _config.healthCheckOperations,
                   _config._executorService,
                   _config.retry,
+                  _config.restRetryEnabled,
+                  _config.streamRetryEnabled,
                   _config.retryLimit,
                   _config.retryUpdateIntervalMs,
                   _config.retryAggregatedIntervalNum,
@@ -205,7 +208,14 @@ public class D2ClientBuilder
     if (_config.retry)
     {
       d2Client = new RetryClient(d2Client, loadBalancer, _config.retryLimit,
-          _config.retryUpdateIntervalMs, _config.retryAggregatedIntervalNum, SystemClock.instance());
+          _config.retryUpdateIntervalMs, _config.retryAggregatedIntervalNum, SystemClock.instance(),
+          true, true);
+    }
+    else if (_config.restRetryEnabled || _config.streamRetryEnabled)
+    {
+      d2Client = new RetryClient(d2Client, loadBalancer, _config.retryLimit,
+          _config.retryUpdateIntervalMs, _config.retryAggregatedIntervalNum, SystemClock.instance(),
+          _config.restRetryEnabled, _config.streamRetryEnabled);
     }
 
     // If we created default transport client factories, we need to shut them down when d2Client
@@ -337,6 +347,18 @@ public class D2ClientBuilder
   public D2ClientBuilder setRetry(boolean retry)
   {
     _config.retry = retry;
+    return this;
+  }
+
+  public D2ClientBuilder setRestRetryEnabled(boolean restRetryEnabled)
+  {
+    _config.restRetryEnabled = restRetryEnabled;
+    return this;
+  }
+
+  public D2ClientBuilder setStreamRetryEnabled(boolean streamRetryEnabled)
+  {
+    _config.streamRetryEnabled = streamRetryEnabled;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -69,7 +69,15 @@ public class D2ClientConfig
    */
   ScheduledExecutorService _executorService = null;
   ScheduledExecutorService _backupRequestsExecutorService = null;
+
+  /**
+   * @deprecated Use restRetryEnabled and streamRetryEnabled instead
+   */
+  @Deprecated()
   boolean retry = false;
+
+  boolean restRetryEnabled = false;
+  boolean streamRetryEnabled = false;
   int retryLimit = DEAULT_RETRY_LIMIT;
   long retryUpdateIntervalMs = RetryClient.DEFAULT_UPDATE_INTERVAL_MS;
   int retryAggregatedIntervalNum = RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM;
@@ -124,6 +132,8 @@ public class D2ClientConfig
                  HealthCheckOperations healthCheckOperations,
                  ScheduledExecutorService executorService,
                  boolean retry,
+                 boolean restRetryEnabled,
+                 boolean streamRetryEnabled,
                  int retryLimit,
                  long retryUpdateIntervalMs,
                  int retryAggregatedIntervalNum,
@@ -173,6 +183,8 @@ public class D2ClientConfig
     this.healthCheckOperations = healthCheckOperations;
     this._executorService = executorService;
     this.retry = retry;
+    this.restRetryEnabled = restRetryEnabled;
+    this.streamRetryEnabled = streamRetryEnabled;
     this.retryLimit = retryLimit;
     this.retryUpdateIntervalMs = retryUpdateIntervalMs;
     this.retryAggregatedIntervalNum = retryAggregatedIntervalNum;

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/RetryClient.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/RetryClient.java
@@ -78,7 +78,7 @@ public class RetryClient extends D2ClientDelegator
 {
   public static final long DEFAULT_UPDATE_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
   public static final int DEFAULT_AGGREGATED_INTERVAL_NUM = 5;
-  public static final boolean DEFAULT_REST_RETRY_ENABLED = true;
+  public static final boolean DEFAULT_REST_RETRY_ENABLED = false;
   public static final boolean DEFAULT_STREAM_RETRY_ENABLED = false;
   private static final Logger LOG = LoggerFactory.getLogger(RetryClient.class);
 
@@ -92,11 +92,14 @@ public class RetryClient extends D2ClientDelegator
 
   ConcurrentMap<String, ClientRetryTracker> _retryTrackerMap;
 
+  @Deprecated
   public RetryClient(D2Client d2Client, LoadBalancer balancer, int limit)
   {
-    this(d2Client, balancer, limit, DEFAULT_UPDATE_INTERVAL_MS, DEFAULT_AGGREGATED_INTERVAL_NUM, SystemClock.instance());
+    this(d2Client, balancer, limit, DEFAULT_UPDATE_INTERVAL_MS, DEFAULT_AGGREGATED_INTERVAL_NUM, SystemClock.instance(),
+        DEFAULT_REST_RETRY_ENABLED, DEFAULT_STREAM_RETRY_ENABLED);
   }
 
+  @Deprecated
   public RetryClient(D2Client d2Client, LoadBalancer balancer, int limit, long updateIntervalMs, int aggregatedIntervalNum, Clock clock)
   {
     this(d2Client, balancer, limit, updateIntervalMs, aggregatedIntervalNum, clock, DEFAULT_REST_RETRY_ENABLED, DEFAULT_STREAM_RETRY_ENABLED);

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/RetryClient.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/RetryClient.java
@@ -78,6 +78,8 @@ public class RetryClient extends D2ClientDelegator
 {
   public static final long DEFAULT_UPDATE_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
   public static final int DEFAULT_AGGREGATED_INTERVAL_NUM = 5;
+  public static final boolean DEFAULT_REST_RETRY_ENABLED = true;
+  public static final boolean DEFAULT_STREAM_RETRY_ENABLED = false;
   private static final Logger LOG = LoggerFactory.getLogger(RetryClient.class);
 
   private final Clock _clock;
@@ -85,6 +87,8 @@ public class RetryClient extends D2ClientDelegator
   private final int _limit;
   private final long _updateIntervalMs;
   private final int _aggregatedIntervalNum;
+  private final boolean _restRetryEnabled;
+  private final boolean _streamRetryEnabled;
 
   ConcurrentMap<String, ClientRetryTracker> _retryTrackerMap;
 
@@ -95,6 +99,13 @@ public class RetryClient extends D2ClientDelegator
 
   public RetryClient(D2Client d2Client, LoadBalancer balancer, int limit, long updateIntervalMs, int aggregatedIntervalNum, Clock clock)
   {
+    this(d2Client, balancer, limit, updateIntervalMs, aggregatedIntervalNum, clock, DEFAULT_REST_RETRY_ENABLED, DEFAULT_STREAM_RETRY_ENABLED);
+  }
+
+  public RetryClient(D2Client d2Client, LoadBalancer balancer, int limit,
+      long updateIntervalMs, int aggregatedIntervalNum, Clock clock,
+      boolean restRetryEnabled, boolean streamRetryEnabled)
+  {
     super(d2Client);
     _balancer = balancer;
     _limit = limit;
@@ -102,6 +113,8 @@ public class RetryClient extends D2ClientDelegator
     _aggregatedIntervalNum = aggregatedIntervalNum;
     _clock = clock;
     _retryTrackerMap = new ConcurrentHashMap<>();
+    _restRetryEnabled = restRetryEnabled;
+    _streamRetryEnabled = streamRetryEnabled;
 
     LOG.debug("Retry client created with limit={}", _limit);
   }
@@ -131,12 +144,19 @@ public class RetryClient extends D2ClientDelegator
       final RequestContext requestContext,
       final Callback<RestResponse> callback)
   {
-    RestRequest newRequest = request.builder()
-        .setHeader(HttpConstants.HEADER_NUMBER_OF_RETRY_ATTEMPTS, "0")
-        .build();
-    ClientRetryTracker retryTracker = updateRetryTracker(newRequest.getURI(), false);
-    final Callback<RestResponse> transportCallback = new RestRetryRequestCallback(newRequest, requestContext, callback, retryTracker);
-    _d2Client.restRequest(newRequest, requestContext, transportCallback);
+    if (_restRetryEnabled)
+    {
+      RestRequest newRequest = request.builder()
+          .setHeader(HttpConstants.HEADER_NUMBER_OF_RETRY_ATTEMPTS, "0")
+          .build();
+      ClientRetryTracker retryTracker = updateRetryTracker(newRequest.getURI(), false);
+      final Callback<RestResponse> transportCallback = new RestRetryRequestCallback(newRequest, requestContext, callback, retryTracker);
+      _d2Client.restRequest(newRequest, requestContext, transportCallback);
+    }
+    else
+    {
+      _d2Client.restRequest(request, requestContext, callback);
+    }
   }
 
   @Override
@@ -148,12 +168,19 @@ public class RetryClient extends D2ClientDelegator
   @Override
   public void streamRequest(StreamRequest request, RequestContext requestContext, Callback<StreamResponse> callback)
   {
-    StreamRequest newRequest = request.builder()
-        .setHeader(HttpConstants.HEADER_NUMBER_OF_RETRY_ATTEMPTS, "0")
-        .build(request.getEntityStream());
-    ClientRetryTracker retryTracker = updateRetryTracker(newRequest.getURI(), false);
-    final Callback<StreamResponse> transportCallback = new StreamRetryRequestCallback(newRequest, requestContext, callback, retryTracker);
-    _d2Client.streamRequest(newRequest, requestContext, transportCallback);
+    if (_streamRetryEnabled)
+    {
+      StreamRequest newRequest = request.builder()
+          .setHeader(HttpConstants.HEADER_NUMBER_OF_RETRY_ATTEMPTS, "0")
+          .build(request.getEntityStream());
+      ClientRetryTracker retryTracker = updateRetryTracker(newRequest.getURI(), false);
+      final Callback<StreamResponse> transportCallback = new StreamRetryRequestCallback(newRequest, requestContext, callback, retryTracker);
+      _d2Client.streamRequest(newRequest, requestContext, transportCallback);
+    }
+    else
+    {
+      _d2Client.streamRequest(request, requestContext, callback);
+    }
   }
 
   private ClientRetryTracker updateRetryTracker(URI uri, boolean isRetry)

--- a/d2/src/test/java/com/linkedin/d2/balancer/clients/RetryClientTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clients/RetryClientTest.java
@@ -93,7 +93,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 3);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        D2ClientConfig.DEAULT_RETRY_LIMIT,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        false);
     URI uri = URI.create("d2://retryService?arg1arg2");
     RestRequest restRequest = new RestRequestBuilder(uri).setEntity(CONTENT).build();
     TrackerClientTest.TestCallback<RestResponse> restCallback = new TrackerClientTest.TestCallback<RestResponse>();
@@ -110,8 +118,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 3, RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
-        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM, SystemClock.instance(), true, true);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        D2ClientConfig.DEAULT_RETRY_LIMIT,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        true);
     URI uri = URI.create("d2://retryService?arg1arg2");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.newEntityStream(new ByteStringWriter(CONTENT)));
     TrackerClientTest.TestCallback<StreamResponse> restCallback = new TrackerClientTest.TestCallback<StreamResponse>();
@@ -128,7 +143,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 3);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        D2ClientConfig.DEAULT_RETRY_LIMIT,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        false);
     URI uri = URI.create("d2://retryService?arg1arg2");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.newEntityStream(new ByteStringWriter(CONTENT)));
     TrackerClientTest.TestCallback<StreamResponse> restCallback = new TrackerClientTest.TestCallback<StreamResponse>();
@@ -146,7 +169,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 3);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        D2ClientConfig.DEAULT_RETRY_LIMIT,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        false);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     RestRequest restRequest = new RestRequestBuilder(uri).build();
     TrackerClientTest.TestCallback<RestResponse> restCallback = new TrackerClientTest.TestCallback<RestResponse>();
@@ -167,7 +198,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 3);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        D2ClientConfig.DEAULT_RETRY_LIMIT,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        true);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.emptyStream());
     TrackerClientTest.TestCallback<StreamResponse> streamCallback = new TrackerClientTest.TestCallback<StreamResponse>();
@@ -188,7 +227,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 1);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        1,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        false);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     RestRequest restRequest = new RestRequestBuilder(uri).build();
     TrackerClientTest.TestCallback<RestResponse> restCallback = new TrackerClientTest.TestCallback<RestResponse>();
@@ -206,7 +253,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 1);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        1,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        true);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.emptyStream());
     TrackerClientTest.TestCallback<StreamResponse> streamCallback = new TrackerClientTest.TestCallback<StreamResponse>();
@@ -224,7 +279,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 3);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        D2ClientConfig.DEAULT_RETRY_LIMIT,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        false);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     RestRequest restRequest = new RestRequestBuilder(uri).build();
     TrackerClientTest.TestCallback<RestResponse> restCallback = new TrackerClientTest.TestCallback<RestResponse>();
@@ -242,8 +305,15 @@ public class RetryClientTest
         HttpClientFactory.UNLIMITED_CLIENT_REQUEST_RETRY_RATIO);
 
     DynamicClient dynamicClient = new DynamicClient(balancer, null);
-    RetryClient client = new RetryClient(dynamicClient, balancer, 3, RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
-        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM, SystemClock.instance(), true, true);
+    RetryClient client = new RetryClient(
+        dynamicClient,
+        balancer,
+        D2ClientConfig.DEAULT_RETRY_LIMIT,
+        RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
+        RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
+        SystemClock.instance(),
+        true,
+        true);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     StreamRequest streamRequest = new StreamRequestBuilder(uri).build(EntityStreams.emptyStream());
     FutureCallback<StreamResponse> streamCallback = new FutureCallback<>();
@@ -272,7 +342,9 @@ public class RetryClientTest
         D2ClientConfig.DEAULT_RETRY_LIMIT,
         RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
         RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
-        clock);
+        clock,
+        true,
+        false);
     URI uri1 = URI.create("d2://retryService1?arg1=empty&arg2=empty");
     RestRequest restRequest1 = new RestRequestBuilder(uri1).build();
 
@@ -326,7 +398,9 @@ public class RetryClientTest
         D2ClientConfig.DEAULT_RETRY_LIMIT,
         RetryClient.DEFAULT_UPDATE_INTERVAL_MS,
         RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM,
-        clock);
+        clock,
+        true,
+        false);
     URI uri = URI.create("d2://retryService?arg1=empty&arg2=empty");
     RestRequest restRequest = new RestRequestBuilder(uri).build();
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.15.8
+version=29.15.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The current implementation of RetryClient will buffer every single incoming StreamRequest regardless of its entity stream size, which could potentially cause memory issues. Therefore, we would like to disable client retry for stream request by default. We will be adding two separate configs to control restRetry (enable by default) and streamRetry (disable by default).