### PR TITLE
Add TypeRef Infos to corresponding Spec files

### DIFF
--- a/restli-client/src/test/java/com/linkedin/restli/client/TestParSeqBasedCompletionStage.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestParSeqBasedCompletionStage.java
@@ -688,7 +688,7 @@ public class TestParSeqBasedCompletionStage
     Consumer<Object> consumer = mock(Consumer.class);
     CountDownLatch waitLatch = new CountDownLatch(1);
     CompletionStage<String> completionStage = createTestStage(TESTVALUE1);
-    CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 5000).thenApply((v) -> {
+    CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 1000).thenApply((v) -> {
       waitLatch.countDown();
       return v;
     });
@@ -791,7 +791,7 @@ public class TestParSeqBasedCompletionStage
     Function<Object, ?> function = mock(Function.class);
     CountDownLatch waitLatch = new CountDownLatch(1);
     CompletionStage<String> completionStage = createTestStage(TESTVALUE1);
-    CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 5000).thenApply((v) -> {
+    CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 1000).thenApply((v) -> {
       waitLatch.countDown();
       return v;
     });
@@ -895,7 +895,7 @@ public class TestParSeqBasedCompletionStage
     Runnable runnable = mock(Runnable.class);
     CountDownLatch waitLatch = new CountDownLatch(1);
     CompletionStage<String> completionStage = createTestStage(TESTVALUE1);
-    CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 5000).thenApply((v) -> {
+    CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 1000).thenApply((v) -> {
       waitLatch.countDown();
       return v;
     });

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParseqBasedFluentClientApi.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParseqBasedFluentClientApi.java
@@ -32,16 +32,18 @@ import com.linkedin.restli.common.IdEntityResponse;
 import com.linkedin.restli.common.PatchRequest;
 import com.linkedin.restli.common.UpdateEntityStatus;
 import com.linkedin.restli.common.UpdateStatus;
+import com.linkedin.restli.examples.custom.types.CustomLong;
 import com.linkedin.restli.examples.greetings.api.Greeting;
 import com.linkedin.restli.examples.greetings.api.Message;
 import com.linkedin.restli.examples.greetings.api.Tone;
 import com.linkedin.restli.examples.greetings.api.TwoPartKey;
+import com.linkedin.restli.examples.greetings.client.AssociationsAssociationsFluentClient;
 import com.linkedin.restli.examples.greetings.client.AssociationsAssociationsSubFluentClient;
 import com.linkedin.restli.examples.greetings.client.AssociationsFluentClient;
 import com.linkedin.restli.examples.greetings.client.AssociationsSubFluentClient;
-import com.linkedin.restli.examples.greetings.client.AssociationsAssociationsFluentClient;
 import com.linkedin.restli.examples.greetings.client.ComplexKeysSubFluentClient;
 import com.linkedin.restli.examples.greetings.client.CreateGreetingFluentClient;
+import com.linkedin.restli.examples.greetings.client.CustomTypes2FluentClient;
 import com.linkedin.restli.examples.greetings.client.GreetingFluentClient;
 import com.linkedin.restli.examples.greetings.client.GreetingsFluentClient;
 import com.linkedin.restli.examples.greetings.client.GreetingsOfgreetingsOfgreetingsOfgreetingFluentClient;
@@ -849,6 +851,18 @@ public class TestParseqBasedFluentClientApi extends RestLiIntegrationTest
     TwoPartKey response = subFluentClient.get("stringKey").toCompletableFuture().get(5000, TimeUnit.MILLISECONDS);
     Assert.assertEquals(response.getMajor(), "aANDc");
     Assert.assertEquals(response.getMinor(), "bANDd");
+  }
+
+  // ----- Test TypeRef cases ------
+
+  @Test public void testTypeRef_keyTypeRef() throws Exception
+  {
+    CustomTypes2FluentClient customTypes2FluentClient = new CustomTypes2FluentClient(_parSeqRestliClient, _parSeqUnitTestHelper.getEngine());
+    Assert.assertEquals(customTypes2FluentClient.get(new CustomLong(1L))
+        .toCompletableFuture()
+        .get(5000, TimeUnit.MILLISECONDS)
+        .getId()
+        .longValue(), 1L);
   }
 
   // ----- utils used for testing ------

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ActionMethodSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ActionMethodSpec.java
@@ -84,7 +84,7 @@ public class ActionMethodSpec
   public boolean hasReturnTypeRef()
   {
     return hasReturns() && (_declaredValuedClassName != null) &&
-        !ClassUtils.getShortClassName(getValueClassName()).equals(ClassUtils.getShortClassName(_declaredValuedClassName));
+        !SpecUtils.checkIsSameClass(getValueClassName(), _declaredValuedClassName);
   }
 
   // TODO: add to imports so can have a shortened display name

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/AssociationResourceSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/AssociationResourceSpec.java
@@ -108,6 +108,11 @@ public class AssociationResourceSpec extends BaseResourceSpec
     return getShortClassName(CompoundKey.class.getName());
   }
 
+  public String getKeyClassDisplayName()
+  {
+    return getShortClassName(CompoundKey.class.getName());
+  }
+
   @Override
   public Set<String> getResourceSpecificImports(Set<String> imports)
   {

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/CollectionResourceSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/CollectionResourceSpec.java
@@ -141,7 +141,7 @@ public class CollectionResourceSpec extends BaseResourceSpec
     if(_useShortKeyClassName == null)
     {
       // Need to check here  && while importing due to
-      // undeterministic order  in template resolving
+      // undeterministic order in template resolving
       if(!SpecUtils.checkIfShortNameConflictAndUpdateMapping(_importCheckConflict,
           ClassUtils.getShortClassName(getKeyClassName()), getKeyClassName()))
       {
@@ -163,11 +163,11 @@ public class CollectionResourceSpec extends BaseResourceSpec
     if (_useShortKeyTypeRefClassName == null)
     {
       // Need to check here  && while importing due to
-      // undeterministic order  in template resolving
+      // undeterministic order in template resolving
       if(!SpecUtils.checkIfShortNameConflictAndUpdateMapping(_importCheckConflict,
           ClassUtils.getShortClassName(getKeyClassName()), getKeyClassName()))
       {
-        _useShortKeyClassName = true;
+        _useShortKeyTypeRefClassName = true;
       }
     }
     return _useShortKeyTypeRefClassName? ClassUtils.getShortClassName(_keyTypeRefClassName)

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ParameterSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ParameterSpec.java
@@ -61,8 +61,7 @@ public class ParameterSpec
 
   public boolean hasParamTypeRef()
   {
-    return !ClassUtils.getShortClassName(getParamClassName()).equals(ClassUtils.getShortClassName(
-        _declaredTypeRefClassName));
+    return !SpecUtils.checkIsSameClass(getParamClassName(), _declaredTypeRefClassName);
   }
 
   // TODO: add displayable name

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ParameterSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ParameterSpec.java
@@ -19,18 +19,24 @@ package com.linkedin.restli.tools.clientgen.fluentspec;
 import com.linkedin.pegasus.generator.spec.ClassTemplateSpec;
 import com.linkedin.restli.internal.tools.RestLiToolsUtils;
 import com.linkedin.restli.restspec.ParameterSchema;
+import org.apache.commons.lang.ClassUtils;
 
 
 public class ParameterSpec
 {
   private final ParameterSchema _parameterSchema;
   private final BaseResourceSpec _root;
-  private ClassTemplateSpec _classTemplateSpec;
+  private final ClassTemplateSpec _classTemplateSpec;
+  private final String _declaredTypeRefClassName;
+
 
   public ParameterSpec(ParameterSchema parameterSchema, BaseResourceSpec root)
   {
     _parameterSchema = parameterSchema;
     _root = root;
+    String parameterClassType = _parameterSchema.getType();
+    _classTemplateSpec = _root.classToTemplateSpec(parameterClassType);
+    _declaredTypeRefClassName = _root.getClassRefNameForSchema(parameterClassType);
   }
 
   public String getParamName()
@@ -50,11 +56,19 @@ public class ParameterSpec
 
   public ClassTemplateSpec getParamClass()
   {
-    if (_classTemplateSpec == null)
-    {
-      _classTemplateSpec = _root.classToTemplateSpec(_parameterSchema.getType());
-    }
     return _classTemplateSpec;
+  }
+
+  public boolean hasParamTypeRef()
+  {
+    return !ClassUtils.getShortClassName(getParamClassName()).equals(ClassUtils.getShortClassName(
+        _declaredTypeRefClassName));
+  }
+
+  // TODO: add displayable name
+  public String getParamTypeRefClassName()
+  {
+    return _declaredTypeRefClassName;
   }
 
   public String getParamClassName()

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/SpecUtils.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/SpecUtils.java
@@ -23,8 +23,12 @@ import com.linkedin.pegasus.generator.spec.TyperefTemplateSpec;
 import com.linkedin.restli.common.ResourceMethod;
 import com.linkedin.restli.internal.tools.RestLiToolsUtils;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.text.StringEscapeUtils;
 
 
@@ -32,26 +36,58 @@ import org.apache.commons.text.StringEscapeUtils;
  * Common utility functions for building fluent apis.
  */
 public class SpecUtils {
+  static final String JAVA_LANG_PREFIX = "java.lang";
+  static final Set<String> PRIMITIVE_CLASS_NAMES = new HashSet<String>(Arrays.asList(
+      Integer.class.getSimpleName(),
+      Double.class.getSimpleName(),
+      Boolean.class.getSimpleName(),
+      String.class.getSimpleName(),
+      Long.class.getSimpleName(),
+      Float.class.getSimpleName()
+  ));
   private SpecUtils()
   {
   }
+
+  /**
+   * For checking if two class names are from same class
+   *
+   * This method can be used tell, for example, if declared class name is a TypeRef to the value class
+   *
+   * @param valueClassName the class which has been used a value
+   * @param declaredClassNameToCheck the declared class which might be different than the value class
+   * @return true if two names are pointing to same class, false otherwise
+   */
+  public static boolean checkIsSameClass(String valueClassName, String declaredClassNameToCheck)
+  {
+    if (PRIMITIVE_CLASS_NAMES.contains(valueClassName) || PRIMITIVE_CLASS_NAMES.contains(declaredClassNameToCheck))
+    {
+      return ClassUtils.getShortClassName(valueClassName).equals(ClassUtils.getShortClassName(declaredClassNameToCheck));
+    }
+    else
+    {
+      return valueClassName.equals(declaredClassNameToCheck);
+    }
+
+  }
+
   public static String getClassName(ClassTemplateSpec classTemplateSpec) {
     if (classTemplateSpec instanceof PrimitiveTemplateSpec)
     {
       switch (classTemplateSpec.getSchema().getType())
       {
         case INT:
-          return Integer.class.getSimpleName();
+          return Integer.class.getName();
         case DOUBLE:
-          return Double.class.getSimpleName();
+          return Double.class.getName();
         case BOOLEAN:
-          return Boolean.class.getSimpleName();
+          return Boolean.class.getName();
         case STRING:
-          return String.class.getSimpleName();
+          return String.class.getName();
         case LONG:
-          return Long.class.getSimpleName();
+          return Long.class.getName();
         case FLOAT:
-          return Float.class.getSimpleName();
+          return Float.class.getName();
         case BYTES:
           return ByteString.class.getName();
 

--- a/restli-tools/src/main/resources/apiVmTemplates/resource.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/resource.vm
@@ -108,9 +108,9 @@ public class ${spec.className}${class_name_suffix} implements ${spec.toImplement
         requestMetadataMap,
         responseMetadataMap,
         #if(${spec.hasKeyTypeRef()})
-        ${spec.getKeyTypeRefClassName()}.class,
+        ${spec.getKeyTypeRefClassDisplayName()}.class,
         #else
-        ${spec.getKeyClassName(false)}.class,
+        ${spec.getKeyClassDisplayName(false)}.class,
         #end
         null,
         null,
@@ -172,7 +172,7 @@ public class ${spec.className}${class_name_suffix} implements ${spec.toImplement
   ## generate impl class for subResources
   #foreach($subSpec in $spec.childSubResourceSpecs)
   @Override
-  public #if(${subSpec.namespace.equals($subSpec.parentNamespace)})${subSpec.className}#else${subSpec.bindingName}#end ${util.nameCamelCase($subSpec.className)}Of(#if(${subSpec.diffPathKey})${subSpec.parent.keyClassName} ${subSpec.diffPathKey}#end)
+  public #if(${subSpec.namespace.equals($subSpec.parentNamespace)})${subSpec.className}#else${subSpec.bindingName}#end ${util.nameCamelCase($subSpec.className)}Of(#if(${subSpec.diffPathKey})${subSpec.parent.keyClassDisplayName} ${subSpec.diffPathKey}#end)
   {
     return new #if(${subSpec.namespace.equals($subSpec.parentNamespace)})${subSpec.className}#else${subSpec.bindingName}#end${class_name_suffix}(_client, _engine)#if(${spec.getPathKeys().size()} > 0).pathKeys(_pathKeyMap)#end
                #if(${subSpec.diffPathKey})

--- a/restli-tools/src/main/resources/apiVmTemplates/resource.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/resource.vm
@@ -107,7 +107,11 @@ public class ${spec.className}${class_name_suffix} implements ${spec.toImplement
         #end
         requestMetadataMap,
         responseMetadataMap,
+        #if(${spec.hasKeyTypeRef()})
+        ${spec.getKeyTypeRefClassName()}.class,
+        #else
         ${spec.getKeyClassName(false)}.class,
+        #end
         null,
         null,
         ${spec.entityClassName}.class,

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_create_id.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_create_id.vm
@@ -15,7 +15,7 @@
 *#
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<List<CreateIdStatus<${spec.keyClassName}>>> batchCreate(
+    public CompletionStage<List<CreateIdStatus<${spec.keyClassDisplayName}>>> batchCreate(
         List<${spec.entityClassName}> entities#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
           ){
@@ -26,7 +26,7 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<List<CreateIdStatus<${spec.keyClassName}>>> batchCreate(
+  public CompletionStage<List<CreateIdStatus<${spec.keyClassDisplayName}>>> batchCreate(
       List<${spec.entityClassName}> entities#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
@@ -37,13 +37,13 @@
       #**##returnEntityParam("false")
     #end
     @SuppressWarnings("unchecked")
-    BatchCreateIdDecoder<${spec.keyClassName}> idResponseDecoder = new BatchCreateIdDecoder<>(
-        (TypeSpec<${spec.keyClassName}>) _resourceSpec.getKeyType(),
+    BatchCreateIdDecoder<${spec.keyClassDisplayName}> idResponseDecoder = new BatchCreateIdDecoder<>(
+        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
         _resourceSpec.getKeyParts(),
         _resourceSpec.getComplexKeyType());
     CollectionRequest<${spec.entityClassName}> input = FluentClientUtils.buildBatchEntityInputs(entities, ${spec.entityClassName}.class);
 
-    BatchCreateIdRequest<${spec.keyClassName}, ${spec.entityClassName}> request = new BatchCreateIdRequest<>(
+    BatchCreateIdRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchCreateIdRequest<>(
         Collections.emptyMap(),
         Collections.emptyList(),
         idResponseDecoder,
@@ -56,13 +56,13 @@
         RestliRequestOptions.DEFAULT_OPTIONS,
         ## Streaming attachments
         null);
-    CompletableFuture<List<CreateIdStatus<${spec.keyClassName}>>> result = new CompletableFuture<>();
+    CompletableFuture<List<CreateIdStatus<${spec.keyClassDisplayName}>>> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<BatchCreateIdResponse<${spec.keyClassName}>> response = responseTry.get();
+            Response<BatchCreateIdResponse<${spec.keyClassDisplayName}>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_create_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_create_return_entity.vm
@@ -15,7 +15,7 @@
 *#
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassName}, ${spec.entityClassName}>>> batchCreateAndGet(
+    public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> batchCreateAndGet(
         List<${spec.entityClassName}> entities#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
         ){
@@ -26,7 +26,7 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassName}, ${spec.entityClassName}>>> batchCreateAndGet(
+  public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> batchCreateAndGet(
       List<${spec.entityClassName}> entities#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
@@ -35,14 +35,14 @@
     #fillQueryParams($method)
     #**##returnEntityParam("true")
     @SuppressWarnings("unchecked")
-    BatchCreateIdEntityDecoder<${spec.keyClassName}, ${spec.entityClassName}> idEntityResponseDecoder = new BatchCreateIdEntityDecoder<>(
-        (TypeSpec<${spec.keyClassName}>) _resourceSpec.getKeyType(),
+    BatchCreateIdEntityDecoder<${spec.keyClassDisplayName}, ${spec.entityClassName}> idEntityResponseDecoder = new BatchCreateIdEntityDecoder<>(
+        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
         (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType(),
         _resourceSpec.getKeyParts(),
         _resourceSpec.getComplexKeyType());
     CollectionRequest<${spec.entityClassName}> input = FluentClientUtils.buildBatchEntityInputs(entities, ${spec.entityClassName}.class);
 
-    BatchCreateIdEntityRequest<${spec.keyClassName}, ${spec.entityClassName}> request = new BatchCreateIdEntityRequest<>(
+    BatchCreateIdEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchCreateIdEntityRequest<>(
         Collections.emptyMap(),
         Collections.emptyList(),
         idEntityResponseDecoder,
@@ -55,13 +55,13 @@
         RestliRequestOptions.DEFAULT_OPTIONS,
         ## Streaming attachments
         null);
-    CompletableFuture<List<CreateIdEntityStatus<${spec.keyClassName}, ${spec.entityClassName}>>> result = new CompletableFuture<>();
+    CompletableFuture<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<BatchCreateIdEntityResponse<${spec.keyClassName}, ${spec.entityClassName}>> response = responseTry.get();
+            Response<BatchCreateIdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_delete.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_delete.vm
@@ -15,8 +15,8 @@
 *#
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<Map<${spec.keyClassName}, UpdateStatus>> batchDelete(
-        Set<$spec.keyClassName> ids#if($method.requiredParams.size() > 0),#end
+    public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchDelete(
+        Set<$spec.keyClassDisplayName> ids#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
         ) {
       return batchDelete(ids,
@@ -26,15 +26,15 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassName}, UpdateStatus>> batchDelete(
-      Set<$spec.keyClassName> ids#if( $method.hasParams()),#end
+  public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchDelete(
+      Set<$spec.keyClassDisplayName> ids#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
     Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
     Map<String, Class<?>> queryParamClasses = #if($method.hasParams())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
     #fillQueryParams($method)
     queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, ids);
-    BatchDeleteRequest<${spec.keyClassName}, ${spec.entityClassName}> request = new BatchDeleteRequest<>(
+    BatchDeleteRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchDeleteRequest<>(
         Collections.emptyMap(),
         Collections.emptyList(),
         queryParams,
@@ -43,13 +43,13 @@
         ORIGINAL_RESOURCE_PATH,
         buildReadOnlyPathKeys(),
         RestliRequestOptions.DEFAULT_OPTIONS);
-    CompletableFuture<Map<${spec.keyClassName}, UpdateStatus>> result = new CompletableFuture<>();
+    CompletableFuture<Map<${spec.keyClassDisplayName}, UpdateStatus>> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<BatchKVResponse<${spec.keyClassName}, UpdateStatus>> response = responseTry.get();
+            Response<BatchKVResponse<${spec.keyClassDisplayName}, UpdateStatus>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_get.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_get.vm
@@ -15,8 +15,8 @@
 *#
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<Map<${spec.keyClassName}, EntityResponse<${spec.entityClassName}>>> batchGet(
-        Set<$spec.keyClassName> ids#if($method.requiredParams.size() > 0),#end
+    public CompletionStage<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> batchGet(
+        Set<$spec.keyClassDisplayName> ids#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
         ) {
       return batchGet(ids,
@@ -26,8 +26,8 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassName}, EntityResponse<${spec.entityClassName}>>> batchGet(
-      Set<$spec.keyClassName> ids#if( $method.hasParams()),#end
+  public CompletionStage<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> batchGet(
+      Set<$spec.keyClassDisplayName> ids#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
     Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
@@ -35,12 +35,12 @@
     #fillQueryParams($method)
     queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, ids);
     @SuppressWarnings("unchecked")
-    BatchGetEntityRequest<${spec.keyClassName}, ${spec.entityClassName}> request = new BatchGetEntityRequest<>(
+    BatchGetEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchGetEntityRequest<>(
         Collections.emptyMap(),
         Collections.emptyList(),
         new BatchEntityResponseDecoder<>(
             (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType(),
-            (TypeSpec<${spec.keyClassName}>) _resourceSpec.getKeyType(),
+            (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
             _resourceSpec.getKeyParts(),
             _resourceSpec.getComplexKeyType()),
         queryParams,
@@ -49,13 +49,13 @@
         ORIGINAL_RESOURCE_PATH,
         buildReadOnlyPathKeys(),
         RestliRequestOptions.DEFAULT_OPTIONS);
-    CompletableFuture<Map<${spec.keyClassName}, EntityResponse<${spec.entityClassName}>>> result = new CompletableFuture<>();
+    CompletableFuture<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<BatchKVResponse<${spec.keyClassName}, EntityResponse<${spec.entityClassName}>>> response = responseTry.get();
+            Response<BatchKVResponse<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else{

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_partial_update_no_return.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_partial_update_no_return.vm
@@ -14,16 +14,16 @@
    limitations under the License.
 *#
   @SuppressWarnings("unchecked")
-  private static final KeyValueRecordFactory<${spec.keyClassName}, PatchRequest<${spec.entityClassName}>> PATCH_VALUE_FACTORY = new KeyValueRecordFactory<${spec.keyClassName}, PatchRequest<${spec.entityClassName}>>(
-        (TypeSpec<${spec.keyClassName}>) _resourceSpec.getKeyType(),
+  private static final KeyValueRecordFactory<${spec.keyClassDisplayName}, PatchRequest<${spec.entityClassName}>> PATCH_VALUE_FACTORY = new KeyValueRecordFactory<${spec.keyClassDisplayName}, PatchRequest<${spec.entityClassName}>>(
+        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
         _resourceSpec.getComplexKeyType(),
         _resourceSpec.getKeyParts(),
         (TypeSpec<PatchRequest<${spec.entityClassName}>>) (Object) new TypeSpec<>(PatchRequest.class));
 
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<Map<$spec.keyClassName, UpdateStatus>> batchPartialUpdate(
-        Map<$spec.keyClassName, PatchRequest<${spec.entityClassName}>> patches#if($method.requiredParams.size() > 0),#end
+    public CompletionStage<Map<$spec.keyClassDisplayName, UpdateStatus>> batchPartialUpdate(
+        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
         ) {
       return batchPartialUpdate(patches,
@@ -33,8 +33,8 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<Map<$spec.keyClassName, UpdateStatus>> batchPartialUpdate(
-      Map<$spec.keyClassName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams()),#end
+  public CompletionStage<Map<$spec.keyClassDisplayName, UpdateStatus>> batchPartialUpdate(
+      Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
     Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
@@ -44,10 +44,10 @@
       #**##returnEntityParam("false")
     #end
     queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, patches.keySet());
-    CollectionRequest<KeyValueRecord<$spec.keyClassName, PatchRequest<${spec.entityClassName}>>> inputs = FluentClientUtils.buildBatchKVInputs(
+    CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>>> inputs = FluentClientUtils.buildBatchKVInputs(
         patches, PATCH_VALUE_FACTORY);
 
-    BatchPartialUpdateRequest<${spec.keyClassName}, ${spec.entityClassName}> request = new BatchPartialUpdateRequest<>(
+    BatchPartialUpdateRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchPartialUpdateRequest<>(
         Collections.emptyMap(),
         Collections.emptyList(),
         inputs,
@@ -59,13 +59,13 @@
         RestliRequestOptions.DEFAULT_OPTIONS,
         patches,
         null);
-    CompletableFuture<Map<$spec.keyClassName, UpdateStatus>> result = new CompletableFuture<>();
+    CompletableFuture<Map<$spec.keyClassDisplayName, UpdateStatus>> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<BatchKVResponse<$spec.keyClassName, UpdateStatus>> response = responseTry.get();
+            Response<BatchKVResponse<$spec.keyClassDisplayName, UpdateStatus>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_partial_update_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_partial_update_return_entity.vm
@@ -15,8 +15,8 @@
 *#
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<Map<$spec.keyClassName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
-        Map<$spec.keyClassName, PatchRequest<${spec.entityClassName}>> patches#if($method.requiredParams.size() > 0),#end
+    public CompletionStage<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
+        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
         ) {
       return batchPartialUpdateAndGet(patches,
@@ -26,8 +26,8 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<Map<$spec.keyClassName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
-      Map<$spec.keyClassName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams()),#end
+  public CompletionStage<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
+      Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
     Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
@@ -35,10 +35,10 @@
     #fillQueryParams($method)
     #**##returnEntityParam("true")
     queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, patches.keySet());
-    CollectionRequest<KeyValueRecord<$spec.keyClassName, PatchRequest<${spec.entityClassName}>>> inputs = FluentClientUtils.buildBatchKVInputs(
+    CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>>> inputs = FluentClientUtils.buildBatchKVInputs(
         patches, PATCH_VALUE_FACTORY);
 
-    BatchPartialUpdateEntityRequest<${spec.keyClassName}, ${spec.entityClassName}> request = new BatchPartialUpdateEntityRequest<>(
+    BatchPartialUpdateEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchPartialUpdateEntityRequest<>(
         Collections.emptyMap(),
         Collections.emptyList(),
         inputs,
@@ -50,13 +50,13 @@
         RestliRequestOptions.DEFAULT_OPTIONS,
         patches,
         null);
-    CompletableFuture<Map<$spec.keyClassName, UpdateEntityStatus<${spec.entityClassName}>>> result = new CompletableFuture<>();
+    CompletableFuture<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<BatchKVResponse<$spec.keyClassName, UpdateEntityStatus<${spec.entityClassName}>>> response = responseTry.get();
+            Response<BatchKVResponse<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_update.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_update.vm
@@ -14,16 +14,16 @@
    limitations under the License.
 *#
   @SuppressWarnings("unchecked")
-  private static final KeyValueRecordFactory<${spec.keyClassName}, ${spec.entityClassName}> UPDATE_VALUE_FACTORY = new KeyValueRecordFactory<${spec.keyClassName}, ${spec.entityClassName}>(
-      (TypeSpec<${spec.keyClassName}>) _resourceSpec.getKeyType(),
+  private static final KeyValueRecordFactory<${spec.keyClassDisplayName}, ${spec.entityClassName}> UPDATE_VALUE_FACTORY = new KeyValueRecordFactory<${spec.keyClassDisplayName}, ${spec.entityClassName}>(
+      (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
       _resourceSpec.getComplexKeyType(),
       _resourceSpec.getKeyParts(),
       (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType());
 
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<Map<${spec.keyClassName}, UpdateStatus>> batchUpdate(
-        Map<$spec.keyClassName, ${spec.entityClassName}> entities#if($method.requiredParams.size() > 0),#end
+    public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchUpdate(
+        Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
       ) {
       return batchUpdate(entities,
@@ -33,17 +33,17 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassName}, UpdateStatus>> batchUpdate(
-      Map<$spec.keyClassName, ${spec.entityClassName}> entities#if( $method.hasParams()),#end
+  public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchUpdate(
+      Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
     Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
     Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
     #fillQueryParams($method)
     queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, entities.keySet());
-    CollectionRequest<KeyValueRecord<$spec.keyClassName, ${spec.entityClassName}>> inputs = FluentClientUtils.buildBatchKVInputs(
+    CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, ${spec.entityClassName}>> inputs = FluentClientUtils.buildBatchKVInputs(
         entities, UPDATE_VALUE_FACTORY);
-    BatchUpdateRequest<$spec.keyClassName, ${spec.entityClassName}> request = new BatchUpdateRequest<>(
+    BatchUpdateRequest<$spec.keyClassDisplayName, ${spec.entityClassName}> request = new BatchUpdateRequest<>(
         Collections.emptyMap(),
         Collections.emptyList(),
         inputs,
@@ -55,13 +55,13 @@
         RestliRequestOptions.DEFAULT_OPTIONS,
         entities,
         null);
-    CompletableFuture<Map<${spec.keyClassName}, UpdateStatus>> result = new CompletableFuture<>();
+    CompletableFuture<Map<${spec.keyClassDisplayName}, UpdateStatus>> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<BatchKVResponse<${spec.keyClassName}, UpdateStatus>> response = responseTry.get();
+            Response<BatchKVResponse<${spec.keyClassDisplayName}, UpdateStatus>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.create_id.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.create_id.vm
@@ -15,7 +15,7 @@
 *#
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<${spec.keyClassName}> create(
+    public CompletionStage<${spec.keyClassDisplayName}> create(
         ${spec.entityClassName} entity#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
       ) {
@@ -26,7 +26,7 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<${spec.keyClassName}> create(
+  public CompletionStage<${spec.keyClassDisplayName}> create(
       ${spec.entityClassName} entity#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
@@ -37,11 +37,11 @@
       #**##returnEntityParam("false")
     #end
     @SuppressWarnings("unchecked")
-    IdResponseDecoder<${spec.keyClassName}> idResponseDecoder = new IdResponseDecoder<>(
-        (TypeSpec<${spec.keyClassName}>) _resourceSpec.getKeyType(),
+    IdResponseDecoder<${spec.keyClassDisplayName}> idResponseDecoder = new IdResponseDecoder<>(
+        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
         _resourceSpec.getKeyParts(),
         _resourceSpec.getComplexKeyType());
-    CreateIdRequest<${spec.keyClassName}, ${spec.entityClassName}> request = new CreateIdRequest<>(
+    CreateIdRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new CreateIdRequest<>(
         entity,
         Collections.emptyMap(),
         Collections.emptyList(),
@@ -53,13 +53,13 @@
         buildReadOnlyPathKeys(),
         RestliRequestOptions.DEFAULT_OPTIONS,
         null);
-    CompletableFuture<${spec.keyClassName}> result = new CompletableFuture<>();
+    CompletableFuture<${spec.keyClassDisplayName}> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<IdResponse<${spec.keyClassName}>> response = responseTry.get();
+            Response<IdResponse<${spec.keyClassDisplayName}>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.create_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.create_return_entity.vm
@@ -15,7 +15,7 @@
 *#
   #if($method.optionalParams.size() > 0 || $method.supportedProjectionParams.size() > 0)
     #doc($method.schema.doc)
-    public CompletionStage<IdEntityResponse<${spec.keyClassName}, ${spec.entityClassName}>> createAndGet(
+    public CompletionStage<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> createAndGet(
         ${spec.entityClassName} entity#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
       ) {
@@ -26,7 +26,7 @@
   #end
 
   #doc($method.schema.doc)
-  public CompletionStage<IdEntityResponse<${spec.keyClassName}, ${spec.entityClassName}>> createAndGet(
+  public CompletionStage<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> createAndGet(
       ${spec.entityClassName} entity#if( $method.hasParams()),#end
       #**##methodParams($method, true)##
       ) {
@@ -35,12 +35,12 @@
     #fillQueryParams($method)
     #**##returnEntityParam("true")
     @SuppressWarnings("unchecked")
-    IdEntityResponseDecoder<${spec.keyClassName}, ${spec.entityClassName}> idEntityResponseDecoder = new IdEntityResponseDecoder<>(
-        (TypeSpec<${spec.keyClassName}>) _resourceSpec.getKeyType(),
+    IdEntityResponseDecoder<${spec.keyClassDisplayName}, ${spec.entityClassName}> idEntityResponseDecoder = new IdEntityResponseDecoder<>(
+        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
         _resourceSpec.getKeyParts(),
         _resourceSpec.getComplexKeyType(),
         (Class<${spec.entityClassName}>) _resourceSpec.getValueClass());
-    CreateIdEntityRequest<${spec.keyClassName}, ${spec.entityClassName}> request = new CreateIdEntityRequest<>(
+    CreateIdEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new CreateIdEntityRequest<>(
         entity,
         Collections.emptyMap(),
         Collections.emptyList(),
@@ -52,13 +52,13 @@
         buildReadOnlyPathKeys(),
         RestliRequestOptions.DEFAULT_OPTIONS,
         null);
-    CompletableFuture<IdEntityResponse<${spec.keyClassName}, ${spec.entityClassName}>> result = new CompletableFuture<>();
+    CompletableFuture<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> result = new CompletableFuture<>();
     Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
         responseTry -> {
           if (responseTry.isFailed()) {
             result.completeExceptionally(responseTry.getError());
           } else {
-            Response<IdEntityResponse<${spec.keyClassName}, ${spec.entityClassName}>> response = responseTry.get();
+            Response<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> response = responseTry.get();
             if (response.hasError()) {
               result.completeExceptionally(response.getError());
             } else {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
@@ -17,7 +17,7 @@
     #doc($method.schema.doc)
     public CompletionStage<Void> delete(
       #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassName $spec.idName#if($method.requiredParams.size() > 0),#end
+        $spec.keyClassDisplayName $spec.idName#if($method.requiredParams.size() > 0),#end
       #end
         #**##methodParams($method, false)##
       ) {
@@ -30,7 +30,7 @@
   #doc($method.schema.doc)
   public CompletionStage<Void> delete(
     #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassName $spec.idName#if( $method.hasParams()),#end
+      $spec.keyClassDisplayName $spec.idName#if( $method.hasParams()),#end
     #end
       #**##methodParams($method, true)##
       ) {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
@@ -17,7 +17,7 @@
     #doc($method.schema.doc)
     public CompletionStage<${spec.entityClassName}> get(
       #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassName $spec.idName#if($method.requiredParams.size() > 0),#end
+        $spec.keyClassDisplayName $spec.idName#if($method.requiredParams.size() > 0),#end
       #end
         #**##methodParams($method, false)##
       ) {
@@ -30,7 +30,7 @@
   #doc($method.schema.doc)
   public CompletionStage<${spec.entityClassName}> get(
     #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassName $spec.idName#if( $method.hasParams()),#end
+      $spec.keyClassDisplayName $spec.idName#if( $method.hasParams()),#end
     #end
       #**##methodParams($method, true)##
       ) {

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
@@ -17,7 +17,7 @@
     #doc($method.schema.doc)
     public CompletionStage<Void> partialUpdate(
       #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassName $spec.idName,
+        $spec.keyClassDisplayName $spec.idName,
       #end
         PatchRequest<${spec.entityClassName}> entity#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
@@ -32,7 +32,7 @@
   #doc($method.schema.doc)
   public CompletionStage<Void> partialUpdate(
     #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassName $spec.idName,
+      $spec.keyClassDisplayName $spec.idName,
     #end
       PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams()),#end
       #**##methodParams($method, true)##

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
@@ -17,7 +17,7 @@
     #doc($method.schema.doc)
     public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
       #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassName $spec.idName,
+          $spec.keyClassDisplayName $spec.idName,
       #end
         PatchRequest<${spec.entityClassName}> entity#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
@@ -32,7 +32,7 @@
   #doc($method.schema.doc)
   public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
     #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassName $spec.idName,
+      $spec.keyClassDisplayName $spec.idName,
     #end
       PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams()),#end
       #**##methodParams($method, true)##

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
@@ -17,7 +17,7 @@
     #doc($method.schema.doc)
     public CompletionStage<Void> update(
         #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassName $spec.idName,
+          $spec.keyClassDisplayName $spec.idName,
         #end
         ${spec.entityClassName} entity#if($method.requiredParams.size() > 0),#end
         #**##methodParams($method, false)##
@@ -32,7 +32,7 @@
   #doc($method.schema.doc)
   public CompletionStage<Void> update(
     #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassName $spec.idName,
+      $spec.keyClassDisplayName $spec.idName,
     #end
     ${spec.entityClassName} entity#if( $method.hasParams()),#end
     #**##methodParams($method, true)##


### PR DESCRIPTION
=== Included in PR & already done ===
KeyTypeRef : in CollectionResourceSpec
AssocKeyTypeRef : in AssociateResourceSpec's CompoundKeySpec
Action ReturnTypeRef : in ActionMethodSpec

ParameterSpec (which will handle following)
  Action's ActionParam
  Finder' QueryParam

Tests for KeyTypeRef
p.s. AssocKeyTypeRef already tested in AssocKeys
p.s. Action's return and actionParam will be tested in https://github.com/linkedin/rest.li/pull/580


=== Not Included in PR ===
Finder's use of AssocKeyParam
Finder's use of QueryParam


**All the TODO will be handled in follow up PRs**