### PR TITLE
Adding compatibility level configs for extension schema compatibility check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.19.11] - 2021-07-20
+- Add compatibility level config for extension schema compatibility check.
+   - "pegasusPlugin.extensionSchema.compatibility" is the compatibility level config for extension schema compatibility check. 
+      It supports following 4 levels:
+     - "off": the extension schema compatibility check will not be run.
+     - "ignore": the extension schema compatibility check will run, but it allows backward incompatible changes.
+     - "backwards": Changes that are considered backwards compatible will pass the check, otherwise changes will fail the check.
+     - "equivalent": No changes to extension schemas will pass.
+   - If this config is not provided by users, by default the extension schema compatibility check is using "backwards".
+   - How to use it: users could add 'pegasusPlugin.extensionSchema.compatibility=<compatibility level>' in the gradle.properties file 
+     or directly add this property '-PpegasusPlugin.extensionSchema.compatibility=<compatibility level>' to the gradle build.
+   
 - Revert "Relax extension schema check to make '@extension' annotation is optional for 1-to-1 injections."
 
 ## [29.19.10] - 2021-07-16
@@ -5009,7 +5022,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.11...master
+[29.19.11]: https://github.com/linkedin/rest.li/compare/v29.19.10...v29.19.11
 [29.19.10]: https://github.com/linkedin/rest.li/compare/v29.19.9...v29.19.10
 [29.19.9]: https://github.com/linkedin/rest.li/compare/v29.19.8...v29.19.9
 [29.19.8]: https://github.com/linkedin/rest.li/compare/v29.19.7...v29.19.8

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/FileCompatibilityType.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/FileCompatibilityType.java
@@ -18,5 +18,6 @@ package com.linkedin.pegasus.gradle;
 public enum FileCompatibilityType {
   SNAPSHOT,
   IDL,
-  PEGASUS_SCHEMA_SNAPSHOT
+  PEGASUS_SCHEMA_SNAPSHOT,
+  PEGASUS_EXTENSION_SCHEMA_SNAPSHOT
 }

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PropertyUtil.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PropertyUtil.java
@@ -17,9 +17,10 @@ package com.linkedin.pegasus.gradle;
 
 import org.gradle.api.Project;
 
-import static com.linkedin.pegasus.gradle.PegasusPlugin.SNAPSHOT_COMPAT_REQUIREMENT;
-import static com.linkedin.pegasus.gradle.PegasusPlugin.IDL_COMPAT_REQUIREMENT;
+import static com.linkedin.pegasus.gradle.PegasusPlugin.PEGASUS_EXTENSION_SCHEMA_SNAPSHOT_REQUIREMENT;
 import static com.linkedin.pegasus.gradle.PegasusPlugin.PEGASUS_SCHEMA_SNAPSHOT_REQUIREMENT;
+import static com.linkedin.pegasus.gradle.PegasusPlugin.IDL_COMPAT_REQUIREMENT;
+import static com.linkedin.pegasus.gradle.PegasusPlugin.SNAPSHOT_COMPAT_REQUIREMENT;
 
 
 public class PropertyUtil
@@ -52,6 +53,8 @@ public class PropertyUtil
         return IDL_COMPAT_REQUIREMENT;
       case PEGASUS_SCHEMA_SNAPSHOT:
         return PEGASUS_SCHEMA_SNAPSHOT_REQUIREMENT;
+      case PEGASUS_EXTENSION_SCHEMA_SNAPSHOT:
+        return PEGASUS_EXTENSION_SCHEMA_SNAPSHOT_REQUIREMENT;
       default:
         return null;
     }
@@ -74,7 +77,8 @@ public class PropertyUtil
     }
     else
     {
-      if (propertyName.equals(SNAPSHOT_COMPAT_REQUIREMENT) || propertyName.equals(PEGASUS_SCHEMA_SNAPSHOT_REQUIREMENT))
+      if (propertyName.equals(SNAPSHOT_COMPAT_REQUIREMENT) || propertyName.equals(PEGASUS_SCHEMA_SNAPSHOT_REQUIREMENT) ||
+              propertyName.equals(PEGASUS_EXTENSION_SCHEMA_SNAPSHOT_REQUIREMENT))
       {
         // backwards compatible by default.
         return "BACKWARDS";

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.10
+version=29.19.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityInfoMap.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityInfoMap.java
@@ -330,9 +330,25 @@ public class CompatibilityInfoMap
     _annotationMap.get(infoType.getLevel()).add(info);
   }
 
+  /**
+   * This method indicates whether the schema annotation changes are compatible or not,
+   * by default it uses "backwards" as compatibility level.
+   * @return boolean
+   */
   public boolean isAnnotationCompatible()
   {
-    return _annotationMap.get(CompatibilityInfo.Level.INCOMPATIBLE).size() == 0;
+    return isAnnotationCompatible(CompatibilityLevel.BACKWARDS);
+  }
+
+  /**
+   * This method indicates whether the schema annotation changes are compatible or not based on the given compatibility level.
+   * @param level, the given {@link CompatibilityLevel}.
+   * @return boolean
+   */
+  public boolean isAnnotationCompatible(CompatibilityLevel level)
+  {
+    return isCompatible(_annotationMap.get(CompatibilityInfo.Level.INCOMPATIBLE),
+            _annotationMap.get(CompatibilityInfo.Level.COMPATIBLE), level);
   }
 
   public Collection<CompatibilityInfo> getAnnotationInfo(CompatibilityInfo.Level level)

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityReport.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityReport.java
@@ -68,7 +68,7 @@ public class CompatibilityReport
           .stream()
           .map(it -> "[SCHEMA-ANNOTATION-I]:" + it)
           .collect(Collectors.joining("\n"));
-      annotationIsCompat = String.format("[SCHEMA-ANNOTATION-COMPAT]: %b", _infoMap.isAnnotationCompatible());
+      annotationIsCompat = String.format("[SCHEMA-ANNOTATION-COMPAT]: %b", _infoMap.isAnnotationCompatible(_compatibilityLevel));
     }
 
     String restSpecIsCompat = String.format("[RS-COMPAT]: %b", _infoMap.isRestSpecCompatible(_compatibilityLevel));


### PR DESCRIPTION
This PR is adding the compatibility level configuration for extension schema compatibility check.

1. It supports 4 compatibility levels which are the same as restModel compatibility levels: OFF, IGNORE, BACKWARDS, EQUIVALENT(https://linkedin.github.io/rest.li/modeling/compatibility_check#compatibility-levels).
2. The configuration name is "pegasusPlugin.extensionSchema.compatibility".
3. Users could use this config to define the compatibility level when running the extension schema compatibility check, for example:
"./gradlew checkPegasusExtensionSchemaSnapshot -PpegasusPlugin.extensionSchema.compatibility=ignore"
or directly add this property in the gradle.properties file.

Test:
Generated snapshot and manual tested the configs.

Todo: update Rest.li doc for this change.