### PR TITLE
Add support for resolving from multiple schema source directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add support for resolving from multiple schema source directories.
+  - This change also introduces the concept of "source" and "resolver" directories when 
+    creating a `DataSchemaParser`. "Source" directories are used to parse/load the input
+    schemas, while the "resolver" directories will only be used for resolving referenced
+    schemas.
 
 ## [29.19.15] - 2021-08-09
 - Provide the ability to set cookies and projection params in request context's local attributes to avoid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5044,8 +5044,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.15...master
-[29.19.15]: https://github.com/linkedin/rest.li/compare/v29.19.14...v29.19.15
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.20.0...master
+[29.20.0]: https://github.com/linkedin/rest.li/compare/v29.19.14...v29.20.0
 [29.19.14]: https://github.com/linkedin/rest.li/compare/v29.19.13...v29.19.14
 [29.19.13]: https://github.com/linkedin/rest.li/compare/v29.19.12...v29.19.13
 [29.19.12]: https://github.com/linkedin/rest.li/compare/v29.19.11...v29.19.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.19.16] - 2021-08-09
 - Add support for resolving from multiple schema source directories.
   - This change also introduces the concept of "source" and "resolver" directories when 
     creating a `DataSchemaParser`. "Source" directories are used to parse/load the input
@@ -5044,7 +5046,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.15...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.16...master
+[29.19.16]: https://github.com/linkedin/rest.li/compare/v29.19.15...v29.19.16
 [29.19.15]: https://github.com/linkedin/rest.li/compare/v29.19.14...v29.19.15
 [29.19.14]: https://github.com/linkedin/rest.li/compare/v29.19.13...v29.19.14
 [29.19.13]: https://github.com/linkedin/rest.li/compare/v29.19.12...v29.19.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5044,8 +5044,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.20.0...master
-[29.20.0]: https://github.com/linkedin/rest.li/compare/v29.19.14...v29.20.0
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.15...master
+[29.19.15]: https://github.com/linkedin/rest.li/compare/v29.19.14...v29.19.15
 [29.19.14]: https://github.com/linkedin/rest.li/compare/v29.19.13...v29.19.14
 [29.19.13]: https://github.com/linkedin/rest.li/compare/v29.19.12...v29.19.13
 [29.19.12]: https://github.com/linkedin/rest.li/compare/v29.19.11...v29.19.12

--- a/data/src/main/java/com/linkedin/data/schema/DataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/DataSchemaResolver.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.data.schema;
 
+import com.linkedin.data.schema.resolver.SchemaDirectory;
 import com.linkedin.data.schema.resolver.SchemaDirectoryName;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -161,7 +162,7 @@ public interface DataSchemaResolver
    * Returns the list of schema directories this resolver will check when resolving schemas.
    * Defaults to the single {@link SchemaDirectoryName#PEGASUS} directory.
    */
-  default List<SchemaDirectoryName> getSchemaDirectories()
+  default List<SchemaDirectory> getSchemaDirectories()
   {
     return Collections.singletonList(SchemaDirectoryName.PEGASUS);
   }

--- a/data/src/main/java/com/linkedin/data/schema/DataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/DataSchemaResolver.java
@@ -17,9 +17,11 @@
 package com.linkedin.data.schema;
 
 import com.linkedin.data.schema.resolver.SchemaDirectoryName;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
 
 /**
  * A {@link DataSchemaResolver} is used to resolve names to {@link NamedDataSchema}s.
@@ -147,9 +149,20 @@ public interface DataSchemaResolver
 
   /**
    * Returns the schema file directory name for schemas location
+   * @deprecated use {@link #getSchemaDirectories()} instead.
    */
+  @Deprecated
   default SchemaDirectoryName getSchemasDirectoryName()
   {
     return SchemaDirectoryName.PEGASUS;
+  }
+
+  /**
+   * Returns the list of schema directories this resolver will check when resolving schemas.
+   * Defaults to the single {@link SchemaDirectoryName#PEGASUS} directory.
+   */
+  default List<SchemaDirectoryName> getSchemaDirectories()
+  {
+    return Collections.singletonList(SchemaDirectoryName.PEGASUS);
   }
 }

--- a/data/src/main/java/com/linkedin/data/schema/resolver/AbstractDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/AbstractDataSchemaResolver.java
@@ -55,7 +55,7 @@ import java.util.Set;
  * <li> the locations to search for the named DataSchema
  *      (by implementing {@link #possibleLocations(String)},
  * <li> how transform the name and a search path into a location
- *      (by implementing {@link AbstractPathAndSchemaDirectoryIterator#transform(String, SchemaDirectoryName)}, and
+ *      (by implementing {@link AbstractPathAndSchemaDirectoryIterator#transform(String, SchemaDirectory)}, and
  * <li> how to obtain an {@link InputStream} from a location
  *      (by implementing {@link #locationToInputStream(DataSchemaLocation, StringBuilder)}.
  * </ul>
@@ -167,7 +167,7 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
    */
   abstract static class AbstractPathAndSchemaDirectoryIterator implements Iterator<DataSchemaLocation>
   {
-    protected abstract DataSchemaLocation transform(String path, SchemaDirectoryName schemaDirectory);
+    protected abstract DataSchemaLocation transform(String path, SchemaDirectory schemaDirectory);
 
     /**
      * Constructor.
@@ -176,7 +176,7 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
      * @param schemaDirectories List of schema directories to use as possible schema locations.
      */
     protected AbstractPathAndSchemaDirectoryIterator(
-        Iterable<String> paths, List<SchemaDirectoryName> schemaDirectories)
+        Iterable<String> paths, List<SchemaDirectory> schemaDirectories)
     {
       _it = paths.iterator();
       _schemaDirectories = schemaDirectories;
@@ -207,7 +207,7 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
     }
 
     /**
-     * Obtains the next element, invokes and returns the output of {@link #transform(String, SchemaDirectoryName)}.
+     * Obtains the next element, invokes and returns the output of {@link #transform(String, SchemaDirectory)}.
      *
      * @return the next location to search.
      */
@@ -238,8 +238,8 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
      */
     private final Iterator<String> _it;
     private String _currentPath;
-    private Iterator<SchemaDirectoryName> _directoryNameIterator;
-    private final List<SchemaDirectoryName> _schemaDirectories;
+    private Iterator<SchemaDirectory> _directoryNameIterator;
+    private final List<SchemaDirectory> _schemaDirectories;
   }
 
   private final DataSchemaResolver _dependencyResolver;
@@ -351,7 +351,7 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
   }
 
   @Override
-  public List<SchemaDirectoryName> getSchemaDirectories()
+  public List<SchemaDirectory> getSchemaDirectories()
   {
     return _schemaDirectories;
   }
@@ -361,7 +361,7 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
    *
    * @param schemaDirectories schema directory names.
    */
-  void setSchemaDirectories(List<SchemaDirectoryName> schemaDirectories)
+  void setSchemaDirectories(List<SchemaDirectory> schemaDirectories)
   {
     _schemaDirectories = schemaDirectories;
   }
@@ -478,7 +478,7 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
    *
    * Ex "pegasus" for data or "extensions" for relationship extension schema files
    */
-  private List<SchemaDirectoryName> _schemaDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
+  private List<SchemaDirectory> _schemaDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
 
   protected static final PrintStream out = new PrintStream(new FileOutputStream(FileDescriptor.out));
 }

--- a/data/src/main/java/com/linkedin/data/schema/resolver/AbstractDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/AbstractDataSchemaResolver.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,7 +55,7 @@ import java.util.Set;
  * <li> the locations to search for the named DataSchema
  *      (by implementing {@link #possibleLocations(String)},
  * <li> how transform the name and a search path into a location
- *      (by implementing {@link AbstractIterator#transform(String)}, and
+ *      (by implementing {@link AbstractPathAndSchemaDirectoryIterator#transform(String, SchemaDirectoryName)}, and
  * <li> how to obtain an {@link InputStream} from a location
  *      (by implementing {@link #locationToInputStream(DataSchemaLocation, StringBuilder)}.
  * </ul>
@@ -85,7 +86,10 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
    * Abstract class to help implement iterator returned by {@link #possibleLocations(String)}.
    *
    * @author slim
+   * @deprecated This class was intended for internal use and was replaced with {@link AbstractPathAndSchemaDirectoryIterator}.
+   * Recommend not depending on this class.
    */
+  @Deprecated
   public abstract static class AbstractIterator implements Iterator<DataSchemaLocation>
   {
     protected abstract DataSchemaLocation transform(String input);
@@ -154,6 +158,88 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
      * The underlying {@link Iterator}.
      */
     private final Iterator<String> _it;
+  }
+
+  /**
+   * Abstract class to help implement iterator returned by {@link #possibleLocations(String)}.
+   *
+   * @author kbalasub
+   */
+  abstract static class AbstractPathAndSchemaDirectoryIterator implements Iterator<DataSchemaLocation>
+  {
+    protected abstract DataSchemaLocation transform(String path, SchemaDirectoryName schemaDirectory);
+
+    /**
+     * Constructor.
+     *
+     * @param paths is the ordered list of search paths.
+     * @param schemaDirectories List of schema directories to use as possible schema locations.
+     */
+    protected AbstractPathAndSchemaDirectoryIterator(
+        Iterable<String> paths, List<SchemaDirectoryName> schemaDirectories)
+    {
+      _it = paths.iterator();
+      _schemaDirectories = schemaDirectories;
+    }
+
+    /**
+     * Return whether there is another location to search. True when there is another path to search or schema
+     * directories to search for the current/last path.
+     *
+     * @return true if there is another location to search.
+     */
+    @Override
+    public boolean hasNext()
+    {
+      if (_currentPath == null || !_directoryNameIterator.hasNext())
+      {
+        if (_it.hasNext())
+        {
+          _currentPath = _it.next();
+          _directoryNameIterator = _schemaDirectories.iterator();
+        }
+        else
+        {
+          return false;
+        }
+      }
+      return _directoryNameIterator.hasNext();
+    }
+
+    /**
+     * Obtains the next element, invokes and returns the output of {@link #transform(String, SchemaDirectoryName)}.
+     *
+     * @return the next location to search.
+     */
+    @Override
+    public DataSchemaLocation next()
+    {
+      if (_currentPath == null || !_directoryNameIterator.hasNext())
+      {
+        _currentPath = _it.next();
+        _directoryNameIterator = _schemaDirectories.iterator();
+      }
+      return transform(_currentPath, _directoryNameIterator.next());
+    }
+
+    /**
+     * Not implemented.
+     *
+     * @throws UnsupportedOperationException always.
+     */
+    @Override
+    public void remove()
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * The underlying {@link Iterator} for paths.
+     */
+    private final Iterator<String> _it;
+    private String _currentPath;
+    private Iterator<SchemaDirectoryName> _directoryNameIterator;
+    private final List<SchemaDirectoryName> _schemaDirectories;
   }
 
   private final DataSchemaResolver _dependencyResolver;
@@ -264,6 +350,22 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
     return _resolvedLocations.contains(location);
   }
 
+  @Override
+  public List<SchemaDirectoryName> getSchemaDirectories()
+  {
+    return _schemaDirectories;
+  }
+
+  /**
+   * Sets the file directory names of all locations the resolver should use for resolving schemas.
+   *
+   * @param schemaDirectories schema directory names.
+   */
+  void setSchemaDirectories(List<SchemaDirectoryName> schemaDirectories)
+  {
+    _schemaDirectories = schemaDirectories;
+  }
+
   /**
    * Locate a {@link NamedDataSchema} with the specified name.
    *
@@ -370,6 +472,13 @@ public abstract class AbstractDataSchemaResolver implements DataSchemaResolver
   private final Set<DataSchemaLocation> _resolvedLocations = new HashSet<>();
   // Map of pending records with the boolean flag indicating if includes are being processed for that schema.
   private final LinkedHashMap<String, Boolean> _pendingSchemas = new LinkedHashMap<>();
+  /**
+   * The top level directory names in which the resolver would look for schemas. Default is a single directory
+   * {@link SchemaDirectoryName#PEGASUS}.
+   *
+   * Ex "pegasus" for data or "extensions" for relationship extension schema files
+   */
+  private List<SchemaDirectoryName> _schemaDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
 
   protected static final PrintStream out = new PrintStream(new FileOutputStream(FileDescriptor.out));
 }

--- a/data/src/main/java/com/linkedin/data/schema/resolver/AbstractMultiFormatDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/AbstractMultiFormatDataSchemaResolver.java
@@ -53,7 +53,7 @@ public abstract class AbstractMultiFormatDataSchemaResolver implements DataSchem
   };
 
   private final List<DataSchemaResolver> _resolvers = new ArrayList<>();
-  private List<SchemaDirectoryName> _schemaDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
+  private List<SchemaDirectory> _schemaDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
 
   public static List<DataSchemaParserFactory> BUILTIN_FORMAT_PARSER_FACTORIES;
   static {
@@ -197,12 +197,12 @@ public abstract class AbstractMultiFormatDataSchemaResolver implements DataSchem
   }
 
   @Override
-  public List<SchemaDirectoryName> getSchemaDirectories()
+  public List<SchemaDirectory> getSchemaDirectories()
   {
     return _schemaDirectories;
   }
 
-  public void setSchemaDirectories(List<SchemaDirectoryName> schemaDirectories)
+  public void setSchemaDirectories(List<SchemaDirectory> schemaDirectories)
   {
     _schemaDirectories = schemaDirectories;
   }

--- a/data/src/main/java/com/linkedin/data/schema/resolver/AbstractMultiFormatDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/AbstractMultiFormatDataSchemaResolver.java
@@ -26,6 +26,7 @@ import com.linkedin.data.schema.SchemaParserFactory;
 import com.linkedin.data.schema.grammar.PdlSchemaParser;
 import com.linkedin.data.schema.grammar.PdlSchemaParserFactory;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,6 +53,7 @@ public abstract class AbstractMultiFormatDataSchemaResolver implements DataSchem
   };
 
   private final List<DataSchemaResolver> _resolvers = new ArrayList<>();
+  private List<SchemaDirectoryName> _schemaDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
 
   public static List<DataSchemaParserFactory> BUILTIN_FORMAT_PARSER_FACTORIES;
   static {
@@ -192,5 +194,16 @@ public abstract class AbstractMultiFormatDataSchemaResolver implements DataSchem
       results.putAll(resolver.getPendingSchemas());
     }
     return results;
+  }
+
+  @Override
+  public List<SchemaDirectoryName> getSchemaDirectories()
+  {
+    return _schemaDirectories;
+  }
+
+  public void setSchemaDirectories(List<SchemaDirectoryName> schemaDirectories)
+  {
+    _schemaDirectories = schemaDirectories;
   }
 }

--- a/data/src/main/java/com/linkedin/data/schema/resolver/ClasspathResourceDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/ClasspathResourceDataSchemaResolver.java
@@ -101,7 +101,7 @@ public class ClasspathResourceDataSchemaResolver extends AbstractMultiFormatData
   @Deprecated
   public ClasspathResourceDataSchemaResolver(ClassLoader classLoader, SchemaDirectoryName schemaDirectoryName)
   {
-    List<SchemaDirectoryName> schemaDirectories = new ArrayList<>();
+    List<SchemaDirectory> schemaDirectories = new ArrayList<>();
     schemaDirectories.add(schemaDirectoryName);
     // The below logic is kept for backwards compatibility. Ideally the constructor that accepts list of schema
     // directories should be used to configure all the resolver directores.
@@ -126,7 +126,7 @@ public class ClasspathResourceDataSchemaResolver extends AbstractMultiFormatData
    * @param classLoader provides the {@link ClassLoader}.
    * @param schemaDirectories The list of schema directories to use for resolving referenced schemas.
    */
-  public ClasspathResourceDataSchemaResolver(ClassLoader classLoader, List<SchemaDirectoryName> schemaDirectories)
+  public ClasspathResourceDataSchemaResolver(ClassLoader classLoader, List<SchemaDirectory> schemaDirectories)
   {
     for (DataSchemaParserFactory parserForFormat: BUILTIN_FORMAT_PARSER_FACTORIES)
     {
@@ -143,7 +143,7 @@ public class ClasspathResourceDataSchemaResolver extends AbstractMultiFormatData
   public SchemaDirectoryName getSchemasDirectoryName()
   {
     assert getSchemaDirectories().size() > 0;
-    return getSchemaDirectories().get(0);
+    return (SchemaDirectoryName) getSchemaDirectories().get(0);
   }
 
   /**

--- a/data/src/main/java/com/linkedin/data/schema/resolver/ExtensionsDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/ExtensionsDataSchemaResolver.java
@@ -44,7 +44,7 @@ import java.util.List;
 @Deprecated
 public class ExtensionsDataSchemaResolver extends AbstractMultiFormatDataSchemaResolver
 {
-  private static final List<SchemaDirectoryName> RESOLVER_SCHEMA_DIRECTORIES =
+  private static final List<SchemaDirectory> RESOLVER_SCHEMA_DIRECTORIES =
       Arrays.asList(SchemaDirectoryName.PEGASUS, SchemaDirectoryName.EXTENSIONS);
   public ExtensionsDataSchemaResolver(String resolverPath)
   {
@@ -73,7 +73,7 @@ public class ExtensionsDataSchemaResolver extends AbstractMultiFormatDataSchemaR
   }
 
   @Override
-  public List<SchemaDirectoryName> getSchemaDirectories()
+  public List<SchemaDirectory> getSchemaDirectories()
   {
     // This override is to maintain backwards compatibility with the old behavior which used the schema directory name
     // to parse the source files. Limiting the extension resolver to load only the extension schemas by using only

--- a/data/src/main/java/com/linkedin/data/schema/resolver/ExtensionsDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/ExtensionsDataSchemaResolver.java
@@ -18,21 +18,39 @@ package com.linkedin.data.schema.resolver;
 
 import com.linkedin.data.schema.DataSchemaParserFactory;
 import com.linkedin.data.schema.DataSchemaResolver;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 
 /**
  * Combines schema resolver for pegasus data and extensions schema directory.
  *
  * @author Aman Gupta
+ * @deprecated Recommended way to handle parsing extension schemas is by using DataSchemaParser initialized with correct
+ * source and resolver directories. Correct way to build the parser:
+ * <p/>
+ * <pre>{@code
+ * List<SchemaDirectoryName> resolverDirectories = Arrays.asList(
+ *     SchemaDirectoryName.EXTENSIONS, SchemaDirectoryName.PEGASUS);
+ * List<SchemaDirectoryName> sourceDirectories =
+ *     Collections.singletonList(SchemaDirectoryName.EXTENSIONS);
+ * DataSchemaParser parser = new DataSchemaParser.Builder(jarFile)
+ *     .setResolverDirectories(resolverDirectories)
+ *     .setSourceDirectories(sourceDirectories)
+ *     .build();
+ * }</pre>
  */
+@Deprecated
 public class ExtensionsDataSchemaResolver extends AbstractMultiFormatDataSchemaResolver
 {
+  private static final List<SchemaDirectoryName> RESOLVER_SCHEMA_DIRECTORIES =
+      Arrays.asList(SchemaDirectoryName.PEGASUS, SchemaDirectoryName.EXTENSIONS);
   public ExtensionsDataSchemaResolver(String resolverPath)
   {
     for (DataSchemaParserFactory parserFactory : AbstractMultiFormatDataSchemaResolver.BUILTIN_FORMAT_PARSER_FACTORIES)
     {
-      addResolver(createSchemaResolver(resolverPath, SchemaDirectoryName.PEGASUS, this, parserFactory));
-      addResolver(createSchemaResolver(resolverPath, SchemaDirectoryName.EXTENSIONS, this, parserFactory));
+      addResolver(createSchemaResolver(resolverPath, this, parserFactory));
     }
   }
 
@@ -40,24 +58,26 @@ public class ExtensionsDataSchemaResolver extends AbstractMultiFormatDataSchemaR
   {
     for (DataSchemaParserFactory parserFactory : AbstractMultiFormatDataSchemaResolver.BUILTIN_FORMAT_PARSER_FACTORIES)
     {
-      addResolver(createSchemaResolver(resolverPath, SchemaDirectoryName.PEGASUS, dependencyResolver, parserFactory));
-      addResolver(createSchemaResolver(resolverPath, SchemaDirectoryName.EXTENSIONS, dependencyResolver, parserFactory));
+      addResolver(createSchemaResolver(resolverPath, dependencyResolver, parserFactory));
     }
   }
 
-  private FileDataSchemaResolver createSchemaResolver(String resolverPath, SchemaDirectoryName schemaDirectoryName,
+  private FileDataSchemaResolver createSchemaResolver(String resolverPath,
       DataSchemaResolver dependencyResolver, DataSchemaParserFactory parserFactory)
   {
     FileDataSchemaResolver resolver =
         new FileDataSchemaResolver(parserFactory, resolverPath, dependencyResolver);
     resolver.setExtension("." + parserFactory.getLanguageExtension());
-    resolver.setSchemasDirectoryName(schemaDirectoryName);
+    resolver.setSchemaDirectories(RESOLVER_SCHEMA_DIRECTORIES);
     return resolver;
   }
 
   @Override
-  public SchemaDirectoryName getSchemasDirectoryName()
+  public List<SchemaDirectoryName> getSchemaDirectories()
   {
-    return SchemaDirectoryName.EXTENSIONS;
+    // This override is to maintain backwards compatibility with the old behavior which used the schema directory name
+    // to parse the source files. Limiting the extension resolver to load only the extension schemas by using only
+    // the extension schema directory.
+    return Collections.singletonList(SchemaDirectoryName.EXTENSIONS);
   }
 }

--- a/data/src/main/java/com/linkedin/data/schema/resolver/FileDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/FileDataSchemaResolver.java
@@ -188,8 +188,8 @@ public class FileDataSchemaResolver extends AbstractDataSchemaResolver
   @SuppressWarnings("deprecation")
   public SchemaDirectoryName getSchemasDirectoryName()
   {
-    assert(getSchemaDirectories().size() == 1);
-    return getSchemaDirectories().get(0);
+    assert getSchemaDirectories().size() == 1;
+    return (SchemaDirectoryName) getSchemaDirectories().get(0);
   }
 
   /**
@@ -241,7 +241,7 @@ public class FileDataSchemaResolver extends AbstractDataSchemaResolver
     return new AbstractPathAndSchemaDirectoryIterator(_paths, getSchemaDirectories())
     {
       @Override
-      protected DataSchemaLocation transform(String path, SchemaDirectoryName schemaDirectoryName)
+      protected DataSchemaLocation transform(String path, SchemaDirectory schemaDirectory)
       {
         boolean isJar = path.endsWith(JAR_EXTENSION);
         if (isJar)
@@ -262,7 +262,7 @@ public class FileDataSchemaResolver extends AbstractDataSchemaResolver
           StringBuilder builder = new StringBuilder();
           // within a JAR file, files are treated as resources. Thus, we should lookup using the resource separator
           // character, which is '/'
-          builder.append(schemaDirectoryName.getName())
+          builder.append(schemaDirectory.getName())
               .append('/')
               .append(transformedName.replace(File.separatorChar, '/'));
           return new InJarFileDataSchemaLocation(jarFile, builder.toString());

--- a/data/src/main/java/com/linkedin/data/schema/resolver/FileDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/FileDataSchemaResolver.java
@@ -67,12 +67,6 @@ public class FileDataSchemaResolver extends AbstractDataSchemaResolver
   public static final String DEFAULT_EXTENSION = SchemaParser.FILE_EXTENSION;
 
   /**
-   * The file directory name for different types of schemas. Default is {@link SchemaDirectoryName#PEGASUS}
-   * Ex "pegasus" for data or "extensions" for relationship extension schema files
-   */
-  private SchemaDirectoryName _schemasDirectoryName = SchemaDirectoryName.PEGASUS;
-
-  /**
    * Constructor.
    *
    * @param parserFactory to be used to construct {@link SchemaParser}'s to parse located files.
@@ -191,9 +185,11 @@ public class FileDataSchemaResolver extends AbstractDataSchemaResolver
   /**
    * Return the current schema file directory name for schemas location
    */
+  @SuppressWarnings("deprecation")
   public SchemaDirectoryName getSchemasDirectoryName()
   {
-    return _schemasDirectoryName;
+    assert(getSchemaDirectories().size() == 1);
+    return getSchemaDirectories().get(0);
   }
 
   /**
@@ -201,10 +197,12 @@ public class FileDataSchemaResolver extends AbstractDataSchemaResolver
    * If not set Defaults to {@link SchemaDirectoryName#PEGASUS}
    *
    * @param schemasDirectoryName schema directory name.
+   * @deprecated Use {@link #setSchemaDirectories(List)} instead.
    */
+  @Deprecated
   void setSchemasDirectoryName(SchemaDirectoryName schemasDirectoryName)
   {
-    _schemasDirectoryName = schemasDirectoryName;
+    setSchemaDirectories(Collections.singletonList(schemasDirectoryName));
   }
 
   /**
@@ -240,10 +238,10 @@ public class FileDataSchemaResolver extends AbstractDataSchemaResolver
     }
     final String transformedName = name;
 
-    return new AbstractIterator(_paths)
+    return new AbstractPathAndSchemaDirectoryIterator(_paths, getSchemaDirectories())
     {
       @Override
-      protected DataSchemaLocation transform(String path)
+      protected DataSchemaLocation transform(String path, SchemaDirectoryName schemaDirectoryName)
       {
         boolean isJar = path.endsWith(JAR_EXTENSION);
         if (isJar)
@@ -264,7 +262,7 @@ public class FileDataSchemaResolver extends AbstractDataSchemaResolver
           StringBuilder builder = new StringBuilder();
           // within a JAR file, files are treated as resources. Thus, we should lookup using the resource separator
           // character, which is '/'
-          builder.append(_schemasDirectoryName.getName())
+          builder.append(schemaDirectoryName.getName())
               .append('/')
               .append(transformedName.replace(File.separatorChar, '/'));
           return new InJarFileDataSchemaLocation(jarFile, builder.toString());

--- a/data/src/main/java/com/linkedin/data/schema/resolver/MultiFormatDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/MultiFormatDataSchemaResolver.java
@@ -66,7 +66,7 @@ public class MultiFormatDataSchemaResolver extends AbstractMultiFormatDataSchema
   public MultiFormatDataSchemaResolver(
       String resolverPath,
       List<DataSchemaParserFactory> parsersForFormats,
-      List<SchemaDirectoryName> schemaDirectories)
+      List<SchemaDirectory> schemaDirectories)
   {
     for (DataSchemaParserFactory parserForFormat: parsersForFormats)
     {

--- a/data/src/main/java/com/linkedin/data/schema/resolver/MultiFormatDataSchemaResolver.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/MultiFormatDataSchemaResolver.java
@@ -17,6 +17,7 @@
 package com.linkedin.data.schema.resolver;
 
 import com.linkedin.data.schema.DataSchemaParserFactory;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -50,11 +51,30 @@ public class MultiFormatDataSchemaResolver extends AbstractMultiFormatDataSchema
       String resolverPath,
       List<DataSchemaParserFactory> parsersForFormats)
   {
+    this(resolverPath, parsersForFormats, Collections.singletonList(SchemaDirectoryName.PEGASUS));
+  }
+
+  /**
+   * Initializes a new resolver with a specific set of file format parsers.  Use @{link withBuiltinFormats}
+   * instead to initialize with the default file format parsers.
+   *
+   * @param resolverPath provides the search paths separated by the provided separator, or null for no search paths.
+   * @param parsersForFormats provides a list of parser factories, one for each file format (e.g. PDSC, PDL)
+   *                          this resolver supports.
+   * @param schemaDirectories List of schema directories to use for resolving schemas.
+   */
+  public MultiFormatDataSchemaResolver(
+      String resolverPath,
+      List<DataSchemaParserFactory> parsersForFormats,
+      List<SchemaDirectoryName> schemaDirectories)
+  {
     for (DataSchemaParserFactory parserForFormat: parsersForFormats)
     {
       FileDataSchemaResolver resolver = new FileDataSchemaResolver(parserForFormat, resolverPath, this);
       resolver.setExtension("." + parserForFormat.getLanguageExtension());
+      resolver.setSchemaDirectories(schemaDirectories);
       addResolver(resolver);
     }
+    setSchemaDirectories(schemaDirectories);
   }
 }

--- a/data/src/main/java/com/linkedin/data/schema/resolver/SchemaDirectory.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/SchemaDirectory.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2020 LinkedIn Corp.
+   Copyright (c) 2021 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/data/src/main/java/com/linkedin/data/schema/resolver/SchemaDirectory.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/SchemaDirectory.java
@@ -17,31 +17,23 @@
 package com.linkedin.data.schema.resolver;
 
 /**
- * Directories within resource jar file that holds different types of pegasus schemas. Ex. Data or Extensions
+ * Represents a schema directory relative to the resolver path (directory or Jar file). This is used to customize
+ * schema resolvers to limit which directories are used for resolving schema references.
  *
- * @author Aman Gupta
+ * @author Karthik Balasubramanian
  */
-public enum SchemaDirectoryName implements SchemaDirectory
+public interface SchemaDirectory
 {
   /**
-   * Directory holds the pegasus schemas. Pegasus parsers and resolvers look for pegasus
-   * files(*.pdl, *.pdsc) only within this directory.
+   * Return the schema directory name.
    */
-  PEGASUS("pegasus"),
+  String getName();
+
   /**
-   * Directory holds the Entity Relationship pegasus schemas.
-   * Pegasus Extensions schema parsers and resolvers look for pegasus files(*.pdl) only within this directory.
+   * Checks if the given jar file path starts with this schema directory name.
    */
-  EXTENSIONS("extensions");
-
-  private String _name;
-
-  SchemaDirectoryName(String name)
+  default boolean matchesJarFilePath(String path)
   {
-    _name = name;
-  }
-
-  public String getName() {
-    return _name;
+    return path.startsWith(getName() + "/");
   }
 }

--- a/data/src/main/java/com/linkedin/data/schema/resolver/SchemaDirectoryName.java
+++ b/data/src/main/java/com/linkedin/data/schema/resolver/SchemaDirectoryName.java
@@ -21,27 +21,49 @@ package com.linkedin.data.schema.resolver;
  *
  * @author Aman Gupta
  */
-public enum SchemaDirectoryName
+public interface SchemaDirectoryName
 {
-  /**
-   * Directory holds the pegasus schemas. Pegasus parsers and resolvers look for pegasus
-   * files(*.pdl, *.pdsc) only within this directory.
-   */
-  PEGASUS("pegasus"),
-  /**
-   * Directory holds the Entity Relationship pegasus schemas.
-   * Pegasus Extensions schema parsers and resolvers look for pegasus files(*.pdl) only within this directory.
-   */
-  EXTENSIONS("extensions");
+  SchemaDirectoryName PEGASUS = BuiltInSchemaDirectory.PEGASUS;
+  SchemaDirectoryName EXTENSIONS = BuiltInSchemaDirectory.EXTENSIONS;
 
-  private String _name;
+  /**
+   * Return the schema directory name.
+   */
+  String getName();
 
-  SchemaDirectoryName(String name)
+  enum BuiltInSchemaDirectory implements SchemaDirectoryName
   {
-    _name = name;
+    /**
+     * Directory holds the pegasus schemas. Pegasus parsers and resolvers look for pegasus
+     * files(*.pdl, *.pdsc) only within this directory.
+     */
+    PEGASUS("pegasus"),
+    /**
+     * Directory holds the Entity Relationship pegasus schemas.
+     * Pegasus Extensions schema parsers and resolvers look for pegasus files(*.pdl) only within this directory.
+     */
+    EXTENSIONS("extensions");
+
+    private final String _name;
+
+    BuiltInSchemaDirectory(String name)
+    {
+      _name = name;
+    }
+
+
+    @Override
+    public String getName()
+    {
+      return _name;
+    }
   }
 
-  public String getName() {
-    return _name;
+  /**
+   * Checks if the given jar file path starts with this schema directory name.
+   */
+  default boolean matchesJarFilePath(String path)
+  {
+    return path.startsWith(getName() + "/");
   }
 }

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
@@ -113,7 +113,7 @@ public class TestDataSchemaResolver
       return new AbstractPathAndSchemaDirectoryIterator(_paths, Collections.singletonList(SchemaDirectoryName.PEGASUS))
       {
         @Override
-        protected DataSchemaLocation transform(String path, SchemaDirectoryName schemaDirectoryName)
+        protected DataSchemaLocation transform(String path, SchemaDirectory schemaDirectoryName)
         {
           return new MapResolverLocation(path + File.separator + transformedName);
         }
@@ -991,13 +991,13 @@ public class TestDataSchemaResolver
 
   static class TestIterator extends AbstractDataSchemaResolver.AbstractPathAndSchemaDirectoryIterator
   {
-    TestIterator(Iterable<String> iterable, List<SchemaDirectoryName> schemaDirectories)
+    TestIterator(Iterable<String> iterable, List<SchemaDirectory> schemaDirectories)
     {
       super(iterable, schemaDirectories);
     }
 
     @Override
-    protected DataSchemaLocation transform(String path, SchemaDirectoryName schemaDirectory)
+    protected DataSchemaLocation transform(String path, SchemaDirectory schemaDirectory)
     {
       return () -> new File(schemaDirectory.getName() + "/" + path);
     }

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestDataSchemaResolver.java
@@ -49,6 +49,7 @@ import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -109,10 +110,10 @@ public class TestDataSchemaResolver
     {
       final String transformedName = name.replace('.', File.separatorChar) + _extension;
 
-      return new AbstractIterator(_paths)
+      return new AbstractPathAndSchemaDirectoryIterator(_paths, Collections.singletonList(SchemaDirectoryName.PEGASUS))
       {
         @Override
-        protected DataSchemaLocation transform(String path)
+        protected DataSchemaLocation transform(String path, SchemaDirectoryName schemaDirectoryName)
         {
           return new MapResolverLocation(path + File.separator + transformedName);
         }
@@ -200,37 +201,37 @@ public class TestDataSchemaResolver
         "referrer",
         FOUND,
         "\"name\" : \"referrer\"",
-        buildSystemIndependentPath("referrer.pdsc").toString()
+        buildSystemIndependentPath("referrer.pdsc")
       },
       {
         "x.y.z",
         FOUND,
         "\"size\" : 7",
-        buildSystemIndependentPath("x", "y", "z.pdsc").toString()
+        buildSystemIndependentPath("x", "y", "z.pdsc")
       },
       {
         "foo",
         FOUND,
         "\"size\" : 4",
-        buildSystemIndependentPath("foo.pdsc").toString()
+        buildSystemIndependentPath("foo.pdsc")
       },
       {
         "bar",
         FOUND,
         "\"size\" : 5",
-        buildSystemIndependentPath("bar.pdsc").toString()
+        buildSystemIndependentPath("bar.pdsc")
       },
       {
         "baz",
         FOUND,
         "\"size\" : 6",
-        buildSystemIndependentPath("baz.pdsc").toString()
+        buildSystemIndependentPath("baz.pdsc")
       },
       {
         "circular1",
         FOUND,
         "\"name\" : \"circular1\"",
-        buildSystemIndependentPath("circular1.pdsc").toString()
+        buildSystemIndependentPath("circular1.pdsc")
       },
       {
         "apple",
@@ -864,6 +865,31 @@ public class TestDataSchemaResolver
   }
 
   @Test
+  public void testClasspathResourceDataSchemaResolverMultipleSchemaDirectories()
+  {
+    // Tests for data schemas
+    ClasspathResourceDataSchemaResolver resolver = new ClasspathResourceDataSchemaResolver(
+        Thread.currentThread().getContextClassLoader(),
+        Arrays.asList(SchemaDirectoryName.EXTENSIONS, SchemaDirectoryName.PEGASUS)
+    );
+    PegasusSchemaParser parser = new SchemaParser(resolver);
+
+    final List<String> expectedSchemas = new ArrayList<>();
+    Collections.addAll(expectedSchemas, "com.linkedin.data.schema.ValidationDemo",
+        "com.linkedin.restli.example.Album",
+        "com.linkedin.restli.example.AlbumExtensions",
+        "com.linkedin.restli.example.FruitsPdl",
+        "com.linkedin.data.schema.RecordWithPdlReference");
+
+    for (String expectedSchemaName : expectedSchemas)
+    {
+      final DataSchema existSchema = parser.lookupName(expectedSchemaName);
+      assertNotNull(existSchema, "Failed parsing : " + expectedSchemaName);
+      assertEquals(((NamedDataSchema) existSchema).getFullName(), expectedSchemaName);
+    }
+  }
+
+  @Test
   public void testAddBadLocation()
   {
     MapDataSchemaResolver resolver = new MapDataSchemaResolver(SchemaParserFactory.instance(), _testPaths, _testSchemas);
@@ -940,6 +966,40 @@ public class TestDataSchemaResolver
       {
         assertTrue(false);
       }
+    }
+  }
+
+  @Test
+  public void testPathAndSchemaDirectoryIterator() throws Exception
+  {
+    List<String> paths = Arrays.asList("path1", "path2");
+    Iterator<DataSchemaLocation> iterator = new TestIterator(
+        paths, Arrays.asList(SchemaDirectoryName.PEGASUS, SchemaDirectoryName.EXTENSIONS));
+
+    List<String> expected = Arrays.asList("pegasus/path1", "extensions/path1", "pegasus/path2", "extensions/path2");
+    List<String> actualList = new ArrayList<>();
+    iterator.forEachRemaining(location -> actualList.add(location.getSourceFile().getPath()));
+
+    Assert.assertEquals(actualList, expected);
+
+    iterator = new TestIterator(paths, Collections.emptyList());
+    assertFalse(iterator.hasNext());
+
+    iterator = new TestIterator(Collections.emptyList(), Collections.singletonList(SchemaDirectoryName.EXTENSIONS));
+    assertFalse(iterator.hasNext());
+  }
+
+  static class TestIterator extends AbstractDataSchemaResolver.AbstractPathAndSchemaDirectoryIterator
+  {
+    TestIterator(Iterable<String> iterable, List<SchemaDirectoryName> schemaDirectories)
+    {
+      super(iterable, schemaDirectories);
+    }
+
+    @Override
+    protected DataSchemaLocation transform(String path, SchemaDirectoryName schemaDirectory)
+    {
+      return () -> new File(schemaDirectory.getName() + "/" + path);
     }
   }
 }

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestExtensionsDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestExtensionsDataSchemaResolver.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
  *
  * @author Aman Gupta
  */
+@SuppressWarnings("deprecation")
 public class TestExtensionsDataSchemaResolver
 {
   // Mapping of JAR entry names (resource names) to the content to be written at that entry

--- a/data/src/test/java/com/linkedin/data/schema/resolver/TestFileDataSchemaResolver.java
+++ b/data/src/test/java/com/linkedin/data/schema/resolver/TestFileDataSchemaResolver.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.JarOutputStream;
@@ -60,10 +61,11 @@ public class TestFileDataSchemaResolver
 
   /**
    * Ensures that the resolver only detects schemas packaged under the default root 'pegasus'
-   * or {@link FileDataSchemaResolver#getSchemasDirectoryName()} directory in data template JARs.
+   * or {@link FileDataSchemaResolver#getSchemaDirectories()} list of directories in data template JARs.
    * Any schemas placed at the root or under some alternative root directory should be ignored by the resolver.
    */
   @Test
+  @SuppressWarnings("deprecation")
   public void testJarResolution() throws IOException
   {
     FileDataSchemaResolver resolver = new FileDataSchemaResolver(PdlSchemaParserFactory.instance(), _tempJar.getCanonicalPath());
@@ -79,6 +81,21 @@ public class TestFileDataSchemaResolver
 
     // Assert that schemas are resolved from provided directory path
     resolver.setSchemasDirectoryName(SchemaDirectoryName.EXTENSIONS);
+    schema = resolver.findDataSchema("com.example.models.FooExtension", new StringBuilder());
+    Assert.assertTrue(schema.getProperties().containsKey("legit"));
+
+    // Assert that alternative root directories are not searched
+    schema = resolver.findDataSchema("com.example.models.IgnoreAlternative", new StringBuilder());
+    Assert.assertNull(schema);
+
+    // Assert that the resolver doesn't search from the root
+    schema = resolver.findDataSchema("com.example.models.IgnoreRoot", new StringBuilder());
+    Assert.assertNull(schema);
+
+    // Assert that schemas are resolved from provided directory path when using list of schema directories
+    resolver = new FileDataSchemaResolver(PdlSchemaParserFactory.instance(), _tempJar.getCanonicalPath());
+    resolver.setExtension(".pdl");
+    resolver.setSchemaDirectories(Collections.singletonList(SchemaDirectoryName.EXTENSIONS));
     schema = resolver.findDataSchema("com.example.models.FooExtension", new StringBuilder());
     Assert.assertTrue(schema.getProperties().containsKey("legit"));
 

--- a/data/src/test/resources/extensions/com/linkedin/restli/example/AlbumExtensions.pdl
+++ b/data/src/test/resources/extensions/com/linkedin/restli/example/AlbumExtensions.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.restli.example
+
+/**
+ * Extensions for album
+ */
+record AlbumExtensions includes Album {
+  locations: array[string]
+}

--- a/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
@@ -44,7 +44,8 @@ import org.apache.commons.io.FilenameUtils;
 
 
 /**
- * Combines multiple file format specific parsers into a single parser for ".pdsc" and ".pdl" files.
+ * Combines multiple file format specific parsers into a single parser for ".pdsc" and ".pdl" files. Use {@link Builder}
+ * to create instances of this parser.
  *
  * @author Joe Betz
  */
@@ -309,6 +310,15 @@ public class DataSchemaParser
     public Builder(String resolverPath)
     {
       _resolverPath = resolverPath;
+    }
+
+    /**
+     * Create a new instance of the builder.
+     * @param resolverPath Resolver path to use for resolving schema references.
+     */
+    public static Builder newBuilder(String resolverPath)
+    {
+      return new Builder(resolverPath);
     }
 
     /**

--- a/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/DataSchemaParser.java
@@ -24,6 +24,7 @@ import com.linkedin.data.schema.resolver.AbstractMultiFormatDataSchemaResolver;
 import com.linkedin.data.schema.resolver.FileDataSchemaLocation;
 import com.linkedin.data.schema.resolver.InJarFileDataSchemaLocation;
 import com.linkedin.data.schema.resolver.MultiFormatDataSchemaResolver;
+import com.linkedin.data.schema.resolver.SchemaDirectory;
 import com.linkedin.data.schema.resolver.SchemaDirectoryName;
 import com.linkedin.util.FileUtil;
 import java.io.File;
@@ -96,8 +97,8 @@ public class DataSchemaParser
 
   private DataSchemaParser(String resolverPath,
       List<DataSchemaParserFactory> parserFactoriesForFormats,
-      List<SchemaDirectoryName> sourceDirectories,
-      List<SchemaDirectoryName> resolverDirectories)
+      List<SchemaDirectory> sourceDirectories,
+      List<SchemaDirectory> resolverDirectories)
   {
     _parserByFileExtension = new HashMap<>();
     _resolverPath = resolverPath;
@@ -207,7 +208,7 @@ public class DataSchemaParser
 
   private void init(AbstractMultiFormatDataSchemaResolver resolver,
       List<DataSchemaParserFactory> parserFactoriesForFormats,
-      List<SchemaDirectoryName> sourceDirectories)
+      List<SchemaDirectory> sourceDirectories)
   {
     for (DataSchemaParserFactory parserForFormat : parserFactoriesForFormats)
     {
@@ -302,8 +303,8 @@ public class DataSchemaParser
   {
     private final String _resolverPath;
     private List<DataSchemaParserFactory> _parserFactoriesForFormats = AbstractMultiFormatDataSchemaResolver.BUILTIN_FORMAT_PARSER_FACTORIES;
-    private List<SchemaDirectoryName> _sourceDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
-    private List<SchemaDirectoryName> _resolverDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
+    private List<SchemaDirectory> _sourceDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
+    private List<SchemaDirectory> _resolverDirectories = Collections.singletonList(SchemaDirectoryName.PEGASUS);
 
     public Builder(String resolverPath)
     {
@@ -323,7 +324,7 @@ public class DataSchemaParser
     /**
      * Set the schema directories to use for parsing source schema files.
      */
-    public Builder setSourceDirectories(List<SchemaDirectoryName> sourceDirectories)
+    public Builder setSourceDirectories(List<SchemaDirectory> sourceDirectories)
     {
       _sourceDirectories = sourceDirectories;
       return this;
@@ -332,7 +333,7 @@ public class DataSchemaParser
     /**
      * Set the schema directories to use for resolving referenced schemas.
      */
-    public Builder setResolverDirectories(List<SchemaDirectoryName> resolverDirectories)
+    public Builder setResolverDirectories(List<SchemaDirectory> resolverDirectories)
     {
       _resolverDirectories = resolverDirectories;
       return this;

--- a/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/FileFormatDataSchemaParser.java
@@ -24,6 +24,7 @@ import com.linkedin.data.schema.NamedDataSchema;
 import com.linkedin.data.schema.PegasusSchemaParser;
 import com.linkedin.data.schema.resolver.FileDataSchemaLocation;
 import com.linkedin.data.schema.resolver.InJarFileDataSchemaLocation;
+import com.linkedin.data.schema.resolver.SchemaDirectory;
 import com.linkedin.data.schema.resolver.SchemaDirectoryName;
 import com.linkedin.util.FileUtil;
 
@@ -51,7 +52,7 @@ public class FileFormatDataSchemaParser
   static final String SCHEMA_PATH_PREFIX = SchemaDirectoryName.PEGASUS.getName() + "/";
   private final DataSchemaResolver _schemaResolver;
   private final DataSchemaParserFactory _schemaParserFactory;
-  private final List<SchemaDirectoryName> _sourceDirectories;
+  private final List<SchemaDirectory> _sourceDirectories;
 
   public FileFormatDataSchemaParser(String resolverPath, DataSchemaResolver schemaResolver, DataSchemaParserFactory schemaParserFactory)
   {
@@ -59,7 +60,7 @@ public class FileFormatDataSchemaParser
   }
 
   public FileFormatDataSchemaParser(DataSchemaResolver schemaResolver,
-      DataSchemaParserFactory schemaParserFactory, List<SchemaDirectoryName> sourceDirectories)
+      DataSchemaParserFactory schemaParserFactory, List<SchemaDirectory> sourceDirectories)
   {
     _schemaResolver = schemaResolver;
     _schemaParserFactory = schemaParserFactory;
@@ -157,9 +158,9 @@ public class FileFormatDataSchemaParser
 
   private boolean shouldParseFile(String path)
   {
-    for (SchemaDirectoryName schemaDirectoryName : _sourceDirectories)
+    for (SchemaDirectory schemaDirectory : _sourceDirectories)
     {
-      if (schemaDirectoryName.matchesJarFilePath(path))
+      if (schemaDirectory.matchesJarFilePath(path))
       {
         return true;
       }

--- a/generator/src/main/java/com/linkedin/pegasus/generator/PegasusDataTemplateGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/PegasusDataTemplateGenerator.java
@@ -126,7 +126,7 @@ public class PegasusDataTemplateGenerator
       String targetDirectoryPath, String[] sources, boolean generateLowercasePath, boolean generateFieldMask)
       throws IOException
   {
-    final DataSchemaParser schemaParser = new DataSchemaParser(resolverPath);
+    final DataSchemaParser schemaParser = new DataSchemaParser.Builder(resolverPath).build();
     final TemplateSpecGenerator specGenerator = new TemplateSpecGenerator(schemaParser.getSchemaResolver());
     JavaDataTemplateGenerator.Config config = new JavaDataTemplateGenerator.Config();
     config.setDefaultPackage(defaultPackage);

--- a/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
+++ b/generator/src/test/java/com/linkedin/pegasus/generator/TestDataSchemaParser.java
@@ -19,6 +19,7 @@ package com.linkedin.pegasus.generator;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaLocation;
 import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.resolver.SchemaDirectory;
 import com.linkedin.data.schema.resolver.SchemaDirectoryName;
 import java.io.File;
 import java.io.FileInputStream;
@@ -105,7 +106,7 @@ public class TestDataSchemaParser
   {
     String tempDirectoryPath = _tempDir.getAbsolutePath();
     String jarFile = tempDirectoryPath + FS + "test.jar";
-    SchemaDirectoryName customSchemaDirectory = () -> "custom";
+    SchemaDirectory customSchemaDirectory = () -> "custom";
     String pegasusFile = TEST_RESOURCES_DIR + FS + pegasusFilename;
     String pegasusFileInJar = customSchemaDirectory.getName() + "/" + pegasusFilename;
     createTempJarFile(Collections.singletonMap(pegasusFile, pegasusFileInJar), jarFile);
@@ -136,16 +137,16 @@ public class TestDataSchemaParser
     String tempDirectoryPath = _tempDir.getAbsolutePath();
     String jarFile = tempDirectoryPath + FS + "test.jar";
     String schemaDir = TEST_RESOURCES_DIR + FS + "extensionSchemas";
-    SchemaDirectoryName customSchemaDirectory = () -> "custom";
+    SchemaDirectory customSchemaDirectory = () -> "custom";
     Map<String, String> entryToFileMap = new HashMap<>();
     // FooExtensions is in "extensions" directory and references "Foo" from "custom" directory.
     entryToFileMap.put(schemaDir + FS + "pegasus/Foo.pdl", "custom/Foo.pdl");
     entryToFileMap.put(schemaDir + FS + "extensions/FooExtensions.pdl", "extensions/FooExtensions.pdl");
     createTempJarFile(entryToFileMap, jarFile);
 
-    List<SchemaDirectoryName> resolverDirectories = Arrays.asList(
+    List<SchemaDirectory> resolverDirectories = Arrays.asList(
         SchemaDirectoryName.EXTENSIONS, customSchemaDirectory);
-    List<SchemaDirectoryName> sourceDirectories = Collections.singletonList(SchemaDirectoryName.EXTENSIONS);
+    List<SchemaDirectory> sourceDirectories = Collections.singletonList(SchemaDirectoryName.EXTENSIONS);
     DataSchemaParser parser = new DataSchemaParser.Builder(jarFile)
         .setResolverDirectories(resolverDirectories)
         .setSourceDirectories(sourceDirectories)
@@ -219,9 +220,9 @@ public class TestDataSchemaParser
         filename -> filename));
     createTempJarFile(entryToFileMap, jarFile);
 
-    List<SchemaDirectoryName> resolverDirectories = Arrays.asList(
+    List<SchemaDirectory> resolverDirectories = Arrays.asList(
         SchemaDirectoryName.EXTENSIONS, SchemaDirectoryName.PEGASUS);
-    List<SchemaDirectoryName> sourceDirectories = Collections.singletonList(SchemaDirectoryName.EXTENSIONS);
+    List<SchemaDirectory> sourceDirectories = Collections.singletonList(SchemaDirectoryName.EXTENSIONS);
     DataSchemaParser parser = new DataSchemaParser.Builder(jarFile)
         .setResolverDirectories(resolverDirectories)
         .setSourceDirectories(sourceDirectories)
@@ -246,9 +247,9 @@ public class TestDataSchemaParser
     String resolverPath = pegasusWithFS + "extensionSchemas/extensions:"
         + pegasusWithFS + "extensionSchemas/others:"
         + pegasusWithFS + "extensionSchemas/pegasus";
-    List<SchemaDirectoryName> resolverDirectories = Arrays.asList(
+    List<SchemaDirectory> resolverDirectories = Arrays.asList(
         SchemaDirectoryName.EXTENSIONS, SchemaDirectoryName.PEGASUS);
-    List<SchemaDirectoryName> sourceDirectories = Collections.singletonList(SchemaDirectoryName.EXTENSIONS);
+    List<SchemaDirectory> sourceDirectories = Collections.singletonList(SchemaDirectoryName.EXTENSIONS);
     DataSchemaParser parser = new DataSchemaParser.Builder(resolverPath)
         .setResolverDirectories(resolverDirectories)
         .setSourceDirectories(sourceDirectories)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.15
+version=29.20.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.20.0
+version=29.19.15
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.15
+version=29.19.16
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/annotation/SchemaAnnotationValidatorCmdLineApp.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/annotation/SchemaAnnotationValidatorCmdLineApp.java
@@ -159,7 +159,7 @@ public class SchemaAnnotationValidatorCmdLineApp
 
   private static List<DataSchema> parseSchemas(String resolverPath, String modelsLocation) throws IOException
   {
-    DataSchemaParser dataSchemaParser = new DataSchemaParser(resolverPath);
+    DataSchemaParser dataSchemaParser = new DataSchemaParser.Builder(resolverPath).build();
     DataSchemaParser.ParseResult parsedSources = dataSchemaParser.parseSources(new String[]{modelsLocation});
 
     Map<DataSchema, DataSchemaLocation> schemaLocations = parsedSources.getSchemaAndLocations();

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/data/SchemaFormatTranslator.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/data/SchemaFormatTranslator.java
@@ -206,7 +206,7 @@ public class SchemaFormatTranslator
   private Map<String, SchemaInfo> getTopLevelSchemaToTranslatedSchemaMap() throws IOException
   {
     Map<String, SchemaInfo> topLevelTranslatedSchemas = new HashMap<>();
-    DataSchemaParser dataSchemaParser = new DataSchemaParser(_resolverPath);
+    DataSchemaParser dataSchemaParser = new DataSchemaParser.Builder(_resolverPath).build();
     DataSchemaParser.ParseResult parsedSources = dataSchemaParser.parseSources(
         new String[]{_sourceDir.getAbsolutePath()});
 

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/clientgen/TestRequestBuilderSpecGenerator.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/clientgen/TestRequestBuilderSpecGenerator.java
@@ -75,7 +75,7 @@ public class TestRequestBuilderSpecGenerator
 
   private Set<BuilderSpec> generateBuilderSpec(String[] sources)
   {
-    final DataSchemaParser schemaParser = new DataSchemaParser(RESOLVER_DIR);
+    final DataSchemaParser schemaParser = new DataSchemaParser.Builder(RESOLVER_DIR).build();
     final TemplateSpecGenerator specGenerator = new TemplateSpecGenerator(schemaParser.getSchemaResolver());
     final RestSpecParser parser = new RestSpecParser();
     final Map<ResourceMethod, String> builderBaseMap = new HashMap<>();


### PR DESCRIPTION
This change also introduces the concept of "source" and "resolver"
directories when creating a `DataSchemaParser`. "Source" directories are
used to parse/load the input schemas, while the "resolver" directories
will only be used for resolving referenced schemas.