### PR TITLE
Do not apply Idea and Eclipse plugins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.19.4] - 2021-06-23
+- Do not apply Idea and Eclipse plugins.
+
 ## [29.19.3] - 2021-06-18
 - More changes for Gradle 7 compatibility.
   - Add schemas as source set resources and rely on the Java plugin to copy them
@@ -4982,7 +4985,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.4...master
+[29.19.4]: https://github.com/linkedin/rest.li/compare/v29.19.3...v29.19.4
 [29.19.3]: https://github.com/linkedin/rest.li/compare/v29.19.2...v29.19.3
 [29.19.2]: https://github.com/linkedin/rest.li/compare/v29.19.1...v29.19.2
 [29.19.1]: https://github.com/linkedin/rest.li/compare/v29.18.15...v29.19.1

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -524,7 +524,6 @@ import org.gradle.util.GradleVersion;
  * test source sets.
  * </p>
  */
-
 public class PegasusPlugin implements Plugin<Project>
 {
   public static boolean debug = false;
@@ -648,8 +647,6 @@ public class PegasusPlugin implements Plugin<Project>
     checkGradleVersion(project);
 
     project.getPlugins().apply(JavaPlugin.class);
-    project.getPlugins().apply(IdeaPlugin.class);
-    project.getPlugins().apply(EclipsePlugin.class);
 
     // this HashMap will have a PegasusOptions per sourceSet
     project.getExtensions().getExtraProperties().set("pegasus", new HashMap<String, PegasusOptions>());

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.3
+version=29.19.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
PegasusPlugin should not force its users to apply either the Idea or
the Eclipse plugins. In some setups, neither plugin is needed, such
as when using IntelliJ's native Gradle import.