### PR TITLE
Fix d2 unmodifiable list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.16.1] - 2021-03-17
 - Add fluent client api for simple resource and association resource.
 - Add support for generating projection mask as the mask data map.
+- Fix UnmodifiableList wrap in d2 relative load balancer
 
 ## [29.16.0] - 2021-03-10
 - Add a ParSeq based CompletionStage implementation
@@ -4883,7 +4886,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.16.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.16.1...master
+[29.16.1]: https://github.com/linkedin/rest.li/compare/v29.16.0...v29.16.1
 [29.16.0]: https://github.com/linkedin/rest.li/compare/v29.15.9...v29.16.0
 [29.15.9]: https://github.com/linkedin/rest.li/compare/v29.15.8...v29.15.9
 [29.15.8]: https://github.com/linkedin/rest.li/compare/v29.15.7...v29.15.8

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/PartitionState.java
@@ -183,7 +183,7 @@ public class PartitionState
 
   List<PartitionStateUpdateListener<PartitionState>> getListeners()
   {
-    return Collections.unmodifiableList(_listeners);
+    return _listeners;
   }
 
   void removeTrackerClient(TrackerClient trackerClient)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.16.0
+version=29.16.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
There is a report from user that UnmodifiableList.forEach stack is unreasonably long: https://harrier.tools.corp.linkedin.com/#/lnkd-services/profiler/event/21019?isAsyncProfiler=true&metric=count

After taking a look, I found that I wrap an UnmodifiableList again and again in the code, each UnmodifiableList points to another UnmodifiableList, hence fix it in the PR.

This method is how I create a new PartitionState and wraps the UnmodifiableList:
  PartitionState (PartitionState oldPartitionState)
  {
    this(oldPartitionState.getPartitionId(),
        oldPartitionState.getRingFactory(),
        oldPartitionState.getPointsPerWeight(),
        new HashSet<>(oldPartitionState.getRecoveryTrackerClients()),
        oldPartitionState.getClusterGenerationId(),
        new HashMap<>(oldPartitionState.getQuarantineMap()),
        new HashMap<>(oldPartitionState.getQuarantineHistory()),
        new HashMap<>(oldPartitionState.getHealthCheckMap()),
        new HashMap<>(oldPartitionState.getTrackerClientStateMap()),
        **oldPartitionState.getListeners()**);
  }
