### PR TITLE
Squash a flea. ConstantQps burst value should never eval to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.19.16] - 2021-08-09
+- Fix bug in ConstantQpsDarkClusterStrategy that would call ConstantRateLimiter.setRate with an invalid burst value
+
 ## [29.19.14] - 2021-07-29
 - Bump netty version to use ALPN support needed for JDK8u282.
 
@@ -5035,7 +5038,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.14...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.16...master
+[29.19.16]: https://github.com/linkedin/rest.li/compare/v29.19.14...v29.19.16
 [29.19.14]: https://github.com/linkedin/rest.li/compare/v29.19.13...v29.19.14
 [29.19.13]: https://github.com/linkedin/rest.li/compare/v29.19.12...v29.19.13
 [29.19.12]: https://github.com/linkedin/rest.li/compare/v29.19.11...v29.19.12

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/ConstantQpsDarkClusterStrategy.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/ConstantQpsDarkClusterStrategy.java
@@ -76,7 +76,7 @@ public class ConstantQpsDarkClusterStrategy implements DarkClusterStrategy
   {
     float sendRate = getSendRate();
     // set burst in such a way that requests are dispatched evenly across the ONE_SECOND_PERIOD
-    int burst = (int) Math.ceil(sendRate / ONE_SECOND_PERIOD);
+    int burst = (int) Math.max(1, Math.ceil(sendRate / ONE_SECOND_PERIOD));
     _rateLimiter.setRate(sendRate, ONE_SECOND_PERIOD, burst);
     return addRequest(originalRequest, darkRequest, requestContext);
   }

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestConstantQpsDarkClusterStrategy.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestConstantQpsDarkClusterStrategy.java
@@ -52,6 +52,7 @@ public class TestConstantQpsDarkClusterStrategy
     return new Object[][]{
         // numIterations, qps, numSourceInstances, numDarkInstances
         {0, 0, 10, 10},
+        {10, 10, 10, 0},
         {0, 100, 10, 10},
         {1000, 10, 10, 10},
         {1000, 30, 10, 10},

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
@@ -46,7 +46,6 @@ import com.linkedin.r2.message.rest.RestRequestBuilder;
 import static com.linkedin.d2.DarkClusterStrategyName.CONSTANT_QPS;
 import static com.linkedin.d2.DarkClusterStrategyName.RELATIVE_TRAFFIC;
 import static com.linkedin.darkcluster.DarkClusterTestUtil.createRelativeTrafficMultiplierConfig;
-import static com.linkedin.darkcluster.DarkClusterTestUtil.createConstantQpsOutboundTargetRateConfig;
 import static com.linkedin.darkcluster.impl.DarkClusterStrategyFactoryImpl.NO_OP_DARK_CLUSTER_STRATEGY;
 import static org.testng.Assert.fail;
 import org.testng.Assert;

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterStrategyFactory.java
@@ -46,6 +46,7 @@ import com.linkedin.r2.message.rest.RestRequestBuilder;
 import static com.linkedin.d2.DarkClusterStrategyName.CONSTANT_QPS;
 import static com.linkedin.d2.DarkClusterStrategyName.RELATIVE_TRAFFIC;
 import static com.linkedin.darkcluster.DarkClusterTestUtil.createRelativeTrafficMultiplierConfig;
+import static com.linkedin.darkcluster.DarkClusterTestUtil.createConstantQpsOutboundTargetRateConfig;
 import static com.linkedin.darkcluster.impl.DarkClusterStrategyFactoryImpl.NO_OP_DARK_CLUSTER_STRATEGY;
 import static org.testng.Assert.fail;
 import org.testng.Assert;

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestRelativeTrafficMultiplierDarkClusterStrategy.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestRelativeTrafficMultiplierDarkClusterStrategy.java
@@ -45,6 +45,7 @@ public class TestRelativeTrafficMultiplierDarkClusterStrategy
       // numIterations, multiplier, numSourceInstances, numDarkInstances
       {0, 0f, 10, 10},
       {0, 1f, 10, 10},
+      {10, 10, 10, 0},
       {1000, 0.1f, 10, 10},
       {1000, 0.25f, 10, 10},
       {1000, 0.5f, 10, 10},

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.16
+version=29.19.17
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.14
+version=29.19.16
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Bug is preventing us from ramping the feature into production. Appears that maybe the clusterInfoProvider returns 0 before it gets a chance to discover what's actually there?