### PR TITLE
Fix bug in generated fluent client APIs when typerefs are used as association key params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Fix bug in generated fluent client APIs when typerefs are used as association key params
 
 ## [29.18.1] - 2021-04-22
 - Add fluent client API for FINDER and BATCH_FINDER methods.

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/CustomTypesResource3.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/CustomTypesResource3.java
@@ -17,6 +17,7 @@
 package com.linkedin.restli.examples.greetings.server;
 
 
+import com.linkedin.restli.examples.greetings.api.Tone;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -83,7 +84,9 @@ public class CustomTypesResource3 extends AssociationResourceTemplate<Greeting>
   @Finder("dateOnly")
   public List<Greeting> dateOnly(@AssocKeyParam(value="dateId", typeref=DateRef.class) Date dateId)
   {
-    return Collections.emptyList();
+    return Collections.singletonList(new Greeting().setId(dateId.getTime())
+        .setMessage("date Only finder")
+        .setTone(Tone.FRIENDLY));
   }
 
 }

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestCustomTypesClient.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestCustomTypesClient.java
@@ -429,7 +429,7 @@ public class TestCustomTypesClient extends RestLiIntegrationTest
     Request<CollectionResponse<Greeting>> request = builders.findBy("DateOnly").setPathKey("dateId", new Date(13L)).build();
     List<Greeting> response = getClient().sendRequest(request).getResponse().getEntity().getElements();
 
-    Assert.assertEquals(response.size(), 0);
+    Assert.assertEquals(response.size(), 1);
   }
 
   @DataProvider(name = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestOptionsDataProvider")

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParseqBasedFluentClientApi.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParseqBasedFluentClientApi.java
@@ -40,7 +40,6 @@ import com.linkedin.restli.common.UpdateStatus;
 import com.linkedin.restli.examples.custom.types.CustomLong;
 import com.linkedin.restli.examples.greetings.api.Greeting;
 import com.linkedin.restli.examples.greetings.api.GreetingCriteria;
-import com.linkedin.restli.examples.greetings.api.GreetingCriteriaArray;
 import com.linkedin.restli.examples.greetings.api.Message;
 import com.linkedin.restli.examples.greetings.api.MessageCriteria;
 import com.linkedin.restli.examples.greetings.api.MessageCriteriaArray;
@@ -54,15 +53,16 @@ import com.linkedin.restli.examples.greetings.client.AssociationsAssociationsSub
 import com.linkedin.restli.examples.greetings.client.AssociationsFluentClient;
 import com.linkedin.restli.examples.greetings.client.AssociationsSubFluentClient;
 import com.linkedin.restli.examples.greetings.client.Batchfinders;
-import com.linkedin.restli.examples.greetings.client.ComplexKeys;
-import com.linkedin.restli.examples.greetings.client.BatchGreetingFluentClient;
 import com.linkedin.restli.examples.greetings.client.BatchfindersFluentClient;
+import com.linkedin.restli.examples.greetings.client.ComplexKeys;
 import com.linkedin.restli.examples.greetings.client.ComplexKeysFluentClient;
 import com.linkedin.restli.examples.greetings.client.ComplexKeysSubFluentClient;
 import com.linkedin.restli.examples.greetings.client.CreateGreeting;
 import com.linkedin.restli.examples.greetings.client.CreateGreetingFluentClient;
 import com.linkedin.restli.examples.greetings.client.CustomTypes2;
 import com.linkedin.restli.examples.greetings.client.CustomTypes2FluentClient;
+import com.linkedin.restli.examples.greetings.client.CustomTypes3;
+import com.linkedin.restli.examples.greetings.client.CustomTypes3FluentClient;
 import com.linkedin.restli.examples.greetings.client.GreetingFluentClient;
 import com.linkedin.restli.examples.greetings.client.Greetings;
 import com.linkedin.restli.examples.greetings.client.GreetingsFluentClient;
@@ -74,6 +74,7 @@ import com.linkedin.restli.examples.groups.client.Groups;
 import com.linkedin.restli.examples.groups.client.GroupsFluentClient;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -757,6 +758,17 @@ public class TestParseqBasedFluentClientApi extends RestLiIntegrationTest
     {
       Assert.assertEquals(message.getId(), AssociationResourceHelpers.URL_MESSAGE.getId());
     }
+  }
+
+  @Test
+  public void testAssociationFinderUsingCustomAssocKey() throws Exception
+  {
+    CustomTypes3 customTypesResource3 =
+        new CustomTypes3FluentClient(_parSeqRestliClient, _parSeqUnitTestHelper.getEngine());
+
+    CollectionResponse<Greeting> greetings =
+        customTypesResource3.findByDateOnly(new Date()).toCompletableFuture().get(5000, TimeUnit.MILLISECONDS);
+    Assert.assertTrue(greetings.getElements().size() > 0);
   }
 
   @Test

--- a/restli-tools/src/main/resources/macros/library.vm
+++ b/restli-tools/src/main/resources/macros/library.vm
@@ -180,7 +180,7 @@
 #macro(assocKeyParams $method $includeOptional $withEG)
     #set($hasMoreParams = $method.hasRequiredParams() || ($includeOptional && ($method.hasOptionalParams() || $method.hasProjectionParams())) || $withEG)
     #foreach($assocKey in $method.assocKeys)
-      $assocKey.declaredType $assocKey.name#if( $foreach.hasNext || $hasMoreParams),#end
+      $assocKey.bindingType $assocKey.name#if( $foreach.hasNext || $hasMoreParams),#end
     #end
 #end
 


### PR DESCRIPTION
Fix bug in generated fluent client APIs when typerefs are used as association key params