### PR TITLE
@ReturnEntity doc: Use ResourceContext's `isReturnEntityRequested()`

### DIFF
--- a/src/reference_return_entity.md
+++ b/src/reference_return_entity.md
@@ -140,7 +140,7 @@ public CreateKVResponse<Long, Greeting> create(Greeting entity)
 {
     
     final ResourceContext resourceContext = getContext();
-    if (resourceContext.shouldReturnEntity())
+    if (resourceContext.isReturnEntityRequested())
     {
         // make upstream call..
         Long id = _upstream.getId(entity);


### PR DESCRIPTION
## Why
Doc uses deprecated `shouldReturnEntity()` which is misleading.