### PR TITLE
Try to tune parameter in tests so it can be stable in Travis-CI's environment

### DIFF
--- a/restli-client/src/test/java/com/linkedin/restli/client/TestParSeqBasedCompletionStage.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestParSeqBasedCompletionStage.java
@@ -687,7 +687,7 @@ public class TestParSeqBasedCompletionStage
   {
     Consumer<Object> consumer = mock(Consumer.class);
     CountDownLatch waitLatch = new CountDownLatch(1);
-    CompletionStage<String> completionStage = createTestStage(TESTVALUE1);
+    CompletionStage<String> completionStage = createTestStage(TESTVALUE1, 0);
     CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 1000).thenApply((v) -> {
       waitLatch.countDown();
       return v;
@@ -790,7 +790,7 @@ public class TestParSeqBasedCompletionStage
   {
     Function<Object, ?> function = mock(Function.class);
     CountDownLatch waitLatch = new CountDownLatch(1);
-    CompletionStage<String> completionStage = createTestStage(TESTVALUE1);
+    CompletionStage<String> completionStage = createTestStage(TESTVALUE1, 0);
     CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 1000).thenApply((v) -> {
       waitLatch.countDown();
       return v;
@@ -894,7 +894,7 @@ public class TestParSeqBasedCompletionStage
   {
     Runnable runnable = mock(Runnable.class);
     CountDownLatch waitLatch = new CountDownLatch(1);
-    CompletionStage<String> completionStage = createTestStage(TESTVALUE1);
+    CompletionStage<String> completionStage = createTestStage(TESTVALUE1, 0);
     CompletionStage<String> completionStage2 = createTestStage(TESTVALUE2, 1000).thenApply((v) -> {
       waitLatch.countDown();
       return v;

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestParSeqBasedCompletionStage.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestParSeqBasedCompletionStage.java
@@ -59,7 +59,7 @@ public class TestParSeqBasedCompletionStage
   ParSeqUnitTestHelper _parSeqUnitTestHelper;
   Engine _engine;
   ParSeqBasedCompletionStageFactory<String> _parSeqBasedCompletionStageFactory;
-  ExecutorService _executor = ForkJoinPool.commonPool();
+  ExecutorService _executor = Executors.newCachedThreadPool();
 
   private static final String TESTVALUE1 = "testValue1";
   private static final String TESTVALUE2 = "testValue2";


### PR DESCRIPTION
It became flaky in Travis-CI because Travis-CI provides so few threads in the common fork-join pool.