### PR TITLE
Add a bit behavior explanation for construting a url using  both "q" and "bq" as query parameter names

### DIFF
--- a/src/batch_finder_resource_method.md
+++ b/src/batch_finder_resource_method.md
@@ -278,6 +278,8 @@ Valid type for batch criteria parameter:
 
 - Can only be Arrays of Record template type, if have to use some other data types like Pegasus Enum, etc as the array item,
 need to wrap it into a Record Template (`.pdl` schema)
+
+Please note that "q" cannot be used as QueryParam name for batch finder. It is reserved for passing Finder's method name.
   
 ### BatchFinderResult
 

--- a/src/guide_restli_server.md
+++ b/src/guide_restli_server.md
@@ -981,6 +981,9 @@ public Task<BatchFinderResult<GreetingCriteria, Greeting, EmptyRecord>> searchGr
                                                                                   @QueryParam("criteria") GreetingCriteria[] criteria,
                                                                                   @QueryParam("message") String message)
 ```
+
+Please note that "q" cannot be used as QueryParam name for batch finder, because that will produce ambiguation when construcitng URL.
+
 See more details about BATCH_FINDER resource method api here: [BatchFinder Resource API](/rest.li/batch_finder_resource_method#resource-api)
 
 

--- a/src/protocol.md
+++ b/src/protocol.md
@@ -472,6 +472,7 @@ At least, 2 query parameters will have to be set for a batch finder:
 - A second query parameter will be used to pass a set of different search criteria. The name of this query parameter is set in the [BatchFinder method annotation](/rest.li/batch_finder_resource_method#method-annotation-and-parameters).
 For example, with @BatchFinder(value="findUsers", batchParam="batchCriteria"), the batch query parameter name is "batchCriteria". 
 The type of this query parameter is a List.
+- "q" cannot be used as a name for query parameters. It is reserved for passing Finder's method name. For URL constructed which uses both "bq" and "q", e.g. " {resource}?bq={bq_argument}&q={q_argument}", it will be interpreted as using "q_argument" as a finder method name and "bq_argument" as argument for a query parameter named "bq".
 
 Different data type has different representation in Rest.li protocol 1.0 and 2.0. See more details in [Rest.li Protocol](/rest.li/spec/protocol).
 


### PR DESCRIPTION
reference:
https://github.com/linkedin/rest.li/pull/651/files