### PR TITLE
Check Gradle version against min required/suggested versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,22 +13,25 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Strictly enforce Gradle version compatibility in the `pegasus` Gradle plugin.
+  - Minimum required Gradle version is now `1.0` (effectively backward-compatible).
+  - Minimum suggested Gradle version is now `5.2.1`
 
 ## [29.18.2] - 2021-04-28
 - Fix bug in generated fluent client APIs when typerefs are used as association key params
 - Add debug log for cluster subsetting updates
 
 ## [29.18.1] - 2021-04-22
-- Add fluent client API for FINDER and BATCH_FINDER methods.
-- Fix a bug when converting enableClusterSubsetting config to Boolean in ServicePropertiesJsonSerializer
+- Add fluent client API for `FINDER` and `BATCH_FINDER` methods.
+- Fix a bug when converting `enableClusterSubsetting` config to Boolean in `ServicePropertiesJsonSerializer`.
 
 ## [29.18.0] - 2021-04-20
 - Use host FQDN instead of nodeUri to get D2 subsetting metadata
 
 ## [29.17.4] - 2021-04-16
 - Migrate the Rest.li release process from Bintray to JFrog Artifactory.
-    - As of this version, Bintray will no longer host Rest.li releases.
-    - Releases can be found on [LinkedIn's JFrog Artifactory instance](https://linkedin.jfrog.io/).
+  - As of this version, Bintray will no longer host Rest.li releases.
+  - Releases can be found on [LinkedIn's JFrog Artifactory instance](https://linkedin.jfrog.io/).
 
 ## [29.17.3] - 2021-04-15
 - Releasing to test new CI behavior.
@@ -52,7 +55,7 @@ and what APIs have changed, if applicable.
 ## [29.16.1] - 2021-03-17
 - Add fluent client api for simple resource and association resource.
 - Add support for generating projection mask as the mask data map.
-- Fix UnmodifiableList wrap in d2 relative load balancer
+- Fix UnmodifiableList wrap in d2 relative load balancer.
 
 ## [29.16.0] - 2021-03-10
 - Add a ParSeq based CompletionStage implementation
@@ -71,17 +74,17 @@ and what APIs have changed, if applicable.
 - Fix bug that if a schema is an enum without any symbols, doc gen should handle it instead of throwing exception.
 
 ## [29.15.5] - 2021-03-03
-- Fix content type header not set in case of RestliResponseException from non streaming server
+- Fix content type header not set in case of `RestliResponseException` from non-streaming server.
 
 ## [29.15.4] - 2021-03-02
-- Fix content type header not set in case of StreamException from rest.li server
+- Fix content type header not set in case of `StreamException` from Rest.li server.
 
 ## [29.15.3] - 2021-02-24
 - Add support for update, partial_update, delete and get_all methods in fluent API bindings.
-- Prevent RetriableRequestException from cascading to the indirect caller.
+- Prevent `RetriableRequestException` from cascading to the indirect caller.
 
 ## [29.15.2] - 2021-02-19
-- Add UnionTemplate.memberKeyName() to directly return the key name for a union member
+- Add `UnionTemplate.memberKeyName()` to directly return the key name for a union member.
 
 ## [29.15.1] - 2021-02-18
 - Cleanup compression code to reduce duplication and minimize memcopies 

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -76,6 +76,7 @@ import org.gradle.plugins.ide.eclipse.EclipsePlugin;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.gradle.plugins.ide.idea.IdeaPlugin;
 import org.gradle.plugins.ide.idea.model.IdeaModule;
+import org.gradle.util.GradleVersion;
 
 
 /**
@@ -520,6 +521,9 @@ public class PegasusPlugin implements Plugin<Project>
 {
   public static boolean debug = false;
 
+  private static final GradleVersion MIN_REQUIRED_VERSION = GradleVersion.version("1.0"); // Next: 5.2.1
+  private static final GradleVersion MIN_SUGGESTED_VERSION = GradleVersion.version("5.2.1"); // Next: 5.3
+
   //
   // Constants for generating sourceSet names and corresponding directory names
   // for generated code
@@ -633,6 +637,8 @@ public class PegasusPlugin implements Plugin<Project>
   @Override
   public void apply(Project project)
   {
+    checkGradleVersion(project);
+
     project.getPlugins().apply(JavaPlugin.class);
     project.getPlugins().apply(IdeaPlugin.class);
     project.getPlugins().apply(EclipsePlugin.class);
@@ -2223,5 +2229,21 @@ public class PegasusPlugin implements Plugin<Project>
           task.into(outputDir);
           task.onlyIf(t -> !SharedFileUtils.getSuffixedFiles(project, inputDir, PDL_FILE_SUFFIX).isEmpty());
         });
+  }
+
+  private void checkGradleVersion(Project project)
+  {
+    if (MIN_REQUIRED_VERSION.compareTo(GradleVersion.current()) > 0)
+    {
+      throw new GradleException(String.format("This plugin does not support %s. Please use %s or later.",
+          GradleVersion.current(),
+          MIN_REQUIRED_VERSION));
+    }
+    if (MIN_SUGGESTED_VERSION.compareTo(GradleVersion.current()) > 0)
+    {
+      project.getLogger().warn(String.format("Pegasus supports %s, but it may not be supported in the next major release. Please use %s or later.",
+          GradleVersion.current(),
+          MIN_SUGGESTED_VERSION));
+    }
   }
 }


### PR DESCRIPTION
During application of the Pegasus Gradle plugin, check the current project version agains the min required/suggested versions and either fail or warn with an actionable message.

For now, only enforce Gradle `1.0` to keep compatibility. I will follow this up with a backward-incompatible PR for the next major release to enforce `5.2.1`.

The recommended version should be what the next enforced version will be. For now, that's `5.2.1` (see above). Then, it'll be `5.3`.