### PR TITLE
Relax extension schema check to make @extension annotation is optional for 1-1 injections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.19.9] - 2021-07-15
+- Relax extension schema check to make '@extension' annotation is optional for 1-to-1 injections.
 - Update RestliRouter to allow "bq", "action" as query parameter name for finder, "q" as action parameter name for action
 
 ## [29.19.8] - 2021-07-02
@@ -5001,7 +5004,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.9...master
+[29.19.9]: https://github.com/linkedin/rest.li/compare/v29.19.8...v29.19.9
 [29.19.8]: https://github.com/linkedin/rest.li/compare/v29.19.7...v29.19.8
 [29.19.7]: https://github.com/linkedin/rest.li/compare/v29.19.6...v29.19.7
 [29.19.6]: https://github.com/linkedin/rest.li/compare/v29.19.5...v29.19.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.8
+version=29.19.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/test/extensions/invalidNoExtensionAnnotation/BazExtensions.pdl
+++ b/restli-tools/src/test/extensions/invalidNoExtensionAnnotation/BazExtensions.pdl
@@ -1,0 +1,6 @@
+record BazExtensions includes Baz {
+  /**
+   * This is invalid because extension annotations are required for 1-to-many relations.
+   */
+  testField: array[DummyKey]
+}

--- a/restli-tools/src/test/extensions/validCase/BazExtensions.pdl
+++ b/restli-tools/src/test/extensions/validCase/BazExtensions.pdl
@@ -1,0 +1,6 @@
+record BazExtensions includes Baz {
+  /**
+   * This is valid because extension annotations are optional for 1-to-1 relations.
+   */
+  testField: DummyKey
+}

--- a/restli-tools/src/test/extensions/validCase/FooExtensions.pdl
+++ b/restli-tools/src/test/extensions/validCase/FooExtensions.pdl
@@ -1,5 +1,4 @@
 record FooExtensions includes Foo {
   @extension.versionSuffix = "V2"
-  @extension.using = "finder: test"
   injectedField: DummyKey
 }

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -77,6 +77,11 @@ public class TestExtensionSchemaValidationCmdLineApp
                     + "{ \"assocKey\" : { \"authorId\" : \"fabricName\", \"objectId\" : \"sessionId\" } } } }, \"resourcePath\" : \"/profiles/{profilesId}\" }, "
                     + "{ \"entity\" : \"ProfileV2\", \"keyConfig\" : { \"keys\" : { \"profilesId\" : { \"assocKey\" : { \"authorId\" : \"fabricName\", \"objectId\" : "
                     + "\"sessionId\" } } } }, \"resourcePath\" : \"/profilesV2/{profilesId}\", \"versionSuffix\" : \"V2\" } ] } } defined in \"BazExtensions\".\n"
+            },
+            {
+                "invalidNoExtensionAnnotation",
+                false,
+                "Field: 'testField' is not annotated with @extension. The @extension annotation is required for 1-to-many relations, but not for 1-to-1 relations."
             }
         };
   }


### PR DESCRIPTION
Summary:
This change is relaxing the extension schema check to make @extension annotation is optional for 1-1 injections. 
For 1-1 injections @extension is not required, If there is no extension annotation, by default ER uses extended entity's urn as the resource key to fetch the injected entity.

Test:
Added unit tests.