### PR TITLE
Fix validation of non-numeric float values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.19.6] - 2021-06-28
+- Fix validation logic for non-numeric float values (i.e. `NaN`, `Infinity`, `-Infinity`).
+  - This affects the underlying implementation for the coercion modes defined by `CoercionMode`
+    (the Javadoc for each mode has been updated accordingly).
+
 ## [29.19.5] - 2021-06-24
 - Fix request builder generator to skip unstructured data sub resources correctly.
 - Use the Java 7 diamond operator everywhere.
@@ -25,32 +30,32 @@ and what APIs have changed, if applicable.
 - More changes for Gradle 7 compatibility.
   - Add schemas as source set resources and rely on the Java plugin to copy them
     into the artifact instead of doing so directly, to avoid copying duplicates.
-  - Change getter names in GenerateDataTemplateTask to conform to what Gradle 7
+  - Change getter names in `GenerateDataTemplateTask` to conform to what Gradle 7
     requires and deprecate the old ones.
 
 ## [29.19.2] - 2021-06-17
-- Allow client-side RetriableRequestException to be retried after ClientRetryFilter
+- Allow client-side `RetriableRequestException` to be retried after `ClientRetryFilter`.
 
 ## [29.19.1] - 2021-06-09
-- Add support for CONSTANT_QPS dark canary cluster strategy
+- Add support for `CONSTANT_QPS` dark canary cluster strategy.
 
 ## [29.18.15] - 2021-06-02
-- Fix race conditions in D2 cluster subsetting. Refactor subsetting cache to SubsettingState.
+- Fix race conditions in D2 cluster subsetting. Refactor subsetting cache to `SubsettingState`.
 
 ## [29.18.14] - 2021-05-27
-- Use class.getClassLoader() instead of thread.getContextClassLoader() to get the class loader.
+- Use `class.getClassLoader()` instead of `thread.getContextClassLoader()` to get the class loader.
 
 ## [29.18.13] - 2021-05-27
-- Remove one more "runtime" configuration reference.
+- Remove one more `"runtime"` configuration reference.
 
 ## [29.18.12] - 2021-05-26
-- Use daemon threads to unregister TimingKeys.
+- Use daemon threads to unregister `TimingKey` instances.
 
 ## [29.18.11] - 2021-05-24
 - Add support for returning location of schema elements from the PDL schema parser.
 
 ## [29.18.10] - 2021-05-24
-- Introduce a readonly attribute on the action annotation
+- Introduce a readonly attribute on the `@Action` annotation.
 
 ## [29.18.9] - 2021-05-24
 - Initial support for the modern `ivy-publish` plugin when producing data-template artifacts
@@ -61,19 +66,19 @@ and what APIs have changed, if applicable.
   - See [Ivy Publish Plugin](https://docs.gradle.org/5.2.1/userguide/publishing_ivy.html) for more information about the modern publishing mechanism.
 
 ## [29.18.8] - 2021-05-21
-- Fix a bug in ZKDeterministicSubsettingMetadataProvider to make host set distinct
+- Fix a bug in `ZKDeterministicSubsettingMetadataProvider` to make host set distinct.
 
 ## [29.18.7] - 2021-05-16
-- Copy the input pegasus data schema when translating to avro
+- Copy the input pegasus data schema when translating to avro.
 
 ## [29.18.6] - 2021-05-13
-- Expose getResourceClass from ResourceDefinition interface.
+- Expose `getResourceClass` from `ResourceDefinition` interface.
 
 ## [29.18.5] - 2021-05-13
-- Add "http.streamingTimeout" to AllowedClientPropertyKeys
+- Add `"http.streamingTimeout"` to `AllowedClientPropertyKeys`.
 
 ## [29.18.4] - 2021-05-06
-- Replace runtime configuration with runtimeClasspath configuration in plugin for compatibility with Gradle 7.
+- Replace `runtime` configuration with `runtimeClasspath` configuration in plugin for compatibility with Gradle 7.
 
 ## [29.18.3] - 2021-05-03
 - Strictly enforce Gradle version compatibility in the `pegasus` Gradle plugin.
@@ -4989,7 +4994,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.6...master
+[29.19.6]: https://github.com/linkedin/rest.li/compare/v29.19.5...v29.19.6
 [29.19.5]: https://github.com/linkedin/rest.li/compare/v29.19.4...v29.19.5
 [29.19.4]: https://github.com/linkedin/rest.li/compare/v29.19.3...v29.19.4
 [29.19.3]: https://github.com/linkedin/rest.li/compare/v29.19.2...v29.19.3

--- a/data/src/main/java/com/linkedin/data/schema/validation/CoercionMode.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/CoercionMode.java
@@ -16,6 +16,9 @@
 
 package com.linkedin.data.schema.validation;
 
+import com.linkedin.data.template.DataTemplateUtil;
+
+
 /**
  * Specifies whether and how primitive types will be coerced from
  * one value type to a value type that conforms to the Java type
@@ -33,7 +36,7 @@ public enum CoercionMode
    * coerces Avro string encoded binary to {@link com.linkedin.data.ByteString}.
    *
    * This coercion mode performs the following type coercions:
-   * 
+   *
    * <table border="1">
    *   <tr>
    *     <th>Schema Type</th>
@@ -44,26 +47,26 @@ public enum CoercionMode
    *   <tr>
    *     <td>int</td>
    *     <td>Number</td>
-   *     <td>Int</td>
-   *     <td>{@link Number#intValue}</td>
+   *     <td>Integer</td>
+   *     <td>{@link DataTemplateUtil#coerceIntOutput(Object)}</td>
    *   </tr>
    *   <tr>
    *     <td>long</td>
    *     <td>Number</td>
    *     <td>Long</td>
-   *     <td>{@link Number#longValue}</td>
+   *     <td>{@link DataTemplateUtil#coerceLongOutput(Object)}</td>
    *   </tr>
    *   <tr>
    *     <td>float</td>
-   *     <td>Number</td>
+   *     <td>Number or String*</td>
    *     <td>Float</td>
-   *     <td>{@link Number#floatValue}</td>
+   *     <td>{@link DataTemplateUtil#coerceFloatOutput(Object)}</td>
    *   </tr>
    *   <tr>
    *     <td>double</td>
-   *     <td>Number</td>
+   *     <td>Number or String*</td>
    *     <td>Double</td>
-   *     <td>{@link Number#doubleValue}</td>
+   *     <td>{@link DataTemplateUtil#coerceDoubleOutput(Object)}</td>
    *   </tr>
    *   <tr>
    *     <td>bytes</td>
@@ -78,6 +81,10 @@ public enum CoercionMode
    *     <td>{@link com.linkedin.data.ByteString#copyAvroString(String, boolean)}</td>
    *   </tr>
    * </table>
+   * <i>
+   *   *String values can be coerced to Float and Double only for non-numeric values
+   *   {@code "NaN"}, {@code "Infinity"}, {@code "-Infinity"}.
+   *  </i>
    */
   NORMAL,
 
@@ -97,7 +104,7 @@ public enum CoercionMode
    *   <tr>
    *     <td>int</td>
    *     <td>String</td>
-   *     <td>Int</td>
+   *     <td>Integer</td>
    *     <td>parsing the string with {@link java.math.BigDecimal} and calling {@link Number#intValue()}</td>
    *   </tr>
    *   <tr>
@@ -110,19 +117,19 @@ public enum CoercionMode
    *     <td>float</td>
    *     <td>String</td>
    *     <td>Float</td>
-   *     <td>parsing the string with {@link java.math.BigDecimal} and calling {@link Number#floatValue()}</td>
+   *     <td>{@link Float#valueOf(String)}</td>
    *   </tr>
    *   <tr>
    *     <td>double</td>
    *     <td>String</td>
    *     <td>Double</td>
-   *     <td>parsing the string with {@link java.math.BigDecimal} and calling {@link Number#doubleValue()}</td>
+   *     <td>{@link Double#valueOf(String)}</td>
    *   </tr>
    *   <tr>
    *     <td>boolean</td>
    *     <td>String</td>
    *     <td>Boolean</td>
-   *     <td>strict case insensitive match against "true" or "false"</td>
+   *     <td>strict case-insensitive match against "true" or "false"</td>
    *   </tr>
    * </table>
    */

--- a/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/validation/ValidateDataAgainstSchema.java
@@ -43,6 +43,8 @@ import com.linkedin.data.schema.validator.Validator;
 import com.linkedin.data.schema.validator.ValidatorContext;
 import com.linkedin.data.template.DataTemplate;
 
+import com.linkedin.data.template.DataTemplateUtil;
+import com.linkedin.data.template.TemplateOutputCastException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -741,34 +743,23 @@ public final class ValidateDataAgainstSchema
         switch (schemaType)
         {
           case INT:
-            return
-              (object instanceof Number) ?
-                (((Number) object).intValue()) :
-                (object.getClass() == String.class && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE) ?
-                  (new BigDecimal((String) object)).intValue() :
-                  object;
+          return (object instanceof String && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE) ?
+              (new BigDecimal((String) object)).intValue() :
+              DataTemplateUtil.coerceIntOutput(object);
           case LONG:
-            return
-              (object instanceof Number) ?
-                (((Number) object).longValue()) :
-                (object.getClass() == String.class && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE) ?
-                  (new BigDecimal((String) object)).longValue() :
-                  object;
+          return (object instanceof String && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE) ?
+              (new BigDecimal((String) object)).longValue() :
+              DataTemplateUtil.coerceLongOutput(object);
           case FLOAT:
-            return
-              (object instanceof Number) ?
-                (((Number) object).floatValue()) :
-                (object.getClass() == String.class && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE) ?
-                  (new BigDecimal((String) object)).floatValue() :
-                  object;
+            return (object instanceof String && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE) ?
+                Float.valueOf((String) object) :
+                DataTemplateUtil.coerceFloatOutput(object);
           case DOUBLE:
-            return
-              (object instanceof Number) ?
-                (((Number) object).doubleValue()) :
-                (object.getClass() == String.class && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE) ?
-                  (new BigDecimal((String) object)).doubleValue() :
-                  object;
+            return (object instanceof String && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE) ?
+                Double.valueOf((String) object) :
+                DataTemplateUtil.coerceDoubleOutput(object);
           case BOOLEAN:
+            // Note that Boolean#parseBoolean cannot be used because it coerces invalid strings into "false"
             if (object.getClass() == String.class && _options.getCoercionMode() == CoercionMode.STRING_TO_PRIMITIVE)
             {
               String string = (String) object;
@@ -788,7 +779,7 @@ public final class ValidateDataAgainstSchema
             return object;
         }
       }
-      catch (NumberFormatException exc)
+      catch (NumberFormatException | TemplateOutputCastException exc)
       {
         return object;
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.5
+version=29.19.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Support has already been added for non-numeric float/double values (`NaN`, `Infinity`, `-Infinity`) in Rest.li, but support wasn't added in the validation logic. This was causing validation failures for serialized (i.e. not in-memory) non-numeric float/double values, which only occured in upstream resources (services receiving these values in a response).

Updates the validation testing to more thoroughly test non-numeric float values.