### PR TITLE
Remove leftover references to deprecated configs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.12] - 2021-05-26
+- Remove leftover references to deprecated configurations to work with Gradle 7.
+
 ## [29.18.11] - 2021-05-24
 - Add support for returning location of schema elements from the PDL schema parser.
 
@@ -4957,7 +4960,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.12...master
+[29.18.12]: https://github.com/linkedin/rest.li/compare/v29.18.11...v29.18.12
 [29.18.11]: https://github.com/linkedin/rest.li/compare/v29.18.10...v29.18.11
 [29.18.10]: https://github.com/linkedin/rest.li/compare/v29.18.9...v29.18.10
 [29.18.9]: https://github.com/linkedin/rest.li/compare/v29.18.8...v29.18.9

--- a/gradle-plugins/src/integTest/resources/ivy/legacy/expectedChildIvyDescriptorContents.txt
+++ b/gradle-plugins/src/integTest/resources/ivy/legacy/expectedChildIvyDescriptorContents.txt
@@ -1,10 +1,11 @@
   <configurations>
     <conf name="annotationProcessor" visibility="private"/>
-    <conf name="apiElements" visibility="private" extends="runtime"/>
+    <conf name="api" visibility="private" extends="compile,dataModel,dataTemplateCompile"/>
+    <conf name="apiElements" visibility="private" extends="api,runtime"/>
     <conf name="archives" visibility="public"/>
     <conf name="avroSchema" visibility="public"/>
     <conf name="avroSchemaGenerator" visibility="private"/>
-    <conf name="compile" visibility="private" extends="dataModel,dataTemplateCompile"/>
+    <conf name="compile" visibility="private"/>
     <conf name="compileClasspath" visibility="private" extends="compileOnly,implementation"/>
     <conf name="compileOnly" visibility="private"/>
     <conf name="dataModel" visibility="public"/>
@@ -14,7 +15,7 @@
     <conf name="default" visibility="public" extends="runtimeElements"/>
     <conf name="generatedJavadoc" visibility="public"/>
     <conf name="generatedSources" visibility="public"/>
-    <conf name="implementation" visibility="private" extends="compile"/>
+    <conf name="implementation" visibility="private" extends="api,compile"/>
     <conf name="mainGeneratedDataTemplateAnnotationProcessor" visibility="private"/>
     <conf name="mainGeneratedDataTemplateCompile" visibility="private"/>
     <conf name="mainGeneratedDataTemplateCompileClasspath" visibility="private" extends="mainGeneratedDataTemplateCompileOnly,mainGeneratedDataTemplateImplementation"/>
@@ -35,7 +36,7 @@
     <conf name="schemaAnnotationHandler" visibility="public"/>
     <conf name="testAnnotationProcessor" visibility="private"/>
     <conf name="testAvroSchema" visibility="public" extends="avroSchema"/>
-    <conf name="testCompile" visibility="private" extends="compile,dataTemplateCompile,testDataModel"/>
+    <conf name="testCompile" visibility="private" extends="compile"/>
     <conf name="testCompileClasspath" visibility="private" extends="testCompileOnly,testImplementation"/>
     <conf name="testCompileOnly" visibility="private"/>
     <conf name="testDataModel" visibility="public" extends="dataModel"/>
@@ -50,7 +51,7 @@
     <conf name="testGeneratedDataTemplateRuntimeOnly" visibility="private"/>
     <conf name="testGeneratedJavadoc" visibility="public" extends="generatedJavadoc"/>
     <conf name="testGeneratedSources" visibility="public" extends="generatedSources"/>
-    <conf name="testImplementation" visibility="private" extends="implementation,testCompile"/>
+    <conf name="testImplementation" visibility="private" extends="dataTemplateCompile,implementation,testCompile,testDataModel"/>
     <conf name="testRestClient" visibility="public" extends="restClient,testDataTemplate"/>
     <conf name="testRestModel" visibility="public" extends="restModel"/>
     <conf name="testRuntime" visibility="private" extends="runtime,testCompile"/>

--- a/gradle-plugins/src/integTest/resources/ivy/legacy/expectedGrandparentIvyDescriptorContents.txt
+++ b/gradle-plugins/src/integTest/resources/ivy/legacy/expectedGrandparentIvyDescriptorContents.txt
@@ -1,10 +1,11 @@
   <configurations>
     <conf name="annotationProcessor" visibility="private"/>
-    <conf name="apiElements" visibility="private" extends="runtime"/>
+    <conf name="api" visibility="private" extends="compile,dataModel,dataTemplateCompile"/>
+    <conf name="apiElements" visibility="private" extends="api,runtime"/>
     <conf name="archives" visibility="public"/>
     <conf name="avroSchema" visibility="public"/>
     <conf name="avroSchemaGenerator" visibility="private"/>
-    <conf name="compile" visibility="private" extends="dataModel,dataTemplateCompile"/>
+    <conf name="compile" visibility="private"/>
     <conf name="compileClasspath" visibility="private" extends="compileOnly,implementation"/>
     <conf name="compileOnly" visibility="private"/>
     <conf name="dataModel" visibility="public"/>
@@ -14,7 +15,7 @@
     <conf name="default" visibility="public" extends="runtimeElements"/>
     <conf name="generatedJavadoc" visibility="public"/>
     <conf name="generatedSources" visibility="public"/>
-    <conf name="implementation" visibility="private" extends="compile"/>
+    <conf name="implementation" visibility="private" extends="api,compile"/>
     <conf name="mainGeneratedDataTemplateAnnotationProcessor" visibility="private"/>
     <conf name="mainGeneratedDataTemplateCompile" visibility="private"/>
     <conf name="mainGeneratedDataTemplateCompileClasspath" visibility="private" extends="mainGeneratedDataTemplateCompileOnly,mainGeneratedDataTemplateImplementation"/>
@@ -35,7 +36,7 @@
     <conf name="schemaAnnotationHandler" visibility="public"/>
     <conf name="testAnnotationProcessor" visibility="private"/>
     <conf name="testAvroSchema" visibility="public" extends="avroSchema"/>
-    <conf name="testCompile" visibility="private" extends="compile,dataTemplateCompile,testDataModel"/>
+    <conf name="testCompile" visibility="private" extends="compile"/>
     <conf name="testCompileClasspath" visibility="private" extends="testCompileOnly,testImplementation"/>
     <conf name="testCompileOnly" visibility="private"/>
     <conf name="testDataModel" visibility="public" extends="dataModel"/>
@@ -50,7 +51,7 @@
     <conf name="testGeneratedDataTemplateRuntimeOnly" visibility="private"/>
     <conf name="testGeneratedJavadoc" visibility="public" extends="generatedJavadoc"/>
     <conf name="testGeneratedSources" visibility="public" extends="generatedSources"/>
-    <conf name="testImplementation" visibility="private" extends="implementation,testCompile"/>
+    <conf name="testImplementation" visibility="private" extends="dataTemplateCompile,implementation,testCompile,testDataModel"/>
     <conf name="testRestClient" visibility="public" extends="restClient,testDataTemplate"/>
     <conf name="testRestModel" visibility="public" extends="restModel"/>
     <conf name="testRuntime" visibility="private" extends="runtime,testCompile"/>

--- a/gradle-plugins/src/integTest/resources/ivy/legacy/expectedParentIvyDescriptorContents.txt
+++ b/gradle-plugins/src/integTest/resources/ivy/legacy/expectedParentIvyDescriptorContents.txt
@@ -1,10 +1,11 @@
   <configurations>
     <conf name="annotationProcessor" visibility="private"/>
-    <conf name="apiElements" visibility="private" extends="runtime"/>
+    <conf name="api" visibility="private" extends="compile,dataModel,dataTemplateCompile"/>
+    <conf name="apiElements" visibility="private" extends="api,runtime"/>
     <conf name="archives" visibility="public"/>
     <conf name="avroSchema" visibility="public"/>
     <conf name="avroSchemaGenerator" visibility="private"/>
-    <conf name="compile" visibility="private" extends="dataModel,dataTemplateCompile"/>
+    <conf name="compile" visibility="private"/>
     <conf name="compileClasspath" visibility="private" extends="compileOnly,implementation"/>
     <conf name="compileOnly" visibility="private"/>
     <conf name="dataModel" visibility="public"/>
@@ -14,7 +15,7 @@
     <conf name="default" visibility="public" extends="runtimeElements"/>
     <conf name="generatedJavadoc" visibility="public"/>
     <conf name="generatedSources" visibility="public"/>
-    <conf name="implementation" visibility="private" extends="compile"/>
+    <conf name="implementation" visibility="private" extends="api,compile"/>
     <conf name="mainGeneratedDataTemplateAnnotationProcessor" visibility="private"/>
     <conf name="mainGeneratedDataTemplateCompile" visibility="private"/>
     <conf name="mainGeneratedDataTemplateCompileClasspath" visibility="private" extends="mainGeneratedDataTemplateCompileOnly,mainGeneratedDataTemplateImplementation"/>
@@ -35,7 +36,7 @@
     <conf name="schemaAnnotationHandler" visibility="public"/>
     <conf name="testAnnotationProcessor" visibility="private"/>
     <conf name="testAvroSchema" visibility="public" extends="avroSchema"/>
-    <conf name="testCompile" visibility="private" extends="compile,dataTemplateCompile,testDataModel"/>
+    <conf name="testCompile" visibility="private" extends="compile"/>
     <conf name="testCompileClasspath" visibility="private" extends="testCompileOnly,testImplementation"/>
     <conf name="testCompileOnly" visibility="private"/>
     <conf name="testDataModel" visibility="public" extends="dataModel"/>
@@ -50,7 +51,7 @@
     <conf name="testGeneratedDataTemplateRuntimeOnly" visibility="private"/>
     <conf name="testGeneratedJavadoc" visibility="public" extends="generatedJavadoc"/>
     <conf name="testGeneratedSources" visibility="public" extends="generatedSources"/>
-    <conf name="testImplementation" visibility="private" extends="implementation,testCompile"/>
+    <conf name="testImplementation" visibility="private" extends="dataTemplateCompile,implementation,testCompile,testDataModel"/>
     <conf name="testRestClient" visibility="public" extends="restClient,testDataTemplate"/>
     <conf name="testRestModel" visibility="public" extends="restModel"/>
     <conf name="testRuntime" visibility="private" extends="runtime,testCompile"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.11
+version=29.18.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
A few remaining references to the deprecated "runtime", "compile", and
"testCompile" configurations need to be replaced to work with Gradle 7.