### PR TITLE
Fix default value resolution logic in avro translator to match PDL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and what APIs have changed, if applicable.
 - Update projection mask builder APIs to support updating the mask objects.
 - Added support for checking if a nested type supports new ProjectionMask API before generating new typesafe APIs for them.
 - Fix a typo in D2ClientConfig
+- Fix the default value resolution logic in Avro schema translator to match the PDL behavior.
 
 ## [29.17.0] - 2021-03-23
 - Implement D2 cluster subsetting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,15 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.17.2] - 2021-04-11
+- Fix the default value resolution logic in Avro schema translator to match the PDL behavior.
+
 ## [29.17.1] - 2021-04-02
 - Add fluent client api for subresources
 - Update fluent client APIs to include projection mask as input parameter.
 - Update projection mask builder APIs to support updating the mask objects.
 - Added support for checking if a nested type supports new ProjectionMask API before generating new typesafe APIs for them.
 - Fix a typo in D2ClientConfig
-- Fix the default value resolution logic in Avro schema translator to match the PDL behavior.
 
 ## [29.17.0] - 2021-03-23
 - Implement D2 cluster subsetting.
@@ -4900,7 +4902,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.17.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.17.2...master
+[29.17.2]: https://github.com/linkedin/rest.li/compare/v29.17.1...v29.17.2
 [29.17.1]: https://github.com/linkedin/rest.li/compare/v29.17.0...v29.17.1
 [29.17.0]: https://github.com/linkedin/rest.li/compare/v29.16.2...v29.17.0
 [29.16.2]: https://github.com/linkedin/rest.li/compare/v29.16.1...v29.16.2

--- a/data-avro/src/main/java/com/linkedin/data/avro/DefaultDataToAvroConvertCallback.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DefaultDataToAvroConvertCallback.java
@@ -215,6 +215,17 @@ class DefaultDataToAvroConvertCallback extends AbstractDefaultDataTranslator imp
           (_options.getOptionalDefaultMode() == OptionalDefaultMode.TRANSLATE_TO_NULL && isTranslatedUnionMember) ||
           (fieldValue == Data.NULL));
     }
+    else if (fieldValue == null)
+    {
+      // If the default specified at parent level doesn't specify a value for the field, use the default specified at
+      // field level.
+      fieldValue = field.getDefault();
+      if (fieldValue == null)
+      {
+        throw new IllegalArgumentException(
+            message(path, "Cannot translate required field without default."));
+      }
+    }
     Object resultFieldValue = translate(path, fieldValue, fieldDataSchema);
     _newDefaultSchema = fieldDataSchema;
     return resultFieldValue;

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -1710,6 +1710,32 @@ public class TestDataTranslator
             false,
             "",
         },
+        // If complex field in pegasus schema has default value and it doesn't specify value for a nested required field,
+        // then the default value specified at field level should be used.
+        {
+            // required int with default value
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ "
+                + "{ \"name\" : \"bar\", \"type\" : "
+                + "{ \"type\": \"record\", \"name\": \"Bar\", \"fields\": ["
+                + " { \"name\": \"barInt\", \"type\": ##T_START \"int\" ##T_END, \"default\" : 42 }"
+                + " ] },"
+                + " \"default\": {}"
+                + " } ] }",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ "
+                + "{ \"name\" : \"bar\", \"type\" : "
+                + "{ \"type\": \"record\", \"name\": \"Bar\", \"fields\": ["
+                + " { \"name\": \"barInt\", \"type\": \"int\", \"default\" : 42 }"
+                + " ] },"
+                + " \"default\": { \"barInt\":42 }"
+                + " } ] }",
+            "{\"bar\":{\"barInt\":42}}",
+            PegasusToAvroDefaultFieldTranslationMode.TRANSLATE,
+            "{\"bar\":{\"barInt\":42}}",
+            false,
+            "",
+        },
+
 
         // Below are test case example for invalid option combination:
         // If the field in pegasus schema has been translated as required, its data cannot be translated as optional
@@ -1724,7 +1750,6 @@ public class TestDataTranslator
             true,
             "null of int in field bar of foo",
         },
-
         {
             // required Union of [int string] with default value
             "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [\"int\", \"string\"] ##T_END, \"default\" : { \"int\" : 42 } } ] }",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.17.1
+version=29.17.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Avro schema translator should use the default value from the nested field if the parent record level default doesn't provide a value for the field.
This behavior is consistent with how PDL schema defaults are handled.