### PR TITLE
Fix a bug in SmoothRateLimiter where getEvents will always return 0

### DIFF
--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/Rate.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/Rate.java
@@ -62,10 +62,18 @@ public class Rate
       _period = newPeriod;
 
     }
-    else
-    {
-      _events = events;
-      _period = period;
+    else {
+      // For events values lower than 1, adjust the period to prevent getEvents() from always returning 0
+      if (events < 1)
+      {
+        _period = period / events;
+        _events = 1;
+      }
+      else
+      {
+        _events = events;
+        _period = period;
+      }
     }
   }
 


### PR DESCRIPTION
When SmoothRateLimiter is supplied for a value that equates to less than 1 event per period, callers to getEvents will always receive 0. In theory this should be understood because of getEvents return type, but in practice this results in unexpected behavior.