### PR TITLE
Use host FQDN instead of nodeUri to get D2 subsetting metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.0] - 2021-04-20
+- Use host FQDN instead of nodeUri to get D2 subsetting metadata
+
 ## [29.17.4] - 2021-04-16
 - Migrate the Rest.li release process from Bintray to JFrog Artifactory.
     - As of this version, Bintray will no longer host Rest.li releases.
@@ -4910,7 +4913,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.17.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.0...master
+[29.18.0]: https://github.com/linkedin/rest.li/compare/v29.17.4...v29.18.0
 [29.17.4]: https://github.com/linkedin/rest.li/compare/v29.17.3...v29.17.4
 [29.17.3]: https://github.com/linkedin/rest.li/compare/v29.17.2...v29.17.3
 [29.17.2]: https://github.com/linkedin/rest.li/compare/v29.17.1...v29.17.2

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -39,7 +39,7 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
 {
   private static final Logger _log = LoggerFactory.getLogger(ZKDeterministicSubsettingMetadataProvider.class);
   private final String _clusterName;
-  private final URI _nodeUri;
+  private final String _hostName;
   private final long _timeout;
   private final TimeUnit _unit;
 
@@ -51,12 +51,12 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
   private DeterministicSubsettingMetadata _subsettingMetadata;
 
   public ZKDeterministicSubsettingMetadataProvider(String clusterName,
-                                      URI nodeUri,
+                                      String hostName,
                                       long timeout,
                                       TimeUnit unit)
   {
     _clusterName = clusterName;
-    _nodeUri = nodeUri;
+    _hostName = hostName;
     _timeout = timeout;
     _unit = unit;
   }
@@ -79,16 +79,16 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
           if (uriProperties != null)
           {
             // Sort the URIs so each client sees the same ordering
-            List<URI> sortedUris = uriProperties.getPartitionDesc().keySet().stream()
-                .filter(uri -> uri.getScheme().equals(_nodeUri.getScheme()))
+            List<String> sortedHosts = uriProperties.getPartitionDesc().keySet().stream()
+                .map(URI::getHost)
                 .sorted()
                 .collect(Collectors.toList());
 
-            int instanceId = sortedUris.indexOf(_nodeUri);
+            int instanceId = sortedHosts.indexOf(_hostName);
 
             if (instanceId >= 0)
             {
-              _subsettingMetadata = new DeterministicSubsettingMetadata(instanceId, sortedUris.size());
+              _subsettingMetadata = new DeterministicSubsettingMetadata(instanceId, sortedHosts.size());
             }
             else
             {

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
@@ -54,7 +54,7 @@ import static org.testng.Assert.assertNull;
 public class ZKDeterministicSubsettingMetadataProviderTest
 {
   private static final String CLUSTER_NAME = "cluster-1";
-  private static final URI NODE_URI = URI.create("http://cluster-1/test2");
+  private static final String HOST_NAME = "test2.linkedin.com";
 
   private MockStore<UriProperties>                                                 _uriRegistry;
   private MockStore<ClusterProperties>                                             _clusterRegistry;
@@ -103,7 +103,7 @@ public class ZKDeterministicSubsettingMetadataProviderTest
             true, null,
             SSL_SESSION_VALIDATOR_FACTORY);
 
-    _metadataProvider = new ZKDeterministicSubsettingMetadataProvider(CLUSTER_NAME, NODE_URI, 1000, TimeUnit.MILLISECONDS);
+    _metadataProvider = new ZKDeterministicSubsettingMetadataProvider(CLUSTER_NAME, HOST_NAME, 1000, TimeUnit.MILLISECONDS);
   }
 
   @Test
@@ -115,7 +115,7 @@ public class ZKDeterministicSubsettingMetadataProviderTest
     Map<URI, Map<Integer, PartitionData>> uriData = new HashMap<>();
     for (int i = 0; i < 10; i++)
     {
-      uriData.put(URI.create("http://cluster-1/test" + i), partitionData);
+      uriData.put(URI.create("http://test" + i + ".linkedin.com:8888/test"), partitionData);
     }
     schemes.add("http");
 
@@ -132,14 +132,14 @@ public class ZKDeterministicSubsettingMetadataProviderTest
     assertEquals(metadata.getInstanceId(), 2);
     assertEquals(metadata.getTotalInstanceCount(), 10);
 
-    uriData.remove(URI.create("http://cluster-1/test0"));
+    uriData.remove(URI.create("http://test0.linkedin.com:8888/test"));
     _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
 
     metadata = _metadataProvider.getSubsettingMetadata(_state);
     assertEquals(metadata.getInstanceId(), 1);
     assertEquals(metadata.getTotalInstanceCount(), 9);
 
-    uriData.remove(URI.create("http://cluster-1/test2"));
+    uriData.remove(URI.create("http://test2.linkedin.com:8888/test"));
     _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
 
     metadata = _metadataProvider.getSubsettingMetadata(_state);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.17.4
+version=29.18.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Instead of using nodeUri, we use host fqdn to fetch D2 subsetting metadata.

Previously, we use the nodeUri in the form of "https://${com.linkedin.metadata.fqdn}:${com.linkedin.metadata.application.port.https}/${com.linkedin.metadata.context_path}${d2.resourcePath}" to get subsetting metadata. After this change, we will simply use "{com.linkedin.metadata.fqdn}"