### PR TITLE
Bump netty version to use ALPN support needed for JDK8u282.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.19.14] - 2021-07-29
+- Bump netty version to use ALPN support needed for JDK8u282.
+
 ## [29.19.13] - 2021-07-26
 - Add support for validating aliased union members.
   - Union members originally didn't support custom properties and thus custom validation
@@ -5032,7 +5035,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.13...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.14...master
+[29.19.14]: https://github.com/linkedin/rest.li/compare/v29.19.13...v29.19.14
 [29.19.13]: https://github.com/linkedin/rest.li/compare/v29.19.12...v29.19.13
 [29.19.12]: https://github.com/linkedin/rest.li/compare/v29.19.11...v29.19.12
 [29.19.11]: https://github.com/linkedin/rest.li/compare/v29.19.10...v29.19.11

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ project.ext.externalDependency = [
   'log4j2Core': 'org.apache.logging.log4j:log4j-core:2.0.2',
   'log4jLog4j2': 'org.apache.logging.log4j:log4j-1.2-api:2.0.2',
   'mail': 'javax.mail:mail:1.4.4',
-  'netty': 'io.netty:netty-all:4.1.41.Final',
+  'netty': 'io.netty:netty-all:4.1.52.Final',
   'objenesis': 'org.objenesis:objenesis:1.2',
   'parseq': 'com.linkedin.parseq:parseq:5.1.2',
   'parseq_tracevis': 'com.linkedin.parseq:parseq-tracevis:5.1.2',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.13
+version=29.19.14
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/TestServer.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/TestServer.java
@@ -229,7 +229,10 @@ public class TestServer
       {
         final String headerName = "X-Long-Header:";
         int size = Integer.parseInt(q.replace("headerSize=", ""));
-        int valueSize = size - headerName.length();
+        // With commit https://github.com/netty/netty/commit/9ae782d632ff18f7c9e645c58458b3180d257ff3
+        // in Netty 4.1.46.Final, we need to subtract 1 from the length of the header content we generate
+        // because Netty counts the trailing "\r\n" as a single character towards the header size.
+        int valueSize = size - headerName.length() - 1;
 
         char[] headerValue = new char[valueSize];
         Arrays.fill(headerValue, 'a');

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/TestServer.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/TestServer.java
@@ -229,7 +229,7 @@ public class TestServer
       {
         final String headerName = "X-Long-Header:";
         int size = Integer.parseInt(q.replace("headerSize=", ""));
-        // With commit https://github.com/netty/netty/commit/9ae782d632ff18f7c9e645c58458b3180d257ff3
+        // With the commit https://github.com/netty/netty/commit/9ae782d632ff18f7c9e645c58458b3180d257ff3
         // in Netty 4.1.46.Final, we need to subtract 1 from the length of the header content we generate
         // because Netty counts the trailing "\r\n" as a single character towards the header size.
         int valueSize = size - headerName.length() - 1;

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyClient.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyClient.java
@@ -261,7 +261,7 @@ public class TestHttpNettyClient
   {
     testHeaderSize(TEST_MAX_HEADER_SIZE - 1, RESPONSE_OK);
 
-    testHeaderSize(TEST_MAX_HEADER_SIZE, TOO_LARGE);
+    testHeaderSize(TEST_MAX_HEADER_SIZE, RESPONSE_OK);
 
     testHeaderSize(TEST_MAX_HEADER_SIZE + 1, TOO_LARGE);
   }

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyClient.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyClient.java
@@ -261,7 +261,7 @@ public class TestHttpNettyClient
   {
     testHeaderSize(TEST_MAX_HEADER_SIZE - 1, RESPONSE_OK);
 
-    testHeaderSize(TEST_MAX_HEADER_SIZE, RESPONSE_OK);
+    testHeaderSize(TEST_MAX_HEADER_SIZE, TOO_LARGE);
 
     testHeaderSize(TEST_MAX_HEADER_SIZE + 1, TOO_LARGE);
   }


### PR DESCRIPTION
With JDK8u282, the ALPN APIs are merged with JDK itself and the ALPN jar is not required. The support for this is added in the netty. Without this newer netty, we get "Unable to wrap SSLEngine of type sun.security.ssl.SSLEngineImpl" runtime error. So this PR updates the netty to avoid this error.