### PR TITLE
Add default fill in for custom metadata and collection metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.16.2] - 2021-03-22
+- Fix an issue where in collection response, we did not fill in the default values in the metadata and paging metadata.
+
 ## [29.16.1] - 2021-03-17
 - Add fluent client api for simple resource and association resource.
 - Add support for generating projection mask as the mask data map.
@@ -4886,7 +4889,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.16.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.16.2...master
+[29.16.2]: https://github.com/linkedin/rest.li/compare/v29.16.1...v29.16.2
 [29.16.1]: https://github.com/linkedin/rest.li/compare/v29.16.0...v29.16.1
 [29.16.0]: https://github.com/linkedin/rest.li/compare/v29.15.9...v29.16.0
 [29.15.9]: https://github.com/linkedin/rest.li/compare/v29.15.8...v29.15.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.16.1
+version=29.16.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.defaults.api.fillInDefaults.restspec.json
+++ b/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.defaults.api.fillInDefaults.restspec.json
@@ -16,6 +16,9 @@
       "method" : "batch_get"
     }, {
       "method" : "get_all",
+      "metadata" : {
+        "type" : "com.linkedin.restli.examples.defaults.api.LowLevelRecordWithDefault"
+      },
       "pagingSupported" : true
     } ],
     "finders" : [ {
@@ -23,7 +26,10 @@
       "parameters" : [ {
         "name" : "noDefaultFieldA",
         "type" : "int"
-      } ]
+      } ],
+      "metadata" : {
+        "type" : "com.linkedin.restli.examples.defaults.api.LowLevelRecordWithDefault"
+      }
     } ],
     "batchFinders" : [ {
       "name" : "searchRecords",

--- a/restli-int-test-api/src/main/pegasus/com/linkedin/restli/examples/defaults/api/HighLevelRecordWithDefault.pdl
+++ b/restli-int-test-api/src/main/pegasus/com/linkedin/restli/examples/defaults/api/HighLevelRecordWithDefault.pdl
@@ -1,5 +1,6 @@
 namespace com.linkedin.restli.examples.defaults.api
 
+
 record HighLevelRecordWithDefault {
   noDefaultFieldA: int,
   intDefaultFieldB: int = -1,

--- a/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.defaults.api.fillInDefaults.snapshot.json
+++ b/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.defaults.api.fillInDefaults.snapshot.json
@@ -101,6 +101,9 @@
         "method" : "batch_get"
       }, {
         "method" : "get_all",
+        "metadata" : {
+          "type" : "com.linkedin.restli.examples.defaults.api.LowLevelRecordWithDefault"
+        },
         "pagingSupported" : true
       } ],
       "finders" : [ {
@@ -108,7 +111,10 @@
         "parameters" : [ {
           "name" : "noDefaultFieldA",
           "type" : "int"
-        } ]
+        } ],
+        "metadata" : {
+          "type" : "com.linkedin.restli.examples.defaults.api.LowLevelRecordWithDefault"
+        }
       } ],
       "batchFinders" : [ {
         "name" : "searchRecords",

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/defaults/FieldFillInDefaultResources.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/defaults/FieldFillInDefaultResources.java
@@ -2,8 +2,10 @@ package com.linkedin.restli.examples.greetings.server.defaults;
 
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.examples.defaults.api.HighLevelRecordWithDefault;
+import com.linkedin.restli.examples.defaults.api.LowLevelRecordWithDefault;
 import com.linkedin.restli.examples.defaults.api.RecordCriteria;
 import com.linkedin.restli.examples.greetings.api.Empty;
+import com.linkedin.restli.examples.greetings.api.Greeting;
 import com.linkedin.restli.server.ActionResult;
 import com.linkedin.restli.server.BatchFinderResult;
 import com.linkedin.restli.server.CollectionResult;
@@ -15,6 +17,7 @@ import com.linkedin.restli.server.annotations.Finder;
 import com.linkedin.restli.server.annotations.PagingContextParam;
 import com.linkedin.restli.server.annotations.QueryParam;
 import com.linkedin.restli.server.annotations.RestLiCollection;
+import com.linkedin.restli.server.annotations.RestMethod;
 import com.linkedin.restli.server.resources.CollectionResourceTemplate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,23 +48,33 @@ public class FieldFillInDefaultResources extends CollectionResourceTemplate<Long
     return result;
   }
 
-  @Override
-  public List<HighLevelRecordWithDefault> getAll(@PagingContextParam PagingContext pagingContext)
+  @RestMethod.GetAll
+  public CollectionResult<HighLevelRecordWithDefault, LowLevelRecordWithDefault> getAllHighLevelRecordWithDefault(
+      @PagingContextParam PagingContext pagingContext)
   {
-    List<HighLevelRecordWithDefault> result = new LinkedList<>();
-    for (int i = 0; i < 3; i++)
+    final int total = 3;
+    List<HighLevelRecordWithDefault> elements = new LinkedList<>();
+    for (int i = 0; i < total; i++)
     {
-      result.add(new HighLevelRecordWithDefault().setNoDefaultFieldA(i));
+      elements.add(new HighLevelRecordWithDefault().setNoDefaultFieldA(i));
     }
-    return result;
+    LowLevelRecordWithDefault metadata = new LowLevelRecordWithDefault();
+    return new CollectionResult<>(elements, total, metadata);
   }
 
   @Finder("findRecords")
-  public List<HighLevelRecordWithDefault> findRecords(@QueryParam("noDefaultFieldA") Integer fieldA)
+  public CollectionResult<HighLevelRecordWithDefault, LowLevelRecordWithDefault> findRecords(
+      @QueryParam("noDefaultFieldA") Integer fieldA)
   {
-    List<HighLevelRecordWithDefault> finderResult = new ArrayList<>();
-    finderResult.add(new HighLevelRecordWithDefault().setNoDefaultFieldA(fieldA));
-    return finderResult;
+    final int total = 3;
+    List<HighLevelRecordWithDefault> elements = new ArrayList<>();
+    for (int i = 0; i < total; i ++)
+    {
+      HighLevelRecordWithDefault record = new HighLevelRecordWithDefault().setNoDefaultFieldA(fieldA);
+      elements.add(record);
+    }
+    LowLevelRecordWithDefault metadata = new LowLevelRecordWithDefault();
+    return new CollectionResult<>(elements, total, metadata);
   }
 
   @BatchFinder(value = "searchRecords", batchParam = "criteria")

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/response/CollectionResponseBuilder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/response/CollectionResponseBuilder.java
@@ -141,8 +141,14 @@ public abstract class CollectionResponseBuilder<D extends RestLiResponseData<? e
     //If the client decides they want total in their paging response, then the resource method will see total in their
     //paging path spec and then decide to set total to a non null value. We will then also include it when we project
     //paging.
-    final CollectionMetadata projectedPaging = new CollectionMetadata(RestUtils.projectFields(paging.data(),
+    DataMap pagingData = paging.data();
+    if (resourceContext.isFillInDefaultsRequested())
+    {
+      pagingData = (DataMap) ResponseUtils.fillInDataDefault(CollectionMetadata.dataSchema(), pagingData);
+    }
+    final CollectionMetadata projectedPaging = new CollectionMetadata(RestUtils.projectFields(pagingData,
             ProjectionMode.AUTOMATIC, resourceContext.getPagingProjectionMask()));
+
 
     //For root object entities
     List<AnyRecord> processedElements = new ArrayList<>(elements.size());
@@ -166,8 +172,13 @@ public abstract class CollectionResponseBuilder<D extends RestLiResponseData<? e
     final AnyRecord projectedCustomMetadata;
     if (customMetadata != null)
     {
+      DataMap customMetadataWithDefault = customMetadata.data();
+      if (resourceContext.isFillInDefaultsRequested())
+      {
+        customMetadataWithDefault = (DataMap) ResponseUtils.fillInDataDefault(customMetadata.schema(), customMetadataWithDefault);
+      }
       projectedCustomMetadata = new AnyRecord(RestUtils
-          .projectFields(customMetadata.data(), resourceContext.getMetadataProjectionMode(),
+          .projectFields(customMetadataWithDefault, resourceContext.getMetadataProjectionMode(),
               resourceContext.getMetadataProjectionMask(), resourceContext.getAlwaysProjectedFields()));
     }
     else


### PR DESCRIPTION
This fix is because we lack of filling in default values in the paging metadata and custom metadata in the collection response for methods like finders and get_all.
Previously we just iterate the elements and filling in the default values, this PR is adding code to check not just elements but also paging metadata and custom metadata