### PR TITLE
Add support for returning location of schema elements from the PDL schema parser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.11] - 2021-05-24
+- Add support for returning location of schema elements from the PDL schema parser.
+
 ## [29.18.10] - 2021-05-24
 - Introduce a readonly attribute on the action annotation
 
@@ -4954,7 +4957,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.11...master
+[29.18.11]: https://github.com/linkedin/rest.li/compare/v29.18.10...v29.18.11
 [29.18.10]: https://github.com/linkedin/rest.li/compare/v29.18.9...v29.18.10
 [29.18.9]: https://github.com/linkedin/rest.li/compare/v29.18.8...v29.18.9
 [29.18.8]: https://github.com/linkedin/rest.li/compare/v29.18.7...v29.18.8

--- a/data/src/test/resources/com/linkedin/data/schema/grammar/TestEnumForParserContextLocations.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/grammar/TestEnumForParserContextLocations.pdl
@@ -1,0 +1,15 @@
+namespace com.linkedin.data.schema.grammar
+
+/**
+ * Enum to test returning context locations from the source file.
+ */
+@location = {"startLine": 3, "startCol": 1, "endLine": 15, "endCol": 1}
+enum TestEnumForParserContextLocations {
+  /**
+   * Symbol docs and properties are included in the location of the enum symbol
+   */
+  @location = {"startLine": 8, "startCol": 3, "endLine": 12, "endCol": 7}
+  TEST1
+  @location = {"startLine": 13, "startCol": 3, "endLine": 14, "endCol": 7}
+  TEST2
+}

--- a/data/src/test/resources/com/linkedin/data/schema/grammar/TestFixedForParserContextLocations.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/grammar/TestFixedForParserContextLocations.pdl
@@ -1,0 +1,7 @@
+namespace com.linkedin.data.schema.grammar
+
+/**
+ * Fixed type to test returning context locations from the source file.
+ */
+@location = {"startLine": 3, "startCol": 1, "endLine": 7, "endCol": 43}
+fixed TestFixedForParserContextLocations  4

--- a/data/src/test/resources/com/linkedin/data/schema/grammar/TestRecordForParserContextLocations.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/grammar/TestRecordForParserContextLocations.pdl
@@ -1,0 +1,88 @@
+namespace com.linkedin.data.schema.grammar
+
+/**
+ * Record to test returning context locations from the source file.
+ */
+@location = {"startLine": 3, "startCol": 1, "endLine": 88, "endCol": 1}
+record TestRecordForParserContextLocations {
+  @location = {"startLine": 8, "startCol": 3, "endLine": 9, "endCol": 39}
+  stringField: string = "default value"  // Field with default.
+  /**
+   * This field has a comment, location includes the comments.
+   */
+  @location = {"startLine": 10, "startCol": 3, "endLine": 14, "endCol": 24}
+  arrayField: array[int]
+  @location = {"startLine": 15, "startCol": 3, "endLine": 25, "endCol": 5}
+  inlineRecord:
+    @location = {"startLine": 17, "startCol": 5, "endLine": 25, "endCol": 5}
+    record InlineRecord {
+      // Non doc comment, this is not included in the location of the field.
+      // Properties are included.
+      @location = {"startLine": 21, "startCol": 7, "endLine": 22, "endCol": 12}
+      a: int
+      @location = {"startLine": 23, "startCol": 7, "endLine": 24, "endCol": 13}
+      b: long
+    }
+
+  // Field location includes the entire inline definition
+  @location = {"startLine": 28, "startCol": 3, "endLine": 44, "endCol": 5}
+  inlineEnum:
+    @location = {"startLine": 30, "startCol": 5, "endLine": 44, "endCol": 5}
+    enum InlineEnum {
+      /**
+       * Symbol docs and properties are included in the location of the enum symbol
+       */
+      @location = {"startLine": 32, "startCol": 7, "endLine": 36, "endCol": 13}
+      SYMBOLA
+      /**
+       * Commas are optional in the grammar and thus are not included.
+       */
+      @location = {"startLine": 37, "startCol": 7, "endLine": 41, "endCol": 13}
+      SYMBOLB,
+      @location = {"startLine": 42, "startCol": 7, "endLine": 43, "endCol": 13}
+      SYMBOLC  // Non doc comments like this are not included in the location.
+    }
+
+  @location = {"startLine": 46, "startCol": 3, "endLine": 55, "endCol": 3}
+  inlineNamespacedField: {
+    namespace com.linkedin.test.inline  // The location for this namespace will be keyed by the namespace string.
+
+    @location = {"startLine": 50, "startCol": 5, "endLine": 54, "endCol": 5}
+    record Nested {
+      @location = {"startLine": 52, "startCol": 7, "endLine": 53, "endCol": 11}
+      a:int
+    }
+  }
+
+  @location = {"startLine": 57, "startCol": 3, "endLine": 62, "endCol": 37}
+  unionField:
+    @location = {"startLine": 59, "startCol": 5, "endLine": 62, "endCol": 37}
+    @location.`com.linkedin.data.schema.grammar.InlineEnum` = {"startLine": 62, "startCol": 12, "endLine": 62, "endCol": 21}
+    @location.`com.linkedin.data.schema.grammar.InlineRecord` = {"startLine": 62, "startCol": 24, "endLine": 62, "endCol": 35}
+    union[ InlineEnum, InlineRecord ]
+
+  @location = {"startLine": 64, "startCol": 3, "endLine": 75, "endCol": 5}
+  aliasedUnionField:
+    @location = {"startLine": 66, "startCol": 5, "endLine": 75, "endCol": 5}
+    union [
+      /**
+       * Only aliased union members can have doc and properties
+       */
+      @location = {"startLine": 68, "startCol": 7, "endLine": 72, "endCol": 17}
+      aliasA: int,
+      @location = {"startLine": 73, "startCol": 7, "endLine": 74, "endCol": 18}
+      aliasB: long
+    ]
+
+  @location = {"startLine": 77, "startCol": 3, "endLine": 78, "endCol": 50}
+  enumReference: TestEnumForParserContextLocations
+
+  @location = {"startLine": 80, "startCol": 3, "endLine": 81, "endCol": 54}
+  typerefRerence: TestTyperefForParserContextLocations
+
+  @location = {"startLine": 83, "startCol": 3, "endLine": 84, "endCol": 44}
+  recordReference: ComplexTypeWithProperties
+
+  @location = {"startLine": 86, "startCol": 3, "endLine": 87, "endCol": 59}
+  mapField: map[string, TestFixedForParserContextLocations]
+}

--- a/data/src/test/resources/com/linkedin/data/schema/grammar/TestTyperefForParserContextLocations.pdl
+++ b/data/src/test/resources/com/linkedin/data/schema/grammar/TestTyperefForParserContextLocations.pdl
@@ -1,0 +1,25 @@
+namespace com.linkedin.data.schema.grammar
+
+/**
+ * Typeref to test returning context locations from the source file.
+ */
+@location = {"startLine": 3, "startCol": 1, "endLine": 25, "endCol": 3}
+typeref TestTyperefForParserContextLocations =
+  @location = {"startLine": 8, "startCol": 3, "endLine": 25, "endCol": 3}
+  union[
+    @location = {"startLine": 10, "startCol": 5, "endLine": 20, "endCol": 9}
+    aRef:
+      @location = {"startLine": 12, "startCol": 7, "endLine": 20, "endCol": 9}
+      typeref ARef =
+        @location = {"startLine": 14, "startCol": 9, "endLine": 20, "endCol": 9}
+        record InlineTyperefRecord {
+          @location = {"startLine": 16, "startCol": 11, "endLine": 17, "endCol": 15}
+          a:int
+          @location = {"startLine": 18, "startCol": 11, "endLine": 19, "endCol": 15}
+          b:int
+        }
+    @location = {"startLine": 21, "startCol": 5, "endLine": 24, "endCol": 24}
+    bRef:
+      @location = {"startLine": 23, "startCol": 7, "endLine": 24, "endCol": 24}
+      typeref BRef = int
+  ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.10
+version=29.18.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This feature would be useful for tools that provide additional functionality like linting, code search etc on the PDL schemas.