### PR TITLE
Use daemon thread to unregister TimingKeys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.12] - 2021-05-26
+- Use daemon threads to unregister TimingKeys.
+
 ## [29.18.11] - 2021-05-24
 - Add support for returning location of schema elements from the PDL schema parser.
 
@@ -4957,7 +4960,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.12...master
+[29.18.12]: https://github.com/linkedin/rest.li/compare/v29.18.11...v29.18.12
 [29.18.11]: https://github.com/linkedin/rest.li/compare/v29.18.10...v29.18.11
 [29.18.10]: https://github.com/linkedin/rest.li/compare/v29.18.9...v29.18.10
 [29.18.9]: https://github.com/linkedin/rest.li/compare/v29.18.8...v29.18.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.11
+version=29.18.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/message/timing/TimingKey.java
+++ b/r2-core/src/main/java/com/linkedin/r2/message/timing/TimingKey.java
@@ -35,7 +35,8 @@ import java.util.concurrent.Executors;
 public class TimingKey
 {
   private static final Map<String, TimingKey> _pool = new ConcurrentHashMap<>();
-  private static final ExecutorService _unregisterExecutor = Executors.newFixedThreadPool(1);
+  private static final ExecutorService _unregisterExecutor = Executors
+      .newFixedThreadPool(1, TimingKey::createDaemonThread);
 
   private final String _name;
   private final String _type;
@@ -156,4 +157,9 @@ public class TimingKey
     return _pool.size();
   }
 
+  private static final Thread createDaemonThread(Runnable runnable) {
+    Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+    thread.setDaemon(true);
+    return thread;
+  }
 }


### PR DESCRIPTION
This is safe because unregistering does no I/O; it only removes from a
concurrent map.

Without using daemon threads, the threads created by the ExecutorService
will never be shut down unless the Java process is killed forceably with
System.exit or by an external system.

We found that this is impacting many internal products that initialize their Espresso databases locally for integration testing. The tool that does that is kept alive indefinitely by the static thread pool in TimingKey. While this has been worked around in new versions of the tool by explicitly calling System.exit, it shouldn't be necessary; and there are compatibility tests that fail because rest.li is updated while the tool is not.