### PR TITLE
Fix race conditions in D2 cluster subsetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.15] - 2021-06-02
+- Fix race conditions in D2 cluster subsetting. Refactor subsetting cache to SubsettingState.
+
 ## [29.18.14] - 2021-05-27
 - Use class.getClassLoader() instead of thread.getContextClassLoader() to get the class loader.
 
@@ -4966,7 +4969,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.14...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.15...master
+[29.18.15]: https://github.com/linkedin/rest.li/compare/v29.18.14...v29.18.15
 [29.18.14]: https://github.com/linkedin/rest.li/compare/v29.18.13...v29.18.14
 [29.18.13]: https://github.com/linkedin/rest.li/compare/v29.18.12...v29.18.13
 [29.18.12]: https://github.com/linkedin/rest.li/compare/v29.18.11...v29.18.12

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
@@ -23,6 +23,7 @@ import com.linkedin.d2.balancer.properties.ClusterProperties;
 import com.linkedin.d2.balancer.properties.ServiceProperties;
 import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
+import com.linkedin.d2.balancer.subsetting.SubsettingState;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
 import com.linkedin.d2.discovery.event.PropertyEventThread.PropertyEventShutdownCallback;
 import com.linkedin.r2.transport.common.bridge.client.TransportClient;
@@ -91,12 +92,13 @@ public interface LoadBalancerState
   List<SchemeStrategyPair> getStrategiesForService(String serviceName,
                                                     List<String> prioritizedSchemes);
 
-  default Map<URI, TrackerClient> getClientsSubset(String serviceName,
+  default SubsettingState.SubsetItem getClientsSubset(String serviceName,
                                                    int minClusterSubsetSize,
                                                    int partitionId,
-                                                   Map<URI, TrackerClient> potentialClients)
+                                                   Map<URI, TrackerClient> potentialClients,
+                                                   long version)
   {
-    return potentialClients;
+    return new SubsettingState.SubsetItem(false, potentialClients);
   }
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClient.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClient.java
@@ -46,6 +46,13 @@ public interface TrackerClient extends LoadBalancerClient
   TransportClient getTransportClient();
 
   /**
+   * @param doNotSlowStart Should the host skip performing slow start
+   */
+  default void setDoNotSlowStart(boolean doNotSlowStart)
+  {
+  }
+
+  /**
    * @return Should the host skip performing slow start
    */
   boolean doNotSlowStart();

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
@@ -74,9 +74,10 @@ public class TrackerClientImpl implements TrackerClient
   private final Map<Integer, PartitionData> _partitionData;
   private final URI _uri;
   private final Predicate<Integer> _isErrorStatus;
-  private final boolean _doNotSlowStart;
   private final ConcurrentMap<Integer, Double> _subsetWeightMap;
   final CallTracker _callTracker;
+
+  private boolean _doNotSlowStart;
 
   private volatile CallTracker.CallStats _latestCallStats;
 
@@ -201,6 +202,12 @@ public class TrackerClientImpl implements TrackerClient
 
       _wrappedCallback.onResponse(response);
     }
+  }
+
+  @Override
+  public void setDoNotSlowStart(boolean doNotSlowStart)
+  {
+    _doNotSlowStart = doNotSlowStart;
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -37,6 +37,7 @@ import com.linkedin.d2.balancer.properties.PartitionData;
 import com.linkedin.d2.balancer.properties.ServiceProperties;
 import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
+import com.linkedin.d2.balancer.subsetting.SubsettingState;
 import com.linkedin.d2.balancer.util.ClientFactoryProvider;
 import com.linkedin.d2.balancer.util.ClusterInfoProvider;
 import com.linkedin.d2.balancer.util.HostOverrideList;
@@ -285,8 +286,10 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
         Ring<URI> ring = null;
         for (LoadBalancerState.SchemeStrategyPair pair : orderedStrategies)
         {
-          Map<URI, TrackerClient> clients = getPotentialClients(serviceName, service, cluster, uris, pair.getScheme(), partitionId);
-          ring = pair.getStrategy().getRing(uriItem.getVersion(), partitionId, clients);
+          SubsettingState.SubsetItem subsetItem = getPotentialClients(serviceName, service,
+              cluster, uris, pair.getScheme(), partitionId, uriItem.getVersion());
+          ring = pair.getStrategy().getRing(uriItem.getVersion(), partitionId, subsetItem.getWeightedSubset(),
+              subsetItem.shouldForceUpdate());
 
           if (!ring.isEmpty())
           {
@@ -336,9 +339,10 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
       {
         for (LoadBalancerState.SchemeStrategyPair pair : orderedStrategies)
         {
-          Map<URI, TrackerClient> trackerClients = getPotentialClients(serviceName, service, cluster, uris,
-              pair.getScheme(), partitionId);
-          Ring<URI> ring = pair.getStrategy().getRing(uriItem.getVersion(), partitionId, trackerClients);
+          SubsettingState.SubsetItem subsetItem = getPotentialClients(serviceName, service, cluster, uris,
+              pair.getScheme(), partitionId, uriItem.getVersion());
+          Ring<URI> ring = pair.getStrategy().getRing(uriItem.getVersion(), partitionId, subsetItem.getWeightedSubset(),
+              subsetItem.shouldForceUpdate());
           // ring will never be null; it can be empty
           ringMap.put(partitionId, ring);
 
@@ -550,12 +554,14 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
       {
         for (LoadBalancerState.SchemeStrategyPair pair : orderedStrategies)
         {
-          Map<URI, TrackerClient> trackerClients = getPotentialClients(serviceName, service, cluster, uris,
-              pair.getScheme(), partitionId);
+          SubsettingState.SubsetItem subsetItem = getPotentialClients(serviceName, service, cluster, uris,
+              pair.getScheme(), partitionId, uriItem.getVersion());
+          Map<URI, TrackerClient> trackerClients = subsetItem.getWeightedSubset();
           int size = Math.min(trackerClients.size(), limitHostPerPartition);
           List<URI> rankedUri = new ArrayList<>(size);
 
-          Ring<URI> ring = pair.getStrategy().getRing(uriItem.getVersion(), partitionId, trackerClients);
+          Ring<URI> ring = pair.getStrategy().getRing(uriItem.getVersion(), partitionId, trackerClients,
+              subsetItem.shouldForceUpdate());
           Iterator<URI> iterator = ring.getIterator(hash);
 
           while (iterator.hasNext() && rankedUri.size() < size)
@@ -709,25 +715,26 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
   }
 
   // supports partitioning
-  private Map<URI, TrackerClient> getPotentialClients(String serviceName,
+  private SubsettingState.SubsetItem getPotentialClients(String serviceName,
                                                   ServiceProperties serviceProperties,
                                                   ClusterProperties clusterProperties,
                                                   UriProperties uris,
                                                   String scheme,
-                                                  int partitionId)
+                                                  int partitionId,
+                                                  long version)
   {
     Set<URI> possibleUris = uris.getUriBySchemeAndPartition(scheme, partitionId);
 
     Map<URI, TrackerClient> clientsToBalance = getPotentialClients(serviceName, serviceProperties, clusterProperties, possibleUris);
-    Map<URI, TrackerClient> clientsSubset = serviceProperties.isEnableClusterSubsetting() ?
+    SubsettingState.SubsetItem subsetItem = serviceProperties.isEnableClusterSubsetting() ?
         _state.getClientsSubset(serviceName, serviceProperties.getMinClusterSubsetSize(),
-            partitionId, clientsToBalance) : clientsToBalance;
+            partitionId, clientsToBalance, version) : new SubsettingState.SubsetItem(false, clientsToBalance);
 
-    if (clientsSubset.isEmpty())
+    if (subsetItem.getWeightedSubset().isEmpty())
     {
       info(_log, "Can not find a host for service: ", serviceName, ", scheme: ", scheme, ", partition: ", partitionId);
     }
-    return clientsSubset;
+    return subsetItem;
   }
 
   private Map<URI, TrackerClient> getPotentialClients(String serviceName,
@@ -839,11 +846,13 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
       LoadBalancerStrategy strategy = pair.getStrategy();
       String scheme = pair.getScheme();
 
-
-      clientsToLoadBalance = getPotentialClients(serviceName, serviceProperties, cluster, uris, scheme, partitionId);
+      SubsettingState.SubsetItem subsetItem = getPotentialClients(serviceName, serviceProperties, cluster,
+          uris, scheme, partitionId, uriItem.getVersion());
+      clientsToLoadBalance = subsetItem.getWeightedSubset();
 
       trackerClient =
-          strategy.getTrackerClient(request, requestContext, uriItem.getVersion(), partitionId, clientsToLoadBalance);
+          strategy.getTrackerClient(request, requestContext, uriItem.getVersion(), partitionId, clientsToLoadBalance,
+              subsetItem.shouldForceUpdate());
 
       debug(_log,
             "load balancer strategy for ",

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -33,8 +33,7 @@ import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
 import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategyV3;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.balancer.subsetting.DeterministicSubsettingMetadataProvider;
-import com.linkedin.d2.balancer.subsetting.SubsettingStrategy;
-import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactory;
+import com.linkedin.d2.balancer.subsetting.SubsettingState;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategyFactoryImpl;
 import com.linkedin.d2.balancer.util.ClientFactoryProvider;
 import com.linkedin.d2.balancer.util.LoadBalancerUtil;
@@ -59,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -145,8 +143,8 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
   private final boolean       _isSSLEnabled;
   private final SslSessionValidatorFactory _sslSessionValidatorFactory;
 
-  private final SubsettingStrategyFactory _subsettingStrategyFactory;
-  private final ConcurrentMap<String, ConcurrentMap<Integer, Map<URI, TrackerClient>>> _weightedSubsetsCache;
+  private final DeterministicSubsettingMetadataProvider _subsettingMetadataProvider;
+  private final SubsettingState _subsettingState;
 
   /*
    * Concurrency considerations:
@@ -314,13 +312,13 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
     _clusterListeners = Collections.synchronizedList(new ArrayList<>());
     if (deterministicSubsettingMetadataProvider != null)
     {
-      _subsettingStrategyFactory = new SubsettingStrategyFactoryImpl(deterministicSubsettingMetadataProvider, this);
+      _subsettingState = new SubsettingState(new SubsettingStrategyFactoryImpl(), deterministicSubsettingMetadataProvider);
     }
     else
     {
-      _subsettingStrategyFactory = SubsettingStrategyFactory.NO_OP_SUBSETTING_STRATEGY_FACTORY;
+      _subsettingState = null;
     }
-    _weightedSubsetsCache = new ConcurrentHashMap<>();
+    _subsettingMetadataProvider = deterministicSubsettingMetadataProvider;
   }
 
   public void register(final SimpleLoadBalancerStateListener listener)
@@ -674,57 +672,30 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
   }
 
   @Override
-  public Map<URI, TrackerClient> getClientsSubset(String serviceName,
+  public SubsettingState.SubsetItem getClientsSubset(String serviceName,
                                                   int minClusterSubsetSize,
                                                   int partitionId,
-                                                  Map<URI, TrackerClient> potentialClients)
+                                                  Map<URI, TrackerClient> potentialClients,
+                                                  long version)
   {
-    SubsettingStrategy<URI> subsettingStrategy = _subsettingStrategyFactory.get(serviceName, minClusterSubsetSize, partitionId);
-
-    if (subsettingStrategy == null)
+    if (_subsettingState == null)
     {
-      return potentialClients;
-    }
-
-    // If cluster version is not changed, return the cached subset if possible
-    if (!subsettingStrategy.isSubsetChanged(_version.get()) &&
-        _weightedSubsetsCache.containsKey(serviceName) &&
-        _weightedSubsetsCache.get(serviceName).containsKey(partitionId))
-    {
-      return _weightedSubsetsCache.get(serviceName).get(partitionId);
-    }
-
-    Map<URI, Double> weightMap = potentialClients.entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getPartitionWeight(partitionId)));
-    Map<URI, Double> subsetMap = subsettingStrategy.getWeightedSubset(weightMap, _version.get());
-
-    if (subsetMap == null)
-    {
-      return potentialClients;
+      return new SubsettingState.SubsetItem(false, potentialClients);
     }
     else
     {
-      Map<URI, TrackerClient> subsetClients = new HashMap<>();
-      for (Map.Entry<URI, Double> entry: subsetMap.entrySet())
-      {
-        URI uri = entry.getKey();
-        TrackerClient client = potentialClients.get(uri);
-        client.setSubsetWeight(partitionId, subsetMap.get(uri));
-        subsetClients.put(uri, client);
-      }
+      SubsettingState.SubsetItem subsetItem = _subsettingState
+          .getClientsSubset(serviceName, minClusterSubsetSize, partitionId, potentialClients, version, this);
 
-      _weightedSubsetsCache.computeIfAbsent(serviceName, k -> new ConcurrentHashMap<>());
-      _weightedSubsetsCache.get(serviceName).put(partitionId, subsetClients);
-
-      debug(_log, "cluster subset updated for service ", serviceName, ": [",
-          subsetClients.values().stream()
-            .limit(LOG_SUBSET_MAX_SIZE)
-            .map(client -> client.getUri() + ":" + client.getSubsetWeight(partitionId))
-            .collect(Collectors.joining(",")),
-          " (total ", subsetClients.size(), ")]"
+      debug(_log, "get cluster subset for service ", serviceName, ": [",
+          subsetItem.getWeightedSubset().values().stream()
+              .limit(LOG_SUBSET_MAX_SIZE)
+              .map(client -> client.getUri() + ":" + client.getSubsetWeight(partitionId))
+              .collect(Collectors.joining(",")),
+          " (total ", subsetItem.getWeightedSubset().size(), ")], shouldForceUpdate = ", subsetItem.shouldForceUpdate()
       );
 
-      return subsetClients;
+      return subsetItem;
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -142,8 +142,6 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
   private final SSLParameters _sslParameters;
   private final boolean       _isSSLEnabled;
   private final SslSessionValidatorFactory _sslSessionValidatorFactory;
-
-  private final DeterministicSubsettingMetadataProvider _subsettingMetadataProvider;
   private final SubsettingState _subsettingState;
 
   /*
@@ -318,7 +316,6 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
     {
       _subsettingState = null;
     }
-    _subsettingMetadataProvider = deterministicSubsettingMetadataProvider;
   }
 
   public void register(final SimpleLoadBalancerStateListener listener)

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/LoadBalancerStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/LoadBalancerStrategy.java
@@ -61,6 +61,17 @@ public interface LoadBalancerStrategy
                                  int partitionId,
                                  Map<URI, TrackerClient> trackerClients);
 
+  @Nullable
+  default TrackerClient getTrackerClient(Request request,
+                                 RequestContext requestContext,
+                                 long clusterGenerationId,
+                                 int partitionId,
+                                 Map<URI, TrackerClient> trackerClients,
+                                 boolean shouldForceUpdate)
+  {
+    return getTrackerClient(request, requestContext, clusterGenerationId, partitionId, trackerClients);
+  }
+
   /**
    * Returns a ring that can be used to choose a host. The ring will contain all the
    * tracker clients passed as the argument.
@@ -78,6 +89,15 @@ public interface LoadBalancerStrategy
   Ring<URI> getRing(long clusterGenerationId,
                     int partitionId,
                     Map<URI, TrackerClient> trackerClients);
+
+  @Nonnull
+  default Ring<URI> getRing(long clusterGenerationId,
+                    int partitionId,
+                    Map<URI, TrackerClient> trackerClients,
+                    boolean shouldForceUpdate)
+  {
+    return getRing(clusterGenerationId, partitionId, trackerClients);
+  }
 
   /**
    * Return the hashFunction which will be applied on {@code Request} to find the host for routing purpose

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/degrader/DegraderLoadBalancerStrategyV3.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/degrader/DegraderLoadBalancerStrategyV3.java
@@ -144,6 +144,17 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
                                         int partitionId,
                                         Map<URI, TrackerClient> trackerClients)
   {
+    return getTrackerClient(request, requestContext, clusterGenerationId, partitionId, trackerClients, false);
+  }
+
+  @Override
+  public TrackerClient getTrackerClient(Request request,
+                                        RequestContext requestContext,
+                                        long clusterGenerationId,
+                                        int partitionId,
+                                        Map<URI, TrackerClient> trackerClients,
+                                        boolean shouldForceUpdate)
+  {
     debug(_log,
           "getTrackerClient with generation id ",
           clusterGenerationId,
@@ -164,7 +175,7 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
 
     // only one thread will be allowed to enter updatePartitionState for any partition
     TimingContextUtil.markTiming(requestContext, TIMING_KEY);
-    checkUpdatePartitionState(clusterGenerationId, partitionId, degraderTrackerClients);
+    checkUpdatePartitionState(clusterGenerationId, partitionId, degraderTrackerClients, shouldForceUpdate);
     TimingContextUtil.markTiming(requestContext, TIMING_KEY);
 
     Ring<URI> ring =  _state.getRing(partitionId);
@@ -304,8 +315,10 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
    * @param clusterGenerationId
    * @param partitionId
    * @param trackerClients
+   * @param shouldForceUpdate
    */
-  private void checkUpdatePartitionState(long clusterGenerationId, int partitionId, List<DegraderTrackerClient> trackerClients)
+  private void checkUpdatePartitionState(long clusterGenerationId, int partitionId,
+      List<DegraderTrackerClient> trackerClients, boolean shouldForceUpdate)
   {
     DegraderLoadBalancerStrategyConfig config = getConfig();
     final Partition partition = _state.getPartition(partitionId);
@@ -337,7 +350,7 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
         lock.unlock();
       }
     }
-    else if(shouldUpdatePartition(clusterGenerationId, partition.getState(), config, _updateEnabled))
+    else if(shouldUpdatePartition(clusterGenerationId, partition.getState(), config, _updateEnabled, shouldForceUpdate))
     {
       // threads attempt to update the state would return immediately if some thread is already in the updating process
       // NOTE: possible racing condition -- if tryLock() fails and the current updating process does not pick up the
@@ -349,7 +362,7 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
       {
         try
         {
-          if(shouldUpdatePartition(clusterGenerationId, partition.getState(), config, _updateEnabled))
+          if(shouldUpdatePartition(clusterGenerationId, partition.getState(), config, _updateEnabled, shouldForceUpdate))
           {
             debug(_log, "updating for cluster generation id: ", clusterGenerationId, ", partitionId: ", partitionId);
             debug(_log, "old state was: ", partition.getState());
@@ -931,7 +944,8 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
         && !state.getTrackerClients().contains(client)                        // client is new
         && config.getRingRampFactor() > FAST_RECOVERY_THRESHOLD               // Fast recovery is enabled
         && degraderControl.getInitialDropRate() > SLOW_START_THRESHOLD        // Slow start is enabled
-        && !degraderControl.isHigh())                                         // current client is not degrading or QPS is too low
+        && !degraderControl.isHigh()                                          // current client is not degrading or QPS is too low
+        && !client.doNotSlowStart())                                          // doNotSlowStart is set to false
     {
       recoveryMap.put(client, clientUpdater.getMaxDropRate());
       // also set the maxDropRate to the computedDropRate if not 1;
@@ -1025,16 +1039,18 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
    *          Current DegraderLoadBalancerStrategyConfig
    * @param updateEnabled
    *          Whether updates to the strategy state is allowed.
-   *
+   * @param shouldForceUpdate
+   *          Whether to force update
    * @return True if we should update, and false otherwise.
    */
   protected static boolean shouldUpdatePartition(long clusterGenerationId, PartitionDegraderLoadBalancerState partitionState,
-                                                 DegraderLoadBalancerStrategyConfig config, boolean updateEnabled)
+      DegraderLoadBalancerStrategyConfig config, boolean updateEnabled, boolean shouldForceUpdate)
   {
     return  updateEnabled
-        && (
+        && (shouldForceUpdate
+        || (
             !config.isUpdateOnlyAtInterval() && partitionState.getClusterGenerationId() != clusterGenerationId ||
-            config.getClock().currentTimeMillis() - partitionState.getLastUpdated() >= config.getUpdateIntervalMs());
+            config.getClock().currentTimeMillis() - partitionState.getLastUpdated() >= config.getUpdateIntervalMs()));
   }
 
   /**
@@ -1078,6 +1094,13 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
   @Override
   public Ring<URI> getRing(long clusterGenerationId, int partitionId, Map<URI, TrackerClient> trackerClients)
   {
+    return getRing(clusterGenerationId, partitionId, trackerClients, false);
+  }
+
+  @Nonnull
+  @Override
+  public Ring<URI> getRing(long clusterGenerationId, int partitionId, Map<URI, TrackerClient> trackerClients, boolean shouldForceUpdate)
+  {
     if (trackerClients.isEmpty())
     {
       // returning empty ring (any implementation) and preventing to update the state with no trackers
@@ -1085,7 +1108,7 @@ public class DegraderLoadBalancerStrategyV3 implements LoadBalancerStrategy
       return new DelegatingRingFactory<URI>(_config).createRing(Collections.emptyMap(), Collections.emptyMap());
     }
 
-    checkUpdatePartitionState(clusterGenerationId, partitionId, castToDegraderTrackerClients(trackerClients));
+    checkUpdatePartitionState(clusterGenerationId, partitionId, castToDegraderTrackerClients(trackerClients), shouldForceUpdate);
     return _state.getRing(partitionId);
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
@@ -72,13 +72,25 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
                                         int partitionId,
                                         Map<URI, TrackerClient> trackerClients)
   {
+    return getTrackerClient(request, requestContext, clusterGenerationId, partitionId, trackerClients, false);
+  }
+
+  @Nullable
+  @Override
+  public TrackerClient getTrackerClient(Request request,
+                                        RequestContext requestContext,
+                                        long clusterGenerationId,
+                                        int partitionId,
+                                        Map<URI, TrackerClient> trackerClients,
+                                        boolean shouldForceUpdate)
+  {
     if (trackerClients == null || trackerClients.size() == 0)
     {
       LOG.warn("getTrackerClient called with null/empty trackerClients, so returning null");
       return null;
     }
 
-    _stateUpdater.updateState(new HashSet<>(trackerClients.values()), partitionId, clusterGenerationId);
+    _stateUpdater.updateState(new HashSet<>(trackerClients.values()), partitionId, clusterGenerationId, shouldForceUpdate);
     Ring<URI> ring = _stateUpdater.getRing(partitionId);
     return _clientSelector.getTrackerClient(request, requestContext, ring, trackerClients);
   }
@@ -87,7 +99,14 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
   @Override
   public Ring<URI> getRing(long clusterGenerationId, int partitionId, Map<URI, TrackerClient> trackerClients)
   {
-    _stateUpdater.updateState(new HashSet<>(trackerClients.values()), partitionId, clusterGenerationId);
+    return getRing(clusterGenerationId, partitionId, trackerClients, false);
+  }
+
+  @Nonnull
+  @Override
+  public Ring<URI> getRing(long clusterGenerationId, int partitionId, Map<URI, TrackerClient> trackerClients, boolean shouldForceUpdate)
+  {
+    _stateUpdater.updateState(new HashSet<>(trackerClients.values()), partitionId, clusterGenerationId, shouldForceUpdate);
     return _stateUpdater.getRing(partitionId);
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadata.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingMetadata.java
@@ -26,11 +26,13 @@ public final class DeterministicSubsettingMetadata
 {
   private final int _instanceId;
   private final int _totalInstanceCount;
+  private final long _peerClusterVersion;
 
-  public DeterministicSubsettingMetadata(int instanceId, int totalInstanceCount)
+  public DeterministicSubsettingMetadata(int instanceId, int totalInstanceCount, long peerClusterVersion)
   {
     _instanceId = instanceId;
     _totalInstanceCount = totalInstanceCount;
+    _peerClusterVersion = peerClusterVersion;
   }
 
   /**
@@ -42,11 +44,18 @@ public final class DeterministicSubsettingMetadata
   }
 
   /**
-   * Get the total number of instances in the peer client cluster.
+   * Get the total number of instances in the peer client cluster
    */
   public int getTotalInstanceCount()
   {
     return _totalInstanceCount;
+  }
+
+  /**
+   * Get peer cluster version
+   */
+  public long getPeerClusterVersion() {
+    return _peerClusterVersion;
   }
 
   @Override
@@ -59,19 +68,21 @@ public final class DeterministicSubsettingMetadata
       return false;
     }
     DeterministicSubsettingMetadata that = (DeterministicSubsettingMetadata) o;
-    return _instanceId == that._instanceId && _totalInstanceCount == that._totalInstanceCount;
+    return _instanceId == that._instanceId
+        && _totalInstanceCount == that._totalInstanceCount
+        && _peerClusterVersion == that._peerClusterVersion;
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(_instanceId, _totalInstanceCount);
+    return Objects.hash(_instanceId, _totalInstanceCount, _peerClusterVersion);
   }
 
   @Override
   public String toString()
   {
     return "DeterministicSubsettingMetadata{" + "_instanceId=" + _instanceId + ", _totalInstanceCount="
-        + _totalInstanceCount + '}';
+        + _totalInstanceCount + ", _peerClusterVersion=" + _peerClusterVersion + '}';
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
@@ -77,12 +77,12 @@ public class SubsettingState
 
     synchronized (_lockMap.computeIfAbsent(serviceName, name -> new Object()))
     {
-      SubsetCache subsetCacahe = _subsetCache.get(serviceName);
-      if (isCacheValid(version, metadata.getPeerClusterVersion(), minClusterSubsetSize, subsetCacahe))
+      SubsetCache subsetCache = _subsetCache.get(serviceName);
+      if (isCacheValid(version, metadata.getPeerClusterVersion(), minClusterSubsetSize, subsetCache))
       {
-        if (subsetCacahe.getWeightedSubsets().containsKey(partitionId))
+        if (subsetCache.getWeightedSubsets().containsKey(partitionId))
         {
-          return new SubsetItem(false, subsetCacahe.getWeightedSubsets().get(partitionId));
+          return new SubsetItem(false, subsetCache.getWeightedSubsets().get(partitionId));
         }
       }
 
@@ -98,9 +98,9 @@ public class SubsettingState
       {
         Set<URI> oldPotentialClients = Collections.emptySet();
 
-        if (subsetCacahe != null)
+        if (subsetCache != null)
         {
-          oldPotentialClients = subsetCacahe.getPotentialClients().getOrDefault(partitionId, Collections.emptySet());
+          oldPotentialClients = subsetCache.getPotentialClients().getOrDefault(partitionId, Collections.emptySet());
         }
 
         Map<URI, TrackerClient> subsetClients = new HashMap<>();
@@ -116,13 +116,13 @@ public class SubsettingState
           subsetClients.put(uri, client);
         }
 
-        if (subsetCacahe != null)
+        if (subsetCache != null)
         {
-          subsetCacahe.setVersion(version);
-          subsetCacahe.setPeerClusterVersion(metadata.getPeerClusterVersion());
-          subsetCacahe.setMinClusterSubsetSize(minClusterSubsetSize);
-          subsetCacahe.getPotentialClients().put(partitionId, potentialClients.keySet());
-          subsetCacahe.getWeightedSubsets().put(partitionId, subsetClients);
+          subsetCache.setVersion(version);
+          subsetCache.setPeerClusterVersion(metadata.getPeerClusterVersion());
+          subsetCache.setMinClusterSubsetSize(minClusterSubsetSize);
+          subsetCache.getPotentialClients().put(partitionId, potentialClients.keySet());
+          subsetCache.getWeightedSubsets().put(partitionId, subsetClients);
         }
         else
         {
@@ -135,7 +135,7 @@ public class SubsettingState
               minClusterSubsetSize, servicePotentialClients, serviceWeightedSubset));
         }
 
-        LOG.debug("Subsetting cache updated for service " + serviceName + ": " + subsetCacahe);
+        LOG.debug("Subset cache updated for service " + serviceName + ": " + subsetCache);
 
         return new SubsetItem(true, subsetClients);
       }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
@@ -1,0 +1,239 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.subsetting;
+
+import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * State of cluster subsetting
+ */
+public class SubsettingState
+{
+  private static final Logger LOG = LoggerFactory.getLogger(SubsettingState.class);
+  private final ConcurrentMap<String, Object> _lockMap = new ConcurrentHashMap<>();
+
+  private final SubsettingStrategyFactory _subsettingStrategyFactory;
+  private final DeterministicSubsettingMetadataProvider _subsettingMetadataProvider;
+
+  /**
+   * Map from serviceName => SubsetCache
+   */
+  private final Map<String, SubsetCache> _subsetCache;
+
+  public SubsettingState(SubsettingStrategyFactory subsettingStrategyFactory,
+      DeterministicSubsettingMetadataProvider subsettingMetadataProvider)
+  {
+    _subsettingMetadataProvider = subsettingMetadataProvider;
+    _subsettingStrategyFactory = subsettingStrategyFactory;
+    _subsetCache = new HashMap<>();
+  }
+
+  public SubsetItem getClientsSubset(String serviceName,
+      int minClusterSubsetSize,
+      int partitionId,
+      Map<URI, TrackerClient> potentialClients,
+      long version,
+      SimpleLoadBalancerState state)
+  {
+    SubsettingStrategy<URI> subsettingStrategy = _subsettingStrategyFactory.get(serviceName, minClusterSubsetSize, partitionId);
+
+    if (subsettingStrategy == null)
+    {
+      return new SubsetItem(false, potentialClients);
+    }
+
+    DeterministicSubsettingMetadata metadata = _subsettingMetadataProvider.getSubsettingMetadata(state);
+
+    if (metadata == null)
+    {
+      return new SubsetItem(false, potentialClients);
+    }
+
+    synchronized (_lockMap.computeIfAbsent(serviceName, name -> new Object()))
+    {
+      SubsetCache subsetCacahe = _subsetCache.get(serviceName);
+      if (isCacheValid(version, metadata.getPeerClusterVersion(), minClusterSubsetSize, subsetCacahe))
+      {
+        if (subsetCacahe.getWeightedSubsets().containsKey(partitionId))
+        {
+          return new SubsetItem(false, subsetCacahe.getWeightedSubsets().get(partitionId));
+        }
+      }
+
+      Map<URI, Double> weightMap = potentialClients.entrySet().stream()
+          .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getPartitionWeight(partitionId)));
+      Map<URI, Double> subsetMap = subsettingStrategy.getWeightedSubset(weightMap, metadata);
+
+      if (subsetMap == null)
+      {
+        return new SubsetItem(false, potentialClients);
+      }
+      else
+      {
+        Set<URI> oldPotentialClients = Collections.emptySet();
+
+        if (subsetCacahe != null)
+        {
+          oldPotentialClients = subsetCacahe.getPotentialClients().getOrDefault(partitionId, Collections.emptySet());
+        }
+
+        Map<URI, TrackerClient> subsetClients = new HashMap<>();
+        for (Map.Entry<URI, Double> entry: subsetMap.entrySet())
+        {
+          URI uri = entry.getKey();
+          TrackerClient client = potentialClients.get(uri);
+          if (oldPotentialClients.contains(uri))
+          {
+            client.setDoNotSlowStart(true);
+          }
+          client.setSubsetWeight(partitionId, entry.getValue());
+          subsetClients.put(uri, client);
+        }
+
+        if (subsetCacahe != null)
+        {
+          subsetCacahe.setVersion(version);
+          subsetCacahe.setPeerClusterVersion(metadata.getPeerClusterVersion());
+          subsetCacahe.setMinClusterSubsetSize(minClusterSubsetSize);
+          subsetCacahe.getPotentialClients().put(partitionId, potentialClients.keySet());
+          subsetCacahe.getWeightedSubsets().put(partitionId, subsetClients);
+        }
+        else
+        {
+          Map<Integer, Set<URI>> servicePotentialClients = new HashMap<>();
+          Map<Integer, Map<URI, TrackerClient>> serviceWeightedSubset = new HashMap<>();
+          servicePotentialClients.put(partitionId, potentialClients.keySet());
+          serviceWeightedSubset.put(partitionId, subsetClients);
+
+          _subsetCache.put(serviceName, new SubsetCache(version, metadata.getPeerClusterVersion(),
+              minClusterSubsetSize, servicePotentialClients, serviceWeightedSubset));
+        }
+
+        LOG.debug("Subsetting cache updated for service " + serviceName + ": " + subsetCacahe);
+
+        return new SubsetItem(true, subsetClients);
+      }
+    }
+  }
+
+  private boolean isCacheValid(long version, long peerClusterVersion, int minClusterSubsetSize, SubsetCache subsetCache)
+  {
+    return subsetCache != null && version == subsetCache.getVersion() &&
+        peerClusterVersion == subsetCache.getPeerClusterVersion() &&
+        minClusterSubsetSize == subsetCache.getMinClusterSubsetSize();
+  }
+
+  private static class SubsetCache
+  {
+    private long _version;
+    private long _peerClusterVersion;
+    private int _minClusterSubsetSize;
+    private final Map<Integer, Set<URI>> _potentialClients;
+    private final Map<Integer, Map<URI, TrackerClient>> _weightedSubsets;
+
+    SubsetCache(long version, long peerClusterVersion, int minClusterSubsetSize,
+        Map<Integer, Set<URI>> potentialClients, Map<Integer, Map<URI, TrackerClient>> weightedSubsets)
+    {
+      _version = version;
+      _peerClusterVersion = peerClusterVersion;
+      _minClusterSubsetSize = minClusterSubsetSize;
+      _potentialClients = potentialClients;
+      _weightedSubsets = weightedSubsets;
+    }
+
+    public long getVersion()
+    {
+      return _version;
+    }
+
+    public long getPeerClusterVersion()
+    {
+      return _peerClusterVersion;
+    }
+
+    public int getMinClusterSubsetSize()
+    {
+      return _minClusterSubsetSize;
+    }
+
+    public Map<Integer, Set<URI>> getPotentialClients()
+    {
+      return _potentialClients;
+    }
+
+    public Map<Integer, Map<URI, TrackerClient>> getWeightedSubsets()
+    {
+      return _weightedSubsets;
+    }
+
+    public void setVersion(long version)
+    {
+      _version = version;
+    }
+
+    public void setPeerClusterVersion(long peerClusterVersion)
+    {
+      _peerClusterVersion = peerClusterVersion;
+    }
+
+    public void setMinClusterSubsetSize(int minClusterSubsetSize)
+    {
+      _minClusterSubsetSize = minClusterSubsetSize;
+    }
+
+    @Override
+    public String toString() {
+      return "SubsetCache{" + "_version=" + _version + ", _peerClusterVersion=" + _peerClusterVersion
+          + ", _minClusterSubsetSize=" + _minClusterSubsetSize + ", _potentialClients=" + _potentialClients
+          + ", _weightedSubsets=" + _weightedSubsets + '}';
+    }
+  }
+
+  public static class SubsetItem
+  {
+    private final boolean _shouldForceUpdate;
+    private final Map<URI, TrackerClient> _weightedSubset;
+
+    public SubsetItem(boolean shouldForceUpdate, Map<URI, TrackerClient> weightedSubset)
+    {
+      _shouldForceUpdate = shouldForceUpdate;
+      _weightedSubset = weightedSubset;
+    }
+
+    public boolean shouldForceUpdate()
+    {
+      return _shouldForceUpdate;
+    }
+
+    public Map<URI, TrackerClient> getWeightedSubset()
+    {
+      return _weightedSubset;
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategy.java
@@ -29,16 +29,11 @@ public interface SubsettingStrategy<T>
   int DEFAULT_CLUSTER_SUBSET_SIZE = -1;
 
   /**
-   * Checks whether the subset is changed given the version number
-   */
-  boolean isSubsetChanged(long version);
-
-  /**
    * Picks a subset from a collection of items
    *
    * @param weightMap Maps each item to its weight on a scale of 0.0 to 1.0.
-   * @param version The version of the weightMap. Subsequent calls with the same version number will return the cached subset.
+   * @param metadata The metadata of peer cluster.
    * @return A subset that maps each item to its weight on a scale of 0.0 to 1.0.
    */
-  Map<T, Double> getWeightedSubset(Map<T, Double> weightMap, long version);
+  Map<T, Double> getWeightedSubset(Map<T, Double> weightMap, DeterministicSubsettingMetadata metadata);
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingStrategyFactory.java
@@ -22,8 +22,6 @@ import java.net.URI;
 
 public interface SubsettingStrategyFactory
 {
-  SubsettingStrategyFactory NO_OP_SUBSETTING_STRATEGY_FACTORY = (serviceName, minClusterSubsetSize, partitionId) -> null;
-
   /**
    * get retrieves the {@link SubsettingStrategy} corresponding to the serviceName and partition Id.
    * @return {@link SubsettingStrategy} or {@code null} if minClusterSubsetSize is less than or equal to 0.

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -46,7 +46,7 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
   private final Object _lock = new Object();
 
   @GuardedBy("_lock")
-  private long _clusterGenerationId = -1;
+  private long _peerCluserVersion = -1;
   @GuardedBy("_lock")
   private DeterministicSubsettingMetadata _subsettingMetadata;
 
@@ -72,9 +72,9 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
 
       synchronized (_lock)
       {
-        if (uriItem.getVersion() != _clusterGenerationId)
+        if (uriItem.getVersion() != _peerCluserVersion)
         {
-          _clusterGenerationId = uriItem.getVersion();
+          _peerCluserVersion = uriItem.getVersion();
           UriProperties uriProperties = uriItem.getProperty();
           if (uriProperties != null)
           {
@@ -89,7 +89,7 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
 
             if (instanceId >= 0)
             {
-              _subsettingMetadata = new DeterministicSubsettingMetadata(instanceId, sortedHosts.size());
+              _subsettingMetadata = new DeterministicSubsettingMetadata(instanceId, sortedHosts.size(), _peerCluserVersion);
             }
             else
             {

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/degrader/DegraderLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/degrader/DegraderLoadBalancerTest.java
@@ -1579,7 +1579,7 @@ public class DegraderLoadBalancerTest
 
     // state is default initialized, new cluster generation
     assertTrue(DegraderLoadBalancerStrategyV3.shouldUpdatePartition(0,
-            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true));
+            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true, false));
 
 
     PartitionDegraderLoadBalancerState current =
@@ -1606,7 +1606,7 @@ public class DegraderLoadBalancerTest
     // haven't gone by
     testClock.addMs(1);
     assertFalse(DegraderLoadBalancerStrategyV3.shouldUpdatePartition(0,
-            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true));
+            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true, false));
 
     // generation Id for the next state is changed
     current = new PartitionDegraderLoadBalancerState(1,
@@ -1630,7 +1630,7 @@ public class DegraderLoadBalancerTest
     // state is not null, and cluster generation has changed so we will update
     testClock.addMs(1);
     assertTrue(DegraderLoadBalancerStrategyV3.shouldUpdatePartition(0,
-            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true));
+            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true, false));
 
     // state is not null, and force 5s to go by with the same cluster generation id
     current = new PartitionDegraderLoadBalancerState(1,
@@ -1653,7 +1653,7 @@ public class DegraderLoadBalancerTest
 
     testClock.addMs(5000);
     assertTrue(DegraderLoadBalancerStrategyV3.shouldUpdatePartition(1,
-            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true));
+            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true, false));
 
 
     current = new PartitionDegraderLoadBalancerState(1,
@@ -1677,7 +1677,7 @@ public class DegraderLoadBalancerTest
     // now try a new cluster generation id so state will be updated again
     testClock.addMs(15);
     assertTrue(DegraderLoadBalancerStrategyV3.shouldUpdatePartition(2,
-            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true));
+            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true, false));
   }
 
   @Test(groups = { "small", "back-end" })
@@ -1698,18 +1698,18 @@ public class DegraderLoadBalancerTest
 
     // state is default initialized, new cluster generation
     assertFalse(DegraderLoadBalancerStrategyV3.shouldUpdatePartition(0,
-            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true));
+            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true, false));
 
 
     // state is not null, but we're on the same cluster generation id, and 5 seconds
     // haven't gone by
     testClock.addMs(1);
     assertFalse(DegraderLoadBalancerStrategyV3.shouldUpdatePartition(0,
-            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true));
+            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true, false));
 
     testClock.addMs(5000);
     assertTrue(DegraderLoadBalancerStrategyV3.shouldUpdatePartition(1,
-            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true));
+            strategy.getState().getPartitionState(DEFAULT_PARTITION_ID), strategy.getConfig(), true, false));
 
     PartitionDegraderLoadBalancerState current =
             strategy.getState().getPartitionState(DEFAULT_PARTITION_ID);

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -80,7 +80,7 @@ public class StateUpdaterTest
 
     assertTrue(_stateUpdater.getPointsMap(partitionId).isEmpty(), "There should be no state before initialization");
 
-    _stateUpdater.updateState(new HashSet<>(trackerClients), partitionId, DEFAULT_CLUSTER_GENERATION_ID);
+    _stateUpdater.updateState(new HashSet<>(trackerClients), partitionId, DEFAULT_CLUSTER_GENERATION_ID, false);
 
     assertEquals(_stateUpdater.getPointsMap(partitionId).get(trackerClients.get(0).getUri()).intValue(), HEALTHY_POINTS);
     assertEquals(_stateUpdater.getPointsMap(partitionId).get(trackerClients.get(1).getUri()).intValue(), HEALTHY_POINTS);
@@ -110,7 +110,7 @@ public class StateUpdaterTest
 
     assertTrue(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).isEmpty(), "There should be no state before initialization");
 
-    _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, DEFAULT_CLUSTER_GENERATION_ID);
+    _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, DEFAULT_CLUSTER_GENERATION_ID, false);
 
     if (!doNotSlowStart)
     {
@@ -151,7 +151,8 @@ public class StateUpdaterTest
     CountDownLatch countDownLatch = new CountDownLatch(numThreads);
     Runnable runnable = () -> {
       PartitionState lastState = _stateUpdater.getPartitionState(DEFAULT_PARTITION_ID);
-      _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, DEFAULT_CLUSTER_GENERATION_ID);
+      _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, DEFAULT_CLUSTER_GENERATION_ID,
+          false);
       PartitionState currentState = _stateUpdater.getPartitionState(DEFAULT_PARTITION_ID);
       if (lastState != null)
       {
@@ -197,7 +198,7 @@ public class StateUpdaterTest
     Mockito.doAnswer(new ExecutionCountDown<>(countDownLatch)).when(_quarantineManager).updateQuarantineState(any(), any(), anyLong());
 
     // Cluster generation id changed from 0 to 1
-    _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, 1);
+    _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, 1, false);
     if (!countDownLatch.await(5, TimeUnit.SECONDS))
     {
       fail("cluster update failed to finish within 5 seconds");

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/DeterministicSubsettingStrategyTest.java
@@ -16,30 +16,20 @@
 
 package com.linkedin.d2.balancer.subsetting;
 
-import com.linkedin.d2.balancer.LoadBalancerState;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class DeterministicSubsettingStrategyTest
 {
   public static final double DELTA_DIFF = 1e-5;
-
-  @Mock
-  private DeterministicSubsettingMetadataProvider _deterministicSubsettingMetadataProvider;
-
-  @Mock
-  private LoadBalancerState _state;
 
   private DeterministicSubsettingStrategy<String> _deterministicSubsettingStrategy;
 
@@ -56,51 +46,6 @@ public class DeterministicSubsettingStrategyTest
     return pointsMap;
   }
 
-  @BeforeMethod
-  public void setUp()
-  {
-    MockitoAnnotations.initMocks(this);
-  }
-
-  @Test
-  public void testCaching()
-  {
-    Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata(_state))
-        .thenReturn(new DeterministicSubsettingMetadata(0, 20));
-    _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
-        "test", 10, _state);
-
-    double[] weights = new double[100];
-    Arrays.fill(weights, 1D);
-
-    assertTrue(_deterministicSubsettingStrategy.isSubsetChanged(0));
-    Map<String, Double> pointsMap = constructPointsMap(weights);
-    Map<String, Double> weightedSubset1 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
-
-    assertFalse(_deterministicSubsettingStrategy.isSubsetChanged(0));
-    pointsMap = constructPointsMap(weights);
-    Map<String, Double> weightedSubset2 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
-
-    assertSame(weightedSubset1, weightedSubset2);
-
-    assertTrue(_deterministicSubsettingStrategy.isSubsetChanged(1));
-    pointsMap = constructPointsMap(weights);
-    Map<String, Double> weightedSubset3 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 1);
-
-    assertEquals(weightedSubset1, weightedSubset3);
-    assertNotSame(weightedSubset1, weightedSubset3);
-
-    assertFalse(_deterministicSubsettingStrategy.isSubsetChanged(1));
-    pointsMap = constructPointsMap(weights);
-    Map<String, Double> weightedSubset4 = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 1);
-
-    assertSame(weightedSubset3, weightedSubset4);
-
-    Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata(_state))
-        .thenReturn(new DeterministicSubsettingMetadata(0, 19));
-    assertTrue(_deterministicSubsettingStrategy.isSubsetChanged(1));
-  }
-
   @Test(dataProvider = "uniformWeightData")
   public void testDistributionWithUniformWeight(int clientNum, int hostNum, int minSubsetSize)
   {
@@ -112,11 +57,9 @@ public class DeterministicSubsettingStrategyTest
 
     for (int i = 0; i < clientNum; i++)
     {
-      Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata(_state))
-          .thenReturn(new DeterministicSubsettingMetadata(i, clientNum));
-      _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
-          "test", minSubsetSize, _state);
-      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
+      _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>("test", minSubsetSize);
+      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap,
+          new DeterministicSubsettingMetadata(i, clientNum, 0));
       assertTrue(weightedSubset.size() >= Math.min(minSubsetSize, hostNum));
 
       for (Map.Entry<String, Double> entry: weightedSubset.entrySet())
@@ -142,11 +85,9 @@ public class DeterministicSubsettingStrategyTest
 
     for (int i = 0; i < clientNum; i++)
     {
-      Mockito.when(_deterministicSubsettingMetadataProvider.getSubsettingMetadata(_state))
-          .thenReturn(new DeterministicSubsettingMetadata(i, clientNum));
-      _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>(_deterministicSubsettingMetadataProvider,
-          "test", minSubsetSize, _state);
-      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap, 0);
+      _deterministicSubsettingStrategy = new DeterministicSubsettingStrategy<>("test", minSubsetSize);
+      Map<String, Double> weightedSubset = _deterministicSubsettingStrategy.getWeightedSubset(pointsMap,
+          new DeterministicSubsettingMetadata(i, clientNum, 0));
       double totalWeights = 0;
       for (Map.Entry<String, Double> entry: weightedSubset.entrySet())
       {
@@ -173,7 +114,6 @@ public class DeterministicSubsettingStrategyTest
   {
     return new Object[][]
         {
-            {5, 0, 10},
             {1, 1, 10},
             {1, 5, 10},
             {5, 1, 10},

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/SubsettingStateTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/SubsettingStateTest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -33,6 +34,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 public class SubsettingStateTest
@@ -147,7 +149,10 @@ public class SubsettingStateTest
       }).start();
     }
 
-    latch.await();
+    if (!latch.await(5, TimeUnit.SECONDS))
+    {
+      fail("subsetting update failed to finish within 5 seconds");
+    }
 
     if (_failure.get() != null)
       throw _failure.get();

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/SubsettingStateTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/SubsettingStateTest.java
@@ -1,0 +1,215 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.subsetting;
+
+import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.clients.TrackerClientImpl;
+import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class SubsettingStateTest
+{
+  private static final int THREAD_NUM = 20;
+  private static final String SERVICE_NAME = "test";
+  private static final int PARTITION_ID = 0;
+
+  private final AtomicReference<AssertionError> _failure = new AtomicReference<>();
+
+  private SubsettingState _subsettingState;
+
+  @Mock
+  private DeterministicSubsettingMetadataProvider _subsettingMetadataProvider;
+
+  @Mock
+  private SimpleLoadBalancerState _state;
+
+  @BeforeMethod
+  public void setUp()
+  {
+    MockitoAnnotations.initMocks(this);
+    _subsettingState = new SubsettingState(new SubsettingStrategyFactoryImpl(), _subsettingMetadataProvider);
+  }
+
+  @Test
+  public void testSingleThreadCase()
+  {
+    Mockito.when(_subsettingMetadataProvider.getSubsettingMetadata(_state))
+        .thenReturn(new DeterministicSubsettingMetadata(0, 5, 0));
+
+    SubsettingState.SubsetItem subsetItem = _subsettingState.getClientsSubset(SERVICE_NAME, 4, 0,
+        mockTrackerClients(30), 0, _state);
+
+    assertEquals(subsetItem.getWeightedSubset().size(), 6);
+    assertTrue(subsetItem.shouldForceUpdate());
+
+    Mockito.when(_subsettingMetadataProvider.getSubsettingMetadata(_state))
+        .thenReturn(new DeterministicSubsettingMetadata(0, 4, 1));
+
+    SubsettingState.SubsetItem subsetItem1 = _subsettingState.getClientsSubset(SERVICE_NAME, 4, 0,
+        mockTrackerClients(30), 0, _state);
+
+    assertEquals(subsetItem1.getWeightedSubset().size(), 8);
+    assertTrue(subsetItem1.shouldForceUpdate());
+
+    SubsettingState.SubsetItem subsetItem2 = _subsettingState.getClientsSubset(SERVICE_NAME, 4, 0,
+        mockTrackerClients(28), 2, _state);
+
+    assertEquals(subsetItem2.getWeightedSubset().size(), 7);
+    assertTrue(subsetItem2.shouldForceUpdate());
+
+    SubsettingState.SubsetItem subsetItem3 = _subsettingState.getClientsSubset(SERVICE_NAME, 8, 0,
+        mockTrackerClients(28), 2, _state);
+
+    assertEquals(subsetItem3.getWeightedSubset().size(), 14);
+    assertTrue(subsetItem3.shouldForceUpdate());
+
+    SubsettingState.SubsetItem subsetItem4 = _subsettingState.getClientsSubset(SERVICE_NAME, 8, 0,
+        mockTrackerClients(28), 2, _state);
+    assertEquals(subsetItem4.getWeightedSubset().size(), 14);
+    assertFalse(subsetItem4.shouldForceUpdate());
+  }
+
+  @Test
+  public void testMultiThreadCase() throws InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(THREAD_NUM * 3);
+
+    Mockito.when(_subsettingMetadataProvider.getSubsettingMetadata(_state))
+        .thenReturn(new DeterministicSubsettingMetadata(0, 5, 0));
+
+    for (int i = 0; i < THREAD_NUM; i++)
+    {
+      new Thread(() ->
+      {
+        SubsettingState.SubsetItem subsetItem = _subsettingState.getClientsSubset("test", 4, PARTITION_ID,
+            mockTrackerClients(30), 0, _state);
+
+        verifySubset(subsetItem.getWeightedSubset().size(), 6);
+        latch.countDown();
+      }).start();
+    }
+
+    Thread.sleep(500);
+
+    Mockito.when(_subsettingMetadataProvider.getSubsettingMetadata(_state))
+        .thenReturn(new DeterministicSubsettingMetadata(0, 4, 1));
+
+    for (int i = 0; i < THREAD_NUM; i++)
+    {
+      new Thread(() ->
+      {
+        SubsettingState.SubsetItem subsetItem = _subsettingState.getClientsSubset("test", 4, PARTITION_ID,
+            mockTrackerClients(30), 0, _state);
+
+        verifySubset(subsetItem.getWeightedSubset().size(), 8);
+        latch.countDown();
+      }).start();
+    }
+
+    Thread.sleep(500);
+
+    for (int i = 0; i < THREAD_NUM; i++)
+    {
+      new Thread(() ->
+      {
+        SubsettingState.SubsetItem subsetItem = _subsettingState.getClientsSubset("test", 4, PARTITION_ID,
+            mockTrackerClients(28), 2, _state);
+
+        verifySubset(subsetItem.getWeightedSubset().size(), 7);
+        latch.countDown();
+      }).start();
+    }
+
+    latch.await();
+
+    if (_failure.get() != null)
+      throw _failure.get();
+  }
+
+  @Test
+  public void testDoNotSlowStart()
+  {
+    Mockito.when(_subsettingMetadataProvider.getSubsettingMetadata(_state))
+        .thenReturn(new DeterministicSubsettingMetadata(0, 5, 0));
+
+    Map<URI, TrackerClient> trackerClients = mockTrackerClients(20);
+    SubsettingState.SubsetItem subsetItem = _subsettingState.getClientsSubset(SERVICE_NAME, 4, 0,
+        trackerClients, 0, _state);
+
+    Map<URI, TrackerClient> trackerClients1 = mockTrackerClients(40);
+    SubsettingState.SubsetItem subsetItem1 = _subsettingState.getClientsSubset(SERVICE_NAME, 4, 0,
+        trackerClients1, 1, _state);
+
+    verifyDoNotSlowStart(subsetItem1.getWeightedSubset(), trackerClients);
+  }
+
+  private void verifyDoNotSlowStart(Map<URI, TrackerClient> subset, Map<URI, TrackerClient> oldPotentialClients)
+  {
+    for (Map.Entry<URI, TrackerClient> entry : subset.entrySet())
+    {
+      if (oldPotentialClients.containsKey(entry.getKey()))
+      {
+        assertTrue(entry.getValue().doNotSlowStart());
+      }
+      else
+      {
+        assertFalse(entry.getValue().doNotSlowStart());
+      }
+    }
+  }
+
+  private void verifySubset(int subsetSize, int expected)
+  {
+    try
+    {
+      assertEquals(subsetSize, expected);
+    }
+    catch (AssertionError e)
+    {
+      _failure.set(e);
+    }
+  }
+
+  private Map<URI, TrackerClient> mockTrackerClients(int numTrackerClients)
+  {
+    Map<URI, TrackerClient> trackerClients = new HashMap<>();
+    for (int index = 0; index < numTrackerClients; index ++)
+    {
+      URI uri = URI.create("URI/" + index);
+      TrackerClient trackerClient = Mockito.mock(TrackerClientImpl.class);
+      Mockito.doCallRealMethod().when(trackerClient).setDoNotSlowStart(Mockito.anyBoolean());
+      Mockito.doCallRealMethod().when(trackerClient).doNotSlowStart();
+      Mockito.when(trackerClient.getUri()).thenReturn(uri);
+      Mockito.when(trackerClient.getPartitionWeight(Mockito.anyInt())).thenReturn(1.0);
+      trackerClients.put(uri, trackerClient);
+    }
+    return trackerClients;
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
@@ -64,7 +64,8 @@ public class ZKDeterministicSubsettingMetadataProviderTest
   private ZKDeterministicSubsettingMetadataProvider _metadataProvider;
 
   private static final SslSessionValidatorFactory SSL_SESSION_VALIDATOR_FACTORY =
-      validationStrings -> sslSession -> {
+      validationStrings -> sslSession ->
+      {
         if (validationStrings == null || validationStrings.isEmpty())
         {
           throw new SslSessionNotTrustedException("no validation string");
@@ -131,6 +132,7 @@ public class ZKDeterministicSubsettingMetadataProviderTest
 
     assertEquals(metadata.getInstanceId(), 2);
     assertEquals(metadata.getTotalInstanceCount(), 10);
+    assertEquals(metadata.getPeerClusterVersion(), 5);
 
     uriData.remove(URI.create("http://test0.linkedin.com:8888/test"));
     _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
@@ -138,6 +140,7 @@ public class ZKDeterministicSubsettingMetadataProviderTest
     metadata = _metadataProvider.getSubsettingMetadata(_state);
     assertEquals(metadata.getInstanceId(), 1);
     assertEquals(metadata.getTotalInstanceCount(), 9);
+    assertEquals(metadata.getPeerClusterVersion(), 7);
 
     uriData.remove(URI.create("http://test2.linkedin.com:8888/test"));
     _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.14
+version=29.18.15
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
1. Fix a race condition where two threads with same clusterGenerationId attempts to update subset simultaneously, one thread still gets the old cached subset. The fix is to make the update a critical section.
2. Fix a bug when client cluster changes, the clusterGenerationId passed into loadBalancerStrategy is not changed, causing stale state.
3. Fix a bug when minClusterSubsetSize changes, the client is still pulling the cached subset.