### PR TITLE
Revert "Relax extension schema check to make @extension annotation is optional for 1-to-1 injections (#654)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Revert "Relax extension schema check to make '@extension' annotation is optional for 1-to-1 injections."
 
 ## [29.19.10] - 2021-07-16
 - Add hooks for customizing documentation (OPTIONS) response.

--- a/restli-tools/src/test/extensions/invalidNoExtensionAnnotation/BazExtensions.pdl
+++ b/restli-tools/src/test/extensions/invalidNoExtensionAnnotation/BazExtensions.pdl
@@ -1,6 +1,0 @@
-record BazExtensions includes Baz {
-  /**
-   * This is invalid because extension annotations are required for 1-to-many relations.
-   */
-  testField: array[DummyKey]
-}

--- a/restli-tools/src/test/extensions/validCase/BazExtensions.pdl
+++ b/restli-tools/src/test/extensions/validCase/BazExtensions.pdl
@@ -1,6 +1,0 @@
-record BazExtensions includes Baz {
-  /**
-   * This is valid because extension annotations are optional for 1-to-1 relations.
-   */
-  testField: DummyKey
-}

--- a/restli-tools/src/test/extensions/validCase/FooExtensions.pdl
+++ b/restli-tools/src/test/extensions/validCase/FooExtensions.pdl
@@ -1,4 +1,5 @@
 record FooExtensions includes Foo {
   @extension.versionSuffix = "V2"
+  @extension.using = "finder: test"
   injectedField: DummyKey
 }

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -77,11 +77,6 @@ public class TestExtensionSchemaValidationCmdLineApp
                     + "{ \"assocKey\" : { \"authorId\" : \"fabricName\", \"objectId\" : \"sessionId\" } } } }, \"resourcePath\" : \"/profiles/{profilesId}\" }, "
                     + "{ \"entity\" : \"ProfileV2\", \"keyConfig\" : { \"keys\" : { \"profilesId\" : { \"assocKey\" : { \"authorId\" : \"fabricName\", \"objectId\" : "
                     + "\"sessionId\" } } } }, \"resourcePath\" : \"/profilesV2/{profilesId}\", \"versionSuffix\" : \"V2\" } ] } } defined in \"BazExtensions\".\n"
-            },
-            {
-                "invalidNoExtensionAnnotation",
-                false,
-                "Field: 'testField' is not annotated with @extension. The @extension annotation is required for 1-to-many relations, but not for 1-to-1 relations."
             }
         };
   }


### PR DESCRIPTION
This RB is revering the #654 commit. 
We decided to make @extension.param is a required annotation when defining 1-to-1 injections.