### PR TITLE
Avoid modifying the input schema when translating pegasus schemas to avro.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.7] - 2021-05-17
+- Avoid modifying pegasus schemas when translating them to AVRO.
+
 ## [29.18.6] - 2021-05-13
 - Expose getResourceClass from ResourceDefinition interface.
 
@@ -4937,7 +4940,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.7...master
+[29.18.7]: https://github.com/linkedin/rest.li/compare/v29.18.6...v29.18.7
 [29.18.6]: https://github.com/linkedin/rest.li/compare/v29.18.5...v29.18.6
 [29.18.5]: https://github.com/linkedin/rest.li/compare/v29.18.4...v29.18.5
 [29.18.4]: https://github.com/linkedin/rest.li/compare/v29.18.3...v29.18.4

--- a/data-avro/src/main/java/com/linkedin/data/avro/FieldOverridesBuilder.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/FieldOverridesBuilder.java
@@ -13,7 +13,7 @@ import java.util.Map;
  */
 class FieldOverridesBuilder {
   private Map<RecordDataSchema.Field, FieldOverride> _defaultValueOverrides;
-  private Map<RecordDataSchema.Field, FieldOverride> _schemaOverrides;
+  private Map<RecordDataSchema.Field, RecordDataSchema.Field> _schemaOverrides;
 
   FieldOverridesBuilder defaultValueOverrides(IdentityHashMap<RecordDataSchema.Field, FieldOverride> defaultValueOverrides)
   {
@@ -21,7 +21,7 @@ class FieldOverridesBuilder {
     return this;
   }
 
-  FieldOverridesBuilder schemaOverrides(IdentityHashMap<RecordDataSchema.Field, FieldOverride> schemaOverrides)
+  FieldOverridesBuilder schemaOverrides(IdentityHashMap<RecordDataSchema.Field, RecordDataSchema.Field> schemaOverrides)
   {
     _schemaOverrides = schemaOverrides;
     return this;
@@ -37,7 +37,7 @@ class FieldOverridesBuilder {
       }
 
       @Override
-      public FieldOverride getSchemaOverride(RecordDataSchema.Field field)
+      public RecordDataSchema.Field getSchemaOverride(RecordDataSchema.Field field)
       {
         return (_schemaOverrides == null) ? null : _schemaOverrides.get(field);
       }

--- a/data-avro/src/main/java/com/linkedin/data/avro/FieldOverridesProvider.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/FieldOverridesProvider.java
@@ -17,5 +17,5 @@ interface FieldOverridesProvider {
   /**
    * Returns a schema {@link FieldOverride} if there exists one for the requested field.
    */
-  FieldOverride getSchemaOverride(RecordDataSchema.Field field);
+  RecordDataSchema.Field getSchemaOverride(RecordDataSchema.Field field);
 }

--- a/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
@@ -317,11 +317,11 @@ public class SchemaTranslator
     // maintained, as we want the Pegasus unions translated before converting the default values.
     Map<DataSchemaTraverse.Order, DataSchemaTraverse.Callback> callbacks = new HashMap<>();
 
-    IdentityHashMap<RecordDataSchema.Field, FieldOverride> schemaOverrides = new IdentityHashMap<>();
+    IdentityHashMap<RecordDataSchema.Field, RecordDataSchema.Field> schemaOverrides = new IdentityHashMap<>();
     callbacks.put(DataSchemaTraverse.Order.PRE_ORDER, new PegasusUnionToAvroRecordConvertCallback(options, schemaOverrides));
 
     IdentityHashMap<RecordDataSchema.Field, FieldOverride> defaultValueOverrides = new IdentityHashMap<>();
-    callbacks.put(DataSchemaTraverse.Order.POST_ORDER, new DefaultDataToAvroConvertCallback(options, defaultValueOverrides));
+    callbacks.put(DataSchemaTraverse.Order.POST_ORDER, new DefaultDataToAvroConvertCallback(options, defaultValueOverrides, schemaOverrides));
 
     schemaTraverser.traverse(dataSchema, callbacks);
 
@@ -330,9 +330,7 @@ public class SchemaTranslator
         .schemaOverrides(schemaOverrides)
         .defaultValueOverrides(defaultValueOverrides)
         .build();
-    String schemaJson = SchemaToAvroJsonEncoder.schemaToAvro(dataSchema, fieldOverridesProvider, options);
-
-    return schemaJson;
+    return SchemaToAvroJsonEncoder.schemaToAvro(dataSchema, fieldOverridesProvider, options);
   }
 
   /**

--- a/data/src/main/java/com/linkedin/data/schema/DataSchemaTraverse.java
+++ b/data/src/main/java/com/linkedin/data/schema/DataSchemaTraverse.java
@@ -139,7 +139,7 @@ public class DataSchemaTraverse
 
   private void traverseChild(String childKey, DataSchema childSchema)
   {
-    if (! _seen.containsKey(childSchema))
+    if (!_seen.containsKey(childSchema))
     {
       _seen.put(childSchema, Boolean.TRUE);
       _path.add(childKey);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.6
+version=29.18.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Modifying the schema can result in situation when the schema used by other threads at runtime can be incorrect. This change ensures the original schema is unmodified and any changes are stored only as overrides.