### PR TITLE
Remove primitive class constructors

### DIFF
--- a/d2-int-test/src/test/java/com/linkedin/d2/D2BaseTest.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/D2BaseTest.java
@@ -216,7 +216,7 @@ public class D2BaseTest implements D2TestConstants
           try
           {
             response = cli.sendRequest(client, clusterName, service, msg);
-            assertTrue(response.contains(LoadBalancerEchoServer.getResponsePostfixString()),"No '"+LoadBalancerEchoServer.getResponsePostfixString()+"' found in response from "+clusterName+"/"+service+". Response:"+response); 
+            assertTrue(response.contains(LoadBalancerEchoServer.getResponsePostfixString()),"No '"+LoadBalancerEchoServer.getResponsePostfixString()+"' found in response from "+clusterName+"/"+service+". Response:"+response);
             _log.error("Assert pass. Response contains "+LoadBalancerEchoServer.getResponsePostfixString());
           }
           catch (Exception e)
@@ -248,7 +248,7 @@ public class D2BaseTest implements D2TestConstants
         try
         {
           response = cli.sendRequest(client, "cluster-"+i,"service-"+i+"_1", msg);
-          assertTrue(response.contains(LoadBalancerEchoServer.getResponsePostfixString()),"No '"+LoadBalancerEchoServer.getResponsePostfixString()+"' found in response from cluster-"+i+"/service-"+i+"_1. Response:"+response); 
+          assertTrue(response.contains(LoadBalancerEchoServer.getResponsePostfixString()),"No '"+LoadBalancerEchoServer.getResponsePostfixString()+"' found in response from cluster-"+i+"/service-"+i+"_1. Response:"+response);
           counts.get("passed").getAndIncrement();
         }
         catch (Exception e)
@@ -315,7 +315,7 @@ public class D2BaseTest implements D2TestConstants
       if (count < weight.length)
       {
         Map<Integer, Double> partitionWeight = new HashMap<Integer, Double> ();
-        partitionWeight.put(new Integer(partitionId), weight[count]);
+        partitionWeight.put(Integer.valueOf(partitionId), weight[count]);
         hash.put(server, partitionWeight);
         count++;
       }

--- a/d2-int-test/src/test/java/com/linkedin/d2/discovery/TestPartitionsWithZKQuorum.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/discovery/TestPartitionsWithZKQuorum.java
@@ -116,7 +116,7 @@ public class TestPartitionsWithZKQuorum extends D2BaseTest
     _client = _cli.createZKFSTogglingLBClient(_quorum.getHosts(), "/d2", null);
     // Echo servers startup
     Map<Integer, Double> partitionWeight = new HashMap<Integer, Double>();
-    partitionWeight.put(new Integer(1), new Double(1.0d));
+    partitionWeight.put(Integer.valueOf(1), Double.valueOf(1.0d));
     startCustomPartitionEchoServers(partitionWeight);
     assertAllEchoServersRegistered(_cli.getZKClient(), _zkUriString, _echoServers);
     assertQuorumProcessAllRequests(D2_CONFIG_CUSTOM_PARTITION_DATA);
@@ -142,7 +142,7 @@ public class TestPartitionsWithZKQuorum extends D2BaseTest
     _client = _cli.createZKFSTogglingLBClient(_quorum.getHosts(), "/d2", null);
     // Echo servers startup
     Map<Integer, Double> partitionWeight = new HashMap<Integer, Double>();
-    partitionWeight.put(new Integer(1), new Double(1.0d));
+    partitionWeight.put(Integer.valueOf(1), Double.valueOf(1.0d));
     startAllEchoServers(partitionWeight);
     assertAllEchoServersRegistered(_cli.getZKClient(), _zkUriString, _echoServers);
     assertQuorumProcessAllRequests(D2_CONFIG_DATA);

--- a/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/TestD2ZKQuorumFailover.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/TestD2ZKQuorumFailover.java
@@ -274,7 +274,7 @@ public class TestD2ZKQuorumFailover extends D2BaseTest
   {
     _echoServers = new ArrayList<LoadBalancerEchoServer>();
     Map<Integer, Double> partitionWeight = new HashMap<Integer, Double>();
-    partitionWeight.put(new Integer(1), new Double(1.0d));
+    partitionWeight.put(Integer.valueOf(1), Double.valueOf(1.0d));
     _echoServers.add(startEchoServer(getHost(_zkHosts[0]), getPort(_zkHosts[0]), ECHO_SERVER_HOST, ECHO_SERVER_PORT1_1, "cluster-1", "service-1_1", "service-1_2", "service-1_3" ));
     _echoServers.add(startEchoServer(getHost(_zkHosts[0]), getPort(_zkHosts[0]), ECHO_SERVER_HOST, ECHO_SERVER_PORT1_2, "cluster-1", "service-1_1", "service-1_2", "service-1_3" ));
     _echoServers.add(startEchoServer(getHost(_zkHosts[0]), getPort(_zkHosts[0]), ECHO_SERVER_HOST, ECHO_SERVER_PORT2_1, "cluster-2", "service-2_1", "service-2_2", "service-2_3" ));

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/ConsistentHashRing.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/ConsistentHashRing.java
@@ -228,7 +228,7 @@ public class ConsistentHashRing<T> implements Ring<T>
       double percentage;
 
       Map<T, Double> coverageMap = getCoverageMap();
-      Double sizeOfInt = new Double(Integer.MAX_VALUE) - new Double(Integer.MIN_VALUE);
+      Double sizeOfInt = Double.valueOf(Integer.MAX_VALUE) - Double.valueOf(Integer.MIN_VALUE);
       double maxPercentage = Double.MIN_VALUE;
       double minPercentage = Double.MAX_VALUE;
       for (Map.Entry<T, Double> entry : coverageMap.entrySet())
@@ -257,7 +257,7 @@ public class ConsistentHashRing<T> implements Ring<T>
     }
 
     Map<T, Double> coverageMap = new HashMap<T, Double>();
-    Double curr = new Double(Integer.MIN_VALUE);
+    Double curr = Double.valueOf(Integer.MIN_VALUE);
     T firstElement = null;
     //we know points are sortedSet and the iterator is iterating from low to high
     for (Point<T> point : _points)
@@ -267,7 +267,7 @@ public class ConsistentHashRing<T> implements Ring<T>
         firstElement = point.getT();
       }
       Double currentCoverage = point.getHash() - curr;
-      curr = new Double(point.getHash());
+      curr = Double.valueOf(point.getHash());
       Double area = coverageMap.get(point.getT());
       if (area == null)
       {
@@ -277,7 +277,7 @@ public class ConsistentHashRing<T> implements Ring<T>
       coverageMap.put(point.getT(), area);
     }
     //don't forget to take into account the last chunk of area
-    Double remainingArea = new Double(Integer.MAX_VALUE - curr);
+    Double remainingArea = Double.valueOf(Integer.MAX_VALUE - curr);
     Double area = coverageMap.get(firstElement);
     area += remainingArea;
     coverageMap.put(firstElement, area);

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/HostToKeyMapperTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/HostToKeyMapperTest.java
@@ -145,8 +145,8 @@ public class HostToKeyMapperTest
     for (Map.Entry<URI, Collection<Integer>> entry: mapResult.entrySet())
     {
       Assert.assertEquals(entry.getKey(), foo2);
-      Assert.assertTrue(entry.getValue().contains(new Integer(10)));
-      Assert.assertTrue(entry.getValue().contains(new Integer(13)));
+      Assert.assertTrue(entry.getValue().contains(Integer.valueOf(10)));
+      Assert.assertTrue(entry.getValue().contains(Integer.valueOf(13)));
     }
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/LoadBalancerEchoServer.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/LoadBalancerEchoServer.java
@@ -415,7 +415,7 @@ public class LoadBalancerEchoServer
     }
     else
     {
-      partitionDataMap.put(DefaultPartitionAccessor.DEFAULT_PARTITION_ID, new Double(1d));
+      partitionDataMap.put(DefaultPartitionAccessor.DEFAULT_PARTITION_ID, Double.valueOf(1d));
     }
 
     for (int partitionId : partitionDataMap.keySet())

--- a/data/src/main/java/com/linkedin/data/codec/BsonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/BsonDataCodec.java
@@ -457,7 +457,7 @@ public class BsonDataCodec implements DataCodec
             break;
           case BSON_BOOLEAN:
             byte b = _buffer.get();
-            o = new Boolean(b != ZERO_BYTE);
+            o = Boolean.valueOf(b != ZERO_BYTE);
             break;
           case BSON_64BIT_INTEGER:
             o = _buffer.getLong();

--- a/data/src/main/java/com/linkedin/data/codec/PsonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/PsonDataCodec.java
@@ -699,7 +699,7 @@ public class PsonDataCodec implements DataCodec
           break;
         case PSON_BOOLEAN:
           byte b = _buffer.get();
-          o = new Boolean(b != ZERO_BYTE);
+          o = Boolean.valueOf(b != ZERO_BYTE);
           break;
         case PSON_BINARY:
           int length = _buffer.getInt();

--- a/data/src/test/java/com/linkedin/data/TestData.java
+++ b/data/src/test/java/com/linkedin/data/TestData.java
@@ -546,11 +546,11 @@ public class TestData
   public void testDataMapAccessors()
   {
     Object[] objects = {
-        new Boolean(true),
-        new Integer(1),
-        new Long(2),
-        new Float(1.5),
-        new Double(2.0),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(2),
+        Float.valueOf(1.5f),
+        Double.valueOf(2.0),
         new String("foo"),
         ByteString.copyAvroString("bar", false)
     };

--- a/data/src/test/java/com/linkedin/data/codec/CodecDataProviders.java
+++ b/data/src/test/java/com/linkedin/data/codec/CodecDataProviders.java
@@ -122,7 +122,7 @@ public class CodecDataProviders
       for (int i = 0; i < 100; ++i)
       {
         String key = "key_" + i;
-        map1.put(key, new Boolean(i % 2 == 1));
+        map1.put(key, Boolean.valueOf(i % 2 == 1));
       }
       inputs.put("Map of 100 booleans", map1);
     }
@@ -133,7 +133,7 @@ public class CodecDataProviders
       map1.put("list", list1);
       for (int i = 0; i < 100; ++i)
       {
-        list1.add(new Integer(i));
+        list1.add(Integer.valueOf(i));
       }
       inputs.put("List of 100 32-bit integers", map1);
     }
@@ -144,7 +144,7 @@ public class CodecDataProviders
       map1.put("list", list1);
       for (int i = 0; i < 100; ++i)
       {
-        list1.add(new Double(i + 0.5));
+        list1.add(Double.valueOf(i + 0.5));
       }
       inputs.put("List of 100 doubles", map1);
     }
@@ -164,7 +164,7 @@ public class CodecDataProviders
       for (int i = 0; i < 100; ++i)
       {
         String key = "key_" + i;
-        map1.put(key, new Integer(i));
+        map1.put(key, Integer.valueOf(i));
       }
       inputs.put("Map of 100 32-bit integers", map1);
     }
@@ -174,7 +174,7 @@ public class CodecDataProviders
       for (int i = 0; i < 100; ++i)
       {
         String key = "key_" + i;
-        map1.put(key, new Double(i + 0.5));
+        map1.put(key, Double.valueOf(i + 0.5));
       }
       inputs.put("Map of 100 doubles", map1);
     }

--- a/data/src/test/java/com/linkedin/data/collections/TestCowList.java
+++ b/data/src/test/java/com/linkedin/data/collections/TestCowList.java
@@ -145,7 +145,7 @@ public class TestCowList
     assertEquals(list8.getRefCounted().getRefCount(), 0);
 
     CowList<Integer> list9 = list1.clone();
-    list9.remove(new Integer(referenceStart1 + 1));
+    list9.remove(Integer.valueOf(referenceStart1 + 1));
     assertEquals(list9.get(1).intValue(), referenceStart1 + 2);
     contains(list1, referenceStart1 + 1);
     contains(list3, referenceStart1 + 1);

--- a/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
+++ b/data/src/test/java/com/linkedin/data/schema/validation/TestValidation.java
@@ -272,11 +272,11 @@ public class TestValidation
 
     Object badObjects[] =
     {
-        new Boolean(false),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.FALSE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
         new DataList()
@@ -298,16 +298,16 @@ public class TestValidation
 
     Object goodObjects[] =
     {
-        new Boolean(true),
-        new Boolean(false)
+        Boolean.TRUE,
+        Boolean.FALSE
     };
 
     Object badObjects[] =
     {
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -333,10 +333,10 @@ public class TestValidation
 
     Object badObjects[] =
         {
-            new Integer(1),
-            new Long(1),
-            new Float(1),
-            new Double(1),
+            Integer.valueOf(1),
+            Long.valueOf(1),
+            Float.valueOf(1f),
+            Double.valueOf(1),
             new String("abc"),
             new DataMap(),
             new DataList()
@@ -354,18 +354,18 @@ public class TestValidation
 
     Object goodObjects[] =
     {
-        new Integer(1),
-        new Integer(-1),
+        Integer.valueOf(1),
+        Integer.valueOf(-1),
         Integer.MAX_VALUE,
         Integer.MAX_VALUE - 1
     };
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -385,18 +385,18 @@ public class TestValidation
 
     Object input[][] =
       {
-        { new Integer(1), new Integer(1) },
-        { new Integer(-1), new Integer(-1) },
+        { Integer.valueOf(1), Integer.valueOf(1) },
+        { Integer.valueOf(-1), Integer.valueOf(-1) },
         { Integer.MAX_VALUE, Integer.MAX_VALUE },
         { Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 1 },
-        { new Long(1), new Integer(1) },
-        { new Float(1), new Integer(1) },
-        { new Double(1), new Integer(1) }
+        { Long.valueOf(1), Integer.valueOf(1) },
+        { Float.valueOf(1f), Integer.valueOf(1) },
+        { Double.valueOf(1), Integer.valueOf(1) }
       };
 
     Object badObjects[] =
       {
-        new Boolean(true),
+        Boolean.TRUE,
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -415,25 +415,25 @@ public class TestValidation
 
     Object input[][] =
         {
-            { new String("1"), new Integer(1) },
-            { new String("-1"), new Integer(-1) },
+            { new String("1"), Integer.valueOf(1) },
+            { new String("-1"), Integer.valueOf(-1) },
             { new String("" + Integer.MAX_VALUE), Integer.MAX_VALUE},
             { new String("" + (Integer.MAX_VALUE - 1)), Integer.MAX_VALUE - 1},
-            { new String("1.5"), new Integer(1) },
-            { new String("-1.5"), new Integer(-1) },
+            { new String("1.5"), Integer.valueOf(1) },
+            { new String("-1.5"), Integer.valueOf(-1) },
 
-            { new Integer(1), new Integer(1) },
-            { new Integer(-1), new Integer(-1) },
+            { Integer.valueOf(1), Integer.valueOf(1) },
+            { Integer.valueOf(-1), Integer.valueOf(-1) },
             { Integer.MAX_VALUE, Integer.MAX_VALUE },
             { Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 1 },
-            { new Long(1), new Integer(1) },
-            { new Float(1), new Integer(1) },
-            { new Double(1), new Integer(1) }
+            { Long.valueOf(1), Integer.valueOf(1) },
+            { Float.valueOf(1f), Integer.valueOf(1) },
+            { Double.valueOf(1), Integer.valueOf(1) }
         };
 
     Object badObjects[] =
         {
-            new Boolean(true),
+            Boolean.TRUE,
             new String("abc"),
             ByteString.copyAvroString("bytes", false),
             new DataMap(),
@@ -452,16 +452,16 @@ public class TestValidation
 
     Object goodObjects[] =
     {
-        new Long(1),
-        new Long(-1)
+        Long.valueOf(1),
+        Long.valueOf(-1)
     };
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -480,16 +480,16 @@ public class TestValidation
 
     Object inputs[][] =
       {
-        { new Long(1), new Long(1) },
-        { new Long(-1), new Long(-1) },
-        { new Integer(1), new Long(1) },
-        { new Float(1), new Long(1) },
-        { new Double(1), new Long(1) }
+        { Long.valueOf(1), Long.valueOf(1) },
+        { Long.valueOf(-1), Long.valueOf(-1) },
+        { Integer.valueOf(1), Long.valueOf(1) },
+        { Float.valueOf(1f), Long.valueOf(1) },
+        { Double.valueOf(1), Long.valueOf(1) }
       };
 
     Object badObjects[] =
       {
-        new Boolean(true),
+        Boolean.TRUE,
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -508,21 +508,21 @@ public class TestValidation
 
     Object inputs[][] =
         {
-            { new String("1"), new Long(1) },
-            { new String("-1"), new Long(-1) },
+            { new String("1"), Long.valueOf(1) },
+            { new String("-1"), Long.valueOf(-1) },
             { new String("" + Long.MAX_VALUE), Long.MAX_VALUE },
 
-            { new Long(1), new Long(1) },
-            { new Long(-1), new Long(-1) },
-            { new Integer(1), new Long(1) },
-            { new Float(1), new Long(1) },
-            { new Double(1), new Long(1) }
+            { Long.valueOf(1), Long.valueOf(1) },
+            { Long.valueOf(-1), Long.valueOf(-1) },
+            { Integer.valueOf(1), Long.valueOf(1) },
+            { Float.valueOf(1f), Long.valueOf(1) },
+            { Double.valueOf(1), Long.valueOf(1) }
         };
 
 
     Object badObjects[] =
         {
-            new Boolean(true),
+            Boolean.TRUE,
             new String("abc"),
             ByteString.copyAvroString("bytes", false),
             new DataMap(),
@@ -541,16 +541,16 @@ public class TestValidation
 
     Object goodObjects[] =
     {
-        new Float(1),
-        new Float(-1)
+        Float.valueOf(1f),
+        Float.valueOf(-1f)
     };
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Double.valueOf(1),
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -569,16 +569,16 @@ public class TestValidation
 
     Object inputs[][] =
       {
-        { new Float(1), new Float(1) },
-        { new Float(-1), new Float(-1) },
-        { new Integer(1), new Float(1) },
-        { new Long(1), new Float(1) },
-        { new Double(1), new Float(1) }
+        { Float.valueOf(1f), Float.valueOf(1f) },
+        { Float.valueOf(-1f), Float.valueOf(-1f) },
+        { Integer.valueOf(1), Float.valueOf(1f) },
+        { Long.valueOf(1), Float.valueOf(1f) },
+        { Double.valueOf(1), Float.valueOf(1f) }
       };
 
     Object badObjects[] =
       {
-        new Boolean(true),
+        Boolean.TRUE,
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -597,23 +597,23 @@ public class TestValidation
 
     Object inputs[][] =
         {
-            { new String("1"), new Float(1) },
-            { new String("-1"), new Float(-1) },
-            { new String("1.01"), new Float(1.01) },
-            { new String("-1.01"), new Float(-1.01) },
+            { new String("1"), Float.valueOf(1f) },
+            { new String("-1"), Float.valueOf(-1f) },
+            { new String("1.01"), Float.valueOf(1.01f) },
+            { new String("-1.01"), Float.valueOf(-1.01f) },
             { new String("" + Float.MAX_VALUE), Float.MAX_VALUE },
 
-            { new Float(1), new Float(1) },
-            { new Float(1), new Float(1) },
-            { new Float(-1), new Float(-1) },
-            { new Integer(1), new Float(1) },
-            { new Long(1), new Float(1) },
-            { new Double(1), new Float(1) }
+            { Float.valueOf(1f), Float.valueOf(1f) },
+            { Float.valueOf(1f), Float.valueOf(1f) },
+            { Float.valueOf(-1f), Float.valueOf(-1f) },
+            { Integer.valueOf(1), Float.valueOf(1f) },
+            { Long.valueOf(1), Float.valueOf(1f) },
+            { Double.valueOf(1), Float.valueOf(1f) }
         };
 
     Object badObjects[] =
         {
-            new Boolean(true),
+            Boolean.TRUE,
             new String("abc"),
             ByteString.copyAvroString("bytes", false),
             new DataMap(),
@@ -632,16 +632,16 @@ public class TestValidation
 
     Object goodObjects[] =
     {
-        new Double(1),
-        new Double(-1)
+        Double.valueOf(1),
+        Double.valueOf(-1)
     };
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -660,16 +660,16 @@ public class TestValidation
 
     Object inputs[][] =
       {
-        { new Double(1), new Double(1) },
-        { new Double(-1), new Double(-1) },
-        { new Integer(1), new Double(1) },
-        { new Long(1), new Double(1) },
-        { new Float(1), new Double(1) }
+        { Double.valueOf(1), Double.valueOf(1) },
+        { Double.valueOf(-1), Double.valueOf(-1) },
+        { Integer.valueOf(1), Double.valueOf(1) },
+        { Long.valueOf(1), Double.valueOf(1) },
+        { Float.valueOf(1f), Double.valueOf(1) }
       };
 
     Object badObjects[] =
       {
-        new Boolean(true),
+        Boolean.TRUE,
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -688,22 +688,22 @@ public class TestValidation
 
     Object inputs[][] =
         {
-            { new String("1"), new Double(1) },
-            { new String("-1"), new Double(-1) },
-            { new String("1.01"), new Double(1.01) },
-            { new String("-1.01"), new Double(-1.01) },
+            { new String("1"), Double.valueOf(1) },
+            { new String("-1"), Double.valueOf(-1) },
+            { new String("1.01"), Double.valueOf(1.01) },
+            { new String("-1.01"), Double.valueOf(-1.01) },
             { new String("" + Double.MAX_VALUE), Double.MAX_VALUE },
 
-            { new Double(1), new Double(1) },
-            { new Double(-1), new Double(-1) },
-            { new Integer(1), new Double(1) },
-            { new Long(1), new Double(1) },
-            { new Float(1), new Double(1) }
+            { Double.valueOf(1), Double.valueOf(1) },
+            { Double.valueOf(-1), Double.valueOf(-1) },
+            { Integer.valueOf(1), Double.valueOf(1) },
+            { Long.valueOf(1), Double.valueOf(1) },
+            { Float.valueOf(1f), Double.valueOf(1) }
         };
 
     Object badObjects[] =
         {
-            new Boolean(true),
+            Boolean.TRUE,
             new String("abc"),
             ByteString.copyAvroString("bytes", false),
             new DataMap(),
@@ -729,11 +729,11 @@ public class TestValidation
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new DataMap(),
         new DataList(),
         new String("\u0100"),
@@ -774,11 +774,11 @@ public class TestValidation
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new DataMap(),
         new DataList(),
         new String(),
@@ -826,11 +826,11 @@ public class TestValidation
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String(),
         new String("foobar"),
         new String("Apple"),
@@ -857,28 +857,28 @@ public class TestValidation
     Object goodObjects[] =
     {
         new DataList(),
-        new DataList(asList(new Integer(1))),
-        new DataList(asList(new Integer(2), new Integer(3))),
+        new DataList(asList(Integer.valueOf(1))),
+        new DataList(asList(Integer.valueOf(2), Integer.valueOf(3))),
     };
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String(),
         new DataMap(),
-        new DataList(asList(new Boolean(true))),
-        new DataList(asList(new Long(1))),
-        new DataList(asList(new Float(1))),
-        new DataList(asList(new Double(1))),
+        new DataList(asList(Boolean.TRUE)),
+        new DataList(asList(Long.valueOf(1))),
+        new DataList(asList(Float.valueOf(1f))),
+        new DataList(asList(Double.valueOf(1))),
         new DataList(asList(new String("1"))),
         new DataList(asList(new DataMap())),
         new DataList(asList(new DataList())),
-        new DataList(asList(new Boolean(true), new Integer(1))),
-        new DataList(asList(new Integer(1), new Boolean(true)))
+        new DataList(asList(Boolean.TRUE, Integer.valueOf(1))),
+        new DataList(asList(Integer.valueOf(1), Boolean.TRUE))
     };
 
     testCoercionValidation(schemaText, "bar", goodObjects, badObjects, noCoercionValidationOption());
@@ -903,19 +903,19 @@ public class TestValidation
 
     Object badObjects[] =
       {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String(),
         new DataMap(),
-        new DataList(asList(new Boolean(true))),
+        new DataList(asList(Boolean.TRUE)),
         new DataList(asList(new String("1"))),
         new DataList(asList(new DataMap())),
         new DataList(asList(new DataList())),
-        new DataList(asList(new Boolean(true), new Integer(1))),
-        new DataList(asList(new Integer(1), new Boolean(true)))
+        new DataList(asList(Boolean.TRUE, Integer.valueOf(1))),
+        new DataList(asList(Integer.valueOf(1), Boolean.TRUE))
       };
 
     testNormalCoercionValidation(schemaText, "bar", inputs, badObjects);
@@ -943,18 +943,18 @@ public class TestValidation
 
     Object badObjects[] =
         {
-            new Boolean(true),
-            new Integer(1),
-            new Long(1),
-            new Float(1),
-            new Double(1),
+            Boolean.TRUE,
+            Integer.valueOf(1),
+            Long.valueOf(1),
+            Float.valueOf(1f),
+            Double.valueOf(1),
             new String(),
             new DataMap(),
-            new DataList(asList(new Boolean(true))),
+            new DataList(asList(Boolean.TRUE)),
             new DataList(asList(new DataMap())),
             new DataList(asList(new DataList())),
-            new DataList(asList(new Boolean(true), new Integer(1))),
-            new DataList(asList(new Integer(1), new Boolean(true)))
+            new DataList(asList(Boolean.TRUE, Integer.valueOf(1))),
+            new DataList(asList(Integer.valueOf(1), Boolean.TRUE))
         };
 
     testStringToPrimitiveCoercionValidation(schemaText, "bar", inputs, badObjects);
@@ -976,22 +976,22 @@ public class TestValidation
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String(),
         new DataList(),
-        new DataMap(asMap("key1", new Boolean(true))),
-        new DataMap(asMap("key1", new Long(1))),
-        new DataMap(asMap("key1", new Float(1))),
-        new DataMap(asMap("key1", new Double(1))),
+        new DataMap(asMap("key1", Boolean.TRUE)),
+        new DataMap(asMap("key1", Long.valueOf(1))),
+        new DataMap(asMap("key1", Float.valueOf(1f))),
+        new DataMap(asMap("key1", Double.valueOf(1))),
         new DataMap(asMap("key1", new String("1"))),
         new DataMap(asMap("key1", new DataMap())),
         new DataMap(asMap("key1", new DataList())),
-        new DataMap(asMap("key1", new Integer(1), "key2", new Long(1))),
-        new DataMap(asMap("key1", new Long(1), "key2", new Integer(1)))
+        new DataMap(asMap("key1", Integer.valueOf(1), "key2", Long.valueOf(1))),
+        new DataMap(asMap("key1", Long.valueOf(1), "key2", Integer.valueOf(1)))
     };
 
     testCoercionValidation(schemaText, "bar", goodObjects, badObjects, noCoercionValidationOption());
@@ -1018,14 +1018,14 @@ public class TestValidation
 
     Object badObjects[] =
       {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String(),
         new DataList(),
-        new DataMap(asMap("key1", new Boolean(true))),
+        new DataMap(asMap("key1", Boolean.TRUE)),
         new DataMap(asMap("key1", new String("1"))),
         new DataMap(asMap("key1", new DataMap())),
         new DataMap(asMap("key1", new DataList())),
@@ -1058,14 +1058,14 @@ public class TestValidation
 
     Object badObjects[] =
         {
-            new Boolean(true),
-            new Integer(1),
-            new Long(1),
-            new Float(1),
-            new Double(1),
+            Boolean.TRUE,
+            Integer.valueOf(1),
+            Long.valueOf(1),
+            Float.valueOf(1f),
+            Double.valueOf(1),
             new String(),
             new DataList(),
-            new DataMap(asMap("key1", new Boolean(true))),
+            new DataMap(asMap("key1", Boolean.TRUE)),
             new DataMap(asMap("key1", new DataMap())),
             new DataMap(asMap("key1", new DataList())),
         };
@@ -1096,7 +1096,7 @@ public class TestValidation
     Object goodObjects[] =
     {
         Data.NULL,
-        new DataMap(asMap("int", new Integer(1))),
+        new DataMap(asMap("int", Integer.valueOf(1))),
         new DataMap(asMap("string", "x")),
         new DataMap(asMap("Fruits", "APPLE")),
         new DataMap(asMap("Fruits", "ORANGE")),
@@ -1104,34 +1104,34 @@ public class TestValidation
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String(),
         new DataList(),
         new DataMap(),
-        new DataMap(asMap("int", new Boolean(true))),
+        new DataMap(asMap("int", Boolean.TRUE)),
         new DataMap(asMap("int", new String("1"))),
-        new DataMap(asMap("int", new Long(1L))),
-        new DataMap(asMap("int", new Float(1.0f))),
-        new DataMap(asMap("int", new Double(1.0))),
+        new DataMap(asMap("int", Long.valueOf(1L))),
+        new DataMap(asMap("int", Float.valueOf(1.0f))),
+        new DataMap(asMap("int", Double.valueOf(1.0))),
         new DataMap(asMap("int", new DataMap())),
         new DataMap(asMap("int", new DataList())),
-        new DataMap(asMap("string", new Boolean(true))),
-        new DataMap(asMap("string", new Integer(1))),
-        new DataMap(asMap("string", new Long(1L))),
-        new DataMap(asMap("string", new Float(1.0f))),
-        new DataMap(asMap("string", new Double(1.0))),
+        new DataMap(asMap("string", Boolean.TRUE)),
+        new DataMap(asMap("string", Integer.valueOf(1))),
+        new DataMap(asMap("string", Long.valueOf(1L))),
+        new DataMap(asMap("string", Float.valueOf(1.0f))),
+        new DataMap(asMap("string", Double.valueOf(1.0))),
         new DataMap(asMap("string", new DataMap())),
         new DataMap(asMap("string", new DataList())),
         new DataMap(asMap("Fruits", "foobar")),
-        new DataMap(asMap("Fruits", new Integer(1))),
+        new DataMap(asMap("Fruits", Integer.valueOf(1))),
         new DataMap(asMap("Fruits", new DataMap())),
         new DataMap(asMap("Fruits", new DataList())),
-        new DataMap(asMap("int", new Integer(1), "string", "x")),
-        new DataMap(asMap("x", new Integer(1), "y", new Long(1))),
+        new DataMap(asMap("int", Integer.valueOf(1), "string", "x")),
+        new DataMap(asMap("x", Integer.valueOf(1), "y", Long.valueOf(1))),
     };
 
     testCoercionValidation(schemaText, "bar", goodObjects, badObjects, noCoercionValidationOption());
@@ -1172,30 +1172,30 @@ public class TestValidation
 
     Object badObjects[] =
       {
-        new Boolean(true),
-        new Integer(1),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Integer.valueOf(1),
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String(),
         new DataList(),
-        new DataMap(asMap("int", new Boolean(true))),
+        new DataMap(asMap("int", Boolean.TRUE)),
         new DataMap(asMap("int", new String("1"))),
         new DataMap(asMap("int", new DataMap())),
         new DataMap(asMap("int", new DataList())),
-        new DataMap(asMap("string", new Boolean(true))),
-        new DataMap(asMap("string", new Integer(1))),
-        new DataMap(asMap("string", new Long(1L))),
-        new DataMap(asMap("string", new Float(1.0f))),
-        new DataMap(asMap("string", new Double(1.0))),
+        new DataMap(asMap("string", Boolean.TRUE)),
+        new DataMap(asMap("string", Integer.valueOf(1))),
+        new DataMap(asMap("string", Long.valueOf(1L))),
+        new DataMap(asMap("string", Float.valueOf(1.0f))),
+        new DataMap(asMap("string", Double.valueOf(1.0))),
         new DataMap(asMap("string", new DataMap())),
         new DataMap(asMap("string", new DataList())),
         new DataMap(asMap("Fruits", "foobar")),
-        new DataMap(asMap("Fruits", new Integer(1))),
+        new DataMap(asMap("Fruits", Integer.valueOf(1))),
         new DataMap(asMap("Fruits", new DataMap())),
         new DataMap(asMap("Fruits", new DataList())),
-        new DataMap(asMap("int", new Integer(1), "string", "x")),
-        new DataMap(asMap("x", new Integer(1), "y", new Long(1))),
+        new DataMap(asMap("int", Integer.valueOf(1), "string", "x")),
+        new DataMap(asMap("x", Integer.valueOf(1), "y", Long.valueOf(1))),
       };
 
     testNormalCoercionValidation(schemaText, "bar", inputs, badObjects);
@@ -1214,16 +1214,16 @@ public class TestValidation
 
     Object goodObjects[] =
     {
-        new Integer(1),
-        new Integer(-1)
+        Integer.valueOf(1),
+        Integer.valueOf(-1)
     };
 
     Object badObjects[] =
     {
-        new Boolean(true),
-        new Long(1),
-        new Float(1),
-        new Double(1),
+        Boolean.TRUE,
+        Long.valueOf(1),
+        Float.valueOf(1f),
+        Double.valueOf(1),
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -1249,16 +1249,16 @@ public class TestValidation
 
     Object inputs[][] =
       {
-        { new Integer(1), new Integer(1) },
-        { new Integer(-1), new Integer(-1) },
-        { new Long(1), new Integer(1) },
-        { new Float(1), new Integer(1) },
-        { new Double(1), new Integer(1) }
+        { Integer.valueOf(1), Integer.valueOf(1) },
+        { Integer.valueOf(-1), Integer.valueOf(-1) },
+        { Long.valueOf(1), Integer.valueOf(1) },
+        { Float.valueOf(1f), Integer.valueOf(1) },
+        { Double.valueOf(1), Integer.valueOf(1) }
       };
 
     Object badObjects[] =
       {
-        new Boolean(true),
+        Boolean.TRUE,
         new String("abc"),
         ByteString.copyAvroString("bytes", false),
         new DataMap(),
@@ -1284,18 +1284,18 @@ public class TestValidation
 
     Object inputs[][] =
         {
-            { new String("1"), new Integer(1) },
+            { new String("1"), Integer.valueOf(1) },
 
-            { new Integer(1), new Integer(1) },
-            { new Integer(-1), new Integer(-1) },
-            { new Long(1), new Integer(1) },
-            { new Float(1), new Integer(1) },
-            { new Double(1), new Integer(1) }
+            { Integer.valueOf(1), Integer.valueOf(1) },
+            { Integer.valueOf(-1), Integer.valueOf(-1) },
+            { Long.valueOf(1), Integer.valueOf(1) },
+            { Float.valueOf(1f), Integer.valueOf(1) },
+            { Double.valueOf(1), Integer.valueOf(1) }
         };
 
     Object badObjects[] =
         {
-            new Boolean(true),
+            Boolean.TRUE,
             new String("abc"),
             ByteString.copyAvroString("bytes", false),
             new DataMap(),
@@ -1353,8 +1353,8 @@ public class TestValidation
           new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "defaultString", "cog", "optionalBoolean", true, "optionalDouble", 999.5)),
           new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "defaultString", "cog", "optionalBoolean", true, "optionalDouble", 999.5, "optionalWithDefaultString", "tag")),
           // unnecessary keys
-          new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "defaultString", "cog", "extra1", new Boolean(true))),
-          new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "defaultString", "cog", "optionalBoolean", true, "optionalDouble", 999.5, "extra1", new Boolean(true)))
+          new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "defaultString", "cog", "extra1", Boolean.TRUE)),
+          new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "defaultString", "cog", "optionalBoolean", true, "optionalDouble", 999.5, "extra1", Boolean.TRUE))
         }
       },
       {
@@ -1369,8 +1369,8 @@ public class TestValidation
           new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "optionalBoolean", true, "optionalDouble", 999.5)),
           new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "optionalBoolean", true, "optionalDouble", 999.5, "optionalWithDefaultString", "tag")),
           // unnecessary keys
-          new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "extra1", new Boolean(true))),
-          new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "optionalBoolean", true, "optionalDouble", 999.5, "extra1", new Boolean(true)))
+          new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "extra1", Boolean.TRUE)),
+          new DataMap(asMap("requiredInt", 78, "requiredString", "dog", "optionalBoolean", true, "optionalDouble", 999.5, "extra1", Boolean.TRUE))
         }
       }
     };
@@ -1388,11 +1388,11 @@ public class TestValidation
           new ValidationOptions(RequiredMode.FIXUP_ABSENT_WITH_DEFAULT, CoercionMode.OFF)
         },
         {
-          new Boolean(true),
-          new Integer(1),
-          new Long(1),
-          new Float(1),
-          new Double(1),
+          Boolean.TRUE,
+          Integer.valueOf(1),
+          Long.valueOf(1),
+          Float.valueOf(1f),
+          Double.valueOf(1),
           new String(),
           new DataList(),
           // invalid field value types
@@ -2098,11 +2098,11 @@ public class TestValidation
     Object disallowedForUnrecognizedField[] =
         {
             "a string",
-            new Boolean(false),
-            new Integer(1),
-            new Long(1),
-            new Float(1),
-            new Double(1),
+            Boolean.FALSE,
+            Integer.valueOf(1),
+            Long.valueOf(1),
+            Float.valueOf(1f),
+            Double.valueOf(1),
             ByteString.copyAvroString("bytes", false),
             new DataMap(),
             new DataList()

--- a/degrader/src/test/java/com/linkedin/util/degrader/TestCallTracker.java
+++ b/degrader/src/test/java/com/linkedin/util/degrader/TestCallTracker.java
@@ -775,11 +775,11 @@ public class TestCallTracker
     Assert.assertEquals(_callTracker.getCurrentErrorCountTotal(), startErrorCountTotal + 8,
                         "Total error count is incorrect");
 
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.REMOTE_INVOCATION_EXCEPTION), new Integer(1),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.REMOTE_INVOCATION_EXCEPTION), Integer.valueOf(1),
                         "Current remote invocation exception count is incorrect");
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CLOSED_CHANNEL_EXCEPTION), new Integer(2),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CLOSED_CHANNEL_EXCEPTION), Integer.valueOf(2),
                         "Current closed channel exception count is incorrect");
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CONNECT_EXCEPTION), new Integer(2),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CONNECT_EXCEPTION), Integer.valueOf(2),
                         "Current connect exception count is incorrect");
 
     _clock.setCurrentTimeMillis(startTime + INTERVAL * 2);
@@ -787,18 +787,18 @@ public class TestCallTracker
     //getCallStats needs to wait for an interval before it produces the stats from previous interval
     Map<ErrorType, Integer> errorTypeCounts = _callTracker.getCallStats().getErrorTypeCounts();
     Map<ErrorType, Integer> errorTypeCountsTotal = _callTracker.getCallStats().getErrorTypeCountsTotal();
-    Assert.assertEquals(errorTypeCounts.get(ErrorType.REMOTE_INVOCATION_EXCEPTION), new Integer(1),
+    Assert.assertEquals(errorTypeCounts.get(ErrorType.REMOTE_INVOCATION_EXCEPTION), Integer.valueOf(1),
                         "Remote invocation exception count is incorrect");
-    Assert.assertEquals(errorTypeCounts.get(ErrorType.CLOSED_CHANNEL_EXCEPTION), new Integer(2),
+    Assert.assertEquals(errorTypeCounts.get(ErrorType.CLOSED_CHANNEL_EXCEPTION), Integer.valueOf(2),
                         "Closed channel exception count is incorrect");
-    Assert.assertEquals(errorTypeCounts.get(ErrorType.CONNECT_EXCEPTION), new Integer(2),
+    Assert.assertEquals(errorTypeCounts.get(ErrorType.CONNECT_EXCEPTION), Integer.valueOf(2),
                         "Connect exception count is incorrect");
 
-    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.REMOTE_INVOCATION_EXCEPTION), new Integer(1),
+    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.REMOTE_INVOCATION_EXCEPTION), Integer.valueOf(1),
                         "Total remote invocation exception count is incorrect");
-    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.CLOSED_CHANNEL_EXCEPTION), new Integer(2),
+    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.CLOSED_CHANNEL_EXCEPTION), Integer.valueOf(2),
                         "Total closed channel exception count is incorrect");
-    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.CONNECT_EXCEPTION), new Integer(2),
+    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.CONNECT_EXCEPTION), Integer.valueOf(2),
                         "Total connect exception count is incorrect");
 
     Assert.assertEquals(_callTracker.getCallStats().getErrorCount(), 6, "Error count is incorrect");
@@ -814,22 +814,22 @@ public class TestCallTracker
     dones.remove(0).endCallWithError(ErrorType.REMOTE_INVOCATION_EXCEPTION);
 
     //this change should be reflected in getCurrentErrorTypeCountsTotal
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.REMOTE_INVOCATION_EXCEPTION), new Integer(4),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.REMOTE_INVOCATION_EXCEPTION), Integer.valueOf(4),
                         "Current remote invocation exception count is incorrect");
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CLOSED_CHANNEL_EXCEPTION), new Integer(2),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CLOSED_CHANNEL_EXCEPTION), Integer.valueOf(2),
                         "Current closed channel exception count is incorrect");
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CONNECT_EXCEPTION), new Integer(2),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CONNECT_EXCEPTION), Integer.valueOf(2),
                         "Current connect exception count is incorrect");
 
     //another simulation of change in the middle of interval
     dones.remove(0).endCallWithError(ErrorType.CLOSED_CHANNEL_EXCEPTION);
     dones.remove(0).endCallWithError(ErrorType.CLOSED_CHANNEL_EXCEPTION);
 
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.REMOTE_INVOCATION_EXCEPTION), new Integer(4),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.REMOTE_INVOCATION_EXCEPTION), Integer.valueOf(4),
                         "Current remote invocation exception count is incorrect");
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CLOSED_CHANNEL_EXCEPTION), new Integer(4),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CLOSED_CHANNEL_EXCEPTION), Integer.valueOf(4),
                         "Current closed channel exception count is incorrect");
-    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CONNECT_EXCEPTION), new Integer(2),
+    Assert.assertEquals(_callTracker.getCurrentErrorTypeCountsTotal().get(ErrorType.CONNECT_EXCEPTION), Integer.valueOf(2),
                         "Current connect exception count is incorrect");
 
      _clock.setCurrentTimeMillis(startTime + INTERVAL * 3);
@@ -839,17 +839,17 @@ public class TestCallTracker
     errorTypeCounts = _callTracker.getCallStats().getErrorTypeCounts();
     errorTypeCountsTotal = _callTracker.getCallStats().getErrorTypeCountsTotal();
 
-    Assert.assertEquals(errorTypeCounts.get(ErrorType.REMOTE_INVOCATION_EXCEPTION), new Integer(3),
+    Assert.assertEquals(errorTypeCounts.get(ErrorType.REMOTE_INVOCATION_EXCEPTION), Integer.valueOf(3),
                         "Remote invocation exception count is incorrect");
-    Assert.assertEquals(errorTypeCounts.get(ErrorType.CLOSED_CHANNEL_EXCEPTION), new Integer(2),
+    Assert.assertEquals(errorTypeCounts.get(ErrorType.CLOSED_CHANNEL_EXCEPTION), Integer.valueOf(2),
                         "Closed channel exception count is incorrect");
     Assert.assertNull(errorTypeCounts.get(ErrorType.CONNECT_EXCEPTION), "Connect exception count is incorrect");
 
-    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.REMOTE_INVOCATION_EXCEPTION), new Integer(4),
+    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.REMOTE_INVOCATION_EXCEPTION), Integer.valueOf(4),
                         "Total remote invocation exception count is incorrect");
-    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.CLOSED_CHANNEL_EXCEPTION), new Integer(4),
+    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.CLOSED_CHANNEL_EXCEPTION), Integer.valueOf(4),
                         "Total closed channel exception count is incorrect");
-    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.CONNECT_EXCEPTION), new Integer(2),
+    Assert.assertEquals(errorTypeCountsTotal.get(ErrorType.CONNECT_EXCEPTION), Integer.valueOf(2),
                         "Total connect exception count is incorrect");
 
     Assert.assertEquals(_callTracker.getCallStats().getErrorCount(), 5, "Error count is incorrect");

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/override/TestInclude.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/override/TestInclude.java
@@ -45,13 +45,13 @@ public class TestInclude
     // fields defined in IncludeA are present in IncludeB
     b.setA1(1);
     b.setA2("a2");
-    assertEquals(b.getA1(), new Integer(1));
+    assertEquals(b.getA1(), Integer.valueOf(1));
     assertEquals(b.getA2(), "a2");
 
     // fields defined in IncludeB.
     b.setB1(2);
     b.setB2("b2");
-    assertEquals(b.getB1(), new Integer(2));
+    assertEquals(b.getB1(), Integer.valueOf(2));
     assertEquals(b.getB2(), "b2");
 
     // include has IncludeA.
@@ -81,19 +81,19 @@ public class TestInclude
     // fields defined in IncludeA are present in IncludeB
     c.setA1(1);
     c.setA2("a2");
-    assertEquals(c.getA1(), new Integer(1));
+    assertEquals(c.getA1(), Integer.valueOf(1));
     assertEquals(c.getA2(), "a2");
 
     // fields defined in IncludeB.
     c.setB1(2);
     c.setB2("b2");
-    assertEquals(c.getB1(), new Integer(2));
+    assertEquals(c.getB1(), Integer.valueOf(2));
     assertEquals(c.getB2(), "b2");
 
     // fields defined in IncludeC.
     c.setC1(3);
     c.setC2("c2");
-    assertEquals(c.getC1(), new Integer(3));
+    assertEquals(c.getC1(), Integer.valueOf(3));
     assertEquals(c.getC2(), "c2");
 
     // include contains IncludeB
@@ -131,31 +131,31 @@ public class TestInclude
     // fields defined in IncludeA are present in IncludeB
     m.setA1(1);
     m.setA2("a2");
-    assertEquals(m.getA1(), new Integer(1));
+    assertEquals(m.getA1(), Integer.valueOf(1));
     assertEquals(m.getA2(), "a2");
 
     // fields defined in IncludeB.
     m.setB1(2);
     m.setB2("b2");
-    assertEquals(m.getB1(), new Integer(2));
+    assertEquals(m.getB1(), Integer.valueOf(2));
     assertEquals(m.getB2(), "b2");
 
     // fields defined in IncludeC.
     m.setC1(3);
     m.setC2("c2");
-    assertEquals(m.getC1(), new Integer(3));
+    assertEquals(m.getC1(), Integer.valueOf(3));
     assertEquals(m.getC2(), "c2");
 
     // fields defined in IncludeD.
     m.setD1(4);
     m.setD2("d2");
-    assertEquals(m.getD1(), new Integer(4));
+    assertEquals(m.getD1(), Integer.valueOf(4));
     assertEquals(m.getD2(), "d2");
 
     // fields defined in IncludeMultiple.
     m.setM1(5);
     m.setM2("m2");
-    assertEquals(m.getM1(), new Integer(5));
+    assertEquals(m.getM1(), Integer.valueOf(5));
     assertEquals(m.getM2(), "m2");
 
     // include contains IncludeC and IncludeD
@@ -206,25 +206,25 @@ public class TestInclude
     // fields defined in IncludeA are present in IncludeB
     t.setA1(1);
     t.setA2("a2");
-    assertEquals(t.getA1(), new Integer(1));
+    assertEquals(t.getA1(), Integer.valueOf(1));
     assertEquals(t.getA2(), "a2");
 
     // fields defined in IncludeB.
     t.setB1(2);
     t.setB2("b2");
-    assertEquals(t.getB1(), new Integer(2));
+    assertEquals(t.getB1(), Integer.valueOf(2));
     assertEquals(t.getB2(), "b2");
 
     // fields defined in IncludeC.
     t.setC1(3);
     t.setC2("c2");
-    assertEquals(t.getC1(), new Integer(3));
+    assertEquals(t.getC1(), Integer.valueOf(3));
     assertEquals(t.getC2(), "c2");
 
     // fields defined in IncludeTypeRef.
     t.setT1(4);
     t.setT2("t2");
-    assertEquals(t.getT1(), new Integer(4));
+    assertEquals(t.getT1(), Integer.valueOf(4));
     assertEquals(t.getT2(), "t2");
 
     // include contains IncludeRef

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/TestInclude.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/TestInclude.java
@@ -42,13 +42,13 @@ public class TestInclude
     // fields defined in IncludeA are present in IncludeB
     b.setA1(1);
     b.setA2("a2");
-    assertEquals(b.getA1(), new Integer(1));
+    assertEquals(b.getA1(), Integer.valueOf(1));
     assertEquals(b.getA2(), "a2");
 
     // fields defined in IncludeB.
     b.setB1(2);
     b.setB2("b2");
-    assertEquals(b.getB1(), new Integer(2));
+    assertEquals(b.getB1(), Integer.valueOf(2));
     assertEquals(b.getB2(), "b2");
 
     // include has IncludeA.
@@ -73,19 +73,19 @@ public class TestInclude
     // fields defined in IncludeA are present in IncludeB
     c.setA1(1);
     c.setA2("a2");
-    assertEquals(c.getA1(), new Integer(1));
+    assertEquals(c.getA1(), Integer.valueOf(1));
     assertEquals(c.getA2(), "a2");
 
     // fields defined in IncludeB.
     c.setB1(2);
     c.setB2("b2");
-    assertEquals(c.getB1(), new Integer(2));
+    assertEquals(c.getB1(), Integer.valueOf(2));
     assertEquals(c.getB2(), "b2");
 
     // fields defined in IncludeC.
     c.setC1(3);
     c.setC2("c2");
-    assertEquals(c.getC1(), new Integer(3));
+    assertEquals(c.getC1(), Integer.valueOf(3));
     assertEquals(c.getC2(), "c2");
 
     // include contains IncludeB
@@ -118,31 +118,31 @@ public class TestInclude
     // fields defined in IncludeA are present in IncludeB
     m.setA1(1);
     m.setA2("a2");
-    assertEquals(m.getA1(), new Integer(1));
+    assertEquals(m.getA1(), Integer.valueOf(1));
     assertEquals(m.getA2(), "a2");
 
     // fields defined in IncludeB.
     m.setB1(2);
     m.setB2("b2");
-    assertEquals(m.getB1(), new Integer(2));
+    assertEquals(m.getB1(), Integer.valueOf(2));
     assertEquals(m.getB2(), "b2");
 
     // fields defined in IncludeC.
     m.setC1(3);
     m.setC2("c2");
-    assertEquals(m.getC1(), new Integer(3));
+    assertEquals(m.getC1(), Integer.valueOf(3));
     assertEquals(m.getC2(), "c2");
 
     // fields defined in IncludeD.
     m.setD1(4);
     m.setD2("d2");
-    assertEquals(m.getD1(), new Integer(4));
+    assertEquals(m.getD1(), Integer.valueOf(4));
     assertEquals(m.getD2(), "d2");
 
     // fields defined in IncludeMultiple.
     m.setM1(5);
     m.setM2("m2");
-    assertEquals(m.getM1(), new Integer(5));
+    assertEquals(m.getM1(), Integer.valueOf(5));
     assertEquals(m.getM2(), "m2");
 
     // include contains IncludeC and IncludeD
@@ -181,25 +181,25 @@ public class TestInclude
     // fields defined in IncludeA are present in IncludeB
     t.setA1(1);
     t.setA2("a2");
-    assertEquals(t.getA1(), new Integer(1));
+    assertEquals(t.getA1(), Integer.valueOf(1));
     assertEquals(t.getA2(), "a2");
 
     // fields defined in IncludeB.
     t.setB1(2);
     t.setB2("b2");
-    assertEquals(t.getB1(), new Integer(2));
+    assertEquals(t.getB1(), Integer.valueOf(2));
     assertEquals(t.getB2(), "b2");
 
     // fields defined in IncludeC.
     t.setC1(3);
     t.setC2("c2");
-    assertEquals(t.getC1(), new Integer(3));
+    assertEquals(t.getC1(), Integer.valueOf(3));
     assertEquals(t.getC2(), "c2");
 
     // fields defined in IncludeTypeRef.
     t.setT1(4);
     t.setT2("t2");
-    assertEquals(t.getT1(), new Integer(4));
+    assertEquals(t.getT1(), Integer.valueOf(4));
     assertEquals(t.getT2(), "t2");
 
     // include contains IncludeRef

--- a/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/AcceptEncoding.java
+++ b/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/AcceptEncoding.java
@@ -195,6 +195,6 @@ public class AcceptEncoding implements Comparable<AcceptEncoding>
   @Override
   public int compareTo(AcceptEncoding target)
   {
-    return new Float(target.getQuality()).compareTo(getQuality());
+    return Float.valueOf(target.getQuality()).compareTo(getQuality());
   }
 }

--- a/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/streaming/AcceptEncoding.java
+++ b/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/streaming/AcceptEncoding.java
@@ -198,6 +198,6 @@ public class AcceptEncoding implements Comparable<AcceptEncoding>
   @Override
   public int compareTo(AcceptEncoding target)
   {
-    return new Float(target.getQuality()).compareTo(getQuality());
+    return Float.valueOf(target.getQuality()).compareTo(getQuality());
   }
 }

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestClientBuilders.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestClientBuilders.java
@@ -1392,7 +1392,7 @@ public class TestClientBuilders
     GetRequestBuilder<Long, TestRecord> builder = new GetRequestBuilder<Long, TestRecord>(TEST_URI, TestRecord.class, _COLL_SPEC, RestliRequestOptions.DEFAULT_OPTIONS);
     GetRequest<TestRecord> request = builder.id(1L).fields(TestRecord.fields().id(), TestRecord.fields().message()).build();
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
-    Assert.assertEquals(request.getObjectId(), new Long(1L));
+    Assert.assertEquals(request.getObjectId(), Long.valueOf(1L));
     Assert.assertEquals(request.getFields(), new HashSet<PathSpec>(Arrays.asList(
             TestRecord.fields().id(), TestRecord.fields().message())));
     Assert.assertEquals(request.isSafe(), true);

--- a/restli-common-testutils/src/test/java/com/linkedin/restli/common/testutils/TestDataCompare.java
+++ b/restli-common-testutils/src/test/java/com/linkedin/restli/common/testutils/TestDataCompare.java
@@ -154,7 +154,7 @@ public class TestDataCompare
     assertTrue(
             DataCompare.compare(
                     toDataMap("numberField", Long.MAX_VALUE),
-                    toDataMap("numberField", new Long(Long.MAX_VALUE-1).doubleValue())
+                    toDataMap("numberField", Long.valueOf(Long.MAX_VALUE-1).doubleValue())
             ).hasError());
   }
 

--- a/restli-common/src/test/java/com/linkedin/restli/internal/common/TestResponseUtils.java
+++ b/restli-common/src/test/java/com/linkedin/restli/internal/common/TestResponseUtils.java
@@ -39,7 +39,7 @@ public class TestResponseUtils
                                                    null,
                                                    null,
                                                    AllProtocolVersions.BASELINE_PROTOCOL_VERSION);
-    Assert.assertEquals(longKey, new Long(1L));
+    Assert.assertEquals(longKey, Long.valueOf(1L));
   }
 
   public void testConvertCustomTyperefKey()

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestActionsResource.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestActionsResource.java
@@ -227,7 +227,7 @@ public class TestActionsResource extends RestLiIntegrationTest
     //variant of testing primitive return types, except with null optional parameters
 
     Request<Integer> intRequest = builders.<Integer>action("ReturnIntOptionalParam").setActionParam("param",
-        new Integer(1)).build();
+        Integer.valueOf(1)).build();
     Integer integer = getClient().sendRequest(intRequest).getResponse().getEntity();
     Assert.assertEquals(1, integer.intValue());
 
@@ -236,7 +236,7 @@ public class TestActionsResource extends RestLiIntegrationTest
     Assert.assertEquals(0, integerNull.intValue());
 
     Request<Boolean> boolRequest = builders.<Boolean>action("ReturnBoolOptionalParam").setActionParam("param",
-        new Boolean(false)).build();
+        Boolean.FALSE).build();
     Boolean bool = getClient().sendRequest(boolRequest).getResponse().getEntity();
     Assert.assertTrue(!bool.booleanValue());
 

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestAssociationsResource.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestAssociationsResource.java
@@ -209,7 +209,7 @@ public class TestAssociationsResource extends RestLiIntegrationTest
     Request<Integer> request = builders.<Integer>action("Action").setPathKey("dest", "dest").setPathKey("src", "src").build();
     Integer integer = getClient().sendRequest(request).getResponse().getEntity();
 
-    Assert.assertEquals(integer, new Integer(1));
+    Assert.assertEquals(integer, Integer.valueOf(1));
   }
 
   @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestSubBuilderDataProvider")

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestComplexKeysResource.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestComplexKeysResource.java
@@ -386,7 +386,7 @@ public class TestComplexKeysResource extends RestLiIntegrationTest
     {
       @SuppressWarnings("unchecked")
       CreateIdStatus<ComplexResourceKey<TwoPartKey, TwoPartKey>> createIdStatus = (CreateIdStatus<ComplexResourceKey<TwoPartKey, TwoPartKey>>) createStatus;
-      Assert.assertEquals(createIdStatus.getStatus(), new Integer(201));
+      Assert.assertEquals(createIdStatus.getStatus(), Integer.valueOf(201));
       Assert.assertTrue(expectedComplexKeys.contains(createIdStatus.getKey()));
 
       try
@@ -443,7 +443,7 @@ public class TestComplexKeysResource extends RestLiIntegrationTest
     expectedComplexKeys.add(expectedComplexKey2);
     for (CreateIdStatus<ComplexResourceKey<TwoPartKey, TwoPartKey>> status : response.getEntity().getElements())
     {
-      Assert.assertEquals(status.getStatus(), new Integer(201));
+      Assert.assertEquals(status.getStatus(), Integer.valueOf(201));
       Assert.assertTrue(expectedComplexKeys.contains(status.getKey()));
 
       try

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestCustomTypesClient.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestCustomTypesClient.java
@@ -372,7 +372,7 @@ public class TestCustomTypesClient extends RestLiIntegrationTest
     Request<Greeting> request = builders.get().setPathKey("customTypes2Id", new CustomLong(id2)).id(new CustomLong(id4)).build();
     Greeting result = getClient().sendRequest(request).getResponse().getEntity();
 
-    Assert.assertEquals(result.getId(), new Long(id2*id4));
+    Assert.assertEquals(result.getId(), Long.valueOf(id2*id4));
   }
 
   @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "request3BuilderDataProvider")
@@ -385,7 +385,7 @@ public class TestCustomTypesClient extends RestLiIntegrationTest
     Request<Greeting> request = builders.get().id(key).build();
     Greeting result = getClient().sendRequest(request).getResponse().getEntity();
 
-    Assert.assertEquals(result.getId(),  new Long(lo+date));
+    Assert.assertEquals(result.getId(),  Long.valueOf(lo+date));
   }
 
   @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "request3BuilderDataProvider")

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestExceptionsResource.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestExceptionsResource.java
@@ -221,7 +221,7 @@ public class TestExceptionsResource extends RestLiIntegrationTest
     @SuppressWarnings("unchecked")
     CreateIdStatus<Long> status0 =  (CreateIdStatus<Long>)createStatuses.get(0);
     Assert.assertEquals(status0.getStatus().intValue(), HttpStatus.S_201_CREATED.getCode());
-    Assert.assertEquals(status0.getKey(), new Long(10));
+    Assert.assertEquals(status0.getKey(), Long.valueOf(10));
     @SuppressWarnings("deprecation")
     String id = status0.getId();
     Assert.assertEquals(BatchResponse.keyToString(status0.getKey(), ProtocolVersionUtil.extractProtocolVersion(response.getHeaders())),
@@ -264,7 +264,7 @@ public class TestExceptionsResource extends RestLiIntegrationTest
     @SuppressWarnings("unchecked")
     CreateIdStatus<Long> status0 =  createStatuses.get(0);
     Assert.assertEquals(status0.getStatus().intValue(), HttpStatus.S_201_CREATED.getCode());
-    Assert.assertEquals(status0.getKey(), new Long(10));
+    Assert.assertEquals(status0.getKey(), Long.valueOf(10));
     @SuppressWarnings("deprecation")
     String id = status0.getId();
     Assert.assertEquals(BatchResponse.keyToString(status0.getKey(), ProtocolVersionUtil.extractProtocolVersion(response.getHeaders())),

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestFilters.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestFilters.java
@@ -336,7 +336,7 @@ public class TestFilters extends RestLiIntegrationTest
   // Filter for testing purposes. Keeps track of number of calls to each function and verifies data in each call
   private class TestFilter implements Filter
   {
-    protected final Integer spValue = new Integer(100);
+    protected final Integer spValue = Integer.valueOf(100);
     protected final String spKey = "Counter";
     protected int numRequests;
     protected int numResponses;

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestGreetingClientContentTypes.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestGreetingClientContentTypes.java
@@ -77,7 +77,7 @@ public class TestGreetingClientContentTypes extends RestLiIntegrationTest
     Request<Greeting> request = builders.get().id(1L).build();
     Response<Greeting> response = restClient.sendRequest(request).getResponse();
     Greeting greeting = response.getEntity();
-    Assert.assertEquals(greeting.getId(), new Long(1));
+    Assert.assertEquals(greeting.getId(), Long.valueOf(1));
   }
 
   @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "clientDataBatchDataProvider")

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestGreetingsClientAcceptTypes.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestGreetingsClientAcceptTypes.java
@@ -77,7 +77,7 @@ public class TestGreetingsClientAcceptTypes extends RestLiIntegrationTest
     Response<Greeting> response = restClient.sendRequest(request).getResponse();
     Assert.assertEquals(response.getHeader("Content-Type"), expectedContentType);
     Greeting greeting = response.getEntity();
-    Assert.assertEquals(greeting.getId(), new Long(1));
+    Assert.assertEquals(greeting.getId(), Long.valueOf(1));
   }
 
   @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "oldBuildersClientDataDataProvider")

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRestLiValidation.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestRestLiValidation.java
@@ -402,11 +402,11 @@ public class TestRestLiValidation extends RestLiIntegrationTest
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED.getCode());
     if (response.getEntity() instanceof CreateResponse)
     {
-      Assert.assertEquals(((CreateResponse<Integer>)response.getEntity()).getId(), new Integer(1234));
+      Assert.assertEquals(((CreateResponse<Integer>)response.getEntity()).getId(), Integer.valueOf(1234));
     }
     else
     {
-      Assert.assertEquals(((IdResponse<Integer>)(Object)response.getEntity()).getId(), new Integer(1234));
+      Assert.assertEquals(((IdResponse<Integer>)(Object)response.getEntity()).getId(), Integer.valueOf(1234));
     }
   }
 

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestTyperefKeysResource.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestTyperefKeysResource.java
@@ -80,7 +80,7 @@ public class TestTyperefKeysResource extends RestLiIntegrationTest
     CreateIdRequest<Long, Greeting> req = new TyperefKeysRequestBuilders(requestOptions).create().input(greeting).build();
 
     Response<IdResponse<Long>> resp = getClient().sendRequest(req).getResponse();
-    Assert.assertEquals(resp.getEntity().getId(), new Long(1L));
+    Assert.assertEquals(resp.getEntity().getId(), Long.valueOf(1L));
   }
 
   @Test(dataProvider = TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestOptionsDataProvider")
@@ -90,8 +90,8 @@ public class TestTyperefKeysResource extends RestLiIntegrationTest
     Response<BatchResponse<Greeting>> resp = getClient().sendRequest(req).getResponse();
 
     Map<String, Greeting> results = resp.getEntity().getResults();
-    Assert.assertEquals(results.get("1").getId(), new Long(1L));
-    Assert.assertEquals(results.get("2").getId(), new Long(2L));
+    Assert.assertEquals(results.get("1").getId(), Long.valueOf(1L));
+    Assert.assertEquals(results.get("2").getId(), Long.valueOf(2L));
   }
 
   @Test(dataProvider = TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestOptionsDataProvider")
@@ -101,8 +101,8 @@ public class TestTyperefKeysResource extends RestLiIntegrationTest
     Response<BatchKVResponse<Long, Greeting>> resp = getClient().sendRequest(req).getResponse();
 
     Map<Long, Greeting> results = resp.getEntity().getResults();
-    Assert.assertEquals(results.get(1L).getId(), new Long(1L));
-    Assert.assertEquals(results.get(2L).getId(), new Long(2L));
+    Assert.assertEquals(results.get(1L).getId(), Long.valueOf(1L));
+    Assert.assertEquals(results.get(2L).getId(), Long.valueOf(2L));
   }
 
   @Test(dataProvider = TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestOptionsDataProvider")
@@ -112,8 +112,8 @@ public class TestTyperefKeysResource extends RestLiIntegrationTest
     Response<BatchKVResponse<Long, EntityResponse<Greeting>>> resp = getClient().sendRequest(req).getResponse();
 
     Map<Long, EntityResponse<Greeting>> results = resp.getEntity().getResults();
-    Assert.assertEquals(results.get(1L).getEntity().getId(), new Long(1L));
-    Assert.assertEquals(results.get(2L).getEntity().getId(), new Long(2L));
+    Assert.assertEquals(results.get(1L).getEntity().getId(), Long.valueOf(1L));
+    Assert.assertEquals(results.get(2L).getEntity().getId(), Long.valueOf(2L));
   }
 
   @DataProvider(name = TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestOptionsDataProvider")

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/methods/arguments/TestCollectionArgumentBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/methods/arguments/TestCollectionArgumentBuilder.java
@@ -138,13 +138,13 @@ public class TestCollectionArgumentBuilder
                 getFinderParams(),
                 finderContextParams,
                 null,
-                new Object[]{new PagingContext(33, 444), new Integer(777), null}
+                new Object[]{new PagingContext(33, 444), Integer.valueOf(777), null}
             },
             {
                 getFinderParams(),
                 finderContextParamsWithOptionalString,
                 null,
-                new Object[]{new PagingContext(33, 444), new Integer(777), "someString"}
+                new Object[]{new PagingContext(33, 444), Integer.valueOf(777), "someString"}
             },
             {
                 finderWithAssocKeyParams,

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/methods/arguments/TestGetArgumentBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/methods/arguments/TestGetArgumentBuilder.java
@@ -94,7 +94,7 @@ public class TestGetArgumentBuilder
             {
                 getIntegerParam(),
                 "myComplexKeyCollectionId",
-                new Integer(123),
+                Integer.valueOf(123),
                 new IntegerDataSchema()
             },
             {
@@ -243,7 +243,7 @@ public class TestGetArgumentBuilder
       throws IOException
   {
     String keyName = "myComplexKeyCollectionId";
-    Object keyValue = new Integer(123);
+    Object keyValue = Integer.valueOf(123);
     DataSchema keySchema = new IntegerDataSchema();
     Key key = new Key(keyName, keyValue.getClass(), keySchema);
 
@@ -267,7 +267,7 @@ public class TestGetArgumentBuilder
       throws IOException
   {
     String keyName = "myComplexKeyCollectionId";
-    Object keyValue = new Integer(123);
+    Object keyValue = Integer.valueOf(123);
     DataSchema keySchema = new IntegerDataSchema();
     Key key = new Key(keyName, keyValue.getClass(), keySchema);
     Map<String, String> headers = new HashMap<String, String>();

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestConvertSimpleValue.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestConvertSimpleValue.java
@@ -122,7 +122,7 @@ public class TestConvertSimpleValue
 
     Assert.assertTrue(convertedCustomLong.getClass().equals(customLongClass));
     CustomLong customLong = (CustomLong) convertedCustomLong;
-    Assert.assertTrue(customLong.toLong().equals(new Long(100)));
+    Assert.assertTrue(customLong.toLong().equals(Long.valueOf(100)));
   }
 
   @Test

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/response/TestErrorResponseBuilder.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/response/TestErrorResponseBuilder.java
@@ -80,7 +80,7 @@ public class TestErrorResponseBuilder
 
     EasyMock.verify(mockDescriptor);
     ErrorResponse errorResponse = (ErrorResponse) restResponse.getEntity();
-    Assert.assertEquals(errorResponse.getStatus(), new Integer(500));
+    Assert.assertEquals(errorResponse.getStatus(), Integer.valueOf(500));
     Assert.assertTrue(errorResponse.getMessage().contains(runtimeException.getMessage()));
   }
 

--- a/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiMethodInvocation.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiMethodInvocation.java
@@ -3251,7 +3251,7 @@ public class TestRestLiMethodInvocation
   public Object[][] dataMapToCompoundKey()
   {
     CompoundKey compoundKey1 = new CompoundKey();
-    compoundKey1.append("foo", new Integer(1));
+    compoundKey1.append("foo", Integer.valueOf(1));
     compoundKey1.append("bar", "hello");
 
     DataMap dataMap1 = new DataMap();
@@ -3263,8 +3263,8 @@ public class TestRestLiMethodInvocation
     keys1.add(new Key("bar", String.class));
 
     CompoundKey compoundKey2 = new CompoundKey();
-    compoundKey2.append("a", new Long(6));
-    compoundKey2.append("b", new Double(3.14));
+    compoundKey2.append("a", Long.valueOf(6));
+    compoundKey2.append("b", Double.valueOf(3.14));
 
     DataMap dataMap2 = new DataMap();
     dataMap2.put("a", "6");

--- a/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiRouting.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiRouting.java
@@ -113,7 +113,7 @@ public class TestRestLiRouting
     assertEquals(resourceMethodDescriptor.getResourceModel().getName(), "statuses");
 
     PathKeys keys = context.getPathKeys();
-    assertEquals(keys.getAsLong("statusID"), new Long(1));
+    assertEquals(keys.getAsLong("statusID"), Long.valueOf(1));
     assertNull(keys.getAsString("foo"));
   }
 
@@ -148,8 +148,8 @@ public class TestRestLiRouting
     assertEquals(resourceMethodDescriptor.getResourceModel().getName(), "follows");
 
     PathKeys keys = context.getPathKeys();
-    assertEquals(keys.getAsLong("followerID"), new Long(1L));
-    assertEquals(keys.getAsLong("followeeID"), new Long(2L));
+    assertEquals(keys.getAsLong("followerID"), Long.valueOf(1L));
+    assertEquals(keys.getAsLong("followeeID"), Long.valueOf(2L));
   }
 
   @Test(dataProvider = TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "routingDetailsCollectionEntity")
@@ -173,7 +173,7 @@ public class TestRestLiRouting
     assertEquals(resourceMethodDescriptor.getResourceModel().getName(), "statuses");
 
     PathKeys keys = context.getPathKeys();
-    assertEquals(keys.getAsLong("statusID"), new Long(1));
+    assertEquals(keys.getAsLong("statusID"), Long.valueOf(1));
     assertNull(keys.getAsString("foo"));
   }
 
@@ -198,7 +198,7 @@ public class TestRestLiRouting
     assertEquals(resourceMethodDescriptor.getResourceModel().getName(), "statuses");
 
     PathKeys keys = context.getPathKeys();
-    assertEquals(keys.getAsLong("statusID"), new Long(1));
+    assertEquals(keys.getAsLong("statusID"), Long.valueOf(1));
     assertNull(keys.getAsString("foo"));
   }
 


### PR DESCRIPTION
Constructors the classes `Boolean`, `Integer`, `Long`, `Float`, and `Double` that accept a primitive input are deprecated in Java 11.

Suggested replacement (as per the [Oracle docs](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Double.html#%3Cinit%3E(double))) is to use `Integer.valueOf(1)` (rather than `new Integer(1)`).

Also, `Boolean.TRUE` and `Boolean.FALSE` are suggested for the `Boolean` class.