### PR TITLE
Support for skipping subproject tests via properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ project.ext {
   isDefaultEnvironment = !project.hasProperty('overrideBuildEnvironment')
   privateModules = ['d2-benchmark', 'd2-int-test', 'generator-test', 'log-test-config', 'r2-int-test',
                      'r2-perf-test', 'restli-internal-testutils'] as Set
+  skipTestsForSubprojects = (project.findProperty('pegasus.skipTestsForSubprojects') ?: '').split(',') as Set
 }
 
 File getEnvironmentScript()
@@ -236,10 +237,6 @@ subprojects {
       maven {
         url "https://linkedin.jfrog.io/artifactory/maven-bintray-temp"
       }
-      // TODO: Remove once Bintray is down for good
-      maven {
-        url "https://dl.bintray.com/linkedin/maven"
-      }
     }
 
     task sourcesJar(type: Jar, dependsOn: classes) {
@@ -396,6 +393,14 @@ subprojects {
       commandLine = ['mkdir','-p', dir]
       workingDir = file(rootDir.toString())
     }
+  }
+
+  // Disable tests for specific subprojects if requested
+  if (project.name in rootProject.ext.skipTestsForSubprojects) {
+    project.tasks.withType(Test) {
+      enabled = false
+    }
+    logger.lifecycle "Tests for subproject ${project.name} will be skipped."
   }
 }
 

--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -7,10 +7,6 @@ subprojects {
     maven {
       url "https://linkedin.jfrog.io/artifactory/maven-bintray-temp"
     }
-    // TODO: Remove once Bintray is down for good
-    maven {
-      url  "https://dl.bintray.com/linkedin/maven"
-    }
   }
 
   project.buildDir = new File(project.rootProject.buildDir, project.name)

--- a/scripts/get-module-dependencies
+++ b/scripts/get-module-dependencies
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# The purpose of this script is to get the inter-module dependencies of some subproject for the testRuntimeClasspath configuration
+
+# Ensure that the script is being run from the root project directory
+PROPERTIES_FILE='gradle.properties'
+if [ ! -f "$PROPERTIES_FILE" ]; then
+  echo "Could not find $PROPERTIES_FILE, please run this script from the root project directory."
+  exit 2
+fi
+
+if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
+  cat ./scripts/help-text/get-module-dependencies.txt
+  exit 0
+fi
+
+while [ $# -gt 0 ]; do
+  if [ "$1" = '-h' ] || [ "$1" = '--help' ]; then
+    cat ./scripts/help-text/get-module-dependencies.txt
+    exit 0
+  else
+    TARGET_MODULE="$1"
+    shift
+    TARGET_CONFIGURATION="$1"
+  fi
+  shift
+done
+
+if [ -z "$TARGET_MODULE" ] || [ -z "$TARGET_CONFIGURATION" ]; then
+  cat ./scripts/help-text/get-module-dependencies.txt
+  exit 2
+fi
+
+set -o pipefail
+set -e
+
+./gradlew :$TARGET_MODULE:dependencies --configuration $TARGET_CONFIGURATION 2> /dev/null | grep '\-\-\- project' | sed 's/.\+\-\-\- project :\(\S\+\).*/\1/' | sort -u

--- a/scripts/help-text/get-module-dependencies.txt
+++ b/scripts/help-text/get-module-dependencies.txt
@@ -1,0 +1,10 @@
+Usage: ./scripts/get-module-dependencies [OPTION]... MODULE CONFIGURATION
+Calculates the inter-module dependencies for a given module (i.e. subproject) for a given configuration
+(e.g. compile, testRuntimeClasspath). This script must be run from the root project directory.
+
+Options:
+  -h, --help                    print this help text and exit
+
+Examples:
+  ./scripts/get-module-dependencies data testRuntimeClasspath
+                                print the modules which :data depends on in the testRuntimeClasspath configuration


### PR DESCRIPTION
When building pegasus, a comma-separated list provided as project property `pegasus.skipTestsForSubprojects` will be read and used to determine which subproject's tests to skip. For now, this is only applied to `r2-int-test` if none of `r2-int-test`'s test dependencies are touched.

I also sequentially ran the tests for each subproject to see which one takes the most time, the results are pretty interesting...

`r2-int-test` has by far the most lengthy tests at 28 minutes, `restli-int-test` in second at 12 minutes, and `d2` in third at around 5 minutes. Most everything else is around or below one minute.

(Note: The results of this test could probably be made more accurate by cleaning build artifacts before each run... but oh well)

```
(1/63) -> d2
BUILD SUCCESSFUL in 4m 51s
(2/63) -> d2-benchmark
BUILD SUCCESSFUL in 10s
(3/63) -> d2-contrib
BUILD SUCCESSFUL in 20s
(4/63) -> d2-int-test
BUILD SUCCESSFUL in 1m 20s
(5/63) -> d2-schemas
BUILD SUCCESSFUL in 6s
(6/63) -> d2-test-api
BUILD SUCCESSFUL in 7s
(7/63) -> darkcluster
BUILD SUCCESSFUL in 15s
(8/63) -> darkcluster-test-api
BUILD SUCCESSFUL in 9s
(9/63) -> data
BUILD SUCCESSFUL in 1m 12s
(10/63) -> data-avro
BUILD SUCCESSFUL in 9s
(11/63) -> data-avro-1_6
BUILD SUCCESSFUL in 10s
(12/63) -> data-avro-generator
BUILD SUCCESSFUL in 7s
(13/63) -> data-testutils
BUILD SUCCESSFUL in 6s
(14/63) -> data-transform
BUILD SUCCESSFUL in 17s
(15/63) -> degrader
BUILD SUCCESSFUL in 5s
(16/63) -> entity-stream
BUILD SUCCESSFUL in 4s
(17/63) -> generator
BUILD SUCCESSFUL in 8s
(18/63) -> generator-test
BUILD SUCCESSFUL in 19s
(19/63) -> gradle-plugins
BUILD SUCCESSFUL in 53s
(20/63) -> li-jersey-uri
BUILD SUCCESSFUL in 3s
(21/63) -> li-protobuf
BUILD SUCCESSFUL in 1s
(22/63) -> log-test-config
BUILD SUCCESSFUL in 1s
(23/63) -> multipart-mime
BUILD SUCCESSFUL in 1m 12s
(24/63) -> pegasus-all
BUILD SUCCESSFUL in 40s
(25/63) -> pegasus-common
BUILD SUCCESSFUL in 4s
(26/63) -> r2
BUILD SUCCESSFUL in 5s
(27/63) -> r2-core
BUILD SUCCESSFUL in 1m 57s
(28/63) -> r2-disruptor
BUILD SUCCESSFUL in 7s
(29/63) -> r2-filter-compression
BUILD SUCCESSFUL in 16s
(30/63) -> r2-int-test
BUILD SUCCESSFUL in 28m 22s
(31/63) -> r2-jetty
BUILD SUCCESSFUL in 4s
(32/63) -> r2-netty
BUILD SUCCESSFUL in 49s
(33/63) -> r2-perf-test
BUILD SUCCESSFUL in 5s
(34/63) -> r2-sample
BUILD SUCCESSFUL in 5s
(35/63) -> r2-testutils
BUILD SUCCESSFUL in 4s
(36/63) -> restli-client
BUILD SUCCESSFUL in 41s
(37/63) -> restli-client-parseq
BUILD SUCCESSFUL in 21s
(38/63) -> restli-client-testutils
BUILD SUCCESSFUL in 20s
(39/63) -> restli-client-util-recorder
BUILD SUCCESSFUL in 22s
(40/63) -> restli-common
BUILD SUCCESSFUL in 20s
(41/63) -> restli-common-testutils
BUILD SUCCESSFUL in 20s
(42/63) -> restli-contrib-spring
BUILD SUCCESSFUL in 1s
(43/63) -> restli-disruptor
BUILD SUCCESSFUL in 9s
(44/63) -> restli-docgen
BUILD SUCCESSFUL in 11s
(45/63) -> restli-example-api
BUILD SUCCESSFUL in 11s
(46/63) -> restli-example-client
BUILD SUCCESSFUL in 15s
(47/63) -> restli-example-server
BUILD SUCCESSFUL in 14s
(48/63) -> restli-extras
BUILD SUCCESSFUL in 14s
(49/63) -> restli-guice-bridge
BUILD SUCCESSFUL in 8s
(50/63) -> restli-internal-testutils
BUILD SUCCESSFUL in 8s
(51/63) -> restli-int-test
BUILD SUCCESSFUL in 12m 35s
(52/63) -> restli-int-test-api
BUILD SUCCESSFUL in 25s
(53/63) -> restli-int-test-client
BUILD SUCCESSFUL in 29s
(54/63) -> restli-int-test-server
BUILD SUCCESSFUL in 35s
(55/63) -> restli-netty-standalone
BUILD SUCCESSFUL in 9s
(56/63) -> restli-server
BUILD SUCCESSFUL in 33s
(57/63) -> restli-server-extras
BUILD SUCCESSFUL in 11s
(58/63) -> restli-server-standalone
BUILD SUCCESSFUL in 9s
(59/63) -> restli-server-testutils
BUILD SUCCESSFUL in 22s
(60/63) -> restli-spring-bridge
BUILD SUCCESSFUL in 7s
(61/63) -> restli-tools
BUILD SUCCESSFUL in 21s
(62/63) -> test-util
BUILD SUCCESSFUL in 1s
(63/63) -> tools
```