### PR TITLE
Make the build fail fast in CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,6 +303,8 @@ subprojects {
           it.options.excludeGroups 'ci-flaky'
         }
         it.systemProperties['test.httpRequestTimeout'] = '20000'
+        // Make the build fail fast in CI (may have unintended consequences locally)
+        it.failFast = true
       }
     }
   }


### PR DESCRIPTION
Since our build is parallel and has some lengthy test suites, failing fast can help to free up the Travis CI environment.

This is disabled locally for now since we're not sure if there are unintended consequences in aborting like this. Perhaps aborting while code generation is going on could be problematic? Since the Travis build is a clean checkout, it doesn't matter as much. (I haven't done any research at all on the danger here, but doing it this way just to be safe).