### PR TITLE
Remove interface method ResourceContext#shouldReturnEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Remove methods `ResourceContext#shouldReturnEntity` and `ResourceContextImpl#shouldReturnEntity`,
+  which have been deprecated since version `27.2.0`.
 
 ## [29.22.14] - 2021-11-24
 - Fix bug where content type was not set for stream requests

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/ResourceContextImpl.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/ResourceContextImpl.java
@@ -633,16 +633,6 @@ public class ResourceContextImpl implements ServerResourceContext
     return _responseStreamingAttachments;
   }
 
-  /**
-   * @deprecated Use {@link #isReturnEntityRequested()} instead.
-   */
-  @Deprecated
-  @Override
-  public boolean shouldReturnEntity()
-  {
-    return isReturnEntityRequested();
-  }
-
   @Override
   public boolean isReturnEntityRequested()
   {

--- a/restli-server/src/main/java/com/linkedin/restli/server/ResourceContext.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/ResourceContext.java
@@ -206,13 +206,6 @@ public interface ResourceContext extends CustomRequestContext
   RestLiResponseAttachments getResponseAttachments();
 
   /**
-   * @deprecated Use {@link #isReturnEntityRequested()} instead.
-   * @return whether the request specifies that the resource should return an entity
-   */
-  @Deprecated
-  boolean shouldReturnEntity();
-
-  /**
    * Returns whether or not the client is requesting that the entity (or entities) be returned. Reads the appropriate
    * query parameter to determine this information, defaults to true if the query parameter isn't present, and throws
    * an exception if the parameter's value is not a boolean value. Keep in mind that the value of this method is


### PR DESCRIPTION
This method has been deprecated since version `27.2.0`, so users have had time to migrate to the preferred method.

Cleaning this up before I forget..