### PR TITLE
Remove support for disabling request validation via headers since doing so can have dangerous side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.21.2] - 2021-08-18
+- Remove support for disabling request validation via headers since doing so can have dangerous side effects.
+
 ## [29.21.1] - 2021-08-18
 - Enable skipping request and response validation via the use of request headers.
 
@@ -5061,7 +5064,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.2...master
+[29.21.2]: https://github.com/linkedin/rest.li/compare/v29.21.1...v29.21.2
 [29.21.1]: https://github.com/linkedin/rest.li/compare/v29.21.0...v29.21.1
 [29.21.0]: https://github.com/linkedin/rest.li/compare/v29.20.1...v29.21.0
 [29.20.1]: https://github.com/linkedin/rest.li/compare/v29.20.0...v29.20.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.21.1
+version=29.21.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/RestConstants.java
@@ -62,11 +62,6 @@ public interface RestConstants
   String HEADER_FETCH_SYMBOL_TABLE = "x-restli-symbol-table-request";
 
   /**
-   * This header if set to true will cause the validation filter to skip request validation.
-   */
-  String HEADER_SKIP_REQUEST_VALIDATION = "x-restli-skip-request-validation";
-
-  /**
    * This header if set to true will cause the validation filter to skip response validation.
    */
   String HEADER_SKIP_RESPONSE_VALIDATION = "x-restli-skip-response-validation";

--- a/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/validation/RestLiValidationFilter.java
@@ -455,13 +455,17 @@ public class RestLiValidationFilter implements Filter
     }
   }
 
+  /**
+   * @return True to validate request, false otherwise.
+   */
   protected boolean shouldValidateOnRequest(FilterRequestContext requestContext)
   {
-    // Skip request validation if the header to skip request validation is set.
-    return !(Boolean.TRUE.toString().equals(
-        requestContext.getRequestHeaders().get(RestConstants.HEADER_SKIP_REQUEST_VALIDATION)));
+    return true;
   }
 
+  /**
+   * @return True to validate response, false otherwise.
+   */
   protected boolean shouldValidateOnResponse(FilterRequestContext requestContext)
   {
     // Skip response validation if the header to skip response validation is set.

--- a/restli-server/src/test/java/com/linkedin/restli/server/validation/TestRestLiValidationFilter.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/validation/TestRestLiValidationFilter.java
@@ -460,14 +460,20 @@ public class TestRestLiValidationFilter
   public void testSkipRequestValidation(ResourceModel resourceModel, ResourceMethod resourceMethod,
       RestLiRequestData restLiRequestData)
   {
-    when(filterRequestContext.getRequestHeaders()).thenReturn(
-        Collections.singletonMap(RestConstants.HEADER_SKIP_REQUEST_VALIDATION, "true"));
     when(filterRequestContext.getRequestData()).thenReturn(restLiRequestData);
     when(filterRequestContext.getMethodType()).thenReturn(resourceMethod);
     when(filterRequestContext.getFilterResourceModel()).thenReturn(new FilterResourceModelImpl(resourceModel));
     when(filterRequestContext.getRestliProtocolVersion()).thenReturn(AllProtocolVersions.LATEST_PROTOCOL_VERSION);
 
-    RestLiValidationFilter validationFilter = new RestLiValidationFilter(Collections.emptyList(), new MockValidationErrorHandler());
+    RestLiValidationFilter validationFilter =
+        new RestLiValidationFilter(Collections.emptyList(), new MockValidationErrorHandler())
+        {
+          @Override
+          protected boolean shouldValidateOnRequest(FilterRequestContext requestContext)
+          {
+            return false;
+          }
+        };
 
     try
     {


### PR DESCRIPTION
We still retain a hook for applications to override and disable request validation on a per-app basis using whatever logic they choose to implement.