### PR TITLE
Expose getResourceClass in ResourceDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Expose getResourceClass from ResourceDefinition interface.
 
 ## [29.18.5] - 2021-05-13
 - Add "http.streamingTimeout" to AllowedClientPropertyKeys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.18.6] - 2021-05-13
 - Expose getResourceClass from ResourceDefinition interface.
 
 ## [29.18.5] - 2021-05-13
@@ -4935,7 +4937,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.6...master
+[29.18.6]: https://github.com/linkedin/rest.li/compare/v29.18.5...v29.18.6
 [29.18.5]: https://github.com/linkedin/rest.li/compare/v29.18.4...v29.18.5
 [29.18.4]: https://github.com/linkedin/rest.li/compare/v29.18.3...v29.18.4
 [29.18.3]: https://github.com/linkedin/rest.li/compare/v29.18.2...v29.18.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.5
+version=29.18.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java
@@ -327,27 +327,31 @@ public class ResourceModel implements ResourceDefinition
   /**
    * @return true if this resource has sub-resources, false otherwise
    */
+  @Override
   public boolean hasSubResources()
   {
     return _pathSubResourceMap.size() > 0;
   }
 
+  @Override
   public Class<?> getResourceClass()
   {
     return _resourceClass;
   }
 
-
+  @Override
   public String getName()
   {
     return _name;
   }
 
+  @Override
   public String getNamespace()
   {
     return _namespace;
   }
 
+  @Override
   public boolean isRoot()
   {
     return _root;

--- a/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
@@ -43,19 +43,11 @@ public interface ResourceDefinition
 
   /**
    * Gets the rest.li resource java class.
-   * By default we assume java resource class name is the same as annotated namespace name,
-   * if that class cannot be found, return null.
    *
    * @return java class for this rest.li resource.
    */
   default Class<?> getResourceClass() {
-
-    String clazzName = getNamespace() + "." + getName();
-    try {
-      return Class.forName(clazzName);
-    } catch (ClassNotFoundException e) {
-      return null;
-    }
+    throw new UnsupportedOperationException();
   }
 
   /**

--- a/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
@@ -42,6 +42,13 @@ public interface ResourceDefinition
   String getNamespace();
 
   /**
+   * Gets the rest.li resource java class.
+   *
+   * @return java class for this rest.li resource.
+   */
+  Class<?> getResourceClass();
+
+  /**
    * Returns whether the resource is a root resource or not.
    *
    * @return true if the resource is a root resource; else false.

--- a/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
@@ -43,10 +43,20 @@ public interface ResourceDefinition
 
   /**
    * Gets the rest.li resource java class.
+   * By default we assume java resource class name is the same as annotated namespace name,
+   * if that class cannot be found, return null.
    *
    * @return java class for this rest.li resource.
    */
-  Class<?> getResourceClass();
+  default Class<?> getResourceClass() {
+
+    String clazzName = getNamespace() + "." + getName();
+    try {
+      return Class.forName(clazzName);
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+  }
 
   /**
    * Returns whether the resource is a root resource or not.


### PR DESCRIPTION
This PR exposes `getResourceClass` in `ResourceDefinition` so that `ResourceDefinitionListener` can code using that information. Current ResourceModel (the implementation of ResourceDefinitionListener) already has that method implemented.