### PR TITLE
Add support for validating aliased union members.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.19.13] - 2021-07-26
+- Add support for validating aliased union members.
+  - Union members originally didn't support custom properties and thus custom validation
+    was not supported for union members. With aliased unions, members now support custom
+    properties and thus can specify custom validation. Validation logic is updated to
+    include custom validations on union members.
+
 ## [29.19.12] - 2021-07-22
 - Add a predicate based bulk remove method for checkedMap.
 
@@ -5025,7 +5032,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.13...master
+[29.19.13]: https://github.com/linkedin/rest.li/compare/v29.19.12...v29.19.13
 [29.19.12]: https://github.com/linkedin/rest.li/compare/v29.19.11...v29.19.12
 [29.19.11]: https://github.com/linkedin/rest.li/compare/v29.19.10...v29.19.11
 [29.19.10]: https://github.com/linkedin/rest.li/compare/v29.19.9...v29.19.10

--- a/data/src/main/java/com/linkedin/data/schema/UnionDataSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/UnionDataSchema.java
@@ -395,6 +395,18 @@ public final class UnionDataSchema extends ComplexDataSchema
   }
 
   /**
+   * Returns the member identified by its member key.
+   *
+   * @param memberKey Union member key of the member.
+   * @return the {@link Member} if key matches a member of the union, else return null.
+   */
+  public Member getMemberByKey(String memberKey)
+  {
+    Integer index = _memberKeyToIndexMap.get(memberKey);
+    return (index != null ? _members.get(index) : null);
+  }
+
+  /**
    * Checks if the union members have aliases specified. Since either all or none of the members can be aliased
    * in a union, a return value of true from this method means all the members (excluding null member, if present)
    * have been aliased and none otherwise.

--- a/data/src/main/java/com/linkedin/data/schema/UnionDataSchema.java
+++ b/data/src/main/java/com/linkedin/data/schema/UnionDataSchema.java
@@ -400,7 +400,7 @@ public final class UnionDataSchema extends ComplexDataSchema
    * @param memberKey Union member key of the member.
    * @return the {@link Member} if key matches a member of the union, else return null.
    */
-  public Member getMemberByKey(String memberKey)
+  public Member getMemberByMemberKey(String memberKey)
   {
     Integer index = _memberKeyToIndexMap.get(memberKey);
     return (index != null ? _members.get(index) : null);

--- a/data/src/main/java/com/linkedin/data/schema/validator/DataSchemaAnnotationValidator.java
+++ b/data/src/main/java/com/linkedin/data/schema/validator/DataSchemaAnnotationValidator.java
@@ -683,7 +683,7 @@ public class DataSchemaAnnotationValidator implements Validator
           }
         }
       }
-      // check if the value belongs to a member in an union and if the member has
+      // check if the value belongs to a member in an aliased union and if the member has
       // validators.
       if (parentSchema != null && parentSchema.getType() == DataSchema.Type.UNION)
       {
@@ -691,11 +691,8 @@ public class DataSchemaAnnotationValidator implements Validator
         Object name = element.getName();
         if (unionDataSchema.areMembersAliased() && unionDataSchema.contains((String) name))
         {
-          UnionDataSchema.Member member = unionDataSchema.getMemberByKey((String) name);
-          if (member != null)
-          {
-            getAndInvokeValidatorList(context, member);
-          }
+          UnionDataSchema.Member member = unionDataSchema.getMemberByMemberKey((String) name);
+          getAndInvokeValidatorList(context, member);
         }
       }
     }

--- a/data/src/test/java/com/linkedin/data/schema/validator/TestValidator.java
+++ b/data/src/test/java/com/linkedin/data/schema/validator/TestValidator.java
@@ -42,6 +42,7 @@ import org.testng.annotations.Test;
 
 import static com.linkedin.data.TestUtil.asMap;
 import static com.linkedin.data.TestUtil.dataMapFromString;
+import static com.linkedin.data.TestUtil.dataSchemaFromPdlString;
 import static com.linkedin.data.TestUtil.dataSchemaFromString;
 import static com.linkedin.data.TestUtil.out;
 import static org.testng.Assert.assertFalse;
@@ -291,7 +292,7 @@ public class TestValidator
                             int tests)
     throws IOException, InstantiationException
   {
-    DataSchema schema = dataSchemaFromString(schemaText);
+    DataSchema schema = dataSchemaFromPdlString(schemaText);
     DataSchemaAnnotationValidator annotationValidator = new DataSchemaAnnotationValidator();
     annotationValidator.init(schema, validatorClassMap);
     if (debug) annotationValidator.setDebugMode(true);
@@ -351,81 +352,37 @@ public class TestValidator
   }
 
   private static final String fooSchemaText =
-      "{ " +
-      "  \"type\" : \"record\", " +
-      "  \"name\" : \"Foo\", " +
-      "  \"fields\" : [ " +
-      "    { " +
-      "      \"name\" : \"strlen10\", " +
-      "      \"type\" : " +
-      "      { " +
-      "        \"name\" : \"StrLen10\", " +
-      "        \"type\" : \"typeref\", " +
-      "        \"ref\"  : \"string\", " +
-      "        \"validate\" : " +
-      "        { " +
-      "          \"strlen\" : { \"max\" : 10 } "+
-      "        } " +
-      "      }, " +
-      "      \"optional\" : true " +
-      "    }, " +
-      "    { " +
-      "      \"name\" : \"digits\", " +
-      "      \"type\" : " +
-      "      { " +
-      "        \"name\" : \"Digits\", " +
-      "        \"type\" : \"typeref\", " +
-      "        \"ref\"  : \"string\", " +
-      "        \"validate\" : " +
-      "        { " +
-      "          \"regex\" : { \"regex\" : \"[0-9]+\" } "+
-      "        } " +
-      "      }, " +
-      "      \"optional\" : true " +
-      "    }, " +
-      "    { " +
-      "      \"name\" : \"digitsMin5\", " +
-      "      \"type\" : " +
-      "      { " +
-      "        \"name\" : \"DigitsMin5\", " +
-      "        \"type\" : \"typeref\", " +
-      "        \"ref\"  : \"Digits\", " +
-      "        \"validate\" : " +
-      "        { " +
-      "          \"strlen\" : { \"min\" : 5 } "+
-      "        } " +
-      "      }," +
-      "      \"optional\" : true " +
-      "    }, " +
-      // validate property at field level
-      "    { " +
-      "      \"name\" : \"lettersMin3\", " +
-      "      \"type\" : \"string\", " +
-      "      \"validate\" : " +
-      "      { " +
-      "        \"strlen\" : { \"min\" : 3 }, "+
-      "        \"regex\" : { \"regex\" : \"[A-Za-z]+\" } "+
-      "      }, " +
-      "      \"optional\" : true " +
-      "    }, " +
-      // validate at within multi-level nested types
-      "    { " +
-      "      \"name\" : \"nested\", " +
-      "      \"type\" : { " +
-      "        \"type\" : \"array\", " +
-      "        \"items\" : { " +
-      "          \"type\" : \"map\", " +
-      "          \"values\" : \"Foo\" " +
-      "        } " +
-      "      }, " +
-      "      \"optional\" : true " +
-      "    } " +
-      "  ], " +
-      "  \"validate\" : " +
-      "  { " +
-      "    \"fooValidator\" : { } " +
-      "  } " +
-      "}";
+      "@validate.fooValidator = {}" +
+          "record Foo {" +
+          "  strlen10: optional" +
+          "    @validate.strlen.max = 10" +
+          "    typeref StrLen10 = string" +
+
+          "  digits: optional" +
+          "    @validate.regex.regex = \"[0-9]+\"" +
+          "    typeref Digits = string" +
+
+          "  digitsMin5: optional" +
+          "    @validate.strlen.min = 5" +
+          "    typeref DigitsMin5 = Digits" +
+
+          // validate property at field level
+          "  @validate.strlen.min = 3" +
+          "  @validate.regex.regex = \"[A-Za-z]+\"" +
+          "  lettersMin3: optional string" +
+
+          // validate property at union member level
+          "  stringAndInt: optional union[" +
+          "    @validate.strlen.min = 3" +
+          "    @validate.regex.regex = \"[A-Za-z]+\"" +
+          "    lettersMin3: string" +
+          "    @validate.regex.regex = \"[0-9]+\"" +
+          "    digits: string" +
+          "  ]" +
+
+          // validate at within multi-level nested types
+          "  nested: optional array[map[string, Foo]]\n" +
+          "}";
 
   String[] _fooSchemaValidatorCheckStrings =
   {
@@ -615,28 +572,51 @@ public class TestValidator
   }
 
   @Test
+  public void testValidateUnionMember() throws IOException, InstantiationException
+  {
+    Object[][] input =
+        {
+            {
+                new DataMap(asMap("stringAndInt", new DataMap(asMap("lettersMin3", "ABC")))),
+                "{\"stringAndInt\":{\"lettersMin3\":\"ABC\"}}"
+            },
+            {
+                new DataMap(asMap("stringAndInt", new DataMap(asMap("digits", "124"))))
+            },
+            {
+                new DataMap(asMap("stringAndInt", new DataMap(asMap("lettersMin3", "012")))),
+                "ERROR", "does not match [A-Za-z]+",
+            },
+            {
+                new DataMap(asMap("stringAndInt", new DataMap(asMap("lettersMin3", "ab")))),
+                "ERROR", "is out of range 3...",
+            },
+            {
+                new DataMap(asMap("stringAndInt", new DataMap(asMap("digits", "abc")))),
+                "ERROR", "\"abc\" does not match [0-9]+",
+            },
+            {
+                new DataMap(asMap("stringAndInt", new DataMap(asMap("lettersMin3", "0")))),
+                "ERROR", "does not match [A-Za-z]+", "is out of range 3..."
+            },
+            {
+                new DataMap(asMap("stringAndInt", new DataMap(asMap("lettersMin3", "0", "digits", "ABC")))),
+                "ERROR", "does not match [A-Za-z]+", "is out of range 3...", "\"ABC\" does not match [0-9]+"
+            }
+        };
+
+    testFooSchemaValidator(input);
+  }
+
+  @Test
   public void testPathNameInValidationMessages() throws IOException, InstantiationException
   {
     String schemaText =
-          "{ \n" +
-          "  \"type\" : \"record\",\n" +
-          "  \"name\" : \"Foo\",\n" +
-          "  \"fields\" : [\n" +
-          "    {\n" +
-          "      \"name\" : \"bar\",\n" +
-          "      \"type\" : {\n" +
-          "        \"name\" : \"Bar\",\n" +
-          "        \"type\" : \"record\",\n" +
-          "        \"fields\" : [\n" +
-          "          {\n" +
-          "            \"name\" : \"baz\",\n" +
-          "            \"type\" : \"int\"\n" +
-          "          }\n" +
-          "        ]\n" +
-          "      }\n" +
-          "    }\n" +
-          "  ]\n" +
-          "}\n";
+          "record Foo {" +
+          "  bar: record Bar {" +
+          "    baz: int" +
+          "  }" +
+          "}";
 
     Object[][] input =
     {
@@ -678,23 +658,11 @@ public class TestValidator
   public void testValidatorHasFixedValue() throws IOException, InstantiationException
   {
     String schemaText =
-          "{ \n" +
-          "  \"type\" : \"record\",\n" +
-          "  \"name\" : \"Foo\",\n" +
-          "  \"fields\" : [\n" +
-          "    {\n" +
-          "      \"name\" : \"baz\",\n" +
-          "      \"type\" : {\n" +
-          "        \"type\" : \"typeref\",\n" +
-          "        \"name\" : \"IntRef\",\n" +
-          "        \"ref\" : \"int\",\n" +
-          "        \"validate\" : {\n" +
-          "          \"instanceOf\" : { \"class\" : \"java.lang.Integer\" }\n" +
-          "        }\n" +
-          "      }\n" +
-          "    }\n" +
-          "  ]\n" +
-          "}\n";
+          "record Foo {\n" +
+              "  baz: \n" +
+              "    @validate.instanceOf.class = \"java.lang.Integer\"\n" +
+              "    typeref IntRef = int\n" +
+              "}";
 
     Object[][] input =
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.12
+version=29.19.13
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Union members originally didn't support custom properties and thus validation on the members was not supported. With aliased unions, members now support custom properties and thus can specify custom validation.

This PR updates the validation logic so these custom validation are applied correctly.