### PR TITLE
Fix a bug in ZKDeterministicSubsettingMetadataProvider to make host set distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.8] - 2021-05-21
+- Fix a bug in ZKDeterministicSubsettingMetadataProvider to make host set distinct
+
 ## [29.18.7] - 2021-05-16
 - Copy the input pegasus data schema when translating to avro
 
@@ -4940,7 +4943,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.8...master
+[29.18.8]: https://github.com/linkedin/rest.li/compare/v29.18.7...v29.18.8
 [29.18.7]: https://github.com/linkedin/rest.li/compare/v29.18.6...v29.18.7
 [29.18.6]: https://github.com/linkedin/rest.li/compare/v29.18.5...v29.18.6
 [29.18.5]: https://github.com/linkedin/rest.li/compare/v29.18.4...v29.18.5

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -82,6 +82,7 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
             List<String> sortedHosts = uriProperties.getPartitionDesc().keySet().stream()
                 .map(URI::getHost)
                 .sorted()
+                .distinct()
                 .collect(Collectors.toList());
 
             int instanceId = sortedHosts.indexOf(_hostName);
@@ -99,6 +100,8 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
           {
             _subsettingMetadata = null;
           }
+
+          _log.debug("Got deterministic subsetting metadata for cluster {}: {}", _clusterName, _subsettingMetadata);
         }
       }
       metadataFutureCallback.onSuccess(_subsettingMetadata);
@@ -108,7 +111,7 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
     {
       return metadataFutureCallback.get(_timeout, _unit);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      _log.warn("Failed to fetch deterministic subsetting metadata from ZooKeeper", e);
+      _log.warn("Failed to fetch deterministic subsetting metadata from ZooKeeper for cluster " + _clusterName, e);
       return null;
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.7
+version=29.18.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Fix a bug in ZKDeterministicSubsettingMetadataProvider to make host set distinct.
Also, make the info/debug level log more verbose.