### PR TITLE
Remove JFrog Bintray backup from Maven repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,9 +234,6 @@ subprojects {
       maven {
         url "https://linkedin.jfrog.io/artifactory/open-source"
       }
-      maven {
-        url "https://linkedin.jfrog.io/artifactory/maven-bintray-temp"
-      }
     }
 
     task sourcesJar(type: Jar, dependsOn: classes) {

--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -4,9 +4,6 @@ subprojects {
     maven {
       url "https://linkedin.jfrog.io/artifactory/open-source"
     }
-    maven {
-      url "https://linkedin.jfrog.io/artifactory/maven-bintray-temp"
-    }
   }
 
   project.buildDir = new File(project.rootProject.buildDir, project.name)


### PR DESCRIPTION
We had to add both LinkedIn's JFrog repo in addition to LinkedIn's JFrog
repo for Bintray backups, but the main JFrog repo was recently
configured to also act as a view into the backups repo. Thus, we no
longer need to explicitly reference the backup repo.