### PR TITLE
Introduce a readonly attribute on the action annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.10] - 2021-05-24
+- Introduce a readonly attribute on the action annotation
+
 ## [29.18.9] - 2021-05-24
 - Initial support for the modern `ivy-publish` plugin when producing data-template artifacts
   - Use of `ivy-publish` plugin requires Gradle 6.1+.
@@ -4951,7 +4954,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.10...master
+[29.18.10]: https://github.com/linkedin/rest.li/compare/v29.18.9...v29.18.10
 [29.18.9]: https://github.com/linkedin/rest.li/compare/v29.18.8...v29.18.9
 [29.18.8]: https://github.com/linkedin/rest.li/compare/v29.18.7...v29.18.8
 [29.18.7]: https://github.com/linkedin/rest.li/compare/v29.18.6...v29.18.7

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.9
+version=29.18.10
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/pegasus/com/linkedin/restli/restspec/ActionSchema.pdl
+++ b/restli-common/src/main/pegasus/com/linkedin/restli/restspec/ActionSchema.pdl
@@ -11,6 +11,12 @@ record ActionSchema includes CustomAnnotationSchema, ServiceErrorsSchema, Succes
   name: string
 
   /**
+   * Placeholder indicating if this action is read-only or not. This is not enforced by the framework
+   * and is just a marker.
+   */
+  readOnly: optional boolean = false
+
+  /**
    * Documentation for this action
    */
   doc: optional string

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceMethodDescriptor.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceMethodDescriptor.java
@@ -69,6 +69,7 @@ public class ResourceMethodDescriptor
   private final String                                  _actionName;
   private final ResourceLevel                           _actionResourceLevel;
   private final FieldDef<?>                             _actionReturnFieldDef;
+  private final boolean                                 _isActionReadOnly;
   private final RecordDataSchema                        _actionReturnRecordDataSchema;
   private final RecordDataSchema                        _requestDataSchema;
   private final InterfaceType                           _interfaceType;
@@ -105,6 +106,7 @@ public class ResourceMethodDescriptor
                                         null,
                                         null,
                                         null,
+                                        false,
                                         null,
                                         metadataType,
                                         interfaceType,
@@ -140,6 +142,7 @@ public class ResourceMethodDescriptor
                                         null,
                                         null,
                                         null,
+                                        false,
                                         null,
                                         metadataType,
                                         interfaceType,
@@ -180,6 +183,50 @@ public class ResourceMethodDescriptor
                                         actionResourceType,
                                         actionReturnType,
                                         actionReturnRecordDataSchema,
+                                        false,
+                                        recordDataSchema,
+                                        null,
+                                        interfaceType,
+                                        customAnnotations);
+  }
+
+  /**
+   * Action resource method descriptor factory.
+   *
+   * @param method resource {@link Method}
+   * @param parameters rest.li method {@link Parameter}s
+   * @param actionName action name
+   * @param actionResourceType action {@link ResourceLevel}
+   * @param actionReturnType action return type class
+   * @param actionReturnRecordDataSchema the RecordDataSchema for the action return
+   * @param recordDataSchema the RecordDataSchema for the method
+   * @param isActionReadOnly true if the action is read only, false otherwise.
+   * @param interfaceType resource method {@link InterfaceType}
+   * @return action {@link ResourceMethodDescriptor}
+   */
+  public static ResourceMethodDescriptor createForAction(
+      final Method method,
+      final List<Parameter<?>> parameters,
+      final String actionName,
+      final ResourceLevel actionResourceType,
+      final FieldDef<?> actionReturnType,
+      final RecordDataSchema actionReturnRecordDataSchema,
+      final boolean isActionReadOnly,
+      final RecordDataSchema recordDataSchema,
+      final InterfaceType interfaceType,
+      final DataMap customAnnotations)
+  {
+    return new ResourceMethodDescriptor(ResourceMethod.ACTION,
+                                        method,
+                                        parameters,
+                                        null,
+                                        null,
+                                        BATCH_FINDER_NULL_CRITERIA_INDEX,
+                                        actionName,
+                                        actionResourceType,
+                                        actionReturnType,
+                                        actionReturnRecordDataSchema,
+                                        isActionReadOnly,
                                         recordDataSchema,
                                         null,
                                         interfaceType,
@@ -234,6 +281,7 @@ public class ResourceMethodDescriptor
                                         null,
                                         null,
                                         null,
+                                        false,
                                         null,
                                         collectionCustomMetadataType,
                                         interfaceType,
@@ -253,6 +301,7 @@ public class ResourceMethodDescriptor
                                    final ResourceLevel actionResourceLevel,
                                    final FieldDef<?> actionReturnType,
                                    final RecordDataSchema actionReturnRecordDataSchema,
+                                   final boolean isActionReadOnly,
                                    final RecordDataSchema requestDataSchema,
                                    final Class<? extends RecordTemplate> collectionCustomMetadataType,
                                    final InterfaceType interfaceType,
@@ -268,6 +317,7 @@ public class ResourceMethodDescriptor
     _actionResourceLevel = actionResourceLevel;
     _actionReturnFieldDef = actionReturnType;
     _actionReturnRecordDataSchema = actionReturnRecordDataSchema;
+    _isActionReadOnly = isActionReadOnly;
     _requestDataSchema = requestDataSchema;
     _collectionCustomMetadataType = collectionCustomMetadataType;
     _interfaceType = interfaceType;
@@ -456,6 +506,11 @@ public class ResourceMethodDescriptor
   public RecordDataSchema getActionReturnRecordDataSchema()
   {
     return _actionReturnRecordDataSchema;
+  }
+
+  public boolean isActionReadOnly()
+  {
+    return _isActionReadOnly;
   }
 
   public RecordDataSchema getRequestDataSchema()

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
@@ -695,6 +695,12 @@ public class ResourceModelEncoder
     ActionSchema action = new ActionSchema();
     action.setName(resourceMethodDescriptor.getActionName());
 
+    // Actions are read-write by default, so write info in the schema only for read-only actions.
+    if (resourceMethodDescriptor.isActionReadOnly())
+    {
+      action.setReadOnly(true);
+    }
+
     //We have to construct the method doc for the action which includes the action return type
     final String methodDoc = _docsProvider.getMethodDoc(resourceMethodDescriptor.getMethod());
     if (methodDoc != null)
@@ -732,7 +738,7 @@ public class ResourceModelEncoder
     final DataMap customAnnotation = resourceMethodDescriptor.getCustomAnnotationData();
     String deprecatedDoc = _docsProvider.getMethodDeprecatedTag(resourceMethodDescriptor.getMethod());
 
-    if(deprecatedDoc != null)
+    if (deprecatedDoc != null)
     {
       customAnnotation.put(DEPRECATED_ANNOTATION_NAME, deprecateDocToAnnotationMap(deprecatedDoc));
     }

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -2409,6 +2409,7 @@ public final class RestLiAnnotationReader
                                                                                                 getActionResourceLevel(actionAnno, model),
                                                                                                 returnFieldDef,
                                                                                                 actionReturnRecordDataSchema,
+                                                                                                actionAnno.readOnly(),
                                                                                                 recordDataSchema,
                                                                                                 getInterfaceType(method),
                                                                                                 annotationsMap);

--- a/restli-server/src/main/java/com/linkedin/restli/server/annotations/Action.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/annotations/Action.java
@@ -48,6 +48,15 @@ public @interface Action
   ResourceLevel resourceLevel() default ResourceLevel.ANY;
 
   /**
+   * Optional placeholder attribute used to indicate whether the action is read-only
+   * or not. Default is false which indicates that this action can result in writes. This
+   * parameter is a placeholder to provide a hint to metadata introspection systems. The
+   * framework itself does not and cannot actually enforce read-only behavior in actions
+   * annotated as such.
+   */
+  boolean readOnly() default false;
+
+  /**
    * Optional attribute used to indicate the desired typeref to use for primitive types.
    */
   Class<? extends TyperefInfo> returnTyperef() default RestAnnotations.NULL_TYPEREF_INFO.class;

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/ResourceCompatibilityChecker.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/ResourceCompatibilityChecker.java
@@ -989,6 +989,10 @@ public class ResourceCompatibilityChecker
                           prevRec.getName(GetMode.DEFAULT),
                           currRec.getName(GetMode.DEFAULT));
 
+    checkEqualSingleValue(prevRec.schema().getField("readOnly"),
+                          prevRec.isReadOnly(GetMode.DEFAULT),
+                          currRec.isReadOnly(GetMode.DEFAULT));
+
     checkDoc(prevRec.schema().getField("doc"), prevRec.getDoc(GetMode.DEFAULT), currRec.getDoc(GetMode.DEFAULT));
 
     checkAnnotationsMap(prevRec.schema().getField("annotations"),

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/compatibility/TestResourceCompatibilityChecker.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/compatibility/TestResourceCompatibilityChecker.java
@@ -514,6 +514,8 @@ public class TestResourceCompatibilityChecker
                                                  CompatibilityInfo.Type.ARRAY_MISSING_ELEMENT, "someString"));
     resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "simple", "actions", "oneAction", "parameters"),
                                                  CompatibilityInfo.Type.PARAMETER_NEW_REQUIRED, "someStringNew"));
+    resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "simple", "actions", "threeAction", "readOnly"),
+                                                 CompatibilityInfo.Type.VALUE_NOT_EQUAL, false, true));
     modelTestErrors.add(new CompatibilityInfo(Arrays.asList("com.linkedin.greetings.api.Greeting"),
                                               CompatibilityInfo.Type.TYPE_BREAKS_NEW_READER, "new record added required fields newField"));
     modelTestErrors.add(new CompatibilityInfo(Arrays.asList("com.linkedin.greetings.api.Greeting"),

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/circular/CircularResource.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/snapshot/circular/CircularResource.java
@@ -31,7 +31,7 @@ import com.linkedin.restli.tools.snapshot.circular.CircularTestDataModels.*;
 @RestLiActions(name="circular")
 public class CircularResource
 {
-  @Action(name="test")
+  @Action(name="test", readOnly = true)
   public void test(@ActionParam("a") A a,
                    @ActionParam("b") B b,
                    @ActionParam("c") C c,

--- a/restli-tools/src/test/resources/idls/curr-greeting-simple-fail.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greeting-simple-fail.restspec.json
@@ -45,6 +45,10 @@
     }, {
       "name" : "twoAction",
       "doc" : "an action to be deprecated"
+    }, {
+      "name" : "threeAction",
+      "doc" : "an action to be marked read-only",
+      "readOnly" : true
     } ],
     "entity" : {
       "path" : "/greetings/{id}"

--- a/restli-tools/src/test/resources/idls/curr-greeting-simple-pass.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greeting-simple-pass.restspec.json
@@ -71,6 +71,9 @@
           "doc" : "this action is deprecated"
         }
       }
+    }, {
+      "name" : "threeAction",
+      "doc" : "an action to be marked read-only"
     } ],
     "entity" : {
       "path" : "/greetings/{id}"

--- a/restli-tools/src/test/resources/idls/prev-greeting-simple.restspec.json
+++ b/restli-tools/src/test/resources/idls/prev-greeting-simple.restspec.json
@@ -48,6 +48,9 @@
     }, {
       "name" : "twoAction",
       "doc" : "an action to be deprecated"
+    }, {
+      "name" : "threeAction",
+      "doc" : "an action to be marked read-only"
     } ],
     "entity" : {
       "path" : "/greetings/{id}"

--- a/restli-tools/src/test/resources/snapshots/circular-circular.snapshot.json
+++ b/restli-tools/src/test/resources/snapshots/circular-circular.snapshot.json
@@ -38,6 +38,7 @@
     "actionsSet" : {
       "actions" : [ {
         "name" : "test",
+        "readOnly" : true,
         "parameters" : [ {
           "name" : "a",
           "type" : "com.linkedin.restli.tools.snapshot.circular.A"


### PR DESCRIPTION
For example, we can use this hint to decide which actions to pull into queries and which into mutations when building GQL schemas off rest.li resources.