### PR TITLE
Use class.getClassLoader() instead thread.getContextClassLoader()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.18.14] - 2021-05-27
+- Use class.getClassLoader() instead of thread.getContextClassLoader() to get the class loader.
+
 ## [29.18.13] - 2021-05-27
 - Remove one more "runtime" configuration reference.
 
@@ -4963,7 +4966,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.13...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.18.14...master
+[29.18.14]: https://github.com/linkedin/rest.li/compare/v29.18.13...v29.18.14
 [29.18.13]: https://github.com/linkedin/rest.li/compare/v29.18.12...v29.18.13
 [29.18.12]: https://github.com/linkedin/rest.li/compare/v29.18.11...v29.18.12
 [29.18.11]: https://github.com/linkedin/rest.li/compare/v29.18.10...v29.18.11

--- a/data/src/main/java/com/linkedin/util/CustomTypeUtil.java
+++ b/data/src/main/java/com/linkedin/util/CustomTypeUtil.java
@@ -56,11 +56,14 @@ public class CustomTypeUtil
     {
       try
       {
-        bindingClass = Class.forName(javaCoercerClassName, false, Thread.currentThread().getContextClassLoader());
+        return Class.forName(javaCoercerClassName, false, CustomTypeUtil.class.getClassLoader());
       }
-      catch (ClassNotFoundException e)
+      catch (SecurityException | ClassNotFoundException e)
       {
-        throw new IllegalArgumentException("Unable to find java coercer class of " + javaCoercerClassName + " for schema " + schema.getUnionMemberKey());
+        // If CustomTypeUtil.class.getClassLoader() throws exception
+        // or CustomTypeUtil.class.getClassLoader() could not load class,
+        // fall back to use thread context class loader
+        return getBindingClass(javaCoercerClassName, Thread.currentThread().getContextClassLoader(), schema);
       }
     }
     else
@@ -90,5 +93,17 @@ public class CustomTypeUtil
 
     return (String) o2;
 
+  }
+
+  private static Class<?> getBindingClass(String javaCoercerClassName, ClassLoader classLoader, DataSchema schema)
+  {
+    try
+    {
+      return Class.forName(javaCoercerClassName, false, classLoader);
+    }
+    catch (ClassNotFoundException e)
+    {
+      throw new IllegalArgumentException("Unable to find java coercer class of " + javaCoercerClassName + " for schema " + schema.getUnionMemberKey());
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.18.13
+version=29.18.14
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Use class.getClassLoader() instead thread.getContextClassLoader() to get the class loader due to the java 8 -> java 11 backward incompatible behavior.

Issue:
In Java 8 a new thread would “inherit” the classloader of the thread that forked it, but in Java 11 the new thread will use the default class loader. Because of this backward incompatible problem between Java 8 and Java 11, thread.getContextClassLoader() is not getting class loader in CustomTypeUtil.

Solution:
We are going to use class.getClassLoader() to get the class loader, if class.getClassLoader() is failing to get the class loader, we fall back to use thread.getContextClassLoader() to get the class loader.