### PR TITLE
Optimize in-process request execution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.19.15] - 2021-08-09
+- Provide the ability to set cookies and projection params in request context's local attributes to avoid
+serializing/deserializing them for requests that are executed in-process.
+
 ## [29.19.14] - 2021-07-29
 - Bump netty version to use ALPN support needed for JDK8u282.
 
@@ -5035,7 +5039,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.14...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.19.15...master
+[29.19.15]: https://github.com/linkedin/rest.li/compare/v29.19.14...v29.19.15
 [29.19.14]: https://github.com/linkedin/rest.li/compare/v29.19.13...v29.19.14
 [29.19.13]: https://github.com/linkedin/rest.li/compare/v29.19.12...v29.19.13
 [29.19.12]: https://github.com/linkedin/rest.li/compare/v29.19.11...v29.19.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.19.14
+version=29.19.15
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/ResourceContextImpl.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/ResourceContextImpl.java
@@ -45,6 +45,7 @@ import com.linkedin.restli.internal.common.URIParamUtils;
 import com.linkedin.restli.internal.server.util.ArgumentUtils;
 import com.linkedin.restli.internal.server.util.MIMEParse;
 import com.linkedin.restli.internal.server.util.RestLiSyntaxException;
+import com.linkedin.restli.server.LocalRequestProjectionMask;
 import com.linkedin.restli.server.ProjectionMode;
 import com.linkedin.restli.server.RestLiResponseAttachments;
 import com.linkedin.restli.server.RestLiServiceException;
@@ -139,6 +140,7 @@ public class ResourceContextImpl implements ServerResourceContext
    * @throws RestLiSyntaxException if the syntax of query parameters in the request is
    *           incorrect
    */
+  @SuppressWarnings("unchecked")
   public ResourceContextImpl(final MutablePathKeys pathKeys,
                              final Request request,
                              final RequestContext requestContext) throws RestLiSyntaxException
@@ -148,7 +150,17 @@ public class ResourceContextImpl implements ServerResourceContext
     _requestHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     _requestHeaders.putAll(request.getHeaders());
     _responseHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    _requestCookies = new ArrayList<>(CookieUtil.decodeCookies(_request.getCookies()));
+
+    List<HttpCookie> contextRequestCookies = (List<HttpCookie>) requestContext.getLocalAttr(CONTEXT_COOKIES_KEY);
+    if (contextRequestCookies != null)
+    {
+      _requestCookies = contextRequestCookies;
+    }
+    else
+    {
+      _requestCookies = CookieUtil.decodeCookies(_request.getCookies());
+    }
+
     _responseCookies = new ArrayList<>();
     _requestContext = requestContext;
     _responseAttachmentsAllowed = isResponseAttachmentsAllowed(request);
@@ -184,31 +196,42 @@ public class ResourceContextImpl implements ServerResourceContext
 
     TimingContextUtil.beginTiming(requestContext, FrameworkTimingKeys.SERVER_REQUEST_RESTLI_PROJECTION_DECODE.key());
 
-    if (_parameters.containsKey(RestConstants.FIELDS_PARAM))
+    LocalRequestProjectionMask localRequestProjectionMask =
+        (LocalRequestProjectionMask) requestContext.getLocalAttr(CONTEXT_PROJECTION_MASKS_KEY);
+    if (localRequestProjectionMask != null)
     {
-      _projectionMask = ArgumentUtils.parseProjectionParameter(getParameter(RestConstants.FIELDS_PARAM));
+      _projectionMask = localRequestProjectionMask.getProjectionMask();
+      _metadataProjectionMask = localRequestProjectionMask.getMetadataProjectionMask();
+      _pagingProjectionMask = localRequestProjectionMask.getPagingProjectionMask();
     }
     else
     {
-      _projectionMask = null;
-    }
+      if (_parameters.containsKey(RestConstants.FIELDS_PARAM))
+      {
+        _projectionMask = ArgumentUtils.parseProjectionParameter(getParameter(RestConstants.FIELDS_PARAM));
+      }
+      else
+      {
+        _projectionMask = null;
+      }
 
-    if (_parameters.containsKey(RestConstants.METADATA_FIELDS_PARAM))
-    {
-      _metadataProjectionMask = ArgumentUtils.parseProjectionParameter(getParameter(RestConstants.METADATA_FIELDS_PARAM));
-    }
-    else
-    {
-      _metadataProjectionMask = null;
-    }
+      if (_parameters.containsKey(RestConstants.METADATA_FIELDS_PARAM))
+      {
+        _metadataProjectionMask = ArgumentUtils.parseProjectionParameter(getParameter(RestConstants.METADATA_FIELDS_PARAM));
+      }
+      else
+      {
+        _metadataProjectionMask = null;
+      }
 
-    if (_parameters.containsKey(RestConstants.PAGING_FIELDS_PARAM))
-    {
-      _pagingProjectionMask = ArgumentUtils.parseProjectionParameter(getParameter(RestConstants.PAGING_FIELDS_PARAM));
-    }
-    else
-    {
-      _pagingProjectionMask = null;
+      if (_parameters.containsKey(RestConstants.PAGING_FIELDS_PARAM))
+      {
+        _pagingProjectionMask = ArgumentUtils.parseProjectionParameter(getParameter(RestConstants.PAGING_FIELDS_PARAM));
+      }
+      else
+      {
+        _pagingProjectionMask = null;
+      }
     }
 
     TimingContextUtil.endTiming(requestContext, FrameworkTimingKeys.SERVER_REQUEST_RESTLI_PROJECTION_DECODE.key());
@@ -225,14 +248,8 @@ public class ResourceContextImpl implements ServerResourceContext
     final String acceptTypeHeader = request.getHeader(RestConstants.HEADER_ACCEPT);
     if (acceptTypeHeader != null)
     {
-      final List<String> acceptTypes = MIMEParse.parseAcceptType(acceptTypeHeader);
-      for (final String acceptType : acceptTypes)
-      {
-        if (acceptType.equalsIgnoreCase(RestConstants.HEADER_VALUE_MULTIPART_RELATED))
-        {
-          return true;
-        }
-      }
+      return MIMEParse.parseAcceptTypeStream(acceptTypeHeader)
+          .anyMatch(acceptType -> acceptType.equalsIgnoreCase(RestConstants.HEADER_VALUE_MULTIPART_RELATED));
     }
     return false;
   }

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/ServerResourceContext.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/ServerResourceContext.java
@@ -28,6 +28,7 @@ import com.linkedin.entitystream.EntityStream;
 import com.linkedin.restli.common.ProtocolVersion;
 import com.linkedin.restli.common.ResourceMethod;
 import com.linkedin.restli.common.attachments.RestLiAttachmentReader;
+import com.linkedin.restli.server.LocalRequestProjectionMask;
 import com.linkedin.restli.server.ResourceContext;
 import com.linkedin.restli.server.RestLiServiceException;
 
@@ -46,6 +47,17 @@ import java.util.Set;
  */
 public interface ServerResourceContext extends ResourceContext
 {
+  /**
+   * Local attribute key for request cookies. Value should be a {@link List} of {@link HttpCookie} objects.
+   */
+  String CONTEXT_COOKIES_KEY = ServerResourceContext.class.getName() + ".cookie";
+
+  /**
+   * Local attribute key for projection masks. Value should be a
+   * {@link LocalRequestProjectionMask} instance.
+   */
+  String CONTEXT_PROJECTION_MASKS_KEY = ServerResourceContext.class.getName() + ".projectionMasks";
+
   /**
    * @return {@link DataMap} of request parameters.
    */

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/util/RestUtils.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/util/RestUtils.java
@@ -226,8 +226,7 @@ public class RestUtils
       }
 
       return MIMEParse.bestMatch(
-          Stream.concat(customMimeTypesSupported.stream(), RestConstants.SUPPORTED_MIME_TYPES.stream())
-              .collect(Collectors.toList()),
+          Stream.concat(customMimeTypesSupported.stream(), RestConstants.SUPPORTED_MIME_TYPES.stream()),
           acceptHeader);
     }
 

--- a/restli-server/src/main/java/com/linkedin/restli/server/LocalRequestProjectionMask.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/LocalRequestProjectionMask.java
@@ -1,0 +1,93 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.restli.server;
+
+import com.linkedin.data.transform.filter.request.MaskTree;
+import javax.annotation.Nullable;
+
+
+/**
+ * Encapsulates projection {@link MaskTree} that can be set in local attributes of
+ * {@link com.linkedin.r2.message.RequestContext} with the
+ * {@link com.linkedin.restli.internal.server.ServerResourceContext#CONTEXT_PROJECTION_MASKS_KEY}.
+ *
+ * <p>This enables a nifty performance optimization that avoids serializing and deserializing the projection
+ * masks for in-process request execution.</p>
+ */
+public class LocalRequestProjectionMask
+{
+  /**
+   * Projection mask for root entity.
+   */
+  @Nullable
+  private final MaskTree _projectionMask;
+
+  /**
+   * Projection mask for metadata.
+   */
+  @Nullable
+  private final MaskTree _metadataProjectionMask;
+
+  /**
+   * Projection mask for paging.
+   */
+  @Nullable
+  private final MaskTree _pagingProjectionMask;
+
+  /**
+   * Constructor
+   *
+   * @param projectionMask           Projection mask for root entity.
+   * @param metadataProjectionMask   Projection mask for metadata.
+   * @param pagingProjectionMask     Projection mask for paging.
+   */
+  public LocalRequestProjectionMask(@Nullable MaskTree projectionMask,
+      @Nullable MaskTree metadataProjectionMask,
+      @Nullable MaskTree pagingProjectionMask)
+  {
+    _projectionMask = projectionMask;
+    _metadataProjectionMask = metadataProjectionMask;
+    _pagingProjectionMask = pagingProjectionMask;
+  }
+
+  /**
+   * @return Projection mask for root entity.
+   */
+  @Nullable
+  public MaskTree getProjectionMask()
+  {
+    return _projectionMask;
+  }
+
+  /**
+   * @return Projection mask for root entity.
+   */
+  @Nullable
+  public MaskTree getMetadataProjectionMask()
+  {
+    return _metadataProjectionMask;
+  }
+
+  /**
+   * @return Projection mask for root entity.
+   */
+  @Nullable
+  public MaskTree getPagingProjectionMask()
+  {
+    return _pagingProjectionMask;
+  }
+}


### PR DESCRIPTION
Provide the ability to set cookies and projection params in request context's local attributes to avoid serializing/deserializing them for requests that are executed in-process.