### PR TITLE
Update RestliRouter to allow "action", "q" as parameter name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Update RestliRouter to allow "bq", "action" as query parameter name for finder, "q" as action parameter name for action
 
 ## [29.19.8] - 2021-07-02
 - Define new Dark Cluster configs in d2 PropertyKeys

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/RestLiRouter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/RestLiRouter.java
@@ -343,19 +343,19 @@ public class RestLiRouter
     boolean contextHasBatchFinderName = context.getRequestBatchFinderName() != null;
 
     // Explicitly setting other flags to false if condition meets:
-    if (context.getRequestMethod().equalsIgnoreCase("GET") && contextHasBatchFinderName )
+    if (context.getRequestMethod().equalsIgnoreCase("GET") && contextHasFinderName )
     {
-      // If "bq" in query params for "GET" methods, then this param considered as BatchFinder name
-      // and "q" and "action" can be used as query param name
-      contextHasActionName = false;
-      contextHasFinderName = false;
-    }
-    else if (context.getRequestMethod().equalsIgnoreCase("GET") && contextHasFinderName)
-    {
-      // If "bq" not in query params for "GET" methods but "q" seen, then this param considered as finder name
-      // and "action" can be used as query param name
+      // If "q" in query params for "GET" methods, then this param considered as Finder name
+      // and "bq" and "action" can be used as query param name
       contextHasActionName = false;
       contextHasBatchFinderName = false;
+    }
+    else if (context.getRequestMethod().equalsIgnoreCase("GET") && contextHasBatchFinderName)
+    {
+      // If "q" not in query params for "GET" methods but "bq" seen, then this param considered as batchFinder name
+      // and "action" can be used as query param name
+      contextHasActionName = false;
+      contextHasFinderName = false;
     }
     else if (context.getRequestMethod().equalsIgnoreCase("POST") && contextHasActionName)
     {

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/RestLiRouter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/RestLiRouter.java
@@ -338,12 +338,39 @@ public class RestLiRouter
   private ResourceMethod mapResourceMethod(final ServerResourceContext context,
                                            final ResourceLevel resourceLevel)
   {
+    boolean contextHasActionName = context.getRequestActionName() != null;
+    boolean contextHasFinderName = context.getRequestFinderName() != null;
+    boolean contextHasBatchFinderName = context.getRequestBatchFinderName() != null;
+
+    // Explicitly setting other flags to false if condition meets:
+    if (context.getRequestMethod().equalsIgnoreCase("GET") && contextHasBatchFinderName )
+    {
+      // If "bq" in query params for "GET" methods, then this param considered as BatchFinder name
+      // and "q" and "action" can be used as query param name
+      contextHasActionName = false;
+      contextHasFinderName = false;
+    }
+    else if (context.getRequestMethod().equalsIgnoreCase("GET") && contextHasFinderName)
+    {
+      // If "bq" not in query params for "GET" methods but "q" seen, then this param considered as finder name
+      // and "action" can be used as query param name
+      contextHasActionName = false;
+      contextHasBatchFinderName = false;
+    }
+    else if (context.getRequestMethod().equalsIgnoreCase("POST") && contextHasActionName)
+    {
+      // If "q" in query params for "POST" method, then this param considered as action name
+      // and "b" and "bq" can be used as action param name
+      contextHasBatchFinderName = false;
+      contextHasFinderName= false;
+    }
+
     ResourceMethodMatchKey key =
         new ResourceMethodMatchKey(context.getRequestMethod(),
                                    context.getRestLiRequestMethod(),
-                                   context.getRequestActionName() != null,
-                                   context.getRequestFinderName() != null,
-                                   context.getRequestBatchFinderName() != null,
+                                   contextHasActionName,
+                                   contextHasFinderName,
+                                   contextHasBatchFinderName,
                                    context.getPathKeys().getBatchIds() != null,
                                    resourceLevel.equals(ResourceLevel.ENTITY));
 

--- a/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiResourceModels.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiResourceModels.java
@@ -273,7 +273,7 @@ public class TestRestLiResourceModels
     ResourceModel resourceModel = buildResourceModel(TwitterAccountsResource.class);
     assertEquals(resourceModel.getResourceType(), ResourceType.ACTIONS);
 
-    assertEquals(resourceModel.getResourceMethodDescriptors().size(), 5);
+    assertEquals(resourceModel.getResourceMethodDescriptors().size(), 6);
 
     ResourceMethodDescriptor methodDescriptor = resourceModel.findActionMethod("register", ResourceLevel.COLLECTION);
     assertNotNull(methodDescriptor);

--- a/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiRouting.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiRouting.java
@@ -1271,12 +1271,20 @@ public class TestRestLiRouting
           "search",
           new String[0]
         },
-        { "/statuses?q=findByAction&action=anyAction",
+        { "/statuses?q=findByAction&action=anyAction&bq=anyBqValue",
             AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(),
             "GET",
             "FINDER",
             ResourceMethod.FINDER,
             "findByAction",
+            new String[0]
+        },
+        { "/statuses?bq=batchFinderByAction&action=anyAction",
+            AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(),
+            "GET",
+            "BATCH_FINDER",
+            ResourceMethod.BATCH_FINDER,
+            "batchFinderByAction",
             new String[0]
         },
         { "/statuses?q=search&keywords=linkedin",
@@ -2686,7 +2694,9 @@ public class TestRestLiRouting
       {
         { AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "/accounts?action=register", "register" },
         { AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "/accounts?action=register", "register"},
-          { AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "/accounts?action=noOps&q=wrong", "noOps" }
+        { AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(),
+            "/accounts?action=noOps&q=some_q_argument&bq=some_bq_argument",
+            "noOps" }
       };
   }
 
@@ -2815,8 +2825,8 @@ public class TestRestLiRouting
         { "/statuses/1/badpath/2", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "GET", HttpStatus.S_404_NOT_FOUND },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
-        { "/statuses?q=noOps&bq=wrongbatchfindername", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
-        { "/statuses?q=noOps&bq=wrongbatchfindername", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
+        { "/statuses?q=wrong&bq=batchFindByAction", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
+        { "/statuses?q=wrong&bq=batchFindByAction", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "PUT", HttpStatus.S_400_BAD_REQUEST },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "PUT", HttpStatus.S_400_BAD_REQUEST },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "DELETE", HttpStatus.S_400_BAD_REQUEST },

--- a/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiRouting.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiRouting.java
@@ -1271,6 +1271,14 @@ public class TestRestLiRouting
           "search",
           new String[0]
         },
+        { "/statuses?q=findByAction&action=anyAction",
+            AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(),
+            "GET",
+            "FINDER",
+            ResourceMethod.FINDER,
+            "findByAction",
+            new String[0]
+        },
         { "/statuses?q=search&keywords=linkedin",
           AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(),
           "GET",
@@ -2676,13 +2684,14 @@ public class TestRestLiRouting
   {
     return new Object[][]
       {
-        { AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "/accounts?action=register" },
-        { AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "/accounts?action=register" }
+        { AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "/accounts?action=register", "register" },
+        { AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "/accounts?action=register", "register"},
+          { AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "/accounts?action=noOps&q=wrong", "noOps" }
       };
   }
 
   @Test(dataProvider = TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "actionRootRouting")
-  public void testActionRootRouting(ProtocolVersion version, String uri) throws Exception
+  public void testActionRootRouting(ProtocolVersion version, String uri, String actionName) throws Exception
   {
     Map<String, ResourceModel> pathRootResourceMap = buildResourceModels(TwitterAccountsResource.class);
     _router = new RestLiRouter(pathRootResourceMap, new RestLiConfig());
@@ -2692,7 +2701,7 @@ public class TestRestLiRouting
     ResourceMethodDescriptor method = _router.process(context);
 
     assertNotNull(method);
-    assertEquals(method.getActionName(), "register");
+    assertEquals(method.getActionName(), actionName);
     assertEquals(method.getType(), ResourceMethod.ACTION);
   }
 
@@ -2806,6 +2815,8 @@ public class TestRestLiRouting
         { "/statuses/1/badpath/2", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "GET", HttpStatus.S_404_NOT_FOUND },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
+        { "/statuses?q=noOps&bq=wrongbatchfindername", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
+        { "/statuses?q=noOps&bq=wrongbatchfindername", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "GET", HttpStatus.S_400_BAD_REQUEST },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "PUT", HttpStatus.S_400_BAD_REQUEST },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_2_0_0.getProtocolVersion(), "PUT", HttpStatus.S_400_BAD_REQUEST },
         { "/statuses?q=wrong&keywords=linkedin", AllProtocolVersions.RESTLI_PROTOCOL_1_0_0.getProtocolVersion(), "DELETE", HttpStatus.S_400_BAD_REQUEST },

--- a/restli-server/src/test/java/com/linkedin/restli/server/twitter/StatusCollectionResource.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/twitter/StatusCollectionResource.java
@@ -89,6 +89,17 @@ public class StatusCollectionResource extends CollectionResourceTemplate<Long,St
   }
 
   /**
+   * find status by a parameter named "action"
+   *
+   */
+  @Finder("findByAction")
+  public List<Status> findByAction(@QueryParam("action") String  actionName
+  )
+  {
+    return null;
+  }
+
+  /**
    * Creates a new Status
    */
   @Override

--- a/restli-server/src/test/java/com/linkedin/restli/server/twitter/StatusCollectionResource.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/twitter/StatusCollectionResource.java
@@ -16,11 +16,13 @@
 
 package com.linkedin.restli.server.twitter;
 
+import com.linkedin.restli.common.EmptyRecord;
 import com.linkedin.restli.common.PatchRequest;
 import com.linkedin.restli.common.attachments.RestLiAttachmentReader;
 import com.linkedin.restli.server.BatchCreateRequest;
 import com.linkedin.restli.server.BatchCreateResult;
 import com.linkedin.restli.server.BatchDeleteRequest;
+import com.linkedin.restli.server.BatchFinderResult;
 import com.linkedin.restli.server.BatchPatchRequest;
 import com.linkedin.restli.server.BatchUpdateRequest;
 import com.linkedin.restli.server.BatchUpdateResult;
@@ -32,6 +34,7 @@ import com.linkedin.restli.server.altkey.AltStatusKeyCoercer;
 import com.linkedin.restli.server.annotations.Action;
 import com.linkedin.restli.server.annotations.ActionParam;
 import com.linkedin.restli.server.annotations.AlternativeKey;
+import com.linkedin.restli.server.annotations.BatchFinder;
 import com.linkedin.restli.server.annotations.Finder;
 import com.linkedin.restli.server.annotations.Optional;
 import com.linkedin.restli.server.annotations.PagingContextParam;
@@ -88,12 +91,25 @@ public class StatusCollectionResource extends CollectionResourceTemplate<Long,St
     return null;
   }
 
-  /**
-   * find status by a parameter named "action"
+  /** * find status by a parameter named "action"
    *
    */
   @Finder("findByAction")
-  public List<Status> findByAction(@QueryParam("action") String  actionName
+  public List<Status> findByAction(@QueryParam("action") String  actionName,
+      @QueryParam("bq") String bqParameterValue
+  )
+  {
+    return null;
+  }
+
+  /** * Batchfinder by a parameter named "action"
+   *    This is an invalid method since the parameter name cannot be named "q"
+   *    in batchFinder
+   */
+  @BatchFinder(value="batchFinderByAction",  batchParam="action")
+  public BatchFinderResult<Status, Status, EmptyRecord> batchFinderByAction(
+      @QueryParam("action") Status[]  actionNames,
+      @QueryParam("q") @Optional String qParam
   )
   {
     return null;

--- a/restli-server/src/test/java/com/linkedin/restli/server/twitter/TwitterAccountsResource.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/twitter/TwitterAccountsResource.java
@@ -65,4 +65,9 @@ public class TwitterAccountsResource
   {
     return 1;
   }
+
+  @Action(name="noOps")
+  public void noOps(@ActionParam("q") String paramNamedQ)
+  {
+  }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/server/twitter/TwitterAccountsResource.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/twitter/TwitterAccountsResource.java
@@ -67,7 +67,9 @@ public class TwitterAccountsResource
   }
 
   @Action(name="noOps")
-  public void noOps(@ActionParam("q") String paramNamedQ)
+  public void noOps(@ActionParam("q") String paramNamedQ,
+      @ActionParam("bq") String paramNamedBq
+      )
   {
   }
 }


### PR DESCRIPTION
In previous RestLiRouter logic, we check:

If query parameter contains
"q" -> we treat that URL contains a finder name -> we thought that URL contains query parameters
"action" -> we treat URL contains  a action name -> we thought that URL contains action parameters

Therefore, a url contains "q" and "action" will be thought as a query which contains both QueryParameters and ActionParameters.

This is essentially werid logic (for example, deciding whether the URL contains query parameters by just checking single query name "q"), but that is what it was.

This bug fix however defined a new rule:

If GET and "bq" in parameters, treat this as a batchFinder, so "q" and "action" can be both query parameter name
If GET and "q" in parameters,  treat this as a Finder, so "action" can be both query parameter name
If Post and "action" in parameters,  treat this as a action, so "q" and "bq" can be both action parameter name

This could allow "action" "q" to be parameter name, while still be backward compatible and no intrution to current other existing logic.