### PR TITLE
Remove one more "runtime" configuration reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.13] - 2021-05-27
+- Remove one more "runtime" configuration reference.
+
 ## [29.18.12] - 2021-05-26
 - Use daemon threads to unregister TimingKeys.
 
@@ -4960,7 +4963,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.13...master
+[29.18.13]: https://github.com/linkedin/rest.li/compare/v29.18.12...v29.18.13
 [29.18.12]: https://github.com/linkedin/rest.li/compare/v29.18.11...v29.18.12
 [29.18.11]: https://github.com/linkedin/rest.li/compare/v29.18.10...v29.18.11
 [29.18.10]: https://github.com/linkedin/rest.li/compare/v29.18.9...v29.18.10

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -1255,7 +1255,7 @@ public class PegasusPlugin implements Plugin<Project>
 
       // generate the rest model
       FileCollection restModelCodegenClasspath = project.getConfigurations().getByName(PEGASUS_PLUGIN_CONFIGURATION)
-          .plus(project.getConfigurations().getByName("runtime"))
+          .plus(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME))
           .plus(sourceSet.getRuntimeClasspath());
       String destinationDirPrefix = getGeneratedDirPath(project, sourceSet, REST_GEN_TYPE) + File.separatorChar;
       FileCollection restModelResolverPath = apiProject.files(getDataSchemaPath(project, sourceSet))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.12
+version=29.18.13
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
I closed a previous version of this change because it included more involved changes to remove references to "compile" and "testCompile" as well. Restoring just this small change to remove the references to "runtime" for Gradle 7 compatibility.