### PR TITLE
Add APIs with assock key param fluentapi

### DIFF
--- a/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.associations.restspec.json
+++ b/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.associations.restspec.json
@@ -47,6 +47,10 @@
     } ],
     "entity" : {
       "path" : "/associations/{associationsId}",
+      "actions" : [ {
+        "name" : "testAction",
+        "returns" : "string"
+      } ],
       "subresources" : [ {
         "name" : "associationsAssociations",
         "namespace" : "com.linkedin.restli.examples.greetings.client",

--- a/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.associations.snapshot.json
+++ b/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.associations.snapshot.json
@@ -87,6 +87,10 @@
       } ],
       "entity" : {
         "path" : "/associations/{associationsId}",
+        "actions" : [ {
+          "name" : "testAction",
+          "returns" : "string"
+        } ],
         "subresources" : [ {
           "name" : "associationsAssociations",
           "namespace" : "com.linkedin.restli.examples.greetings.client",

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/AssociationsResource.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/AssociationsResource.java
@@ -33,8 +33,10 @@ import com.linkedin.restli.server.BatchUpdateResult;
 import com.linkedin.restli.server.CollectionResult;
 import com.linkedin.restli.server.CreateResponse;
 import com.linkedin.restli.server.PagingContext;
+import com.linkedin.restli.server.ResourceLevel;
 import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.server.UpdateResponse;
+import com.linkedin.restli.server.annotations.Action;
 import com.linkedin.restli.server.annotations.AssocKeyParam;
 import com.linkedin.restli.server.annotations.BatchFinder;
 import com.linkedin.restli.server.annotations.Finder;
@@ -165,4 +167,11 @@ public class AssociationsResource extends AssociationResourceTemplate<Message>
 
     return batchFinderResult;
   }
+
+  @Action(name = "testAction", resourceLevel = ResourceLevel.ENTITY)
+  public String testAction()
+  {
+    return "Hello!";
+  }
+
 }

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/altkey/AltKeyDataProvider.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/altkey/AltKeyDataProvider.java
@@ -46,6 +46,10 @@ public class AltKeyDataProvider
     key2.append("message", "b");
     key2.append("greetingId", 2L);
 
+    CompoundKey key3 = new CompoundKey();
+    key3.append("message", "c");
+    key3.append("greetingId", 3L);
+
     Greeting greeting1 = new Greeting();
     greeting1.setTone(Tone.INSULTING);
     greeting1.setId(1l);
@@ -56,10 +60,20 @@ public class AltKeyDataProvider
     greeting2.setId(2l);
     greeting2.setMessage("b");
 
+    Greeting greeting3 = new Greeting();
+    greeting3.setTone(Tone.FRIENDLY);
+    greeting3.setId(3l);
+    greeting3.setMessage("c");
+
     _db1.put(1L, greeting1);
     _db1.put(2L, greeting2);
     _db2.put(key1, greeting1);
     _db2.put(key2, greeting2);
+    _db2.put(key3, greeting3);
+  }
+  private void create(CompoundKey id, Greeting entity)
+  {
+    _db2.put(id, entity);
   }
 
   public Greeting get(Long id)

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/altkey/AssociationAltKeyResource.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/altkey/AssociationAltKeyResource.java
@@ -28,6 +28,7 @@ import com.linkedin.restli.server.CreateResponse;
 import com.linkedin.restli.server.ResourceLevel;
 import com.linkedin.restli.server.UpdateResponse;
 import com.linkedin.restli.server.annotations.Action;
+import com.linkedin.restli.server.annotations.ActionParam;
 import com.linkedin.restli.server.annotations.AlternativeKey;
 import com.linkedin.restli.server.annotations.Key;
 import com.linkedin.restli.server.annotations.RestLiAssociation;
@@ -108,6 +109,7 @@ public class AssociationAltKeyResource extends AssociationResourceTemplate<Greet
       return new UpdateResponse(HttpStatus.S_400_BAD_REQUEST);
     }
 
+    update(key, g);
     return new UpdateResponse(HttpStatus.S_204_NO_CONTENT);
   }
 

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParseqBasedFluentClientApi.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestParseqBasedFluentClientApi.java
@@ -804,10 +804,10 @@ public class TestParseqBasedFluentClientApi extends RestLiIntegrationTest
 
     // Get
     AssociationAltKey client = new AssociationAltKeyFluentClient(_parSeqRestliClient, _parSeqUnitTestHelper.getEngine());
-    String msgKey = "a";
-    Long longKey = 1L;
+    String msgKey = "c";
+    Long longKey = 3L;
     Greeting res = client.get(longKey, msgKey).toCompletableFuture().get(5000, TimeUnit.MILLISECONDS);
-    Assert.assertEquals(res.getTone(), Tone.INSULTING);
+    Assert.assertEquals(res.getTone(), Tone.FRIENDLY);
     Assert.assertEquals(res.getMessage(), msgKey);
 
     // Update
@@ -836,6 +836,8 @@ public class TestParseqBasedFluentClientApi extends RestLiIntegrationTest
     {
       Assert.assertEquals(((RestLiResponseException) e.getCause()).getStatus(), 404);
     }
+
+    // Action
     Assert.assertEquals(client.testAction(longKey, msgKey)
         .toCompletableFuture().get(5000, TimeUnit.MILLISECONDS), "Hello!");
   }

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/MethodSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/MethodSpec.java
@@ -208,5 +208,15 @@ public abstract class MethodSpec
   {
     return getSupportedProjectionParams().size() > 0;
   }
+
+  public List<CompoundKeySpec.AssocKeySpec> getAssocKeys()
+  {
+    if (_resourceSpec instanceof AssociationResourceSpec)
+    {
+      return new ArrayList<>(((AssociationResourceSpec) _resourceSpec).getCompoundKeySpec().getAssocKeySpecs());
+    }
+
+    return Collections.emptyList();
+  }
 }
 

--- a/restli-tools/src/main/resources/apiVmTemplates/action.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/action.vm
@@ -48,7 +48,7 @@ Copyright (c) 2021 LinkedIn Corp.
         );
 
         #end ## end if showTemplate
-      #end ## foreach checkAssoc
+      #end ## foreach flattenAssocKey
     #end ## end withEG
     #if(${method.hasActionParams()})
       #actionAllParamClass($method)
@@ -162,7 +162,7 @@ Copyright (c) 2021 LinkedIn Corp.
               )##
           }
         #end ## end if show template
-      #end ## foreach checkAssoc
+      #end ## foreach flattenAssocKey
     #end ## foreach method
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/action.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/action.vm
@@ -16,27 +16,39 @@ Copyright (c) 2021 LinkedIn Corp.
 #if($is_interface)
   #foreach($method in $spec.actions)
     #foreach($withEG in [true, false])
-      #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
-      #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
-      #doc($method.schema.doc)
+      #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+        #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+        #if ($showTemplate) 
+          #define($keyStubNoOptional)
+            #actionMethodParamsWithEGroup($method, false, $withEG, $checkAssoc)
+          #end ## end define
+          #define($keyStubWithOptional)
+            #actionMethodParamsWithEGroup($method, true, $withEG, $checkAssoc)
+          #end ## end define
 
-      #if(${method.hasRequiredParams()}) ## action with no required Params will only have one API
-        #if($method.hasOptionalParams()) ## when have optional params, the optionalParamsProvider is optional
+        #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
+        #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
+        #doc($method.schema.doc)
+        #if(${method.hasRequiredParams()}) ## action with no required Params will only have one API
+          #if($method.hasOptionalParams()) ## when have optional params, the optionalParamsProvider is optional
+            @SuppressWarnings("unchecked")
+            public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
+              $keyStubNoOptional
+            );
+          #end ## end hasOptionalParams
           @SuppressWarnings("unchecked")
           public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-            #actionMethodParamsWithEGroup($method, false, $withEG)##
+              $keyStubWithOptional 
           );
-        #end ## end hasOptionalParams
+        #end ## end hasRequiredParams
+
         @SuppressWarnings("unchecked")
         public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-            #actionMethodParamsWithEGroup($method, true, $withEG)##
+          #actionMethodProviderParamsWithEGroup($method, $withEG, $checkAssoc)##
         );
-      #end ## end hasRequiredParams
 
-      @SuppressWarnings("unchecked")
-      public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-        #actionMethodProviderParamsWithEGroup($method, $withEG)##
-      );
+        #end ## end if showTemplate
+      #end ## foreach checkAssoc
     #end ## end withEG
     #if(${method.hasActionParams()})
       #actionAllParamClass($method)
@@ -48,94 +60,109 @@ Copyright (c) 2021 LinkedIn Corp.
 #else ## is_interface
   #foreach($withEG in [true, false])
     #foreach($method in $spec.actions)
-      #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
-      #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
-      #doc($method.schema.doc)
+      #setIsEntityActionIdNeeded($method)
+      #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+        #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+        #if ($showTemplate)
+          #define($keyStubNoOptional)
+            #actionMethodParamsWithEGroup($method, false, $withEG, $checkAssoc)
+          #end ## end define
+          #define($keyStubWithOptional)
+            #actionMethodParamsWithEGroup($method, true, $withEG, $checkAssoc)
+          #end ## end define
+        #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
+        #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
+        #doc($method.schema.doc)
 
-      #if(${method.hasRequiredParams()}) ## action with no required Params will only have one API
-        #if($method.hasOptionalParams()) ## when have optional params, the optionalParamsProvider is optional
+        #if(${method.hasRequiredParams()}) ## action with no required Params will only have one API
+          #if($method.hasOptionalParams()) ## when have optional params, the optionalParamsProvider is optional
+            @SuppressWarnings("unchecked")
+            public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
+              $keyStubNoOptional
+            )
+            {
+              #generateAssocKeyAsId($spec, $method, $checkAssoc)
+              return ${util.nameCamelCase(${method.name})}(
+                #if($isEntityActionIdNeeded)
+                $spec.idName,
+                #end
+                #foreach($param in $method.getRequiredParameters())
+                  $param.paramName #if($foreach.hasNext),#end
+                #end,
+                Function.identity() #if($withEG), executionGroup #end
+              )
+              ;
+            }
+          #end ## end hasOptionalParams
           @SuppressWarnings("unchecked")
           public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-            #actionMethodParamsWithEGroup($method, false, $withEG)##
+            $keyStubWithOptional
           )
           {
+            #generateAssocKeyAsId($spec, $method, $checkAssoc)
+            #if(${method.hasOptionalParams()})
+            $actionOptionalParamClassName optionalParams = optionalParamsProvider.apply(new $actionOptionalParamClassName());
+            #end
             return ${util.nameCamelCase(${method.name})}(
-              #if(${method.isEntityAction()})
+              #if($isEntityActionIdNeeded)
               $spec.idName,
               #end
-              #foreach($param in $method.getRequiredParameters())
-                $param.paramName #if($foreach.hasNext),#end
-              #end,
-              Function.identity() #if($withEG), executionGroup #end
+              paramProvider -> paramProvider
+              #foreach($param in ${method.getRequiredParameters()})
+              .set${param.paramNameCaps}($param.paramName)
+              #end
+              #foreach($param in ${method.getOptionalParameters()})
+              .set${param.paramNameCaps}(optionalParams.get${param.paramNameCaps}())
+              #end #if($withEG), executionGroup #end
             )
             ;
           }
-        #end ## end hasOptionalParams
+        #end ## end hasRequiredParams
+
         @SuppressWarnings("unchecked")
         public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-          #actionMethodParamsWithEGroup($method, true, $withEG)##
+          #actionMethodProviderParamsWithEGroup($method, $withEG, $checkAssoc)##
         )
         {
-          #if(${method.hasOptionalParams()})
-          $actionOptionalParamClassName optionalParams = optionalParamsProvider.apply(new $actionOptionalParamClassName());
-          #end
-          return ${util.nameCamelCase(${method.name})}(
-            #if(${method.isEntityAction()})
-            $spec.idName,
-            #end
-            paramProvider -> paramProvider
-            #foreach($param in ${method.getRequiredParameters()})
-            .set${param.paramNameCaps}($param.paramName)
-            #end
-            #foreach($param in ${method.getOptionalParameters()})
-            .set${param.paramNameCaps}(optionalParams.get${param.paramNameCaps}())
-            #end #if($withEG), executionGroup #end
-          )
-          ;
+          RecordDataSchema requestDataSchema =  _resourceSpec.getRequestMetadata("${method.name}").getRecordDataSchema();
+          RecordDataSchema actionResponseDataSchema = _resourceSpec.getActionResponseMetadata("${method.name}").getRecordDataSchema();
+          FieldDef<${method.valueClassDisplayName}> responseFieldDef = (FieldDef<${method.valueClassDisplayName}>)_resourceSpec.getActionResponseMetadata("${method.name}").getFieldDef(ActionResponse.VALUE_NAME);
+
+          ActionResponseDecoder<${method.valueClassDisplayName}> actionResponseDecoder =
+              new ActionResponseDecoder<${method.valueClassDisplayName}>(responseFieldDef, actionResponseDataSchema);
+          DynamicRecordTemplate inputParameters =
+              new DynamicRecordTemplate(requestDataSchema,
+              #if(${method.hasActionParams()})
+                paramsProvider.apply(new $actionParamClassName()).buildParametersMap(_resourceSpec));
+              #else
+                Collections.emptyMap());
+              #end
+          inputParameters.data().setReadOnly();
+          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          ActionRequest<${method.valueClassDisplayName}> request = new ActionRequest<${method.valueClassDisplayName}>(inputParameters,
+                                      Collections.emptyMap(),
+                                      Collections.emptyList(),
+                                      actionResponseDecoder,
+                                      _resourceSpec,
+                                      _${method.name}ActionQueryParams,
+                                      _actionQueryParamsClasses,
+                                      "${method.name}",
+                                      ORIGINAL_RESOURCE_PATH,
+                                      buildReadOnlyPathKeys(),
+                                      RestliRequestOptions.DEFAULT_OPTIONS,
+                                      #if(${method.isEntityAction()} && !${method.getResourceSpec().getResource().hasSimple()})$spec.idName#else null#end,
+                                      ## TODO: Not supporting streaming attachments now
+                                      null
+                                      );
+        #**##makeRequestAndReturn(
+        ${method.valueClassDisplayName},
+        ${method.valueClassDisplayName},
+        "resp.getEntity()",
+              $withEG
+            )##
         }
-      #end ## end hasRequiredParams
-
-      @SuppressWarnings("unchecked")
-      public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-        #actionMethodProviderParamsWithEGroup($method, $withEG)##
-      )
-      {
-        RecordDataSchema requestDataSchema =  _resourceSpec.getRequestMetadata("${method.name}").getRecordDataSchema();
-        RecordDataSchema actionResponseDataSchema = _resourceSpec.getActionResponseMetadata("${method.name}").getRecordDataSchema();
-        FieldDef<${method.valueClassDisplayName}> responseFieldDef = (FieldDef<${method.valueClassDisplayName}>)_resourceSpec.getActionResponseMetadata("${method.name}").getFieldDef(ActionResponse.VALUE_NAME);
-
-        ActionResponseDecoder<${method.valueClassDisplayName}> actionResponseDecoder =
-            new ActionResponseDecoder<${method.valueClassDisplayName}>(responseFieldDef, actionResponseDataSchema);
-        DynamicRecordTemplate inputParameters =
-            new DynamicRecordTemplate(requestDataSchema,
-            #if(${method.hasActionParams()})
-              paramsProvider.apply(new $actionParamClassName()).buildParametersMap(_resourceSpec));
-            #else
-              Collections.emptyMap());
-            #end
-        inputParameters.data().setReadOnly();
-        ActionRequest<${method.valueClassDisplayName}> request = new ActionRequest<${method.valueClassDisplayName}>(inputParameters,
-                                    Collections.emptyMap(),
-                                    Collections.emptyList(),
-                                    actionResponseDecoder,
-                                    _resourceSpec,
-                                    _${method.name}ActionQueryParams,
-                                    _actionQueryParamsClasses,
-                                    "${method.name}",
-                                    ORIGINAL_RESOURCE_PATH,
-                                    buildReadOnlyPathKeys(),
-                                    RestliRequestOptions.DEFAULT_OPTIONS,
-                                    #if(${method.isEntityAction()})$spec.idName#else null#end,
-                                    ## TODO: Not supporting streaming attachments now
-                                    null
-                                    );
-      #**##makeRequestAndReturn(
-      ${method.valueClassDisplayName},
-      ${method.valueClassDisplayName},
-      "resp.getEntity()",
-            $withEG
-          )##
-      }
-    #end ## foreach
+        #end ## end if show template
+      #end ## foreach checkAssoc
+    #end ## foreach method
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/action.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/action.vm
@@ -16,14 +16,14 @@ Copyright (c) 2021 LinkedIn Corp.
 #if($is_interface)
   #foreach($method in $spec.actions)
     #foreach($withEG in [true, false])
-      #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-        #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+        #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
         #if ($showTemplate) 
           #define($keyStubNoOptional)
-            #actionMethodParamsWithEGroup($method, false, $withEG, $checkAssoc)
+            #actionMethodParamsWithEGroup($method, false, $withEG, $flattenAssocKey)
           #end ## end define
           #define($keyStubWithOptional)
-            #actionMethodParamsWithEGroup($method, true, $withEG, $checkAssoc)
+            #actionMethodParamsWithEGroup($method, true, $withEG, $flattenAssocKey)
           #end ## end define
 
         #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
@@ -44,7 +44,7 @@ Copyright (c) 2021 LinkedIn Corp.
 
         @SuppressWarnings("unchecked")
         public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-          #actionMethodProviderParamsWithEGroup($method, $withEG, $checkAssoc)##
+          #actionMethodProviderParamsWithEGroup($method, $withEG, $flattenAssocKey)##
         );
 
         #end ## end if showTemplate
@@ -61,14 +61,14 @@ Copyright (c) 2021 LinkedIn Corp.
   #foreach($withEG in [true, false])
     #foreach($method in $spec.actions)
       #setIsEntityActionIdNeeded($method)
-      #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-        #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+        #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
         #if ($showTemplate)
           #define($keyStubNoOptional)
-            #actionMethodParamsWithEGroup($method, false, $withEG, $checkAssoc)
+            #actionMethodParamsWithEGroup($method, false, $withEG, $flattenAssocKey)
           #end ## end define
           #define($keyStubWithOptional)
-            #actionMethodParamsWithEGroup($method, true, $withEG, $checkAssoc)
+            #actionMethodParamsWithEGroup($method, true, $withEG, $flattenAssocKey)
           #end ## end define
         #set($actionParamClassName = "${util.nameCapsCase($method.name)}ActionParameters")
         #set($actionOptionalParamClassName = "${util.nameCapsCase($method.name)}ActionOptionalParameters")
@@ -81,7 +81,7 @@ Copyright (c) 2021 LinkedIn Corp.
               $keyStubNoOptional
             )
             {
-              #generateAssocKeyAsId($spec, $method, $checkAssoc)
+              #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
               return ${util.nameCamelCase(${method.name})}(
                 #if($isEntityActionIdNeeded)
                 $spec.idName,
@@ -99,7 +99,7 @@ Copyright (c) 2021 LinkedIn Corp.
             $keyStubWithOptional
           )
           {
-            #generateAssocKeyAsId($spec, $method, $checkAssoc)
+            #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
             #if(${method.hasOptionalParams()})
             $actionOptionalParamClassName optionalParams = optionalParamsProvider.apply(new $actionOptionalParamClassName());
             #end
@@ -121,9 +121,10 @@ Copyright (c) 2021 LinkedIn Corp.
 
         @SuppressWarnings("unchecked")
         public CompletionStage<${method.valueClassDisplayName}> ${util.nameCamelCase(${method.name})}(
-          #actionMethodProviderParamsWithEGroup($method, $withEG, $checkAssoc)##
+          #actionMethodProviderParamsWithEGroup($method, $withEG, $flattenAssocKey)##
         )
         {
+          #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
           RecordDataSchema requestDataSchema =  _resourceSpec.getRequestMetadata("${method.name}").getRecordDataSchema();
           RecordDataSchema actionResponseDataSchema = _resourceSpec.getActionResponseMetadata("${method.name}").getRecordDataSchema();
           FieldDef<${method.valueClassDisplayName}> responseFieldDef = (FieldDef<${method.valueClassDisplayName}>)_resourceSpec.getActionResponseMetadata("${method.name}").getFieldDef(ActionResponse.VALUE_NAME);
@@ -138,7 +139,6 @@ Copyright (c) 2021 LinkedIn Corp.
                 Collections.emptyMap());
               #end
           inputParameters.data().setReadOnly();
-          #generateAssocKeyAsId($spec, $method, $checkAssoc)
           ActionRequest<${method.valueClassDisplayName}> request = new ActionRequest<${method.valueClassDisplayName}>(inputParameters,
                                       Collections.emptyMap(),
                                       Collections.emptyList(),
@@ -154,13 +154,13 @@ Copyright (c) 2021 LinkedIn Corp.
                                       ## TODO: Not supporting streaming attachments now
                                       null
                                       );
-        #**##makeRequestAndReturn(
-        ${method.valueClassDisplayName},
-        ${method.valueClassDisplayName},
-        "resp.getEntity()",
-              $withEG
-            )##
-        }
+          #**##makeRequestAndReturn(
+          ${method.valueClassDisplayName},
+          ${method.valueClassDisplayName},
+          "resp.getEntity()",
+                $withEG
+              )##
+          }
         #end ## end if show template
       #end ## foreach checkAssoc
     #end ## foreach method

--- a/restli-tools/src/main/resources/apiVmTemplates/batch_finder.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/batch_finder.vm
@@ -17,13 +17,13 @@
   #foreach($withEG in [true, false])
   #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
     #doc($method.schema.doc)
-    public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false, $withEG)##
+    public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParamsWithOptAndEg($finder, false, $withEG)##
         #**##methodParamsWithEGroup($finder, false, $withEG)##
     );
   #end
 
   #doc($finder.schema.doc)
-  public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true, $withEG)##
+  public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParamsWithOptAndEg($finder, true, $withEG)##
       #**##methodParamsWithEGroup($finder, true, $withEG)##
   );
   #end ## end withEG
@@ -32,17 +32,17 @@
   #foreach($withEG in [true, false])
   #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
     #doc($method.schema.doc)
-    public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false, $withEG)##
+    public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParamsWithOptAndEg($finder, false, $withEG)##
         #**##methodParamsWithEGroup($finder, false, $withEG)##
          ) {
-      return ${finder.methodName}(#assocKeyCallArgs($finder)##
+      return ${finder.methodName}(#assocKeyCallArgs($finder, true)##
           #**##optionalMethodCallArgsWithEGroup($finder, $withEG)##
       );
     }
   #end
 
   #doc($finder.schema.doc)
-  public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true, $withEG)##
+  public CompletionStage<BatchCollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParamsWithOptAndEg($finder, true, $withEG)##
       #**##methodParamsWithEGroup($finder, true, $withEG)##
       ) {
     #**##paramsRequestMap($finder)##

--- a/restli-tools/src/main/resources/apiVmTemplates/finder.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/finder.vm
@@ -17,13 +17,13 @@
   #foreach($withEG in [true, false])
     #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
       #doc($method.schema.doc)
-      public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false, $withEG)##
+      public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParamsWithOptAndEg($finder, false, $withEG)##
           #**##methodParamsWithEGroup($finder, false, $withEG)##
       );
     #end
 
     #doc($finder.schema.doc)
-    public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true, $withEG)##
+    public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParamsWithOptAndEg($finder, true, $withEG)##
         #**##methodParamsWithEGroup($finder, true, $withEG)##
     );
   #end ## end withEG
@@ -32,17 +32,17 @@
   #foreach($withEG in [true, false])
     #if($finder.hasOptionalParams() || $finder.hasProjectionParams())
       #doc($method.schema.doc)
-      public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, false, $withEG)##
+      public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParamsWithOptAndEg($finder, false, $withEG)##
           #**##methodParamsWithEGroup($finder, false, $withEG)##
           ) {
-        return ${finder.methodName}(#assocKeyCallArgs($finder)##
+        return ${finder.methodName}(#assocKeyCallArgs($finder, true)##
             #**##optionalMethodCallArgsWithEGroup($finder, $withEG)##
         );
       }
     #end
 
     #doc($finder.schema.doc)
-    public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParams($finder, true, $withEG)##
+    public CompletionStage<CollectionResponse<${spec.entityClassName}>> ${finder.methodName}(#assocKeyParamsWithOptAndEg($finder, true, $withEG)##
         #**##methodParamsWithEGroup($finder, true, $withEG)##
         ) {
       #**##paramsRequestMap($finder)##

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
@@ -51,7 +51,7 @@
           #**##methodParamsWithEGroup($method, true, $withEG)##
           );
       #end ## end if showTemplate
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
@@ -121,6 +121,6 @@
         )##      
       }
       #end ## end if show template
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
@@ -15,70 +15,112 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate) 
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #assocKeyParamsWithOptAndEg($method, false, $withEG)
+          #end ## end define
+          #define($keyStubWithOptional)
+            #assocKeyParamsWithOptAndEg($method, true, $withEG)
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()|| $withEG),#end
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
+          #end ## end define
+        #end ## endIf
+      #if($method.hasOptionalParams() || $method.hasProjectionParams())
+        #doc($method.schema.doc)
+        public CompletionStage<Void> delete(
+          #if (!${spec.getResource().hasSimple()})
+            $keyStubNoOptional
+          #end
+            #**##methodParamsWithEGroup($method, false, $withEG)##
+          );
+      #end
+
       #doc($method.schema.doc)
       public CompletionStage<Void> delete(
         #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams() || $withEG),#end
+          $keyStubWithOptional
         #end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
-        );
-    #end
-
-    #doc($method.schema.doc)
-    public CompletionStage<Void> delete(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
-      #end
-        #**##methodParamsWithEGroup($method, true, $withEG)##
-        );
+          #**##methodParamsWithEGroup($method, true, $withEG)##
+          );
+      #end ## end if showTemplate
+    #end ## foreach checkAssoc
   #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate)
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #assocKeyParamsWithOptAndEg($method, false, $withEG)
+          #end ## end define
+          #define($keyStubWithOptional)
+            #assocKeyParamsWithOptAndEg($method, true, $withEG)
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()|| $withEG),#end
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
+          #end ## end define
+        #end ## endIf
+      #if($method.hasOptionalParams() || $method.hasProjectionParams())
+        #doc($method.schema.doc)
+        public CompletionStage<Void> delete(
+          #if (!${spec.getResource().hasSimple()})
+            $keyStubNoOptional
+          #end
+            #**##methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          return delete(#if(${spec.idName})$spec.idName,#end
+              #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+          );
+        }
+      #end
+
       #doc($method.schema.doc)
       public CompletionStage<Void> delete(
         #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams() || $withEG),#end
+          $keyStubWithOptional
         #end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
-        ) {
-        return delete(#if(${spec.idName})$spec.idName,#end
-            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
-        );
+          #**##methodParamsWithEGroup($method, true, $withEG)##
+          ) {
+        #generateAssocKeyAsId($spec, $method, $checkAssoc)
+        #**##paramsRequestMap($method)##
+        DeleteRequest<${spec.entityClassName}> request = new DeleteRequest<>(
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            _resourceSpec,
+            queryParams,
+            queryParamClasses,
+            ORIGINAL_RESOURCE_PATH,
+            buildReadOnlyPathKeys(),
+            RestliRequestOptions.DEFAULT_OPTIONS,
+            #if(${spec.idName})
+        #**#$spec.idName##
+            #else
+        #**#null##
+            #end
+            );
+        #**##makeRequestAndReturn(
+          "Void",
+          "?",
+          "(Void) null",
+          $withEG
+        )##      
       }
-    #end
-
-    #doc($method.schema.doc)
-    public CompletionStage<Void> delete(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
-      #end
-        #**##methodParamsWithEGroup($method, true, $withEG)##
-        ) {
-      #**##paramsRequestMap($method)##
-      DeleteRequest<${spec.entityClassName}> request = new DeleteRequest<>(
-          Collections.emptyMap(),
-          Collections.emptyList(),
-          _resourceSpec,
-          queryParams,
-          queryParamClasses,
-          ORIGINAL_RESOURCE_PATH,
-          buildReadOnlyPathKeys(),
-          RestliRequestOptions.DEFAULT_OPTIONS,
-          #if(${spec.idName})
-      #**#$spec.idName##
-          #else
-      #**#null##
-          #end
-          );
-      #**##makeRequestAndReturn(
-        "Void",
-        "?",
-        "(Void) null",
-        $withEG
-      )##      
-    }
+      #end ## end if show template
+    #end ## foreach checkAssoc
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.delete.vm
@@ -15,10 +15,10 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate) 
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #assocKeyParamsWithOptAndEg($method, false, $withEG)
           #end ## end define
@@ -56,10 +56,10 @@
 #optionalParamClass($method)
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate)
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #assocKeyParamsWithOptAndEg($method, false, $withEG)
           #end ## end define
@@ -82,7 +82,7 @@
           #end
             #**##methodParamsWithEGroup($method, false, $withEG)##
           ) {
-          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
           return delete(#if(${spec.idName})$spec.idName,#end
               #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
           );
@@ -96,7 +96,7 @@
         #end
           #**##methodParamsWithEGroup($method, true, $withEG)##
           ) {
-        #generateAssocKeyAsId($spec, $method, $checkAssoc)
+        #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
         #**##paramsRequestMap($method)##
         DeleteRequest<${spec.entityClassName}> request = new DeleteRequest<>(
             Collections.emptyMap(),

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
@@ -51,7 +51,7 @@
             #**##methodParamsWithEGroup($method, true, $withEG)##
             );
       #end ## end if showTemplate
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
@@ -121,6 +121,6 @@
               )##
             }
       #end ## end if show template
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
@@ -33,7 +33,6 @@
             $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
           #end ## end define
         #end ## endIf
-
         #if($method.hasOptionalParams() || $method.hasProjectionParams())
           #doc($method.schema.doc)
           public CompletionStage<${spec.entityClassName}> get(
@@ -75,8 +74,6 @@
             $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
           #end ## end define
         #end ## endIf
-
-
         #if($method.hasOptionalParams() || $method.hasProjectionParams())
           #doc($method.schema.doc)
           public CompletionStage<${spec.entityClassName}> get(

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
@@ -15,10 +15,10 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate) 
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #assocKeyParamsWithOptAndEg($method, false, $withEG)
           #end ## end define
@@ -56,10 +56,10 @@
 #optionalParamClass($method)
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate)
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #assocKeyParamsWithOptAndEg($method, false, $withEG)
           #end ## end define
@@ -82,7 +82,7 @@
             #end
               #**##methodParamsWithEGroup($method, false, $withEG)##
             ) {
-            #generateAssocKeyAsId($spec, $method, $checkAssoc)
+            #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
             return get(#if(${spec.idName})${spec.idName},#end
                 #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
             );
@@ -96,7 +96,7 @@
           #end
             #**##methodParamsWithEGroup($method, true, $withEG)##
             ) {
-          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
           #**##paramsRequestMap($method)##
           GetRequest<${spec.entityClassName}> request = new GetRequest<>(
               Collections.emptyMap(),

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.get.vm
@@ -15,70 +15,115 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
-      #doc($method.schema.doc)
-      public CompletionStage<${spec.entityClassName}> get(
-        #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()|| $withEG),#end
-        #end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
-        );
-    #end
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate) 
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #assocKeyParamsWithOptAndEg($method, false, $withEG)
+          #end ## end define
+          #define($keyStubWithOptional)
+            #assocKeyParamsWithOptAndEg($method, true, $withEG)
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()|| $withEG),#end
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
+          #end ## end define
+        #end ## endIf
 
-    #doc($method.schema.doc)
-    public CompletionStage<${spec.entityClassName}> get(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
-      #end
-        #**##methodParamsWithEGroup($method, true, $withEG)##
-        );
+        #if($method.hasOptionalParams() || $method.hasProjectionParams())
+          #doc($method.schema.doc)
+          public CompletionStage<${spec.entityClassName}> get(
+            #if (!${spec.getResource().hasSimple()})
+              $keyStubNoOptional
+            #end
+              #**##methodParamsWithEGroup($method, false, $withEG)##
+            );
+        #end
+
+        #doc($method.schema.doc)
+        public CompletionStage<${spec.entityClassName}> get(
+          #if (!${spec.getResource().hasSimple()})
+            $keyStubWithOptional
+          #end
+            #**##methodParamsWithEGroup($method, true, $withEG)##
+            );
+      #end ## end if showTemplate
+    #end ## foreach checkAssoc
   #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
-      #doc($method.schema.doc)
-      public CompletionStage<${spec.entityClassName}> get(
-        #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()|| $withEG),#end
-        #end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
-        ) {
-        return get(#if(${spec.idName})${spec.idName},#end
-            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
-        );
-      }
-    #end
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate)
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #assocKeyParamsWithOptAndEg($method, false, $withEG)
+          #end ## end define
+          #define($keyStubWithOptional)
+            #assocKeyParamsWithOptAndEg($method, true, $withEG)
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName#if($method.hasRequiredParams()|| $withEG),#end
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
+          #end ## end define
+        #end ## endIf
 
-    #doc($method.schema.doc)
-    public CompletionStage<${spec.entityClassName}> get(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName#if( $method.hasParams() || $withEG),#end
-      #end
-        #**##methodParamsWithEGroup($method, true, $withEG)##
-        ) {
-      #**##paramsRequestMap($method)##
-      GetRequest<${spec.entityClassName}> request = new GetRequest<>(
-          Collections.emptyMap(),
-          Collections.emptyList(),
-          ${spec.entityClassName}.class,
-          #if(${spec.idName})
-      #**#$spec.idName##
-          #else
-      #**#null##
-          #end,
-          queryParams,
-          queryParamClasses,
-          _resourceSpec,
-          ORIGINAL_RESOURCE_PATH,
-          buildReadOnlyPathKeys(),
-          RestliRequestOptions.DEFAULT_OPTIONS);
-      #**##makeRequestAndReturn(
-      ${spec.entityClassName},
-      ${spec.entityClassName},
-      "resp.getEntity()",
-            $withEG
-          )##
-        }
+
+        #if($method.hasOptionalParams() || $method.hasProjectionParams())
+          #doc($method.schema.doc)
+          public CompletionStage<${spec.entityClassName}> get(
+            #if (!${spec.getResource().hasSimple()})
+              $keyStubNoOptional
+            #end
+              #**##methodParamsWithEGroup($method, false, $withEG)##
+            ) {
+            #generateAssocKeyAsId($spec, $method, $checkAssoc)
+            return get(#if(${spec.idName})${spec.idName},#end
+                #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+            );
+          }
+        #end
+
+        #doc($method.schema.doc)
+        public CompletionStage<${spec.entityClassName}> get(
+          #if (!${spec.getResource().hasSimple()})
+            $keyStubWithOptional
+          #end
+            #**##methodParamsWithEGroup($method, true, $withEG)##
+            ) {
+          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          #**##paramsRequestMap($method)##
+          GetRequest<${spec.entityClassName}> request = new GetRequest<>(
+              Collections.emptyMap(),
+              Collections.emptyList(),
+              ${spec.entityClassName}.class,
+              #if(${spec.idName})
+          #**#$spec.idName##
+              #else
+          #**#null##
+              #end,
+              queryParams,
+              queryParamClasses,
+              _resourceSpec,
+              ORIGINAL_RESOURCE_PATH,
+              buildReadOnlyPathKeys(),
+              RestliRequestOptions.DEFAULT_OPTIONS);
+          #**##makeRequestAndReturn(
+          ${spec.entityClassName},
+          ${spec.entityClassName},
+          "resp.getEntity()",
+                $withEG
+              )##
+            }
+      #end ## end if show template
+    #end ## foreach checkAssoc
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
@@ -15,10 +15,10 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate) 
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #associateKeyParams($spec),
           #end ## end define
@@ -58,10 +58,10 @@
 #optionalParamClass($method)
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate)
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #associateKeyParams($spec),
           #end ## end define
@@ -85,7 +85,7 @@
             PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
             #**##methodParamsWithEGroup($method, false, $withEG)##
           ) {
-          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
           return partialUpdate(#if(${spec.idName})$spec.idName,#end
               entity,
               #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
@@ -101,7 +101,7 @@
           PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
           #**##methodParamsWithEGroup($method, true, $withEG)##
           ) {
-        #generateAssocKeyAsId($spec, $method, $checkAssoc)
+        #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
         Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
         Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
         #fillQueryParams($method)

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
@@ -53,7 +53,7 @@
           #**##methodParamsWithEGroup($method, true, $withEG)##
           );
       #end ## end if showTemplate
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
@@ -131,6 +131,6 @@
         )##
       }
       #end ## end if show template
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_no_return.vm
@@ -15,80 +15,122 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate) 
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+          #define($keyStubWithOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+        #end ## endIf
+      #if($method.hasOptionalParams() || $method.hasProjectionParams())
+        #doc($method.schema.doc)
+        public CompletionStage<Void> partialUpdate(
+          #if (!${spec.getResource().hasSimple()})
+            $keyStubNoOptional
+          #end
+            PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
+            #**##methodParamsWithEGroup($method, false, $withEG)##
+          );
+      #end
+
       #doc($method.schema.doc)
       public CompletionStage<Void> partialUpdate(
         #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName,
+          $keyStubWithOptional
         #end
-          PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
-        );
-    #end
-
-    #doc($method.schema.doc)
-    public CompletionStage<Void> partialUpdate(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName,
-      #end
-        PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
-        #**##methodParamsWithEGroup($method, true, $withEG)##
-        );
+          PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, true, $withEG)##
+          );
+      #end ## end if showTemplate
+    #end ## foreach checkAssoc
   #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate)
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+          #define($keyStubWithOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+        #end ## endIf
+      #if($method.hasOptionalParams() || $method.hasProjectionParams())
+        #doc($method.schema.doc)
+        public CompletionStage<Void> partialUpdate(
+          #if (!${spec.getResource().hasSimple()})
+            $keyStubNoOptional
+          #end
+            PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
+            #**##methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          return partialUpdate(#if(${spec.idName})$spec.idName,#end
+              entity,
+              #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+          );
+        }
+      #end
+
       #doc($method.schema.doc)
       public CompletionStage<Void> partialUpdate(
         #if (!${spec.getResource().hasSimple()})
-          $spec.keyClassDisplayName $spec.idName,
+          $keyStubWithOptional
         #end
-          PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
-        ) {
-        return partialUpdate(#if(${spec.idName})$spec.idName,#end
+          PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, true, $withEG)##
+          ) {
+        #generateAssocKeyAsId($spec, $method, $checkAssoc)
+        Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+        Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
+        #fillQueryParams($method)
+        #if($method.returnsEntity())
+            #**##returnEntityParam("false")
+        #end
+        PartialUpdateRequest<${spec.entityClassName}> request = new PartialUpdateRequest<>(
             entity,
-            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
-        );
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            _resourceSpec,
+            queryParams,
+            queryParamClasses,
+            ORIGINAL_RESOURCE_PATH,
+            buildReadOnlyPathKeys(),
+            RestliRequestOptions.DEFAULT_OPTIONS,
+            #if(${spec.idName})
+        #**#$spec.idName##
+            #else
+        #**#null##
+            #end, null);
+        #**##makeRequestAndReturn(
+          "Void",
+          "?",
+          "(Void) null",
+          $withEG
+        )##
       }
-    #end
-
-    #doc($method.schema.doc)
-    public CompletionStage<Void> partialUpdate(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName,
-      #end
-        PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
-        #**##methodParamsWithEGroup($method, true, $withEG)##
-        ) {
-      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-      Map<String, Class<?>> queryParamClasses = #if($method.hasParams() || $method.returnsEntity())new HashMap<>($method.getQueryParamMapSize());#else Collections.emptyMap();#end
-      #fillQueryParams($method)
-      #if($method.returnsEntity())
-          #**##returnEntityParam("false")
-      #end
-      PartialUpdateRequest<${spec.entityClassName}> request = new PartialUpdateRequest<>(
-          entity,
-          Collections.emptyMap(),
-          Collections.emptyList(),
-          _resourceSpec,
-          queryParams,
-          queryParamClasses,
-          ORIGINAL_RESOURCE_PATH,
-          buildReadOnlyPathKeys(),
-          RestliRequestOptions.DEFAULT_OPTIONS,
-          #if(${spec.idName})
-      #**#$spec.idName##
-          #else
-      #**#null##
-          #end, null);
-      #**##makeRequestAndReturn(
-        "Void",
-        "?",
-        "(Void) null",
-        $withEG
-      )##
-    }
+      #end ## end if show template
+    #end ## foreach checkAssoc
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
@@ -15,10 +15,10 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate) 
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #associateKeyParams($spec),
           #end ## end define
@@ -57,10 +57,10 @@
   #end ## end withEG
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate)
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #associateKeyParams($spec),
           #end ## end define
@@ -84,7 +84,7 @@
             PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
             #**##methodParamsWithEGroup($method, false, $withEG)##
           ) {
-          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
           return partialUpdateAndGet(#if(${spec.idName})$spec.idName,#end
               entity,
               #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
@@ -100,7 +100,7 @@
           PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
           #**##methodParamsWithEGroup($method, true, $withEG)##
           ) {
-        #generateAssocKeyAsId($spec, $method, $checkAssoc)
+        #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
         Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
         Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
         #fillQueryParams($method)

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
@@ -15,11 +15,29 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate) 
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+          #define($keyStubWithOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+        #end ## endIf
     #if($method.hasOptionalParams() || $method.hasProjectionParams())
       #doc($method.schema.doc)
       public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
         #if (!${spec.getResource().hasSimple()})
-            $spec.keyClassDisplayName $spec.idName,
+            $keyStubNoOptional
         #end
           PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
           #**##methodParamsWithEGroup($method, false, $withEG)##
@@ -29,67 +47,91 @@
     #doc($method.schema.doc)
     public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
       #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName,
+        $keyStubWithOptional
       #end
         PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
         #**##methodParamsWithEGroup($method, true, $withEG)##
         );
+      #end ## end if showTemplate
+    #end ## foreach checkAssoc
   #end ## end withEG
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate)
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+          #define($keyStubWithOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+        #end ## endIf
+      #if($method.hasOptionalParams() || $method.hasProjectionParams())
+        #doc($method.schema.doc)
+        public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
+          #if (!${spec.getResource().hasSimple()})
+              $keyStubNoOptional
+          #end
+            PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
+            #**##methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          return partialUpdateAndGet(#if(${spec.idName})$spec.idName,#end
+              entity,
+              #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+          );
+        }
+      #end
+
       #doc($method.schema.doc)
       public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
         #if (!${spec.getResource().hasSimple()})
-            $spec.keyClassDisplayName $spec.idName,
+          $keyStubWithOptional
         #end
-          PatchRequest<${spec.entityClassName}> entity#if($method.hasRequiredParams() || $withEG),#end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
-        ) {
-        return partialUpdateAndGet(#if(${spec.idName})$spec.idName,#end
+          PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
+          #**##methodParamsWithEGroup($method, true, $withEG)##
+          ) {
+        #generateAssocKeyAsId($spec, $method, $checkAssoc)
+        Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
+        Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
+        #fillQueryParams($method)
+        #**##returnEntityParam("true")
+        @SuppressWarnings("unchecked")
+        EntityResponseDecoder<${spec.entityClassName}> entityResponseDecoder = new EntityResponseDecoder<>(
+            (Class<${spec.entityClassName}>) _resourceSpec.getValueClass());
+        PartialUpdateEntityRequest<${spec.entityClassName}> request = new PartialUpdateEntityRequest<>(
             entity,
-            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
-        );
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            entityResponseDecoder,
+            _resourceSpec,
+            queryParams,
+            queryParamClasses,
+            ORIGINAL_RESOURCE_PATH,
+            buildReadOnlyPathKeys(),
+            RestliRequestOptions.DEFAULT_OPTIONS,
+            #if(${spec.idName})
+        #**#$spec.idName##
+            #else
+        #**#null##
+            #end,null);
+        #**##makeRequestAndReturn(
+          "${spec.entityClassName}",
+          "${spec.entityClassName}",
+          "resp.getEntity()",
+          $withEG
+        )##
       }
-    #end
-
-    #doc($method.schema.doc)
-    public CompletionStage<${spec.entityClassName}> partialUpdateAndGet(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName,
-      #end
-        PatchRequest<${spec.entityClassName}> entity#if( $method.hasParams() || $withEG),#end
-        #**##methodParamsWithEGroup($method, true, $withEG)##
-        ) {
-      Map<String, Object> queryParams = new HashMap<>($method.getQueryParamMapSize());
-      Map<String, Class<?>> queryParamClasses = new HashMap<>($method.getQueryParamMapSize());
-      #fillQueryParams($method)
-      #**##returnEntityParam("true")
-      @SuppressWarnings("unchecked")
-      EntityResponseDecoder<${spec.entityClassName}> entityResponseDecoder = new EntityResponseDecoder<>(
-          (Class<${spec.entityClassName}>) _resourceSpec.getValueClass());
-      PartialUpdateEntityRequest<${spec.entityClassName}> request = new PartialUpdateEntityRequest<>(
-          entity,
-          Collections.emptyMap(),
-          Collections.emptyList(),
-          entityResponseDecoder,
-          _resourceSpec,
-          queryParams,
-          queryParamClasses,
-          ORIGINAL_RESOURCE_PATH,
-          buildReadOnlyPathKeys(),
-          RestliRequestOptions.DEFAULT_OPTIONS,
-          #if(${spec.idName})
-      #**#$spec.idName##
-          #else
-      #**#null##
-          #end,null);
-      #**##makeRequestAndReturn(
-        "${spec.entityClassName}",
-        "${spec.entityClassName}",
-        "resp.getEntity()",
-        $withEG
-      )##
-    }
+      #end ## end if show template
+    #end ## foreach checkAssoc
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.partial_update_return_entity.vm
@@ -53,7 +53,7 @@
         #**##methodParamsWithEGroup($method, true, $withEG)##
         );
       #end ## end if showTemplate
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #else ## is_interface
   #foreach($withEG in [true, false])
@@ -132,6 +132,6 @@
         )##
       }
       #end ## end if show template
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
@@ -15,10 +15,10 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate) 
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #associateKeyParams($spec),
           #end ## end define
@@ -58,10 +58,10 @@
 #optionalParamClass($method)
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
-      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+    #foreach($flattenAssocKey in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$flattenAssocKey ||  ${spec.getResource().hasAssociation()}))
       #if ($showTemplate)
-        #if ($checkAssoc)
+        #if ($flattenAssocKey)
           #define($keyStubNoOptional)
             #associateKeyParams($spec),
           #end ## end define
@@ -85,7 +85,7 @@
             ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
             #**##methodParamsWithEGroup($method, false, $withEG)##
           ) {
-          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
           return update(#if(${spec.idName})$spec.idName,#end
               entity,
               #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
@@ -101,7 +101,7 @@
         ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
         #**##methodParamsWithEGroup($method, true, $withEG)##
         ) {
-        #generateAssocKeyAsId($spec, $method, $checkAssoc)
+        #generateAssocKeyAsId($spec, $method, $flattenAssocKey)
         #**##paramsRequestMap($method)##
         UpdateRequest<${spec.entityClassName}> request = new UpdateRequest<>(
             entity,

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
@@ -15,76 +15,118 @@
 *#
 #if($is_interface)
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate) 
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+          #define($keyStubWithOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+        #end ## endIf
+      #if($method.hasOptionalParams() || $method.hasProjectionParams())
+        #doc($method.schema.doc)
+        public CompletionStage<Void> update(
+            #if (!${spec.getResource().hasSimple()})
+              $keyStubNoOptional
+            #end
+            ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
+            #**##methodParamsWithEGroup($method, false, $withEG)##
+          );
+      #end
+
       #doc($method.schema.doc)
       public CompletionStage<Void> update(
-          #if (!${spec.getResource().hasSimple()})
-            $spec.keyClassDisplayName $spec.idName,
-          #end
-          ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
+        #if (!${spec.getResource().hasSimple()})
+          $keyStubWithOptional
+        #end
+        ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         );
-    #end
-
-    #doc($method.schema.doc)
-    public CompletionStage<Void> update(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName,
-      #end
-      ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
-      #**##methodParamsWithEGroup($method, true, $withEG)##
-      );
+      #end ## end if showTemplate
+    #end ## foreach checkAssoc
   #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
   #foreach($withEG in [true, false])
-    #if($method.hasOptionalParams() || $method.hasProjectionParams())
+    #foreach($checkAssoc in [true, false]) ##  association key colleciton will have API with assocKeyParamsWithOptAndEg for Get, Delete, Update, PartialUpdate, Action
+      #set($showTemplate =(!$checkAssoc ||  ${spec.getResource().hasAssociation()}))
+      #if ($showTemplate)
+        #if ($checkAssoc)
+          #define($keyStubNoOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+          #define($keyStubWithOptional)
+            #associateKeyParams($spec),
+          #end ## end define
+        #else
+          #define($keyStubNoOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+          #define($keyStubWithOptional)
+            $spec.keyClassDisplayName $spec.idName,
+          #end ## end define
+        #end ## endI
+      #if($method.hasOptionalParams() || $method.hasProjectionParams())
+        #doc($method.schema.doc)
+        public CompletionStage<Void> update(
+            #if (!${spec.getResource().hasSimple()})
+              $keyStubNoOptional
+            #end
+            ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
+            #**##methodParamsWithEGroup($method, false, $withEG)##
+          ) {
+          #generateAssocKeyAsId($spec, $method, $checkAssoc)
+          return update(#if(${spec.idName})$spec.idName,#end
+              entity,
+              #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
+          );
+        }
+      #end
+
       #doc($method.schema.doc)
       public CompletionStage<Void> update(
-          #if (!${spec.getResource().hasSimple()})
-            $spec.keyClassDisplayName $spec.idName,
-          #end
-          ${spec.entityClassName} entity#if($method.hasRequiredParams() || $withEG),#end
-          #**##methodParamsWithEGroup($method, false, $withEG)##
+        #if (!${spec.getResource().hasSimple()})
+          $keyStubWithOptional
+        #end
+        ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
+        #**##methodParamsWithEGroup($method, true, $withEG)##
         ) {
-        return update(#if(${spec.idName})$spec.idName,#end
+        #generateAssocKeyAsId($spec, $method, $checkAssoc)
+        #**##paramsRequestMap($method)##
+        UpdateRequest<${spec.entityClassName}> request = new UpdateRequest<>(
             entity,
-            #**##optionalMethodCallArgsWithEGroup($method, $withEG)##
-        );
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            _resourceSpec,
+            queryParams,
+            queryParamClasses,
+            ORIGINAL_RESOURCE_PATH,
+            buildReadOnlyPathKeys(),
+            RestliRequestOptions.DEFAULT_OPTIONS,
+            #if(${spec.idName})
+        #**#$spec.idName##
+            #else
+        #**#null##
+            #end,
+            null);
+        #**##makeRequestAndReturn(
+          "Void",
+          "?",
+          "(Void) null",
+          $withEG
+        )##
       }
-    #end
-
-    #doc($method.schema.doc)
-    public CompletionStage<Void> update(
-      #if (!${spec.getResource().hasSimple()})
-        $spec.keyClassDisplayName $spec.idName,
-      #end
-      ${spec.entityClassName} entity#if( $method.hasParams() || $withEG),#end
-      #**##methodParamsWithEGroup($method, true, $withEG)##
-      ) {
-      #**##paramsRequestMap($method)##
-      UpdateRequest<${spec.entityClassName}> request = new UpdateRequest<>(
-          entity,
-          Collections.emptyMap(),
-          Collections.emptyList(),
-          _resourceSpec,
-          queryParams,
-          queryParamClasses,
-          ORIGINAL_RESOURCE_PATH,
-          buildReadOnlyPathKeys(),
-          RestliRequestOptions.DEFAULT_OPTIONS,
-          #if(${spec.idName})
-      #**#$spec.idName##
-          #else
-      #**#null##
-          #end,
-          null);
-      #**##makeRequestAndReturn(
-        "Void",
-        "?",
-        "(Void) null",
-        $withEG
-      )##
-    }
+      #end ## end if show template
+    #end ## foreach checkAssoc
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
+++ b/restli-tools/src/main/resources/apiVmTemplates/rest.update.vm
@@ -53,7 +53,7 @@
         #**##methodParamsWithEGroup($method, true, $withEG)##
         );
       #end ## end if showTemplate
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #optionalParamClass($method)
 #else ## is_interface
@@ -127,6 +127,6 @@
         )##
       }
       #end ## end if show template
-    #end ## foreach checkAssoc
+    #end ## foreach flattenAssocKey
   #end ## end withEG
 #end ## is_interface

--- a/restli-tools/src/main/resources/macros/library.vm
+++ b/restli-tools/src/main/resources/macros/library.vm
@@ -40,7 +40,8 @@
   #end
 #end
 
-#macro(associateKeyParams)
+
+#macro(associateKeyParams $spec)
 #foreach($assoc_key in ${spec.getCompoundKeySpec().getAssocKeySpecs()})
   ${assoc_key.bindingType} ${assoc_key.name}#if($foreach.hasNext),#end
 #end
@@ -48,13 +49,13 @@
 
 #macro(assocCompoundKeyGenInterface $spec)
   CompoundKey generate${util.nameCapsCase($spec.className)}CompoundKey(
-    #associateKeyParams
+    #associateKeyParams($spec)
   );
 #end
 
 #macro(assocCompoundKeyGenImpl $spec)
   public CompoundKey generate${util.nameCapsCase($spec.className)}CompoundKey(
-    #associateKeyParams
+    #associateKeyParams($spec)
   ) {
     return new Key().
       #foreach($assoc_key in ${spec.getCompoundKeySpec().getAssocKeySpecs()})
@@ -81,6 +82,14 @@
       }
       #end
   }
+#end
+
+#macro(generateAssocKeyAsId $spec $method $checkAssoc)
+  #if($checkAssoc && ${spec.idName})
+  CompoundKey ${spec.idName} = generate${util.nameCapsCase($spec.className)}CompoundKey (
+        #assocKeyCallArgs($method, false)
+      );
+  #end
 #end
 
 #macro(optionalParamClass $method)
@@ -177,7 +186,7 @@
   #end
 #end
 
-#macro(assocKeyParams $method $includeOptional $withEG)
+#macro(assocKeyParamsWithOptAndEg $method $includeOptional $withEG)
     #set($hasMoreParams = $method.hasRequiredParams() || ($includeOptional && ($method.hasOptionalParams() || $method.hasProjectionParams())) || $withEG)
     #foreach($assocKey in $method.assocKeys)
       $assocKey.bindingType $assocKey.name#if( $foreach.hasNext || $hasMoreParams),#end
@@ -195,10 +204,19 @@
   #if($withEG)ExecutionGroup executionGroup #end
 #end
 
-#macro(actionMethodParamsWithEGroup $method $includeOptional $withEG)
+#macro(setIsEntityActionIdNeeded $method)
+  #set($isEntityActionIdNeeded = ${method.isEntityAction()} && !${method.getResourceSpec().getResource().hasSimple()})
+#end
+
+#macro(actionMethodParamsWithEGroup $method $includeOptional $withEG $checkAssoc)
   #set($hasOptionalParams = $includeOptional && $method.hasOptionalParams())
-  #if(${method.isEntityAction()})
-    $spec.keyClassName $spec.idName,
+  #setIsEntityActionIdNeeded($method)
+  #if($isEntityActionIdNeeded)
+    #if($checkAssoc && ${method.getResourceSpec().getResource().hasAssociation()})
+      #associateKeyParams(${method.getResourceSpec()})
+    #else
+      $spec.keyClassName $spec.idName
+    #end #if(${method.hasActionParams()} || $withEG),#end
   #end
   #foreach($param in $method.getRequiredParameters())
     $param.paramClassDisplayName $param.paramName #if($foreach.hasNext || ($hasOptionalParams || $withEG)),#end
@@ -210,10 +228,15 @@
   #if($withEG)ExecutionGroup executionGroup #end
 #end
 
-#macro(actionMethodProviderParamsWithEGroup $method $withEG)
+#macro(actionMethodProviderParamsWithEGroup $method $withEG $checkAssoc)
     #set($hasParams = ($method.isEntityAction() || $method.hasActionParams()))
-    #if(${method.isEntityAction()})
-    $spec.keyClassName $spec.idName #if(${method.hasActionParams()} || $withEG),#end
+    #setIsEntityActionIdNeeded($method)
+    #if($isEntityActionIdNeeded)
+      #if($checkAssoc && ${method.getResourceSpec().getResource().hasAssociation()})
+        #associateKeyParams(${method.getResourceSpec()})
+      #else
+        $spec.keyClassName $spec.idName
+      #end #if(${method.hasActionParams()} || $withEG),#end
     #end
     #if(${method.hasActionParams()})
     Function<$actionParamClassName, $actionParamClassName> paramsProvider #if($withEG), #end
@@ -221,9 +244,9 @@
     #if($withEG)ExecutionGroup executionGroup #end
 #end
 
-#macro(assocKeyCallArgs $method)
+#macro(assocKeyCallArgs $method $checkParams)
   #foreach($assocKey in $method.assocKeys)
-    $assocKey.name#if( $foreach.hasNext || $method.parameters.size() > 0 || $method.hasProjectionParams()),#end
+    $assocKey.name#if( $foreach.hasNext || ($checkParams && ($method.parameters.size() > 0 || $method.hasProjectionParams()))),#end
   #end
 #end
 

--- a/restli-tools/src/main/resources/macros/library.vm
+++ b/restli-tools/src/main/resources/macros/library.vm
@@ -84,8 +84,8 @@
   }
 #end
 
-#macro(generateAssocKeyAsId $spec $method $checkAssoc)
-  #if($checkAssoc && ${spec.idName})
+#macro(generateAssocKeyAsId $spec $method $flattenAssocKey)
+  #if($flattenAssocKey && ${spec.idName})
   CompoundKey ${spec.idName} = generate${util.nameCapsCase($spec.className)}CompoundKey (
         #assocKeyCallArgs($method, false)
       );
@@ -208,11 +208,11 @@
   #set($isEntityActionIdNeeded = ${method.isEntityAction()} && !${method.getResourceSpec().getResource().hasSimple()})
 #end
 
-#macro(actionMethodParamsWithEGroup $method $includeOptional $withEG $checkAssoc)
+#macro(actionMethodParamsWithEGroup $method $includeOptional $withEG $flattenAssocKey)
   #set($hasOptionalParams = $includeOptional && $method.hasOptionalParams())
   #setIsEntityActionIdNeeded($method)
   #if($isEntityActionIdNeeded)
-    #if($checkAssoc && ${method.getResourceSpec().getResource().hasAssociation()})
+    #if($flattenAssocKey && ${method.getResourceSpec().getResource().hasAssociation()})
       #associateKeyParams(${method.getResourceSpec()})
     #else
       $spec.keyClassName $spec.idName
@@ -228,11 +228,11 @@
   #if($withEG)ExecutionGroup executionGroup #end
 #end
 
-#macro(actionMethodProviderParamsWithEGroup $method $withEG $checkAssoc)
+#macro(actionMethodProviderParamsWithEGroup $method $withEG $flattenAssocKey)
     #set($hasParams = ($method.isEntityAction() || $method.hasActionParams()))
     #setIsEntityActionIdNeeded($method)
     #if($isEntityActionIdNeeded)
-      #if($checkAssoc && ${method.getResourceSpec().getResource().hasAssociation()})
+      #if($flattenAssocKey && ${method.getResourceSpec().getResource().hasAssociation()})
         #associateKeyParams(${method.getResourceSpec()})
       #else
         $spec.keyClassName $spec.idName


### PR DESCRIPTION
Current FluentAPI uses API such as
`get(CompoundKey)`

this change another set of API which use spreaded version of the compoundKey
e.g., if CompoundKey consists of Long and String, it would be
`get(Long id, String message)`