### PR TITLE
Add oraclejdk11 to the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk11
 
 # Anything after trusty doesn't have Java 8
 dist: trusty


### PR DESCRIPTION
Just testing to see what will happen.

NOTE: Investigate how this affects the deploy/publish process. We only want to run this with one jdk.