### PR TITLE
DarkClusterConfig's dispatcherOutboundTargetRate: int -> float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.21.5] - 2021-08-31
+- DarkClusterConfig's dispatcherOutboundTargetRate: int -> float
+
 ## [29.21.4] - 2021-08-30
 - Expose an API to build a URI without query params. Expose a local attr for passing query params for in-process calls. 
 
@@ -5070,7 +5073,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.5...master
+[29.21.5]: https://github.com/linkedin/rest.li/compare/v29.21.4...v29.21.5
 [29.21.4]: https://github.com/linkedin/rest.li/compare/v29.21.3...v29.21.4
 [29.21.3]: https://github.com/linkedin/rest.li/compare/v29.21.2...v29.21.3
 [29.21.2]: https://github.com/linkedin/rest.li/compare/v29.21.1...v29.21.2

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
@@ -13,7 +13,7 @@ record DarkClusterConfig {
   /**
    * Desired query rate to be maintained to the dark cluster per dark cluster host by the CONSTANT_QPS strategy. Measured in qps.
    */
-  dispatcherOutboundTargetRate: int = 0
+  dispatcherOutboundTargetRate: float = 0
 
   /**
    * Number of requests to store in the circular buffer used for asynchronous dispatching by the CONSTANT_QPS strategy.

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
@@ -126,7 +126,7 @@ public class DarkClustersConverter
       if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE))
       {
         darkClusterConfig.setDispatcherOutboundTargetRate(
-            PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE), Integer.class));
+            PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE), Float.class));
       }
       else
       {

--- a/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
@@ -104,7 +104,7 @@ public class DarkClustersConverterTest
 
     DarkClusterConfig resultConfig = DarkClustersConverter.toConfig(DarkClustersConverter.toProperties(configMap)).get(DARK_CLUSTER_KEY);
     Assert.assertEquals(resultConfig.getMultiplier(), DARK_CLUSTER_DEFAULT_MULTIPLIER);
-    Assert.assertEquals((int)resultConfig.getDispatcherOutboundTargetRate(), DARK_CLUSTER_DEFAULT_TARGET_RATE);
+    Assert.assertEquals(resultConfig.getDispatcherOutboundTargetRate(), DARK_CLUSTER_DEFAULT_TARGET_RATE);
     Assert.assertEquals((int)resultConfig.getDispatcherMaxRequestsToBuffer(), DARK_CLUSTER_DEFAULT_MAX_REQUESTS_TO_BUFFER);
     Assert.assertEquals((int)resultConfig.getDispatcherBufferedRequestExpiryInSeconds(), DARK_CLUSTER_DEFAULT_BUFFERED_REQUEST_EXPIRY_IN_SECONDS);
     Assert.assertEquals(resultConfig.getDarkClusterStrategyPrioritizedList().size(), 1, "default strategy list should be size 1");

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/ConstantQpsDarkClusterStrategy.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/ConstantQpsDarkClusterStrategy.java
@@ -49,7 +49,7 @@ public class ConstantQpsDarkClusterStrategy implements DarkClusterStrategy
 {
   private final String _originalClusterName;
   private final String _darkClusterName;
-  private final Integer _darkClusterPerHostQps;
+  private final Float _darkClusterPerHostQps;
   private final BaseDarkClusterDispatcher _baseDarkClusterDispatcher;
   private final Notifier _notifier;
   private final ClusterInfoProvider _clusterInfoProvider;
@@ -59,7 +59,7 @@ public class ConstantQpsDarkClusterStrategy implements DarkClusterStrategy
   private static final int NUM_REQUESTS_TO_SEND_PER_RATE_LIMITER_CYCLE = 1;
 
   public ConstantQpsDarkClusterStrategy(@Nonnull String originalClusterName, @Nonnull String darkClusterName,
-      @Nonnull Integer darkClusterPerHostQps, @Nonnull BaseDarkClusterDispatcher baseDarkClusterDispatcher,
+      @Nonnull Float darkClusterPerHostQps, @Nonnull BaseDarkClusterDispatcher baseDarkClusterDispatcher,
       @Nonnull Notifier notifier, @Nonnull ClusterInfoProvider clusterInfoProvider, @Nonnull ConstantQpsRateLimiter rateLimiter)
   {
     _originalClusterName = originalClusterName;
@@ -132,7 +132,7 @@ public class ConstantQpsDarkClusterStrategy implements DarkClusterStrategy
       int numSourceClusterInstances = _clusterInfoProvider.getHttpsClusterCount(_originalClusterName);
       if (numSourceClusterInstances != 0)
       {
-        return (float) (numDarkClusterInstances * _darkClusterPerHostQps) / numSourceClusterInstances;
+        return (numDarkClusterInstances * _darkClusterPerHostQps) / numSourceClusterInstances;
       }
 
       return 0F;

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestConstantQpsDarkClusterStrategy.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestConstantQpsDarkClusterStrategy.java
@@ -60,6 +60,7 @@ public class TestConstantQpsDarkClusterStrategy
         {1000, 100, 10, 10},
         {1000, 150, 10, 10},
         {100, 200, 10, 10},
+        {1000, 9.5f, 400, 10},
         // now test typical case of differing qps with different instance sizes
         {1000, 100, 10, 1},
         {1000, 90, 10, 1},
@@ -74,7 +75,7 @@ public class TestConstantQpsDarkClusterStrategy
   }
 
   @Test(dataProvider = "qpsKeys")
-  public void testStrategy(int numIterations, int qps, int numSourceInstances, int numDarkInstances)
+  public void testStrategy(int numIterations, float qps, int numSourceInstances, int numDarkInstances)
   {
     IntStream.of(1, 1000, 1000000).forEach(capacity ->
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.21.4
+version=29.21.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
No reason this shouldn't be a float. This will support usecases with low qps.