### PR TITLE
Fix bottlenecks in DataSchemaParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.18.3] - 2021-05-03
 - Strictly enforce Gradle version compatibility in the `pegasus` Gradle plugin.
   - Minimum required Gradle version is now `1.0` (effectively backward-compatible).
   - Minimum suggested Gradle version is now `5.2.1`
 - Fix TimingKey Memory Leak
+- Fix bottlenecks in DataSchemaParser
 
 ## [29.18.2] - 2021-04-28
 - Fix bug in generated fluent client APIs when typerefs are used as association key params
@@ -4925,7 +4928,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.3...master
+[29.18.3]: https://github.com/linkedin/rest.li/compare/v29.18.2...v29.18.3
 [29.18.2]: https://github.com/linkedin/rest.li/compare/v29.18.1...v29.18.2
 [29.18.1]: https://github.com/linkedin/rest.li/compare/v29.18.0...v29.18.1
 [29.18.0]: https://github.com/linkedin/rest.li/compare/v29.17.4...v29.18.0

--- a/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
@@ -30,13 +30,13 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FilenameUtils;
 
@@ -118,9 +118,9 @@ public class DataSchemaParser
    * Parses all schemas from the specified sources. Sources can be schema files, jars containing schemas or directories
    * with schema files.
    *
-   * @param sources sources to scan and parse for pegasus schemas.
+   * @param rawSources sources to scan and parse for pegasus schemas.
    */
-  public DataSchemaParser.ParseResult parseSources(String[] sources) throws IOException
+  public DataSchemaParser.ParseResult parseSources(String[] rawSources) throws IOException
   {
     Set<String> fileExtensions = _parserByFileExtension.keySet();
     Map<String, List<String>> byExtension = new HashMap<>(fileExtensions.size());
@@ -129,8 +129,11 @@ public class DataSchemaParser
       byExtension.put(fileExtension, new ArrayList<>());
     }
 
+    String[] sortedSources = Arrays.copyOf(rawSources, rawSources.length);
+    Arrays.sort(sortedSources);
+
     // Extract all schema files from the given source paths and group by extension (JARs are handled specially)
-    for (String source : sources)
+    for (String source : sortedSources)
     {
       final File sourceFile = new File(source);
       if (sourceFile.exists())
@@ -205,8 +208,8 @@ public class DataSchemaParser
   public static class ParseResult
   {
     private static final String EXTENSION_FILENAME_SUFFIX = "Extensions.pdl";
-    // Sort the results to ensure that the output is deterministic for a given set of source inputs
-    private final Map<DataSchema, DataSchemaLocation> _schemaAndLocations = new TreeMap<>(Comparator.comparing(DataSchema::toString));
+    // Store the results in a LinkedHashMap to ensure ordering is deterministic for a given set of source inputs
+    private final Map<DataSchema, DataSchemaLocation> _schemaAndLocations = new LinkedHashMap<>();
     private final Set<File> _sourceFiles = new HashSet<>();
     protected final StringBuilder _messageBuilder = new StringBuilder();
 

--- a/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
@@ -134,7 +134,7 @@ public class FileFormatDataSchemaParser
 
       for (Map.Entry<String, DataSchemaLocation> entry : _schemaResolver.nameToDataSchemaLocations().entrySet())
       {
-        final DataSchema schema = _schemaResolver.bindings().get(entry.getKey());
+        final DataSchema schema = _schemaResolver.existingDataSchema(entry.getKey());
         result.getSchemaAndLocations().put(schema, entry.getValue());
       }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.2
+version=29.18.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Both of these optimizations combined, reduce the entirety of client code
generation from 2 minutes to 20 seconds on a large codebase. These 
bottlenecks were discovered by using a flame-graph attached below. The 
sections highlighted in purple essentially don't exist after these changes.

1) Remove usage of `TreeMap`. Using a `TreeMap` with a `DataSchema` key is
very expensive. Every single comparison was calling `toString()` which
forces both schemas to be serialized to JSON, then compared.
The point of this `TreeMap` was just to have deterministic
ordering, when the source file ordering has changed. To maintain this
behavior we can just sort the input up front, and maintain a
`LinkedHashMap` for consistent ordering.

2) Replace `binding()` call in loop with `existingDataSchema()`. The
implementation of `AbstractMultiFormatDataSchemaResolver.bindings()`
is very expensive. It creates a new aggregated map on each invocation. 
So calling this once for a single lookup is actually more expensive than 
a linear search would have been. Replaced this call with 
`existingDataSchema()` which is an equivalent and much cheaper 
operation. Ideally, the `DataSchemaResolver` interface wouldn't contain
methods that expose `Map` objects directly, but that would require a
major backwards-incompatible change.

<img width="1192" alt="Screen Shot 2021-05-02 at 11 31 57 AM" src="https://user-images.githubusercontent.com/2974876/116823659-89021500-ab3a-11eb-9c26-a9d76536a371.png">
