### PR TITLE
Fix converting enableClusterSubsetting to Boolean in ServicePropertiesJsonSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.18.1] - 2021-04-22
 - Add fluent client API for FINDER and BATCH_FINDER methods.
+- Fix a bug when converting enableClusterSubsetting config to Boolean in ServicePropertiesJsonSerializer
 
 ## [29.18.0] - 2021-04-20
 - Use host FQDN instead of nodeUri to get D2 subsetting metadata
@@ -4914,7 +4917,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.1...master
+[29.18.1]: https://github.com/linkedin/rest.li/compare/v29.18.0...v29.18.1
 [29.18.0]: https://github.com/linkedin/rest.li/compare/v29.17.4...v29.18.0
 [29.17.4]: https://github.com/linkedin/rest.li/compare/v29.17.3...v29.17.4
 [29.17.3]: https://github.com/linkedin/rest.li/compare/v29.17.2...v29.17.3

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceProperties.java
@@ -289,6 +289,8 @@ public class ServiceProperties
         + _serviceMetadataProperties
         + ", backupRequests="
         + _backupRequests
+        + ", enableClusterSubsetting="
+        + _enableClusterSubsetting
         + ", minimumClusterSubsetSize="
         + _minClusterSubsetSize
         + "]";

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.balancer.properties;
 
 
+import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategy;
 import com.linkedin.d2.balancer.util.JacksonUtil;
 import com.linkedin.d2.discovery.PropertyBuilder;
@@ -203,8 +204,10 @@ public class ServicePropertiesJsonSerializer implements
     Map<String, Object> transportClientProperties = mapGetOrDefault(map, PropertyKeys.TRANSPORT_CLIENT_PROPERTIES, Collections.emptyMap());
     Map<String, String> degraderProperties = mapGetOrDefault(map, PropertyKeys.DEGRADER_PROPERTIES, Collections.emptyMap());
     Map<String, Object> relativeStrategyProperties = mapGetOrDefault(map, PropertyKeys.RELATIVE_STRATEGY_PROPERTIES, Collections.emptyMap());
-    boolean enableClusterSubsetting = mapGetOrDefault(map, PropertyKeys.ENABLE_CLUSTER_SUBSETTING, SubsettingStrategy.DEFAULT_ENABLE_CLUSTER_SUBSETTING);
-    int minClusterSubsetSize = mapGetOrDefault(map, PropertyKeys.MIN_CLUSTER_SUBSET_SIZE, SubsettingStrategy.DEFAULT_CLUSTER_SUBSET_SIZE);
+    boolean enableClusterSubsetting = map.containsKey(PropertyKeys.ENABLE_CLUSTER_SUBSETTING) ? PropertyUtil.coerce(
+        map.get(PropertyKeys.ENABLE_CLUSTER_SUBSETTING), Boolean.class) : SubsettingStrategy.DEFAULT_ENABLE_CLUSTER_SUBSETTING;
+    int minClusterSubsetSize = map.containsKey(PropertyKeys.MIN_CLUSTER_SUBSET_SIZE) ? PropertyUtil.coerce(
+        map.get(PropertyKeys.MIN_CLUSTER_SUBSET_SIZE), Integer.class) : SubsettingStrategy.DEFAULT_CLUSTER_SUBSET_SIZE;
 
     List<URI> bannedList = mapGetOrDefault(map, PropertyKeys.BANNED_URIS, Collections.emptyList());
     Set<URI> banned = new HashSet<>(bannedList);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.0
+version=29.18.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Address the bug where the String config value is not able to auto convert to Boolean:

```
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Boolean
        at com.linkedin.d2.balancer.properties.ServicePropertiesJsonSerializer.fromMap(ServicePropertiesJsonSerializer.java:206)
        at com.linkedin.d2.balancer.properties.ServicePropertiesJsonSerializer.fromMap(ServicePropertiesJsonSerializer.java:40)

```