### PR TITLE
Enable skipping request and response validation via the use of request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.21.1] - 2021-08-18
+- Enable skipping request and response validation via the use of request headers.
+
 ## [29.21.0] - 2021-08-17
 - Fixed relative load balancer executor schedule cancellation due to silent runtime exception.
 
@@ -5058,7 +5061,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.1...master
+[29.21.1]: https://github.com/linkedin/rest.li/compare/v29.21.0...v29.21.1
 [29.21.0]: https://github.com/linkedin/rest.li/compare/v29.20.1...v29.21.0
 [29.20.1]: https://github.com/linkedin/rest.li/compare/v29.20.0...v29.20.1
 [29.20.0]: https://github.com/linkedin/rest.li/compare/v29.19.17...v29.20.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.21.0
+version=29.21.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
@@ -61,6 +61,16 @@ public interface RestConstants
   String HEADER_SERVICE_SCOPED_PATH = "x-restli-service-scoped-path";
   String HEADER_FETCH_SYMBOL_TABLE = "x-restli-symbol-table-request";
 
+  /**
+   * This header if set to true will cause the validation filter to skip request validation.
+   */
+  String HEADER_SKIP_REQUEST_VALIDATION = "x-restli-skip-request-validation";
+
+  /**
+   * This header if set to true will cause the validation filter to skip response validation.
+   */
+  String HEADER_SKIP_RESPONSE_VALIDATION = "x-restli-skip-response-validation";
+
   // Default supported mime types.
   Set<String> SUPPORTED_MIME_TYPES = new LinkedHashSet<>(
       Arrays.asList(HEADER_VALUE_APPLICATION_LICOR_TEXT,

--- a/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
@@ -29,6 +29,7 @@ import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.common.PatchRequest;
 import com.linkedin.restli.common.ProtocolVersion;
 import com.linkedin.restli.common.ResourceMethod;
+import com.linkedin.restli.common.RestConstants;
 import com.linkedin.restli.common.UpdateEntityStatus;
 import com.linkedin.restli.common.util.ProjectionMaskApplier;
 import com.linkedin.restli.common.util.ProjectionMaskApplier.InvalidProjectionException;
@@ -141,6 +142,11 @@ public class RestLiValidationFilter implements Filter
           throw new RestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR, TEMPLATE_RUNTIME_EXCEPTION_MESSAGE);
         }
       }
+    }
+
+    if (!shouldValidateOnRequest(requestContext))
+    {
+      return CompletableFuture.completedFuture(null);
     }
 
     Class<?> resourceClass = requestContext.getFilterResourceModel().getResourceClass();
@@ -449,8 +455,22 @@ public class RestLiValidationFilter implements Filter
     }
   }
 
-  private boolean shouldValidateOnResponse(FilterRequestContext requestContext)
+  protected boolean shouldValidateOnRequest(FilterRequestContext requestContext)
   {
+    // Skip request validation if the header to skip request validation is set.
+    return !(Boolean.TRUE.toString().equals(
+        requestContext.getRequestHeaders().get(RestConstants.HEADER_SKIP_REQUEST_VALIDATION)));
+  }
+
+  protected boolean shouldValidateOnResponse(FilterRequestContext requestContext)
+  {
+    // Skip response validation if the header to skip response validation is set.
+    if (Boolean.TRUE.toString().equals(
+        requestContext.getRequestHeaders().get(RestConstants.HEADER_SKIP_RESPONSE_VALIDATION)))
+    {
+      return false;
+    }
+
     MaskTree projectionMask = requestContext.getProjectionMask();
 
     // Make sure the request is for one of the methods to be validated and has either null or a non-empty projection


### PR DESCRIPTION
This is useful if clients are doing validation or don't care about it.