### PR TITLE
Add a predicate based bulk remove method for checkedMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.19.12] - 2021-07-22
+- Add a predicate based bulk remove method for checkedMap.
+
 ## [29.19.11] - 2021-07-20
 - Add compatibility level config for extension schema compatibility check.
    - "pegasusPlugin.extensionSchema.compatibility" is the compatibility level config for extension schema compatibility check. 
@@ -5022,7 +5025,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.12...master
+[29.19.12]: https://github.com/linkedin/rest.li/compare/v29.19.11...v29.19.12
 [29.19.11]: https://github.com/linkedin/rest.li/compare/v29.19.10...v29.19.11
 [29.19.10]: https://github.com/linkedin/rest.li/compare/v29.19.9...v29.19.10
 [29.19.9]: https://github.com/linkedin/rest.li/compare/v29.19.8...v29.19.9

--- a/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
+++ b/data/src/main/java/com/linkedin/data/collections/CheckedMap.java
@@ -23,10 +23,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 
 /**
@@ -289,6 +291,19 @@ public class CheckedMap<K,V> implements CommonMap<K,V>, Cloneable
   public void forEach(BiConsumer<? super K, ? super V> action)
   {
     _map.forEach(action);
+  }
+
+  /**
+   * Removes all of the entries of this map that satisfy the given predicate.
+   *
+   * @param filter a predicate which returns {@code true} for elements to be
+   *        removed
+   * @return {@code true} if any elements were removed
+   */
+  public boolean removeIf(Predicate<? super Entry<K, V>> filter)
+  {
+    checkMutability();
+    return _map.entrySet().removeIf(filter);
   }
 
   @Override

--- a/data/src/test/java/com/linkedin/data/collections/TestCheckedMap.java
+++ b/data/src/test/java/com/linkedin/data/collections/TestCheckedMap.java
@@ -18,6 +18,7 @@ package com.linkedin.data.collections;
 
 import com.linkedin.data.DataMap;
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -79,5 +80,28 @@ public class TestCheckedMap
       // Do nothing.
     });
     Assert.assertNull(map._changeListenerHead);
+  }
+
+  @Test
+  public void testRemoveIf()
+  {
+    final DataMap map = new DataMap();
+    map.put("key1", 100);
+    map.put("key2", 200);
+    map.put("key3", 500);
+
+    Assert.assertFalse(map.removeIf(entry -> entry.getKey().equals("Unknown")));
+    Assert.assertTrue(map.removeIf(entry -> entry.getKey().equals("key2") || ((Integer) entry.getValue() == 100)));
+    Assert.assertEquals(map, Collections.singletonMap("key3", 500));
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testRemoveIfOnReadOnlyMap()
+  {
+    final DataMap map = new DataMap();
+    map.put("key1", 100);
+    map.setReadOnly();
+
+    map.removeIf(entry -> entry.getKey().equals("Unknown"));
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.11
+version=29.19.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This is useful because entrySet() by default returns an unmodifiableMap making bulk remove operations painful and inefficient (store all keys to be removed into another data structure and then do another pass to remove).