### PR TITLE
More changes for Gradle 7 compatibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.19.3] - 2021-06-18
+- More changes for Gradle 7 compatibility.
+  - Add schemas as source set resources and rely on the Java plugin to copy them
+    into the artifact instead of doing so directly, to avoid copying duplicates.
+  - Change getter names in GenerateDataTemplateTask to conform to what Gradle 7
+    requires and deprecate the old ones.
+
 ## [29.19.2] - 2021-06-17
 - Allow client-side RetriableRequestException to be retried after ClientRetryFilter
 
@@ -4975,7 +4982,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.3...master
+[29.19.3]: https://github.com/linkedin/rest.li/compare/v29.19.2...v29.19.3
 [29.19.2]: https://github.com/linkedin/rest.li/compare/v29.19.1...v29.19.2
 [29.19.1]: https://github.com/linkedin/rest.li/compare/v29.18.15...v29.19.1
 [29.18.15]: https://github.com/linkedin/rest.li/compare/v29.18.14...v29.18.15

--- a/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginCacheabilityTest.groovy
+++ b/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginCacheabilityTest.groovy
@@ -5,6 +5,7 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.*
 
@@ -12,9 +13,11 @@ class PegasusPluginCacheabilityTest extends Specification {
   @Rule
   TemporaryFolder tempDir = new TemporaryFolder()
 
-  def 'mainDataTemplateJar tasks are up-to-date'() {
+  @Unroll
+  def "mainDataTemplateJar tasks are up-to-date with Gradle #gradleVersion"() {
     setup:
     def runner = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
         .withProjectDir(tempDir.root)
         .withPluginClasspath()
         .withArguments('mainDataTemplateJar')
@@ -64,7 +67,7 @@ class PegasusPluginCacheabilityTest extends Specification {
     result.task(':mainDestroyStaleFiles').outcome == SKIPPED
     result.task(':mainCopyPdscSchemas').outcome == SKIPPED
     result.task(':mainCopySchemas').outcome == SUCCESS
-    result.task(':processMainGeneratedDataTemplateResources').outcome == NO_SOURCE
+    result.task(':processMainGeneratedDataTemplateResources').outcome == SUCCESS
     result.task(':mainGeneratedDataTemplateClasses').outcome ==  SUCCESS
     result.task(':mainTranslateSchemas').outcome == SUCCESS
     result.task(':mainDataTemplateJar').outcome == SUCCESS
@@ -83,7 +86,7 @@ class PegasusPluginCacheabilityTest extends Specification {
     result.task(':mainDestroyStaleFiles').outcome == SKIPPED
     result.task(':mainCopyPdscSchemas').outcome == SKIPPED
     result.task(':mainCopySchemas').outcome == UP_TO_DATE
-    result.task(':processMainGeneratedDataTemplateResources').outcome == NO_SOURCE
+    result.task(':processMainGeneratedDataTemplateResources').outcome == UP_TO_DATE
     result.task(':mainGeneratedDataTemplateClasses').outcome == UP_TO_DATE
     result.task(':mainTranslateSchemas').outcome == UP_TO_DATE
     result.task(':mainDataTemplateJar').outcome == UP_TO_DATE
@@ -91,5 +94,8 @@ class PegasusPluginCacheabilityTest extends Specification {
     // Validate compiled and prepared schemas exist
     compiledSchema.exists()
     preparedSchema.exists()
+
+    where:
+    gradleVersion << [ '4.0', '5.2.1', '5.6.4', '6.9', '7.0.2' ]
   }
 }

--- a/gradle-plugins/src/integTest/resources/ivy/modern/gradle7/expectedChildIvyDescriptorContents.txt
+++ b/gradle-plugins/src/integTest/resources/ivy/modern/gradle7/expectedChildIvyDescriptorContents.txt
@@ -1,0 +1,26 @@
+  <configurations>
+    <conf name="compile" visibility="public"/>
+    <conf name="dataTemplate" visibility="public" extends="mainGeneratedDataTemplateApiElements,mainGeneratedDataTemplateRuntimeElements"/>
+    <conf name="default" visibility="public" extends="runtime"/>
+    <conf name="mainGeneratedDataTemplateApiElements" visibility="public"/>
+    <conf name="mainGeneratedDataTemplateRuntimeElements" visibility="public"/>
+    <conf name="runtime" visibility="public"/>
+    <conf name="testDataTemplate" visibility="public" extends="testGeneratedDataTemplateApiElements,testGeneratedDataTemplateRuntimeElements"/>
+    <conf name="testGeneratedDataTemplateApiElements" visibility="public"/>
+    <conf name="testGeneratedDataTemplateRuntimeElements" visibility="public"/>
+  </configurations>
+  <publications>
+    <artifact name="child" type="jar" ext="jar" conf="compile,runtime"/>
+    <artifact name="child" type="jar" ext="jar" conf="mainGeneratedDataTemplateApiElements,mainGeneratedDataTemplateRuntimeElements" m:classifier="data-template"/>
+    <artifact name="child" type="jar" ext="jar" conf="testGeneratedDataTemplateApiElements,testGeneratedDataTemplateRuntimeElements" m:classifier="test-data-template"/>
+  </publications>
+  <dependencies>
+    <dependency org="com.linkedin.pegasus-parent-demo" name="parent" rev="1.0.0" conf="mainGeneratedDataTemplateApiElements-&gt;dataTemplate"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="mainGeneratedDataTemplateApiElements-&gt;default"/>
+    <dependency org="com.linkedin.pegasus-parent-demo" name="parent" rev="1.0.0" conf="mainGeneratedDataTemplateRuntimeElements-&gt;dataTemplate"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="mainGeneratedDataTemplateRuntimeElements-&gt;default"/>
+    <dependency org="com.linkedin.pegasus-parent-demo" name="parent" rev="1.0.0" conf="testGeneratedDataTemplateApiElements-&gt;dataTemplate"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="testGeneratedDataTemplateApiElements-&gt;default"/>
+    <dependency org="com.linkedin.pegasus-parent-demo" name="parent" rev="1.0.0" conf="testGeneratedDataTemplateRuntimeElements-&gt;dataTemplate"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="testGeneratedDataTemplateRuntimeElements-&gt;default"/>
+  </dependencies>

--- a/gradle-plugins/src/integTest/resources/ivy/modern/gradle7/expectedGrandparentIvyDescriptorContents.txt
+++ b/gradle-plugins/src/integTest/resources/ivy/modern/gradle7/expectedGrandparentIvyDescriptorContents.txt
@@ -1,0 +1,22 @@
+  <configurations>
+    <conf name="compile" visibility="public"/>
+    <conf name="dataTemplate" visibility="public" extends="mainGeneratedDataTemplateApiElements,mainGeneratedDataTemplateRuntimeElements"/>
+    <conf name="default" visibility="public" extends="runtime"/>
+    <conf name="mainGeneratedDataTemplateApiElements" visibility="public"/>
+    <conf name="mainGeneratedDataTemplateRuntimeElements" visibility="public"/>
+    <conf name="runtime" visibility="public"/>
+    <conf name="testDataTemplate" visibility="public" extends="testGeneratedDataTemplateApiElements,testGeneratedDataTemplateRuntimeElements"/>
+    <conf name="testGeneratedDataTemplateApiElements" visibility="public"/>
+    <conf name="testGeneratedDataTemplateRuntimeElements" visibility="public"/>
+  </configurations>
+  <publications>
+    <artifact name="grandparent" type="jar" ext="jar" conf="compile,runtime"/>
+    <artifact name="grandparent" type="jar" ext="jar" conf="mainGeneratedDataTemplateApiElements,mainGeneratedDataTemplateRuntimeElements" m:classifier="data-template"/>
+    <artifact name="grandparent" type="jar" ext="jar" conf="testGeneratedDataTemplateApiElements,testGeneratedDataTemplateRuntimeElements" m:classifier="test-data-template"/>
+  </publications>
+  <dependencies>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="mainGeneratedDataTemplateApiElements-&gt;default"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="mainGeneratedDataTemplateRuntimeElements-&gt;default"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="testGeneratedDataTemplateApiElements-&gt;default"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="testGeneratedDataTemplateRuntimeElements-&gt;default"/>
+  </dependencies>

--- a/gradle-plugins/src/integTest/resources/ivy/modern/gradle7/expectedParentIvyDescriptorContents.txt
+++ b/gradle-plugins/src/integTest/resources/ivy/modern/gradle7/expectedParentIvyDescriptorContents.txt
@@ -1,0 +1,26 @@
+  <configurations>
+    <conf name="compile" visibility="public"/>
+    <conf name="dataTemplate" visibility="public" extends="mainGeneratedDataTemplateApiElements,mainGeneratedDataTemplateRuntimeElements"/>
+    <conf name="default" visibility="public" extends="runtime"/>
+    <conf name="mainGeneratedDataTemplateApiElements" visibility="public"/>
+    <conf name="mainGeneratedDataTemplateRuntimeElements" visibility="public"/>
+    <conf name="runtime" visibility="public"/>
+    <conf name="testDataTemplate" visibility="public" extends="testGeneratedDataTemplateApiElements,testGeneratedDataTemplateRuntimeElements"/>
+    <conf name="testGeneratedDataTemplateApiElements" visibility="public"/>
+    <conf name="testGeneratedDataTemplateRuntimeElements" visibility="public"/>
+  </configurations>
+  <publications>
+    <artifact name="parent" type="jar" ext="jar" conf="compile,runtime"/>
+    <artifact name="parent" type="jar" ext="jar" conf="mainGeneratedDataTemplateApiElements,mainGeneratedDataTemplateRuntimeElements" m:classifier="data-template"/>
+    <artifact name="parent" type="jar" ext="jar" conf="testGeneratedDataTemplateApiElements,testGeneratedDataTemplateRuntimeElements" m:classifier="test-data-template"/>
+  </publications>
+  <dependencies>
+    <dependency org="com.linkedin.pegasus-grandparent-demo" name="grandparent" rev="1.0.0" conf="mainGeneratedDataTemplateApiElements-&gt;dataTemplate"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="mainGeneratedDataTemplateApiElements-&gt;default"/>
+    <dependency org="com.linkedin.pegasus-grandparent-demo" name="grandparent" rev="1.0.0" conf="mainGeneratedDataTemplateRuntimeElements-&gt;dataTemplate"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="mainGeneratedDataTemplateRuntimeElements-&gt;default"/>
+    <dependency org="com.linkedin.pegasus-grandparent-demo" name="grandparent" rev="1.0.0" conf="testGeneratedDataTemplateApiElements-&gt;dataTemplate"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="testGeneratedDataTemplateApiElements-&gt;default"/>
+    <dependency org="com.linkedin.pegasus-grandparent-demo" name="grandparent" rev="1.0.0" conf="testGeneratedDataTemplateRuntimeElements-&gt;dataTemplate"/>
+    <dependency org="com.google.code.findbugs" name="jsr305" rev="3.0.2" conf="testGeneratedDataTemplateRuntimeElements-&gt;default"/>
+  </dependencies>

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
@@ -47,14 +47,10 @@ public class GenerateDataTemplateTask extends DefaultTask
   private FileCollection _codegenClasspath;
   private boolean _enableArgFile;
   private Boolean _generateLowercasePath;
-  private Boolean _generateFieldMask;
+  private boolean _generateFieldMask;
 
   // Output Task Property
   private File _destinationDir;
-
-  public GenerateDataTemplateTask()
-  {
-  }
 
   /**
    * Directory containing the data schema files.
@@ -127,8 +123,19 @@ public class GenerateDataTemplateTask extends DefaultTask
     _enableArgFile = enable;
   }
 
-  @Input
+  /**
+   * @deprecated by {@link #isGenerateFieldMask()} because Gradle 7 requires
+   *     input and output properties to be annotated on getters, which have a
+   *     prefix of "is" or "get".
+   */
+  @Deprecated
   public boolean generateFieldMask()
+  {
+    return isGenerateFieldMask();
+  }
+
+  @Input
+  public boolean isGenerateFieldMask()
   {
     return _generateFieldMask;
   }
@@ -138,9 +145,20 @@ public class GenerateDataTemplateTask extends DefaultTask
     _generateFieldMask = generateFieldMask;
   }
 
+  /**
+   * @deprecated by {@link #isGenerateLowercasePath()} ()} because Gradle 7
+   *     requires input and output properties to be annotated on getters, which
+   *     have a prefix of "is" or "get".
+   */
+  @Deprecated
+  public Boolean generateLowercasePath()
+  {
+    return isGenerateLowercasePath();
+  }
+
   @Optional
   @Input
-  public Boolean generateLowercasePath()
+  public Boolean isGenerateLowercasePath()
   {
     return _generateLowercasePath;
   }
@@ -200,7 +218,7 @@ public class GenerateDataTemplateTask extends DefaultTask
       {
         javaExecSpec.jvmArgs("-Dgenerator.generate.lowercase.path=" + _generateLowercasePath); //.run(generateLowercasePath)
       }
-      if (_generateFieldMask != null && _generateFieldMask)
+      if (_generateFieldMask)
       {
         javaExecSpec.jvmArgs("-Dgenerator.generate.field.mask=true");
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.2
+version=29.19.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
1. Add schemas as source set resources and rely on the Java plugin to
   copy them into the artifact instead of doing so directly, to avoid
   copying duplicates. Copying the same file twice now throws an error
   by default in Gradle 7.

2. Change getter names in GenerateDataTemplateTask to conform to what
   Gradle 7 requires and deprecate the old ones.

3. Run most plugin tests against a matrix of Gradle versions, including
   Gradle 7.

4. Update integration tests to pass.