### PR TITLE
Integration execution group to fluent API

### DIFF
--- a/restli-client/src/main/java/com/linkedin/restli/client/ExecutionGroup.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/ExecutionGroup.java
@@ -120,11 +120,11 @@ public class ExecutionGroup
       throw new IllegalStateException(MULTIPLE_EXECUTION_ERROR);
     }
     _fired = true;
-    for (Map.Entry<ParSeqBasedFluentClient, List<Task<?>>> entry : _clientToTaskListMap.entrySet()) {
+    for (Map.Entry<ParSeqBasedFluentClient, List<Task<?>>> entry : _clientToTaskListMap.entrySet())
+    {
       List<Task<?>> taskList = entry.getValue();
       // the Task.par(Iterable) version does not fast-fail comparing to Task.par(Task...)
-      ParTask<Object> perFluentClientTasks =
-          Task.par(taskList);
+      ParTask<Object> perFluentClientTasks = Task.par(taskList);
       _clientToTaskListMap.remove(entry.getKey());
       // starts a plan for tasks from one client due to performance consideration
       // TODO: optimize, use scheduleAndRun
@@ -149,14 +149,18 @@ public class ExecutionGroup
         fluentClients.length > 0 ? new ArrayList<ParSeqBasedFluentClient>(Arrays.asList(fluentClients))
             : _fluentClientAll;
 
-    for (ParSeqBasedFluentClient fluentClient : batchedClients) {
+    for (ParSeqBasedFluentClient fluentClient : batchedClients)
+    {
       fluentClient.setExecutionGroup(this);
     }
-    try {
+    try
+    {
       runnable.run();
       this.execute();
-    } finally {
-      for (ParSeqBasedFluentClient fluentClient : batchedClients) {
+    } finally
+    {
+      for (ParSeqBasedFluentClient fluentClient : batchedClients)
+      {
         fluentClient.removeExecutionGroup();
       }
     }

--- a/restli-client/src/main/java/com/linkedin/restli/client/ExecutionGroup.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/ExecutionGroup.java
@@ -33,7 +33,11 @@ import java.util.Map;
  * The request grouped by execution group will be further grouped by Client so requests will
  * be batched per Client.
  *
- * There are two way to use this
+ * {@link ExecutionGroup} is not supposed to be instantiated directly. Check {@link FluentClient} to see the
+ * method that instantiate them. {@link FluentClient} also provides convenient method to use
+ * {@link ##batchOn(Runnable, FluentClient...)}
+ *
+ * Once given an {@link ExecutionGroup} instance, are two way to use it:
  * Method 1: Using it with the fluent api and ask the executionGroup to execute explicitly.
  * Example:
  * <blockquote>
@@ -66,7 +70,7 @@ import java.util.Map;
  *     });
  *   </pre>
  * </blockquote>
- * Note: You can use nested executiongroup and each lambda clause have a separate scope.
+ * Note: One can use nested executiongroup and each lambda clause have a separate scope.
  * Example:
  * <blockquote>
  *   <pre>

--- a/restli-client/src/main/java/com/linkedin/restli/client/FluentClient.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/FluentClient.java
@@ -1,6 +1,18 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package com.linkedin.restli.client;
 
-import java.util.ArrayList;
+import com.linkedin.parseq.Engine;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -8,7 +20,7 @@ import java.util.List;
 /**
  * A common interface for client that implements FluentAPIs
  */
-interface FluentClient
+public interface FluentClient
 {
 
   ThreadLocal<List<ExecutionGroup>> _executionGroup = new ThreadLocal<List<ExecutionGroup>>()
@@ -20,20 +32,65 @@ interface FluentClient
     }
   };
 
+  /**
+   * Add the specified {@link ExecutionGroup} to the tail of the ThreadLocal list
+   * @param eg the {@link ExecutionGroup} instance to add to the ThreadLocal List;
+   */
   default void setExecutionGroup(ExecutionGroup eg)
   {
     _executionGroup.get().add(eg);
   }
 
+  /**
+   * Try to fetch an ExecutionGroup instance from the ThreadLocal context
+   *
+   * Since the ExecutionGroup can be stacked recursively, this method will get the one from the most recent layer
+   * i.e. from the tail of the ThreadLocal list.
+   *
+   * @return the {@link ExecutionGroup} instance if there is one in the context; Otherwise return null
+   */
   default ExecutionGroup getExecutionGroupFromContext()
   {
     List<ExecutionGroup> groupList = _executionGroup.get();
+    if (groupList.size() == 0)
+    {
+      return null;
+    }
     return groupList.get(groupList.size() - 1);
   }
 
+  /**
+   * Remove the most recent ExecutionGroup form the ThreadLocal list
+   */
   default void removeExecutionGroup()
   {
     List<ExecutionGroup> groupList = _executionGroup.get();
-    groupList.remove(groupList.size() - 1);
+    if(groupList.size() > 0)
+    {
+      groupList.remove(groupList.size() - 1);
+    }
   }
+
+  /**
+   * Generate an {@link ExecutionGroup} instance
+   *
+   * @return an {@link ExecutionGroup} instance
+   */
+  default ExecutionGroup generateExecutionGroup()
+  {
+    return new ExecutionGroup(getEngine());
+  }
+
+  Engine getEngine();
+
+  /**
+   * This method will generate an {@link ExecutionGroup} instance and run its
+   * {@link ExecutionGroup#batchOn(Runnable, FluentClient...)} method, with this fluentClient being the only {@link FluentClient}
+   * in the argument.
+   *
+   * @param runnable the runnable that executes user's logic
+   * @throws Exception the exceptions encountered when running the runnable
+   */
+  void runBatchOnClient(Runnable runnable) throws Exception;
+
 }

--- a/restli-client/src/main/java/com/linkedin/restli/client/ParSeqBasedCompletionStage.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/ParSeqBasedCompletionStage.java
@@ -561,7 +561,7 @@ public class ParSeqBasedCompletionStage<T> implements CompletionStage<T>
     return _task.toCompletionStage().toCompletableFuture();
   }
 
-  protected Task<T> getTask()
+  public Task<T> getTask()
   {
     return _task;
   }

--- a/restli-client/src/main/java/com/linkedin/restli/client/ParSeqBasedFluentClient.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/ParSeqBasedFluentClient.java
@@ -69,7 +69,7 @@ public interface ParSeqBasedFluentClient
   default void removeExecutionGroup()
   {
     List<ExecutionGroup> groupList = _executionGroup.get();
-    if(groupList.size() > 0)
+    if (groupList.size() > 0)
     {
       groupList.remove(groupList.size() - 1);
     }
@@ -96,5 +96,4 @@ public interface ParSeqBasedFluentClient
    * @throws Exception the exceptions encountered when running the runnable
    */
   void runBatchOnClient(Runnable runnable) throws Exception;
-
 }

--- a/restli-client/src/main/java/com/linkedin/restli/client/ParSeqBasedFluentClient.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/ParSeqBasedFluentClient.java
@@ -19,8 +19,12 @@ import java.util.List;
 
 /**
  * A common interface for client that implements FluentAPIs
+ *
+ * Note currently the FluentClient is ParSeq based and the execution
+ * of request is coupled with ParSeq {@link Engine} and {@link com.linkedin.parseq.Task}
+ *
  */
-public interface FluentClient
+public interface ParSeqBasedFluentClient
 {
 
   ThreadLocal<List<ExecutionGroup>> _executionGroup = new ThreadLocal<List<ExecutionGroup>>()
@@ -85,7 +89,7 @@ public interface FluentClient
 
   /**
    * This method will generate an {@link ExecutionGroup} instance and run its
-   * {@link ExecutionGroup#batchOn(Runnable, FluentClient...)} method, with this fluentClient being the only {@link FluentClient}
+   * {@link ExecutionGroup#batchOn(Runnable, ParSeqBasedFluentClient...)} method, with this fluentClient being the only {@link ParSeqBasedFluentClient}
    * in the argument.
    *
    * @param runnable the runnable that executes user's logic

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestExecutionGroup.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestExecutionGroup.java
@@ -189,7 +189,7 @@ public class TestExecutionGroup
   }
 }
 
-class MockBatchableResource implements FluentClient
+class MockBatchableResource implements ParSeqBasedFluentClient
 {
   public String get(Long key)
   {

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestExecutionGroup.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestExecutionGroup.java
@@ -184,7 +184,7 @@ public class TestExecutionGroup
     } else
     {
       throw new RuntimeException(
-          "Tried to shut down Engine but it either has not even been created or has " + "already been shut down");
+          "Tried to shut down Engine but it either has not even been created or has already been shut down");
     }
   }
 

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestExecutionGroup.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestExecutionGroup.java
@@ -46,7 +46,8 @@ public class TestExecutionGroup
     eg = new ExecutionGroup(_engine);
     client1 = mock(MockBatchableResource.class);
     when(client1.get(any())).thenReturn("1");
-    task1 = Task.callable(() -> {
+    task1 = Task.callable(() ->
+    {
       client1.get(1L);
       return null;
     });
@@ -113,7 +114,8 @@ public class TestExecutionGroup
   public void testCallableExecution() throws Exception
   {
     MockBatchableResource client = new MockBatchableResource();
-    eg.batchOn(() -> {
+    eg.batchOn(() ->
+    {
       Assert.assertTrue(client.validateExecutionGroupFromContext(eg));
     }, client);
   }
@@ -122,20 +124,25 @@ public class TestExecutionGroup
   public void testCallableExecution_Nested() throws Exception
   {
     MockBatchableResource client = new MockBatchableResource();
-    eg.batchOn(() -> {
+    eg.batchOn(() ->
+    {
       Assert.assertTrue(client.validateExecutionGroupFromContext(eg)); //outer - eg
       ExecutionGroup eg2 = new ExecutionGroup(_engine);
-      try {
-        eg2.batchOn(() -> {
+      try
+      {
+        eg2.batchOn(() ->
+        {
           Assert.assertTrue(client.validateExecutionGroupFromContext(eg2)); // inner - eg2
         }, client);
-      } catch (Exception ignored) {
+      } catch (Exception ignored)
+      {
       }
       Assert.assertTrue(client.validateExecutionGroupFromContext(eg)); // outer -eg
     }, client);
   }
 
-  @Test public void testExecuteOnlyOnce() throws Exception
+  @Test
+  public void testExecuteOnlyOnce() throws Exception
   {
     ExecutionGroup eg = new ExecutionGroup(_engine);
     MockBatchableResource client = new MockBatchableResource();
@@ -145,14 +152,14 @@ public class TestExecutionGroup
     {
       eg.execute();
       Assert.fail("Should fail here");
-    }
-    catch (IllegalStateException e)
+    } catch (IllegalStateException e)
     {
       Assert.assertEquals(ExecutionGroup.MULTIPLE_EXECUTION_ERROR, e.getMessage());
     }
   }
 
-  @Test public void testAddingAfterExecutedNotAllowed() throws Exception
+  @Test
+  public void testAddingAfterExecutedNotAllowed() throws Exception
   {
     ExecutionGroup eg = new ExecutionGroup(_engine);
     MockBatchableResource client = new MockBatchableResource();
@@ -162,20 +169,20 @@ public class TestExecutionGroup
     {
       eg.addTaskByFluentClient(client, task1);
       Assert.fail("Should fail here");
-    }
-    catch (IllegalStateException e)
+    } catch (IllegalStateException e)
     {
       Assert.assertEquals(ExecutionGroup.ADD_AFTER_EXECUTION_ERROR, e.getMessage());
     }
-
   }
 
   @AfterClass
   void tearDown() throws Exception
   {
-    if (_parSeqUnitTestHelper != null) {
+    if (_parSeqUnitTestHelper != null)
+    {
       _parSeqUnitTestHelper.tearDown();
-    } else {
+    } else
+    {
       throw new RuntimeException(
           "Tried to shut down Engine but it either has not even been created or has " + "already been shut down");
     }
@@ -183,7 +190,8 @@ public class TestExecutionGroup
 
   void awaitAllTasks(Task... tasks) throws Exception
   {
-    for (Task t : tasks) {
+    for (Task t : tasks)
+    {
       t.await();
     }
   }
@@ -211,6 +219,7 @@ class MockBatchableResource implements ParSeqBasedFluentClient
   {
     return null;
   }
+
   @Override
   public void runBatchOnClient(Runnable runnable) throws Exception
   {

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestExecutionGroup.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestExecutionGroup.java
@@ -198,12 +198,23 @@ class MockBatchableResource implements FluentClient
 
   public Map<Long, String> batchGet(Collection<Long> keys)
   {
-    return keys.stream().collect(Collectors.toMap(key -> key, key -> get(key)));
+    return keys.stream().collect(Collectors.toMap(key -> key, this::get));
   }
 
   public boolean validateExecutionGroupFromContext(ExecutionGroup eg)
   {
     return eg == this.getExecutionGroupFromContext();
+  }
+
+  @Override
+  public Engine getEngine()
+  {
+    return null;
+  }
+  @Override
+  public void runBatchOnClient(Runnable runnable) throws Exception
+  {
+
   }
 }
 

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParSeqBasedFluentClientApiWithExecutionGroup.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParSeqBasedFluentClientApiWithExecutionGroup.java
@@ -1,0 +1,194 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.linkedin.restli.examples;
+
+import com.linkedin.parseq.ParSeqUnitTestHelper;
+import com.linkedin.parseq.Task;
+import com.linkedin.parseq.batching.BatchingSupport;
+import com.linkedin.parseq.trace.Trace;
+import com.linkedin.parseq.trace.TraceUtil;
+import com.linkedin.restli.client.ExecutionGroup;
+import com.linkedin.restli.client.ParSeqBasedCompletionStage;
+import com.linkedin.restli.client.ParSeqRestliClient;
+import com.linkedin.restli.client.ParSeqRestliClientBuilder;
+import com.linkedin.restli.client.ParSeqRestliClientConfig;
+import com.linkedin.restli.client.ParSeqRestliClientConfigBuilder;
+import com.linkedin.restli.examples.greetings.api.Greeting;
+import com.linkedin.restli.examples.greetings.client.GreetingsFluentClient;
+import com.linkedin.restli.server.validation.RestLiValidationFilter;
+import com.linkedin.util.clock.Time;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestParSeqBasedFluentClientApiWithExecutionGroup extends RestLiIntegrationTest
+{
+  public static final String MESSAGE = "Create a new greeting";
+  ParSeqUnitTestHelper _parSeqUnitTestHelper;
+  ParSeqRestliClient _parSeqRestliClient;
+
+  @BeforeClass
+  void setUp() throws Exception
+  {
+    super.init(Arrays.asList(new RestLiValidationFilter()));
+    ParSeqRestliClientConfig config = new ParSeqRestliClientConfigBuilder()
+        .addBatchingEnabled("*.*/*.*", Boolean.TRUE)
+        .addMaxBatchSize("*.*/*.*", 3)
+        .build();
+    BatchingSupport batchingSupport = new BatchingSupport();
+    _parSeqUnitTestHelper = new ParSeqUnitTestHelper(engineBuilder -> {
+      engineBuilder.setPlanDeactivationListener(batchingSupport);
+    });
+    _parSeqUnitTestHelper.setUp();
+    _parSeqRestliClient = new ParSeqRestliClientBuilder()
+        .setBatchingSupport(batchingSupport) // RestClient Registered Strategy
+        .setClient(getClient())
+        .setConfig(config)
+        .build();
+  }
+
+  @AfterClass
+  void tearDown() throws Exception
+  {
+    if (_parSeqUnitTestHelper != null)
+    {
+      _parSeqUnitTestHelper.tearDown();
+    }
+    else
+    {
+      throw new RuntimeException("Tried to shut down Engine but it either has not even been created or has "
+          + "already been shut down");
+    }
+    super.shutdown();
+  }
+
+  /**
+    This test is to test if the batch method has been triggered.
+
+    Note: Currently ParSeqRestClient only support "batch" for gets.
+  */
+  @Test public void testBatchGet() throws Exception
+  {
+    // Test 3+1 = 4 calls using the "runBatchOnClient" method in the fluent Client
+    GreetingsFluentClient greetings = new GreetingsFluentClient(_parSeqRestliClient, _parSeqUnitTestHelper.getEngine());
+    final List<CompletionStage<Greeting>> results = new ArrayList<>(4);
+    greetings.runBatchOnClient(
+        () -> {
+          try {
+            results.add(greetings.get(1L));
+            results.add(greetings.get(1L));
+            results.add(greetings.get(1L));
+            results.add(greetings.get(1L));
+          } catch (Exception e)
+          {
+            throw new RuntimeException();
+          }
+        }
+    );
+    results.get(0).toCompletableFuture().get(5000, TimeUnit.MILLISECONDS);
+    assert(results.get(0) instanceof ParSeqBasedCompletionStage);
+    Task<Greeting> t = ((ParSeqBasedCompletionStage<Greeting>) results.get(0)).getTask();
+    System.out.println(TraceUtil.getJsonTrace(t.getTrace()));
+    Assert.assertTrue(hasTask("greetings batch_get(reqs: 1, ids: 3)",t.getTrace()));
+
+    // Test 3+1 = 4 calls generating a new ExecutionGroup and explicitly call the methods with ExecutionGroup
+    results.clear();
+    ExecutionGroup eg = greetings.generateExecutionGroup();
+    results.add(greetings.get(1L, eg));
+    results.add(greetings.get(1L, eg));
+    results.add(greetings.get(1L, eg));
+    results.add(greetings.get(1L, eg));
+    assert(results.get(0) instanceof ParSeqBasedCompletionStage);
+    t = ((ParSeqBasedCompletionStage<Greeting>) results.get(0)).getTask();
+    Assert.assertFalse(t.isDone());
+    Assert.assertFalse(hasTask("greetings batch_get(reqs: 1, ids: 3)",t.getTrace()));
+    eg.execute();
+    for (CompletionStage<Greeting> stage : results)
+    {
+      stage.toCompletableFuture().get(5000, TimeUnit.MILLISECONDS);
+    }
+    Assert.assertTrue(hasTask("greetings batch_get(reqs: 1, ids: 3)",t.getTrace()));
+
+    // Test 2( less than 3 ) calls using client's batchOn
+    results.clear();
+    greetings.runBatchOnClient(
+        () -> {
+          try {
+            results.add(greetings.get(1L));
+            results.add(greetings.get(1L));
+          } catch (Exception e)
+          {
+            throw new RuntimeException();
+          }
+        }
+    );
+    results.get(0).toCompletableFuture().get(5000, TimeUnit.MILLISECONDS);
+    assert(results.get(0) instanceof ParSeqBasedCompletionStage);
+    t = ((ParSeqBasedCompletionStage<Greeting>) results.get(0)).getTask();
+    Assert.assertTrue(hasTask("greetings batch_get(reqs: 1, ids: 2)",t.getTrace()));
+
+    // Test 2( less than 3 ) calls execution group
+    results.clear();
+    eg = greetings.generateExecutionGroup();
+    results.add(greetings.get(1L, eg));
+    results.add(greetings.get(1L, eg));
+    assert(results.get(0) instanceof ParSeqBasedCompletionStage);
+    t = ((ParSeqBasedCompletionStage<Greeting>) results.get(0)).getTask();
+    Assert.assertFalse(t.isDone());
+    Assert.assertFalse(hasTask("greetings batch_get(reqs: 1, ids: 2)",t.getTrace()));
+    eg.execute();
+    for (CompletionStage<Greeting> stage : results)
+    {
+      stage.toCompletableFuture().get(5000, TimeUnit.MILLISECONDS);
+    }
+    Assert.assertTrue(hasTask("greetings batch_get(reqs: 1, ids: 2)",t.getTrace()));
+
+
+    results.clear();
+    try
+    {
+      greetings.runBatchOnClient(
+          () -> {
+            try {
+              results.add(greetings.get(1L));
+              results.add(greetings.get(1L));
+              results.get(0).toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
+            } catch (Exception e)
+            {
+              throw new RuntimeException(e);
+            }
+          }
+      );
+      Assert.fail("Should fail due: the CompletionStage cannot be read ");
+    }
+    catch (Exception e)
+    {
+      Assert.assertTrue(e.getCause() instanceof  TimeoutException);
+    }
+  }
+
+  protected boolean hasTask(final String name, final Trace trace) {
+    return trace.getTraceMap().values().stream().anyMatch(shallowTrace -> shallowTrace.getName().equals(name));
+  }
+}

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParSeqBasedFluentClientApiWithExecutionGroup.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParSeqBasedFluentClientApiWithExecutionGroup.java
@@ -165,6 +165,7 @@ public class TestParSeqBasedFluentClientApiWithExecutionGroup extends RestLiInte
     Assert.assertTrue(hasTask("greetings batch_get(reqs: 1, ids: 2)",t.getTrace()));
 
 
+    // Testing read the completion Stage within the runnable: Not allowed; should fail
     results.clear();
     try
     {
@@ -173,14 +174,14 @@ public class TestParSeqBasedFluentClientApiWithExecutionGroup extends RestLiInte
             try {
               results.add(greetings.get(1L));
               results.add(greetings.get(1L));
-              results.get(0).toCompletableFuture().get(1000, TimeUnit.MILLISECONDS);
+              results.get(0).toCompletableFuture().get(500, TimeUnit.MILLISECONDS);
             } catch (Exception e)
             {
               throw new RuntimeException(e);
             }
           }
       );
-      Assert.fail("Should fail due: the CompletionStage cannot be read ");
+      Assert.fail("Should fail: the CompletionStage cannot be read ");
     }
     catch (Exception e)
     {

--- a/restli-tools/src/main/resources/apiVmTemplates/action.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/action.vm
@@ -15,138 +15,127 @@ Copyright (c) 2021 LinkedIn Corp.
 *#
 #if($is_interface)
   #foreach($method in $spec.actions)
-    #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
-    #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
-    #doc($method.schema.doc)
+    #foreach($withEG in [true, false])
+      #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
+      #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
+      #doc($method.schema.doc)
 
-    #if(${method.hasRequiredParams()}) ## action with no required Params will only have one API
-    @SuppressWarnings("unchecked")
-    public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-      #if(${method.isEntityAction()})
-        $spec.keyClassName $spec.idName,
-      #end
-      #foreach($param in $method.getRequiredParameters())
-        $param.paramClassDisplayName $param.paramName #if($foreach.hasNext || $method.hasOptionalParams()),#end
-      #end
-      #if($method.hasOptionalParams())
-        Function<$actionOptionalParamClassName, $actionOptionalParamClassName> optionalParamsProvider
-      #end
-    );
-    #end
+      #if(${method.hasRequiredParams()}) ## action with no required Params will only have one API
+        #if($method.hasOptionalParams()) ## when have optional params, the optionalParamsProvider is optional
+          @SuppressWarnings("unchecked")
+          public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
+            #actionMethodParamsWithEGroup($method, false, $withEG)##
+          );
+        #end ## end hasOptionalParams
+        @SuppressWarnings("unchecked")
+        public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
+            #actionMethodParamsWithEGroup($method, true, $withEG)##
+        );
+      #end ## end hasRequiredParams
 
-    @SuppressWarnings("unchecked")
-    public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-      #if(${method.isEntityAction()})
-      $spec.keyClassName $spec.idName #if(${method.hasActionParams()}),#end
-      #end
-      #if(${method.hasActionParams()})
-      Function<$actionParamClassName, $actionParamClassName> paramsProvider
-      #end
-    );
-
+      @SuppressWarnings("unchecked")
+      public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
+        #actionMethodProviderParamsWithEGroup($method, $withEG)##
+      );
+    #end ## end withEG
     #if(${method.hasActionParams()})
       #actionAllParamClass($method)
     #end
     #if(${method.hasRequiredParams()} && ${method.hasOptionalParams()})
       #actionOptParamClass($method)
     #end
-  #end ## foreach
+  #end ## foreach method
 #else ## is_interface
-  #foreach($method in $spec.actions)
-    #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
-    #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
-    #doc($method.schema.doc)
+  #foreach($withEG in [true, false])
+    #foreach($method in $spec.actions)
+      #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
+      #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
+      #doc($method.schema.doc)
 
-    #if(${method.hasRequiredParams()}) ## action with no required Params will only have one API
-    @SuppressWarnings("unchecked")
-    public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-      #if(${method.isEntityAction()})
-      $spec.keyClassName $spec.idName,
-      #end
-      #foreach($param in $method.getRequiredParameters())
-        $param.paramClassDisplayName $param.paramName #if($foreach.hasNext || $method.hasOptionalParams()),#end
-      #end
-      #if($method.hasOptionalParams())
-        Function<$actionOptionalParamClassName, $actionOptionalParamClassName> optionalParamsProvider
-      #end
-    )
-    {
-      #if(${method.hasOptionalParams()})
-      $actionOptionalParamClassName optionalParams = optionalParamsProvider.apply(new $actionOptionalParamClassName());
-      #end
-      return ${util.nameCamelCase(${method.name})}(
-        #if(${method.isEntityAction()})
-        $spec.idName,
-        #end
-        paramProvider -> paramProvider
-        #foreach($param in ${method.getRequiredParameters()})
-        .set${param.paramNameCaps}($param.paramName)
-        #end
-        #foreach($param in ${method.getOptionalParameters()})
-        .set${param.paramNameCaps}(optionalParams.get${param.paramNameCaps}())
-        #end
-      )
-      ;
-    }
-    #end
-
-    @SuppressWarnings("unchecked")
-    public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-      #if(${method.isEntityAction()})
-      $spec.keyClassName $spec.idName #if(${method.hasActionParams()}),#end
-      #end
-      #if(${method.hasActionParams()})
-      Function<$actionParamClassName, $actionParamClassName> paramsProvider
-      #end
-    )
-    {
-      RecordDataSchema requestDataSchema =  _resourceSpec.getRequestMetadata("${method.name}").getRecordDataSchema();
-      RecordDataSchema actionResponseDataSchema = _resourceSpec.getActionResponseMetadata("${method.name}").getRecordDataSchema();
-      FieldDef<${method.valueClassDisplayName}> responseFieldDef = (FieldDef<${method.valueClassDisplayName}>)_resourceSpec.getActionResponseMetadata("${method.name}").getFieldDef(ActionResponse.VALUE_NAME);
-
-      ActionResponseDecoder<${method.valueClassDisplayName}> actionResponseDecoder =
-          new ActionResponseDecoder<${method.valueClassDisplayName}>(responseFieldDef, actionResponseDataSchema);
-      DynamicRecordTemplate inputParameters =
-          new DynamicRecordTemplate(requestDataSchema,
-          #if(${method.hasActionParams()})
-            paramsProvider.apply(new $actionParamClassName()).buildParametersMap(_resourceSpec));
-          #else
-            Collections.emptyMap());
+      #if(${method.hasRequiredParams()}) ## action with no required Params will only have one API
+        #if($method.hasOptionalParams()) ## when have optional params, the optionalParamsProvider is optional
+          @SuppressWarnings("unchecked")
+          public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
+            #actionMethodParamsWithEGroup($method, false, $withEG)##
+          )
+          {
+            return ${util.nameCamelCase(${method.name})}(
+              #if(${method.isEntityAction()})
+              $spec.idName,
+              #end
+              #foreach($param in $method.getRequiredParameters())
+                $param.paramName #if($foreach.hasNext),#end
+              #end,
+              Function.identity() #if($withEG), executionGroup #end
+            )
+            ;
+          }
+        #end ## end hasOptionalParams
+        @SuppressWarnings("unchecked")
+        public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
+          #actionMethodParamsWithEGroup($method, true, $withEG)##
+        )
+        {
+          #if(${method.hasOptionalParams()})
+          $actionOptionalParamClassName optionalParams = optionalParamsProvider.apply(new $actionOptionalParamClassName());
           #end
-      inputParameters.data().setReadOnly();
-      ActionRequest<${method.valueClassDisplayName}> request = new ActionRequest<${method.valueClassDisplayName}>(inputParameters,
-                                  Collections.emptyMap(),
-                                  Collections.emptyList(),
-                                  actionResponseDecoder,
-                                  _resourceSpec,
-                                  _${method.name}ActionQueryParams,
-                                  _actionQueryParamsClasses,
-                                  "${method.name}",
-                                  ORIGINAL_RESOURCE_PATH,
-                                  buildReadOnlyPathKeys(),
-                                  RestliRequestOptions.DEFAULT_OPTIONS,
-                                  #if(${method.isEntityAction()})$spec.idName#else null#end,
-                                  ## TODO: Not supporting streaming attachments now
-                                  null
-                                  );
+          return ${util.nameCamelCase(${method.name})}(
+            #if(${method.isEntityAction()})
+            $spec.idName,
+            #end
+            paramProvider -> paramProvider
+            #foreach($param in ${method.getRequiredParameters()})
+            .set${param.paramNameCaps}($param.paramName)
+            #end
+            #foreach($param in ${method.getOptionalParameters()})
+            .set${param.paramNameCaps}(optionalParams.get${param.paramNameCaps}())
+            #end #if($withEG), executionGroup #end
+          )
+          ;
+        }
+      #end ## end hasRequiredParams
 
-      CompletableFuture<${method.valueClassDisplayName}> result = new CompletableFuture<>();
-      Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-          responseTry -> {
-            if (responseTry.isFailed()) {
-              result.completeExceptionally(responseTry.getError());
-            } else {
-              Response<${method.valueClassDisplayName}> resp = responseTry.get();
-              if (resp.hasError()) {
-                result.completeExceptionally(resp.getError());
-              } else {
-                result.complete(resp.getEntity());
-              }
-            }
-            return Success.of((Void) null);
-          });
-      _engine.run(responseTask);
-      return result;
-    }
-  #end ## foreach
+      @SuppressWarnings("unchecked")
+      public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
+        #actionMethodProviderParamsWithEGroup($method, $withEG)##
+      )
+      {
+        RecordDataSchema requestDataSchema =  _resourceSpec.getRequestMetadata("${method.name}").getRecordDataSchema();
+        RecordDataSchema actionResponseDataSchema = _resourceSpec.getActionResponseMetadata("${method.name}").getRecordDataSchema();
+        FieldDef<${method.valueClassDisplayName}> responseFieldDef = (FieldDef<${method.valueClassDisplayName}>)_resourceSpec.getActionResponseMetadata("${method.name}").getFieldDef(ActionResponse.VALUE_NAME);
+
+        ActionResponseDecoder<${method.valueClassDisplayName}> actionResponseDecoder =
+            new ActionResponseDecoder<${method.valueClassDisplayName}>(responseFieldDef, actionResponseDataSchema);
+        DynamicRecordTemplate inputParameters =
+            new DynamicRecordTemplate(requestDataSchema,
+            #if(${method.hasActionParams()})
+              paramsProvider.apply(new $actionParamClassName()).buildParametersMap(_resourceSpec));
+            #else
+              Collections.emptyMap());
+            #end
+        inputParameters.data().setReadOnly();
+        ActionRequest<${method.valueClassDisplayName}> request = new ActionRequest<${method.valueClassDisplayName}>(inputParameters,
+                                    Collections.emptyMap(),
+                                    Collections.emptyList(),
+                                    actionResponseDecoder,
+                                    _resourceSpec,
+                                    _${method.name}ActionQueryParams,
+                                    _actionQueryParamsClasses,
+                                    "${method.name}",
+                                    ORIGINAL_RESOURCE_PATH,
+                                    buildReadOnlyPathKeys(),
+                                    RestliRequestOptions.DEFAULT_OPTIONS,
+                                    #if(${method.isEntityAction()})$spec.idName#else null#end,
+                                    ## TODO: Not supporting streaming attachments now
+                                    null
+                                    );
+      #**##makeRequestAndReturn(
+      ${method.valueClassDisplayName},
+      ${method.valueClassDisplayName},
+      "resp.getEntity()",
+            $withEG
+          )##
+      }
+    #end ## foreach
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/batch_finder.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/batch_finder.vm
@@ -14,33 +14,36 @@
    limitations under the License.
 *#
 #if($is_interface)
+  #foreach($withEG in [true, false])
   #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
     #doc($method.schema.doc)
-    public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false)##
-        #**##methodParams($finder, false)##
+    public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false, $withEG)##
+        #**##methodParamsWithEGroup($finder, false, $withEG)##
     );
   #end
 
   #doc($finder.schema.doc)
-  public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true)##
-      #**##methodParams($finder, true)##
+  public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true, $withEG)##
+      #**##methodParamsWithEGroup($finder, true, $withEG)##
   );
+  #end ## end withEG
   #optionalParamClass($finder)
 #else
+  #foreach($withEG in [true, false])
   #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
     #doc($method.schema.doc)
-    public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false)##
-        #**##methodParams($finder, false)##
+    public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false, $withEG)##
+        #**##methodParamsWithEGroup($finder, false, $withEG)##
          ) {
       return ${finder.methodName}(#assocKeyCallArgs($finder)##
-          #**##optionalMethodCallArgs($finder)##
+          #**##optionalMethodCallArgsWithEGroup($finder, $withEG)##
       );
     }
   #end
 
   #doc($finder.schema.doc)
-  public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true)##
-      #**##methodParams($finder, true)##
+  public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true, $withEG)##
+      #**##methodParamsWithEGroup($finder, true, $withEG)##
       ) {
     #**##paramsRequestMap($finder)##
     #if($finder.assocKeys.size() > 0)
@@ -62,22 +65,12 @@
         buildReadOnlyPathKeys(),
         RestliRequestOptions.DEFAULT_OPTIONS,
         #**##if($finder.assocKeys.size() > 0)assocKey #else null #end);
-    CompletableFuture<BatchCollectionResponse<${spec.entityClassName}>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<BatchCollectionResponse<${spec.entityClassName}>> resp = responseTry.get();
-            if (resp.hasError()) {
-              result.completeExceptionally(resp.getError());
-            } else {
-              result.complete(resp.getEntity());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
+      #**##makeRequestAndReturn(
+      "BatchCollectionResponse<${spec.entityClassName}>",
+      "BatchCollectionResponse<${spec.entityClassName}>",
+      "resp.getEntity()",
+                  $withEG
+                )##
   }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/finder.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/finder.vm
@@ -14,70 +14,63 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
-    #doc($method.schema.doc)
-    public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false)##
-        #**##methodParams($finder, false)##
-    );
-  #end
+  #foreach($withEG in [true, false])
+    #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false, $withEG)##
+          #**##methodParamsWithEGroup($finder, false, $withEG)##
+      );
+    #end
 
-  #doc($finder.schema.doc)
-  public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true)##
-      #**##methodParams($finder, true)##
-  );
+    #doc($finder.schema.doc)
+    public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true, $withEG)##
+        #**##methodParamsWithEGroup($finder, true, $withEG)##
+    );
+  #end ## end withEG
   #optionalParamClass($finder)
 #else
-  #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
-    #doc($method.schema.doc)
-    public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false)##
-        #**##methodParams($finder, false)##
-         ) {
-      return ${finder.methodName}(#assocKeyCallArgs($finder)##
-          #**##optionalMethodCallArgs($finder)##
-      );
-    }
-  #end
-
-  #doc($finder.schema.doc)
-  public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true)##
-      #**##methodParams($finder, true)##
-      ) {
-    #**##paramsRequestMap($finder)##
-    #if($finder.assocKeys.size() > 0)
-      CompoundKey assocKey = new CompoundKey();
-      #foreach($assocKey in $finder.assocKeys)
-        assocKey.append("$assocKey.name", $assocKey.name);
-      #end
+  #foreach($withEG in [true, false])
+    #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false, $withEG)##
+          #**##methodParamsWithEGroup($finder, false, $withEG)##
+          ) {
+        return ${finder.methodName}(#assocKeyCallArgs($finder)##
+            #**##optionalMethodCallArgsWithEGroup($finder, $withEG)##
+        );
+      }
     #end
-    queryParams.put(RestConstants.QUERY_TYPE_PARAM, "$finder.name");
-    FindRequest<${spec.entityClassName}> request = new FindRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        ${spec.entityClassName}.class,
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        "$finder.name",
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        #**##if($finder.assocKeys.size() > 0)assocKey #else null #end);
-    CompletableFuture<CollectionResponse<${spec.entityClassName}>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<CollectionResponse<${spec.entityClassName}>> resp = responseTry.get();
-            if (resp.hasError()) {
-              result.completeExceptionally(resp.getError());
-            } else {
-              result.complete(resp.getEntity());
-            }
+
+    #doc($finder.schema.doc)
+    public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true, $withEG)##
+        #**##methodParamsWithEGroup($finder, true, $withEG)##
+        ) {
+      #**##paramsRequestMap($finder)##
+      #if($finder.assocKeys.size() > 0)
+        CompoundKey assocKey = new CompoundKey();
+        #foreach($assocKey in $finder.assocKeys)
+          assocKey.append("$assocKey.name", $assocKey.name);
+        #end
+      #end
+      queryParams.put(RestConstants.QUERY_TYPE_PARAM, "$finder.name");
+      FindRequest<${spec.entityClassName}> request = new FindRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          ${spec.entityClassName}.class,
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          "$finder.name",
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          #**##if($finder.assocKeys.size() > 0)assocKey #else null #end);
+      #**##makeRequestAndReturn(
+      "CollectionResponse<${spec.entityClassName}>",
+      "CollectionResponse<${spec.entityClassName}>",
+      "resp.getEntity()",
+                  $withEG
+                )##
           }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/resource.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/resource.vm
@@ -32,7 +32,7 @@ import com.linkedin.restli.client.Response;
 import com.linkedin.restli.client.RestliRequestOptions;
 import com.linkedin.restli.client.util.FluentClientUtils;
 import com.linkedin.restli.client.AbstractRequestBuilder;
-import com.linkedin.restli.client.FluentClient;
+import com.linkedin.restli.client.ParSeqBasedFluentClient;
 import com.linkedin.restli.common.ResourceMethod;
 import com.linkedin.restli.common.ResourceSpec;
 import com.linkedin.restli.common.ResourceSpecImpl;
@@ -57,7 +57,7 @@ import javax.annotation.Generated;
 
 @Generated("Generated from $spec.sourceIdlName")
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class ${spec.className}${class_name_suffix} implements ${spec.toImplementInterfaceName}, FluentClient {
+public class ${spec.className}${class_name_suffix} implements ${spec.toImplementInterfaceName}, ParSeqBasedFluentClient {
   private final static String ORIGINAL_RESOURCE_PATH = "$util.getResourcePath($spec.resource.path)";
   private static ResourceSpec _resourceSpec;
   #if(${spec.getPathKeys().size()} > 0)

--- a/restli-tools/src/main/resources/apiVmTemplates/resource.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/resource.vm
@@ -24,11 +24,15 @@ import com.linkedin.data.template.DynamicRecordMetadata;
 import com.linkedin.parseq.Engine;
 import com.linkedin.parseq.Task;
 import com.linkedin.parseq.function.Success;
+import com.linkedin.parseq.function.Failure;
+import com.linkedin.restli.client.ExecutionGroup;
+import com.linkedin.restli.client.ParSeqBasedCompletionStageFactory;
 import com.linkedin.restli.client.ParSeqRestliClient;
 import com.linkedin.restli.client.Response;
 import com.linkedin.restli.client.RestliRequestOptions;
 import com.linkedin.restli.client.util.FluentClientUtils;
 import com.linkedin.restli.client.AbstractRequestBuilder;
+import com.linkedin.restli.client.FluentClient;
 import com.linkedin.restli.common.ResourceMethod;
 import com.linkedin.restli.common.ResourceSpec;
 import com.linkedin.restli.common.ResourceSpecImpl;
@@ -52,13 +56,15 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 
 @Generated("Generated from $spec.sourceIdlName")
-@SuppressWarnings({"rawtypes"})
-public class ${spec.className}${class_name_suffix} implements ${spec.toImplementInterfaceName} {
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class ${spec.className}${class_name_suffix} implements ${spec.toImplementInterfaceName}, FluentClient {
   private final static String ORIGINAL_RESOURCE_PATH = "$util.getResourcePath($spec.resource.path)";
   private static ResourceSpec _resourceSpec;
   #if(${spec.getPathKeys().size()} > 0)
   private Map<String, Object> _pathKeyMap = new HashMap<>();
   #end
+  private ParSeqBasedCompletionStageFactory _completionStageFactory;
+
   #if(${spec.getActions().size()} > 0)
   private final Map<String, Class<?>> _actionQueryParamsClasses = Collections.singletonMap("action", String.class);
   #foreach($method in $spec.actions)
@@ -169,6 +175,7 @@ public class ${spec.className}${class_name_suffix} implements ${spec.toImplement
   public ${spec.className}${class_name_suffix}(ParSeqRestliClient client, Engine engine) {
     _client = client;
     _engine = engine;
+    _completionStageFactory = new ParSeqBasedCompletionStageFactory(engine);
   }
 
   ## Merge another pathKeyMap
@@ -222,4 +229,14 @@ public class ${spec.className}${class_name_suffix} implements ${spec.toImplement
     return Collections.emptyMap();
   }
   #end
+
+  public void runBatchOnClient(Runnable runnable) throws Exception
+  {
+    generateExecutionGroup().batchOn(runnable, this);
+  }
+
+  public Engine getEngine()
+  {
+    return _engine;
+  }
 }

--- a/restli-tools/src/main/resources/apiVmTemplates/resource_interface.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/resource_interface.vm
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import com.linkedin.restli.client.ExecutionGroup;
 
 
 @Generated("Generated from $spec.sourceIdlName")

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_create_id.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_create_id.vm
@@ -14,80 +14,73 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<List<CreateIdStatus<${spec.keyClassDisplayName}>>> batchCreate(
+          List<${spec.entityClassName}> entities#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+            );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<List<CreateIdStatus<${spec.keyClassDisplayName}>>> batchCreate(
-        List<${spec.entityClassName}> entities#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-          );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<List<CreateIdStatus<${spec.keyClassDisplayName}>>> batchCreate(
-      List<${spec.entityClassName}> entities#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+        List<${spec.entityClassName}> entities#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<List<CreateIdStatus<${spec.keyClassDisplayName}>>> batchCreate(
+          List<${spec.entityClassName}> entities#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+            ){
+        return batchCreate(entities,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<List<CreateIdStatus<${spec.keyClassDisplayName}>>> batchCreate(
-        List<${spec.entityClassName}> entities#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-          ){
-      return batchCreate(entities,
-          #**##optionalMethodCallArgs($method)##
-      );
+        List<${spec.entityClassName}> entities#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
+      #fillQueryParams($method)
+      #if($method.returnsEntity())
+        #**##returnEntityParam("false")
+      #end
+      @SuppressWarnings("unchecked")
+      BatchCreateIdDecoder<${spec.keyClassDisplayName}> idResponseDecoder = new BatchCreateIdDecoder<>(
+          (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
+          _resourceSpec.getKeyParts(),
+          _resourceSpec.getComplexKeyType());
+      CollectionRequest<${spec.entityClassName}> input = FluentClientUtils.buildBatchEntityInputs(entities, ${spec.entityClassName}.class);
+
+      BatchCreateIdRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchCreateIdRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          idResponseDecoder,
+          input,
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          ## Streaming attachments
+          null);
+      #**##makeRequestAndReturn(
+        "List<CreateIdStatus<${spec.keyClassName}>>",
+        "BatchCreateIdResponse<${spec.keyClassName}>",
+        "resp.getEntity().getElements()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<List<CreateIdStatus<${spec.keyClassDisplayName}>>> batchCreate(
-      List<${spec.entityClassName}> entities#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
-    #fillQueryParams($method)
-    #if($method.returnsEntity())
-      #**##returnEntityParam("false")
-    #end
-    @SuppressWarnings("unchecked")
-    BatchCreateIdDecoder<${spec.keyClassDisplayName}> idResponseDecoder = new BatchCreateIdDecoder<>(
-        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
-        _resourceSpec.getKeyParts(),
-        _resourceSpec.getComplexKeyType());
-    CollectionRequest<${spec.entityClassName}> input = FluentClientUtils.buildBatchEntityInputs(entities, ${spec.entityClassName}.class);
-
-    BatchCreateIdRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchCreateIdRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        idResponseDecoder,
-        input,
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        ## Streaming attachments
-        null);
-    CompletableFuture<List<CreateIdStatus<${spec.keyClassDisplayName}>>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<BatchCreateIdResponse<${spec.keyClassDisplayName}>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity().getElements());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_create_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_create_return_entity.vm
@@ -14,78 +14,71 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> batchCreateAndGet(
+          List<${spec.entityClassName}> entities#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> batchCreateAndGet(
-        List<${spec.entityClassName}> entities#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        List<${spec.entityClassName}> entities#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> batchCreateAndGet(
-      List<${spec.entityClassName}> entities#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+  #end ## end withEG
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> batchCreateAndGet(
+          List<${spec.entityClassName}> entities#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          ){
+        return batchCreateAndGet(entities,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> batchCreateAndGet(
-        List<${spec.entityClassName}> entities#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-        ){
-      return batchCreateAndGet(entities,
-          #**##optionalMethodCallArgs($method)##
-      );
+        List<${spec.entityClassName}> entities#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
+      #fillQueryParams($method)
+      #**##returnEntityParam("true")
+      @SuppressWarnings("unchecked")
+      BatchCreateIdEntityDecoder<${spec.keyClassDisplayName}, ${spec.entityClassName}> idEntityResponseDecoder = new BatchCreateIdEntityDecoder<>(
+          (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
+          (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType(),
+          _resourceSpec.getKeyParts(),
+          _resourceSpec.getComplexKeyType());
+      CollectionRequest<${spec.entityClassName}> input = FluentClientUtils.buildBatchEntityInputs(entities, ${spec.entityClassName}.class);
+
+      BatchCreateIdEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchCreateIdEntityRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          idEntityResponseDecoder,
+          input,
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          ## Streaming attachments
+          null);
+      #**##makeRequestAndReturn(
+        "List<CreateIdEntityStatus<${spec.keyClassName}, ${spec.entityClassName}>>",
+        "BatchCreateIdEntityResponse<${spec.keyClassName}, ${spec.entityClassName}>",
+        "resp.getEntity().getElements()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> batchCreateAndGet(
-      List<${spec.entityClassName}> entities#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
-    #fillQueryParams($method)
-    #**##returnEntityParam("true")
-    @SuppressWarnings("unchecked")
-    BatchCreateIdEntityDecoder<${spec.keyClassDisplayName}, ${spec.entityClassName}> idEntityResponseDecoder = new BatchCreateIdEntityDecoder<>(
-        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
-        (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType(),
-        _resourceSpec.getKeyParts(),
-        _resourceSpec.getComplexKeyType());
-    CollectionRequest<${spec.entityClassName}> input = FluentClientUtils.buildBatchEntityInputs(entities, ${spec.entityClassName}.class);
-
-    BatchCreateIdEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchCreateIdEntityRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        idEntityResponseDecoder,
-        input,
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        ## Streaming attachments
-        null);
-    CompletableFuture<List<CreateIdEntityStatus<${spec.keyClassDisplayName}, ${spec.entityClassName}>>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<BatchCreateIdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity().getElements());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_delete.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_delete.vm
@@ -14,67 +14,60 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchDelete(
+          Set<$spec.keyClassDisplayName> ids#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchDelete(
-        Set<$spec.keyClassDisplayName> ids#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        Set<$spec.keyClassDisplayName> ids#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchDelete(
-      Set<$spec.keyClassDisplayName> ids#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchDelete(
+          Set<$spec.keyClassDisplayName> ids#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+        return batchDelete(ids,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchDelete(
-        Set<$spec.keyClassDisplayName> ids#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        Set<$spec.keyClassDisplayName> ids#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         ) {
-      return batchDelete(ids,
-          #**##optionalMethodCallArgs($method)##
-      );
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = #if($method.hasParams())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
+      #fillQueryParams($method)
+      queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, ids);
+      BatchDeleteRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchDeleteRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          queryParams,
+          queryParamClasses,
+          _resourceSpec,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS);
+      #**##makeRequestAndReturn(
+        "Map<${spec.keyClassName}, UpdateStatus>",
+        "BatchKVResponse<${spec.keyClassName}, UpdateStatus>",
+        "resp.getEntity().getResults()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchDelete(
-      Set<$spec.keyClassDisplayName> ids#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = #if($method.hasParams())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
-    #fillQueryParams($method)
-    queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, ids);
-    BatchDeleteRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchDeleteRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        queryParams,
-        queryParamClasses,
-        _resourceSpec,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS);
-    CompletableFuture<Map<${spec.keyClassDisplayName}, UpdateStatus>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<BatchKVResponse<${spec.keyClassDisplayName}, UpdateStatus>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity().getResults());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_get.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_get.vm
@@ -14,73 +14,66 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> batchGet(
+          Set<$spec.keyClassDisplayName> ids#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> batchGet(
-        Set<$spec.keyClassDisplayName> ids#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        Set<$spec.keyClassDisplayName> ids#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> batchGet(
-      Set<$spec.keyClassDisplayName> ids#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> batchGet(
+          Set<$spec.keyClassDisplayName> ids#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+        return batchGet(ids,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> batchGet(
-        Set<$spec.keyClassDisplayName> ids#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        Set<$spec.keyClassDisplayName> ids#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         ) {
-      return batchGet(ids,
-          #**##optionalMethodCallArgs($method)##
-      );
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = #if($method.hasParams())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
+      #fillQueryParams($method)
+      queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, ids);
+      @SuppressWarnings("unchecked")
+      BatchGetEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchGetEntityRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          new BatchEntityResponseDecoder<>(
+              (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType(),
+              (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
+              _resourceSpec.getKeyParts(),
+              _resourceSpec.getComplexKeyType()),
+          queryParams,
+          queryParamClasses,
+          _resourceSpec,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS);
+      #**##makeRequestAndReturn(
+        "Map<${spec.keyClassName}, EntityResponse<${spec.entityClassName}>>", 
+        "BatchKVResponse<${spec.keyClassName}, EntityResponse<${spec.entityClassName}>>", 
+        "resp.getEntity().getResults()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> batchGet(
-      Set<$spec.keyClassDisplayName> ids#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = #if($method.hasParams())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
-    #fillQueryParams($method)
-    queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, ids);
-    @SuppressWarnings("unchecked")
-    BatchGetEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchGetEntityRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        new BatchEntityResponseDecoder<>(
-            (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType(),
-            (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
-            _resourceSpec.getKeyParts(),
-            _resourceSpec.getComplexKeyType()),
-        queryParams,
-        queryParamClasses,
-        _resourceSpec,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS);
-    CompletableFuture<Map<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<BatchKVResponse<${spec.keyClassDisplayName}, EntityResponse<${spec.entityClassName}>>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else{
-              result.complete(response.getEntity().getResults());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_partial_update_no_return.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_partial_update_no_return.vm
@@ -14,83 +14,76 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<$spec.keyClassDisplayName, UpdateStatus>> batchPartialUpdate(
+          Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<$spec.keyClassDisplayName, UpdateStatus>> batchPartialUpdate(
-        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<$spec.keyClassDisplayName, UpdateStatus>> batchPartialUpdate(
-      Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  @SuppressWarnings("unchecked")
-  private static final KeyValueRecordFactory<${spec.keyClassDisplayName}, PatchRequest<${spec.entityClassName}>> PATCH_VALUE_FACTORY = new KeyValueRecordFactory<${spec.keyClassDisplayName}, PatchRequest<${spec.entityClassName}>>(
-        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
-        _resourceSpec.getComplexKeyType(),
-        _resourceSpec.getKeyParts(),
-        (TypeSpec<PatchRequest<${spec.entityClassName}>>) (Object) new TypeSpec<>(PatchRequest.class));
+    @SuppressWarnings("unchecked")
+    private static final KeyValueRecordFactory<${spec.keyClassDisplayName}, PatchRequest<${spec.entityClassName}>> PATCH_VALUE_FACTORY = new KeyValueRecordFactory<${spec.keyClassDisplayName}, PatchRequest<${spec.entityClassName}>>(
+          (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
+          _resourceSpec.getComplexKeyType(),
+          _resourceSpec.getKeyParts(),
+          (TypeSpec<PatchRequest<${spec.entityClassName}>>) (Object) new TypeSpec<>(PatchRequest.class));
+  #foreach($withEG in [true, false])
 
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<$spec.keyClassDisplayName, UpdateStatus>> batchPartialUpdate(
+          Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+        return batchPartialUpdate(patches,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<$spec.keyClassDisplayName, UpdateStatus>> batchPartialUpdate(
-        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         ) {
-      return batchPartialUpdate(patches,
-          #**##optionalMethodCallArgs($method)##
-      );
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
+      #fillQueryParams($method)
+      #if($method.returnsEntity())
+        #**##returnEntityParam("false")
+      #end
+      queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, patches.keySet());
+      CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>>> inputs = FluentClientUtils.buildBatchKVInputs(
+          patches, PATCH_VALUE_FACTORY);
+
+      BatchPartialUpdateRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchPartialUpdateRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          inputs,
+          queryParams,
+          queryParamClasses,
+          _resourceSpec,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          patches,
+          null);
+      #**##makeRequestAndReturn(
+        "Map<$spec.keyClassName, UpdateStatus>",
+        "BatchKVResponse<$spec.keyClassName, UpdateStatus>",
+        "resp.getEntity().getResults()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<$spec.keyClassDisplayName, UpdateStatus>> batchPartialUpdate(
-      Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
-    #fillQueryParams($method)
-    #if($method.returnsEntity())
-      #**##returnEntityParam("false")
-    #end
-    queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, patches.keySet());
-    CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>>> inputs = FluentClientUtils.buildBatchKVInputs(
-        patches, PATCH_VALUE_FACTORY);
-
-    BatchPartialUpdateRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchPartialUpdateRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        inputs,
-        queryParams,
-        queryParamClasses,
-        _resourceSpec,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        patches,
-        null);
-    CompletableFuture<Map<$spec.keyClassDisplayName, UpdateStatus>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<BatchKVResponse<$spec.keyClassDisplayName, UpdateStatus>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity().getResults());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_partial_update_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_partial_update_return_entity.vm
@@ -14,73 +14,66 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
+          Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
-        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
-      Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+  #end ## end withEG
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
+          Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+        return batchPartialUpdateAndGet(patches,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
-        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+        Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         ) {
-      return batchPartialUpdateAndGet(patches,
-          #**##optionalMethodCallArgs($method)##
-      );
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
+      #fillQueryParams($method)
+      #**##returnEntityParam("true")
+      queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, patches.keySet());
+      CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>>> inputs = FluentClientUtils.buildBatchKVInputs(
+          patches, PATCH_VALUE_FACTORY);
+
+      BatchPartialUpdateEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchPartialUpdateEntityRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          inputs,
+          queryParams,
+          queryParamClasses,
+          _resourceSpec,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          patches,
+          null);
+      #**##makeRequestAndReturn(
+        "Map<$spec.keyClassName, UpdateEntityStatus<${spec.entityClassName}>>",
+        "BatchKVResponse<$spec.keyClassName, UpdateEntityStatus<${spec.entityClassName}>>",
+        "resp.getEntity().getResults()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> batchPartialUpdateAndGet(
-      Map<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>> patches#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
-    #fillQueryParams($method)
-    #**##returnEntityParam("true")
-    queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, patches.keySet());
-    CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, PatchRequest<${spec.entityClassName}>>> inputs = FluentClientUtils.buildBatchKVInputs(
-        patches, PATCH_VALUE_FACTORY);
-
-    BatchPartialUpdateEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new BatchPartialUpdateEntityRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        inputs,
-        queryParams,
-        queryParamClasses,
-        _resourceSpec,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        patches,
-        null);
-    CompletableFuture<Map<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<BatchKVResponse<$spec.keyClassDisplayName, UpdateEntityStatus<${spec.entityClassName}>>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity().getResults());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.batch_update.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.batch_update.vm
@@ -14,79 +14,72 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchUpdate(
+          Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchUpdate(
-        Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchUpdate(
-      Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+        Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  @SuppressWarnings("unchecked")
-  private static final KeyValueRecordFactory<${spec.keyClassDisplayName}, ${spec.entityClassName}> UPDATE_VALUE_FACTORY = new KeyValueRecordFactory<${spec.keyClassDisplayName}, ${spec.entityClassName}>(
-      (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
-      _resourceSpec.getComplexKeyType(),
-      _resourceSpec.getKeyParts(),
-      (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType());
+    @SuppressWarnings("unchecked")
+    private static final KeyValueRecordFactory<${spec.keyClassDisplayName}, ${spec.entityClassName}> UPDATE_VALUE_FACTORY = new KeyValueRecordFactory<${spec.keyClassDisplayName}, ${spec.entityClassName}>(
+        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
+        _resourceSpec.getComplexKeyType(),
+        _resourceSpec.getKeyParts(),
+        (TypeSpec<${spec.entityClassName}>) _resourceSpec.getValueType());
+  #foreach($withEG in [true, false])
 
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchUpdate(
+          Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        ) {
+        return batchUpdate(entities,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchUpdate(
-        Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      ) {
-      return batchUpdate(entities,
-          #**##optionalMethodCallArgs($method)##
-      );
+        Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
+      #fillQueryParams($method)
+      queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, entities.keySet());
+      CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, ${spec.entityClassName}>> inputs = FluentClientUtils.buildBatchKVInputs(
+          entities, UPDATE_VALUE_FACTORY);
+      BatchUpdateRequest<$spec.keyClassDisplayName, ${spec.entityClassName}> request = new BatchUpdateRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          inputs,
+          queryParams,
+          queryParamClasses,
+          _resourceSpec,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          entities,
+          null);
+      #**##makeRequestAndReturn(
+        "Map<${spec.keyClassName}, UpdateStatus>",
+        "BatchKVResponse<${spec.keyClassName}, UpdateStatus>",
+        "resp.getEntity().getResults()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Map<${spec.keyClassDisplayName}, UpdateStatus>> batchUpdate(
-      Map<$spec.keyClassDisplayName, ${spec.entityClassName}> entities#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
-    #fillQueryParams($method)
-    queryParams.put(RestConstants.QUERY_BATCH_IDS_PARAM, entities.keySet());
-    CollectionRequest<KeyValueRecord<$spec.keyClassDisplayName, ${spec.entityClassName}>> inputs = FluentClientUtils.buildBatchKVInputs(
-        entities, UPDATE_VALUE_FACTORY);
-    BatchUpdateRequest<$spec.keyClassDisplayName, ${spec.entityClassName}> request = new BatchUpdateRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        inputs,
-        queryParams,
-        queryParamClasses,
-        _resourceSpec,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        entities,
-        null);
-    CompletableFuture<Map<${spec.keyClassDisplayName}, UpdateStatus>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<BatchKVResponse<${spec.keyClassDisplayName}, UpdateStatus>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity().getResults());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.create_id.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.create_id.vm
@@ -14,77 +14,70 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<${spec.keyClassDisplayName}> create(
+          ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<${spec.keyClassDisplayName}> create(
-        ${spec.entityClassName} entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<${spec.keyClassDisplayName}> create(
-      ${spec.entityClassName} entity#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+        ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<${spec.keyClassDisplayName}> create(
+          ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        ) {
+        return create(entity,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<${spec.keyClassDisplayName}> create(
-        ${spec.entityClassName} entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      ) {
-      return create(entity,
-          #**##optionalMethodCallArgs($method)##
-      );
+        ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
+      #fillQueryParams($method)
+      #if($method.returnsEntity())
+        #**##returnEntityParam("false")
+      #end
+      @SuppressWarnings("unchecked")
+      IdResponseDecoder<${spec.keyClassDisplayName}> idResponseDecoder = new IdResponseDecoder<>(
+          (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
+          _resourceSpec.getKeyParts(),
+          _resourceSpec.getComplexKeyType());
+      CreateIdRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new CreateIdRequest<>(
+          entity,
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          idResponseDecoder,
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          null);
+      #**##makeRequestAndReturn(
+        ${spec.keyClassName},
+        "IdResponse<${spec.keyClassName}>",
+        "resp.getEntity().getId()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<${spec.keyClassDisplayName}> create(
-      ${spec.entityClassName} entity#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
-    #fillQueryParams($method)
-    #if($method.returnsEntity())
-      #**##returnEntityParam("false")
-    #end
-    @SuppressWarnings("unchecked")
-    IdResponseDecoder<${spec.keyClassDisplayName}> idResponseDecoder = new IdResponseDecoder<>(
-        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
-        _resourceSpec.getKeyParts(),
-        _resourceSpec.getComplexKeyType());
-    CreateIdRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new CreateIdRequest<>(
-        entity,
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        idResponseDecoder,
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        null);
-    CompletableFuture<${spec.keyClassDisplayName}> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<IdResponse<${spec.keyClassDisplayName}>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity().getId());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.create_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.create_return_entity.vm
@@ -14,75 +14,68 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> createAndGet(
+          ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> createAndGet(
-        ${spec.entityClassName} entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> createAndGet(
-      ${spec.entityClassName} entity#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+        ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        );
+  #end ## end withEG
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> createAndGet(
+          ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        ) {
+        return createAndGet(entity,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> createAndGet(
-        ${spec.entityClassName} entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      ) {
-      return createAndGet(entity,
-          #**##optionalMethodCallArgs($method)##
-      );
+        ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
+      #fillQueryParams($method)
+      #**##returnEntityParam("true")
+      @SuppressWarnings("unchecked")
+      IdEntityResponseDecoder<${spec.keyClassDisplayName}, ${spec.entityClassName}> idEntityResponseDecoder = new IdEntityResponseDecoder<>(
+          (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
+          _resourceSpec.getKeyParts(),
+          _resourceSpec.getComplexKeyType(),
+          (Class<${spec.entityClassName}>) _resourceSpec.getValueClass());
+      CreateIdEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new CreateIdEntityRequest<>(
+          entity,
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          idEntityResponseDecoder,
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          null);
+      #**##makeRequestAndReturn(
+        "IdEntityResponse<${spec.keyClassName}, ${spec.entityClassName}>",
+        "IdEntityResponse<${spec.keyClassName}, ${spec.entityClassName}>",
+        "resp.getEntity()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> createAndGet(
-      ${spec.entityClassName} entity#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
-    #fillQueryParams($method)
-    #**##returnEntityParam("true")
-    @SuppressWarnings("unchecked")
-    IdEntityResponseDecoder<${spec.keyClassDisplayName}, ${spec.entityClassName}> idEntityResponseDecoder = new IdEntityResponseDecoder<>(
-        (TypeSpec<${spec.keyClassDisplayName}>) _resourceSpec.getKeyType(),
-        _resourceSpec.getKeyParts(),
-        _resourceSpec.getComplexKeyType(),
-        (Class<${spec.entityClassName}>) _resourceSpec.getValueClass());
-    CreateIdEntityRequest<${spec.keyClassDisplayName}, ${spec.entityClassName}> request = new CreateIdEntityRequest<>(
-        entity,
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        idEntityResponseDecoder,
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        null);
-    CompletableFuture<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<IdEntityResponse<${spec.keyClassDisplayName}, ${spec.entityClassName}>> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
@@ -14,78 +14,71 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Void> delete(
+        #if (!${spec.getResource().hasSimple()})
+          $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams() || $withEG),#end
+        #end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Void> delete(
       #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()),#end
+        $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
       #end
-        #**##methodParams($method, false)##
-      );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Void> delete(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName#if( $method.hasParams()),#end
-    #end
-      #**##methodParams($method, true)##
-      );
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Void> delete(
+        #if (!${spec.getResource().hasSimple()})
+          $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams() || $withEG),#end
+        #end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        ) {
+        return delete(#if(${spec.idName})$spec.idName,#end
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Void> delete(
       #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()),#end
+        $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
       #end
-        #**##methodParams($method, false)##
-      ) {
-      return delete(#if(${spec.idName})$spec.idName,#end
-          #**##optionalMethodCallArgs($method)##
-      );
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      #**##paramsRequestMap($method)##
+      DeleteRequest<${spec.entityClassName}> request = new DeleteRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          #if(${spec.idName})
+      #**#$spec.idName##
+          #else
+      #**#null##
+          #end
+          );
+      #**##makeRequestAndReturn(
+        "Void",
+        "?",
+        "(Void) null",
+        $withEG
+      )##      
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Void> delete(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName#if( $method.hasParams()),#end
-    #end
-      #**##methodParams($method, true)##
-      ) {
-    #**##paramsRequestMap($method)##
-    DeleteRequest<${spec.entityClassName}> request = new DeleteRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        #if(${spec.idName})
-    #**#$spec.idName##
-        #else
-    #**#null##
-        #end
-        );
-    CompletableFuture<Void> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<?> resp = responseTry.get();
-            if (resp.hasError()) {
-              result.completeExceptionally(resp.getError());
-            } else {
-              result.complete((Void) null);
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
@@ -14,79 +14,71 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<${spec.entityClassName}> get(
+        #if (!${spec.getResource().hasSimple()})
+          $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()|| $withEG),#end
+        #end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<${spec.entityClassName}> get(
       #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()),#end
+        $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
       #end
-        #**##methodParams($method, false)##
-      );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<${spec.entityClassName}> get(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName#if( $method.hasParams()),#end
-    #end
-      #**##methodParams($method, true)##
-      );
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<${spec.entityClassName}> get(
+        #if (!${spec.getResource().hasSimple()})
+          $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()|| $withEG),#end
+        #end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        ) {
+        return get(#if(${spec.idName})${spec.idName},#end
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<${spec.entityClassName}> get(
       #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()),#end
+        $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
       #end
-        #**##methodParams($method, false)##
-      ) {
-      return get(#if(${spec.idName})${spec.idName},#end
-          #**##optionalMethodCallArgs($method)##
-      );
-    }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<${spec.entityClassName}> get(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName#if( $method.hasParams()),#end
-    #end
-      #**##methodParams($method, true)##
-      ) {
-    #**##paramsRequestMap($method)##
-    GetRequest<${spec.entityClassName}> request = new GetRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        ${spec.entityClassName}.class,
-        #if(${spec.idName})
-    #**#$spec.idName##
-        #else
-    #**#null##
-        #end,
-        queryParams,
-        queryParamClasses,
-        _resourceSpec,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS);
-    ## TODO Change this to use custom completion stage.
-    CompletableFuture<${spec.entityClassName}> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<${spec.entityClassName}> resp = responseTry.get();
-            if (resp.hasError()) {
-              result.completeExceptionally(resp.getError());
-            } else {
-              result.complete(resp.getEntity());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      #**##paramsRequestMap($method)##
+      GetRequest<${spec.entityClassName}> request = new GetRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          ${spec.entityClassName}.class,
+          #if(${spec.idName})
+      #**#$spec.idName##
+          #else
+      #**#null##
+          #end,
+          queryParams,
+          queryParamClasses,
+          _resourceSpec,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS);
+      #**##makeRequestAndReturn(
+      ${spec.entityClassName},
+      ${spec.entityClassName},
+      "resp.getEntity()",
+            $withEG
+          )##
+        }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.get_all.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.get_all.vm
@@ -14,58 +14,50 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<CollectionResponse<${spec.entityClassName}>> getAll(#methodParamsWithEGroup($method, false, $withEG)##
+          );
+    #end
+
     #doc($method.schema.doc)
-    public CompletionStage<CollectionResponse<${spec.entityClassName}>> getAll(#methodParams($method, false)##
-         );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<CollectionResponse<${spec.entityClassName}>> getAll(#methodParams($method, true)##
-        );
-
+    public CompletionStage<CollectionResponse<${spec.entityClassName}>> getAll(#methodParamsWithEGroup($method, true, $withEG)##
+          );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
-    #doc($method.schema.doc)
-    public CompletionStage<CollectionResponse<${spec.entityClassName}>> getAll(#methodParams($method, false)##
-         ) {
-      return getAll(#optionalMethodCallArgs($method)##
-          );
-    }
-  #end
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<CollectionResponse<${spec.entityClassName}>> getAll(#methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+        return getAll(#optionalMethodCallArgsWithEGroup($method, $withEG)##
+            );
+      }
+    #end
 
-  #doc($method.schema.doc)
-  public CompletionStage<CollectionResponse<${spec.entityClassName}>> getAll(#methodParams($method, true)##
-        ) {
-    #**##paramsRequestMap($method)##
-    GetAllRequest<${spec.entityClassName}> request = new GetAllRequest<>(
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        ${spec.entityClassName}.class,
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        null);  ## Assoc key will always be null for get_all
-    CompletableFuture<CollectionResponse<${spec.entityClassName}>> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<CollectionResponse<${spec.entityClassName}>> resp = responseTry.get();
-            if (resp.hasError()) {
-              result.completeExceptionally(resp.getError());
-            } else {
-              result.complete(resp.getEntity());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+    #doc($method.schema.doc)
+    public CompletionStage<CollectionResponse<${spec.entityClassName}>> getAll(#methodParamsWithEGroup($method, true, $withEG)##
+          ) {
+      #**##paramsRequestMap($method)##
+      GetAllRequest<${spec.entityClassName}> request = new GetAllRequest<>(
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          ${spec.entityClassName}.class,
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          null);  ## Assoc key will always be null for get_all
+        #**##makeRequestAndReturn(
+        "CollectionResponse<${spec.entityClassName}>",
+        "CollectionResponse<${spec.entityClassName}>",
+        "resp.getEntity()",
+                    $withEG
+                  )##
+    }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
@@ -14,88 +14,81 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Void> partialUpdate(
+        #if (!${spec.getResource().hasSimple()})
+          $spec.keyClassDisplayName $spec.idName,
+        #end
+          PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Void> partialUpdate(
       #if (!${spec.getResource().hasSimple()})
         $spec.keyClassDisplayName $spec.idName,
       #end
-        PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Void> partialUpdate(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName,
-    #end
-      PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+        PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Void> partialUpdate(
+        #if (!${spec.getResource().hasSimple()})
+          $spec.keyClassDisplayName $spec.idName,
+        #end
+          PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        ) {
+        return partialUpdate(#if(${spec.idName})$spec.idName,#end
+            entity,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Void> partialUpdate(
       #if (!${spec.getResource().hasSimple()})
         $spec.keyClassDisplayName $spec.idName,
       #end
-        PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      ) {
-      return partialUpdate(#if(${spec.idName})$spec.idName,#end
+        PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
+      #fillQueryParams($method)
+      #if($method.returnsEntity())
+          #**##returnEntityParam("false")
+      #end
+      PartialUpdateRequest<${spec.entityClassName}> request = new PartialUpdateRequest<>(
           entity,
-          #**##optionalMethodCallArgs($method)##
-      );
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          #if(${spec.idName})
+      #**#$spec.idName##
+          #else
+      #**#null##
+          #end, null);
+      #**##makeRequestAndReturn(
+        "Void",
+        "?",
+        "(Void) null",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Void> partialUpdate(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName,
-    #end
-      PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
-    #fillQueryParams($method)
-    #if($method.returnsEntity())
-        #**##returnEntityParam("false")
-    #end
-    PartialUpdateRequest<${spec.entityClassName}> request = new PartialUpdateRequest<>(
-        entity,
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        #if(${spec.idName})
-    #**#$spec.idName##
-        #else
-    #**#null##
-        #end, null);
-    CompletableFuture<Void> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<?> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete((Void) null);
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
@@ -14,89 +14,82 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
+        #if (!${spec.getResource().hasSimple()})
+            $spec.keyClassDisplayName $spec.idName,
+        #end
+          PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
       #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName,
+        $spec.keyClassDisplayName $spec.idName,
       #end
-        PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName,
-    #end
-      PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      );
+        PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        );
+  #end ## end withEG
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
+        #if (!${spec.getResource().hasSimple()})
+            $spec.keyClassDisplayName $spec.idName,
+        #end
+          PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        ) {
+        return partialUpdateAndGet(#if(${spec.idName})$spec.idName,#end
+            entity,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
       #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName,
+        $spec.keyClassDisplayName $spec.idName,
       #end
-        PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
-      ) {
-      return partialUpdateAndGet(#if(${spec.idName})$spec.idName,#end
+        PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
+        ) {
+      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+      Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
+      #fillQueryParams($method)
+      #**##returnEntityParam("true")
+      @SuppressWarnings("unchecked")
+      EntityResponseDecoder<${spec.entityClassName}> entityResponseDecoder = new EntityResponseDecoder<>(
+          (Class<${spec.entityClassName}>) _resourceSpec.getValueClass());
+      PartialUpdateEntityRequest<${spec.entityClassName}> request = new PartialUpdateEntityRequest<>(
           entity,
-          #**##optionalMethodCallArgs($method)##
-      );
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          entityResponseDecoder,
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          #if(${spec.idName})
+      #**#$spec.idName##
+          #else
+      #**#null##
+          #end,null);
+      #**##makeRequestAndReturn(
+        "${spec.entityClassName}",
+        "${spec.entityClassName}",
+        "resp.getEntity()",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName,
-    #end
-      PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams()),#end
-      #**##methodParams($method, true)##
-      ) {
-    Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-    Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
-    #fillQueryParams($method)
-    #**##returnEntityParam("true")
-    @SuppressWarnings("unchecked")
-    EntityResponseDecoder<${spec.entityClassName}> entityResponseDecoder = new EntityResponseDecoder<>(
-        (Class<${spec.entityClassName}>) _resourceSpec.getValueClass());
-    PartialUpdateEntityRequest<${spec.entityClassName}> request = new PartialUpdateEntityRequest<>(
-        entity,
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        entityResponseDecoder,
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        #if(${spec.idName})
-    #**#$spec.idName##
-        #else
-    #**#null##
-        #end,null);
-    CompletableFuture<${spec.entityClassName}> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<${spec.entityClassName}> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete(response.getEntity());
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
@@ -14,84 +14,77 @@
    limitations under the License.
 *#
 #if($is_interface)
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Void> update(
+          #if (!${spec.getResource().hasSimple()})
+            $spec.keyClassDisplayName $spec.idName,
+          #end
+          ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        );
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Void> update(
-        #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName,
-        #end
-        ${spec.entityClassName} entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+      #if (!${spec.getResource().hasSimple()})
+        $spec.keyClassDisplayName $spec.idName,
+      #end
+      ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
+      #**##methodParamsWithEGroup($method, true, $withEG)##
       );
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Void> update(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName,
-    #end
-    ${spec.entityClassName} entity#if( $method.hasParams()),#end
-    #**##methodParams($method, true)##
-    );
+  #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
-  #if($method.hasOptionalParams() || $method.hasProjectionParams())
+  #foreach($withEG in [true, false])
+    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+      #doc($method.schema.doc)
+      public CompletionStage<Void> update(
+          #if (!${spec.getResource().hasSimple()})
+            $spec.keyClassDisplayName $spec.idName,
+          #end
+          ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, false, $withEG)##
+        ) {
+        return update(#if(${spec.idName})$spec.idName,#end
+            entity,
+            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+        );
+      }
+    #end
+
     #doc($method.schema.doc)
     public CompletionStage<Void> update(
-        #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName,
-        #end
-        ${spec.entityClassName} entity#if($method.hasRequiredParams()),#end
-        #**##methodParams($method, false)##
+      #if (!${spec.getResource().hasSimple()})
+        $spec.keyClassDisplayName $spec.idName,
+      #end
+      ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
+      #**##methodParamsWithEGroup($method, true, $withEG)##
       ) {
-      return update(#if(${spec.idName})$spec.idName,#end
+      #**##paramsRequestMap($method)##
+      UpdateRequest<${spec.entityClassName}> request = new UpdateRequest<>(
           entity,
-          #**##optionalMethodCallArgs($method)##
-      );
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          _resourceSpec,
+          queryParams,
+          queryParamClasses,
+          ORIGINAL_RESOURCE_PATH,
+          buildReadOnlyPathKeys(),
+          RestliRequestOptions.DEFAULT_OPTIONS,
+          #if(${spec.idName})
+      #**#$spec.idName##
+          #else
+      #**#null##
+          #end,
+          null);
+      #**##makeRequestAndReturn(
+        "Void",
+        "?",
+        "(Void) null",
+        $withEG
+      )##
     }
-  #end
-
-  #doc($method.schema.doc)
-  public CompletionStage<Void> update(
-    #if (!${spec.getResource().hasSimple()})
-      $spec.keyClassDisplayName $spec.idName,
-    #end
-    ${spec.entityClassName} entity#if( $method.hasParams()),#end
-    #**##methodParams($method, true)##
-    ) {
-    #**##paramsRequestMap($method)##
-    UpdateRequest<${spec.entityClassName}> request = new UpdateRequest<>(
-        entity,
-        Collections.emptyMap(),
-        Collections.emptyList(),
-        _resourceSpec,
-        queryParams,
-        queryParamClasses,
-        ORIGINAL_RESOURCE_PATH,
-        buildReadOnlyPathKeys(),
-        RestliRequestOptions.DEFAULT_OPTIONS,
-        #if(${spec.idName})
-    #**#$spec.idName##
-        #else
-    #**#null##
-        #end,
-        null);
-    CompletableFuture<Void> result = new CompletableFuture<>();
-    Task<Void> responseTask = _client.createTask(request).transform("Task to completion stage",
-        responseTry -> {
-          if (responseTry.isFailed()) {
-            result.completeExceptionally(responseTry.getError());
-          } else {
-            Response<?> response = responseTry.get();
-            if (response.hasError()) {
-              result.completeExceptionally(response.getError());
-            } else {
-              result.complete((Void) null);
-            }
-          }
-          return Success.of((Void) null);
-        });
-    _engine.run(responseTask);
-    return result;
-  }
+  #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/macros/library.vm
+++ b/restli-tools/src/main/resources/macros/library.vm
@@ -184,16 +184,6 @@
     #end
 #end
 
-#macro(methodParams $method $includeOptional)
-  #set($hasOptionalParams = $includeOptional && ($method.hasOptionalParams() || $method.hasProjectionParams()))
-  #foreach($param in $method.requiredParameters)
-    $param.paramClassDisplayName $param.paramName#if( $foreach.hasNext || $hasOptionalParams),#end
-  #end
-  #if($hasOptionalParams)
-    Function<${util.restMethodToClassPrefix($method.methodName)}OptionalParameters, ${util.restMethodToClassPrefix($method.methodName)}OptionalParameters> optionalParamsProvider
-  #end
-#end
-
 #macro(methodParamsWithEGroup $method $includeOptional $withEG)
   #set($hasOptionalParams = $includeOptional && ($method.hasOptionalParams() || $method.hasProjectionParams()))
   #foreach($param in $method.requiredParameters)
@@ -204,20 +194,6 @@
   #end 
   #if($withEG)ExecutionGroup executionGroup #end
 
-#end
-
-#macro(actionMethodParams $method $includeOptional)
-  #set($hasOptionalParams = $includeOptional && $method.hasOptionalParams())
-  #if(${method.isEntityAction()})
-    $spec.keyClassName $spec.idName,
-  #end
-  #foreach($param in $method.getRequiredParameters())
-    $param.paramClassDisplayName $param.paramName #if($foreach.hasNext || $hasOptionalParams),#end
-  #end
-
-  #if($hasOptionalParams)
-    Function<$actionOptionalParamClassName, $actionOptionalParamClassName> optionalParamsProvider
-  #end
 #end
 
 #macro(actionMethodParamsWithEGroup $method $includeOptional $withEG)
@@ -235,15 +211,6 @@
   #if($withEG)ExecutionGroup executionGroup #end
 #end
 
-#macro(actionMethodProviderParams $method)
-    #if(${method.isEntityAction()})
-    $spec.keyClassName $spec.idName #if(${method.hasActionParams()}),#end
-    #end
-    #if(${method.hasActionParams()})
-    Function<$actionParamClassName, $actionParamClassName> paramsProvider
-    #end
-#end
-
 #macro(actionMethodProviderParamsWithEGroup $method $withEG)
     #set($hasParams = ($method.isEntityAction() || $method.hasActionParams()))
     #if(${method.isEntityAction()})
@@ -258,15 +225,6 @@
 #macro(assocKeyCallArgs $method)
   #foreach($assocKey in $method.assocKeys)
     $assocKey.name#if( $foreach.hasNext || $method.parameters.size() > 0 || $method.hasProjectionParams()),#end
-  #end
-#end
-
-#macro(optionalMethodCallArgs $method)
-  #foreach($param in $method.requiredParameters)
-    $param.paramName#if( $foreach.hasNext || $method.hasOptionalParams() || $method.hasProjectionParams()),#end
-  #end
-  #if(($method.hasOptionalParams() || $method.hasProjectionParams()))
-    Function.identity()
   #end
 #end
 

--- a/restli-tools/src/main/resources/macros/library.vm
+++ b/restli-tools/src/main/resources/macros/library.vm
@@ -191,9 +191,8 @@
   #end
   #if($hasOptionalParams)
     Function<${util.restMethodToClassPrefix($method.methodName)}OptionalParameters, ${util.restMethodToClassPrefix($method.methodName)}OptionalParameters> optionalParamsProvider #if($withEG),#end
-  #end 
+  #end
   #if($withEG)ExecutionGroup executionGroup #end
-
 #end
 
 #macro(actionMethodParamsWithEGroup $method $includeOptional $withEG)
@@ -207,7 +206,7 @@
 
   #if($hasOptionalParams)
     Function<$actionOptionalParamClassName, $actionOptionalParamClassName> optionalParamsProvider #if($withEG), #end
-  #end 
+  #end
   #if($withEG)ExecutionGroup executionGroup #end
 #end
 
@@ -234,7 +233,7 @@
   #end
   #if(($method.hasOptionalParams() || $method.hasProjectionParams()))
     Function.identity() #if($withEG), #end
-  #end 
+  #end
   #if($withEG) executionGroup #end
 #end
 

--- a/restli-tools/src/main/resources/macros/library.vm
+++ b/restli-tools/src/main/resources/macros/library.vm
@@ -194,6 +194,67 @@
   #end
 #end
 
+#macro(methodParamsWithEGroup $method $includeOptional $withEG)
+  #set($hasOptionalParams = $includeOptional && ($method.hasOptionalParams() || $method.hasProjectionParams()))
+  #foreach($param in $method.requiredParameters)
+    $param.paramClassDisplayName $param.paramName#if( $foreach.hasNext || ($hasOptionalParams || $withEG)),#end
+  #end
+  #if($hasOptionalParams)
+    Function<${util.restMethodToClassPrefix($method.methodName)}OptionalParameters, ${util.restMethodToClassPrefix($method.methodName)}OptionalParameters> optionalParamsProvider #if($withEG),#end
+  #end 
+  #if($withEG)ExecutionGroup executionGroup #end
+
+#end
+
+#macro(actionMethodParams $method $includeOptional)
+  #set($hasOptionalParams = $includeOptional && $method.hasOptionalParams())
+  #if(${method.isEntityAction()})
+    $spec.keyClassName $spec.idName,
+  #end
+  #foreach($param in $method.getRequiredParameters())
+    $param.paramClassDisplayName $param.paramName #if($foreach.hasNext || $hasOptionalParams),#end
+  #end
+
+  #if($hasOptionalParams)
+    Function<$actionOptionalParamClassName, $actionOptionalParamClassName> optionalParamsProvider
+  #end
+#end
+
+#macro(actionMethodParamsWithEGroup $method $includeOptional $withEG)
+  #set($hasOptionalParams = $includeOptional && $method.hasOptionalParams())
+  #if(${method.isEntityAction()})
+    $spec.keyClassName $spec.idName,
+  #end
+  #foreach($param in $method.getRequiredParameters())
+    $param.paramClassDisplayName $param.paramName #if($foreach.hasNext || ($hasOptionalParams || $withEG)),#end
+  #end
+
+  #if($hasOptionalParams)
+    Function<$actionOptionalParamClassName, $actionOptionalParamClassName> optionalParamsProvider #if($withEG), #end
+  #end 
+  #if($withEG)ExecutionGroup executionGroup #end
+#end
+
+#macro(actionMethodProviderParams $method)
+    #if(${method.isEntityAction()})
+    $spec.keyClassName $spec.idName #if(${method.hasActionParams()}),#end
+    #end
+    #if(${method.hasActionParams()})
+    Function<$actionParamClassName, $actionParamClassName> paramsProvider
+    #end
+#end
+
+#macro(actionMethodProviderParamsWithEGroup $method $withEG)
+    #set($hasParams = ($method.isEntityAction() || $method.hasActionParams()))
+    #if(${method.isEntityAction()})
+    $spec.keyClassName $spec.idName #if(${method.hasActionParams()} || $withEG),#end
+    #end
+    #if(${method.hasActionParams()})
+    Function<$actionParamClassName, $actionParamClassName> paramsProvider #if($withEG), #end
+    #end
+    #if($withEG)ExecutionGroup executionGroup #end
+#end
+
 #macro(assocKeyCallArgs $method)
   #foreach($assocKey in $method.assocKeys)
     $assocKey.name#if( $foreach.hasNext || $method.parameters.size() > 0 || $method.hasProjectionParams()),#end
@@ -207,6 +268,16 @@
   #if(($method.hasOptionalParams() || $method.hasProjectionParams()))
     Function.identity()
   #end
+#end
+
+#macro(optionalMethodCallArgsWithEGroup $method $withEG)
+  #foreach($param in $method.requiredParameters)
+    $param.paramName#if( $foreach.hasNext || ($method.hasOptionalParams() || $method.hasProjectionParams() || $withEG)),#end
+  #end
+  #if(($method.hasOptionalParams() || $method.hasProjectionParams()))
+    Function.identity() #if($withEG), #end
+  #end 
+  #if($withEG) executionGroup #end
 #end
 
 #macro(pagingParams $method)
@@ -248,6 +319,35 @@
 #macro(returnEntityParam $value)
 #**#queryParams.put(RestConstants.RETURN_ENTITY_PARAM, $value);
     queryParamClasses.put(RestConstants.RETURN_ENTITY_PARAM, Boolean.class);
+#end
+
+#macro(makeRequestAndReturn $returnClassName, $responseType, $resposneEntity, $withEG)
+#**#
+Task<$returnClassName> responseTask = _client.createTask(request).transform("Task to completion stage",
+    responseTry -> {
+      if (responseTry.isFailed()) {
+        return Failure.of(responseTry.getError());
+      } else {
+        Response<$responseType> resp = responseTry.get();
+        if (resp.hasError()) {
+          return Failure.of(resp.getError());
+        } else {
+          return Success.of($resposneEntity);
+        }
+      }
+    });
+    #if(!$withEG)
+    ExecutionGroup executionGroup = this.getExecutionGroupFromContext();
+    #end
+    if (executionGroup == null)
+    {
+      return _completionStageFactory.buildStageFromTaskToRun(responseTask);
+    }
+    else
+    {
+      executionGroup.addTaskByFluentClient(this, responseTask);
+      return _completionStageFactory.buildStageFromTask(responseTask);
+    }
 #end
 
 #macro(subResourceInterface $spec)

--- a/restli-tools/src/main/resources/macros/library.vm
+++ b/restli-tools/src/main/resources/macros/library.vm
@@ -177,8 +177,8 @@
   #end
 #end
 
-#macro(assocKeyParams $method $includeOptional)
-    #set($hasMoreParams = $method.hasRequiredParams() || ($includeOptional && ($method.hasOptionalParams() || $method.hasProjectionParams())))
+#macro(assocKeyParams $method $includeOptional $withEG)
+    #set($hasMoreParams = $method.hasRequiredParams() || ($includeOptional && ($method.hasOptionalParams() || $method.hasProjectionParams())) || $withEG)
     #foreach($assocKey in $method.assocKeys)
       $assocKey.declaredType $assocKey.name#if( $foreach.hasNext || $hasMoreParams),#end
     #end


### PR DESCRIPTION
- Integrated the execution group into the template
- The FluentClient interface has been renamed to ParSeqBasedFluentClient