### PR TITLE
Exclude 3xx status from logging errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.15.8] - 2021-03-05
+- Exclude 3XX http status from adding error logs during build error response from restli server.
+
 ## [29.15.7] - 2021-03-05
 - Include accept header params when setting the response content type.
 
@@ -4871,7 +4874,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.15.8...master
+[29.15.8]: https://github.com/linkedin/rest.li/compare/v29.15.7...v29.15.8
 [29.15.7]: https://github.com/linkedin/rest.li/compare/v29.15.6...v29.15.7
 [29.15.6]: https://github.com/linkedin/rest.li/compare/v29.15.5...v29.15.6
 [29.15.5]: https://github.com/linkedin/rest.li/compare/v29.15.4...v29.15.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.15.7
+version=29.15.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/response/ErrorResponseBuilder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/response/ErrorResponseBuilder.java
@@ -76,7 +76,10 @@ public final class ErrorResponseBuilder
 
   public ErrorResponse buildErrorResponse(RestLiServiceException result)
   {
-    if (result.getStatus() != null && result.getStatus().getCode() < 400)
+    // In some cases, people use 3XX to signal client a redirection. This falls into the category of blurred boundary
+    // whether this should be an error or not, in order to not disrupt change the behavior of existing code
+    // Thus excluding logging errors for 3XX
+    if (result.getStatus() != null && result.getStatus().getCode() < HttpStatus.S_300_MULTIPLE_CHOICES.getCode())
     {
       // Invalid to send an error response with success status codes. This should be converted to 500 errors.
       // Logging an error message now to detect and fix current use cases before we start converting to 500.


### PR DESCRIPTION
In previous changes, we add error logs to 2xx and 3xx status where an exception is thrown from the servers to tell developers that this is anti-pattern. But sometimes there is a blurred boundary in the category of 3xx. (Which is mostly for redirect traffic) 
The added error logs propagated to the client side and causing some excessive and troubled client to judge poorly. (Because we added more information to the log) 
Thus I exclude 3xx from adding the error log to help them.