### PR TITLE
ConstantQpsRateLimiter - Introduce randomness while maintaining constant per period rate

### DIFF
--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ConstantQpsRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ConstantQpsRateLimiter.java
@@ -16,9 +16,11 @@
 
 package com.linkedin.r2.transport.http.client;
 
+import com.linkedin.r2.transport.http.client.ratelimiter.Rate;
 import com.linkedin.r2.transport.http.client.ratelimiter.RateLimiterExecutionTracker;
 import com.linkedin.util.clock.Clock;
 import java.time.temporal.ChronoUnit;
+import java.util.Random;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -67,6 +69,7 @@ public class ConstantQpsRateLimiter extends SmoothRateLimiter
   private static class UnboundedRateLimiterExecutionTracker implements RateLimiterExecutionTracker
   {
     private final AtomicBoolean _paused = new AtomicBoolean(true);
+    private final Random _random = new Random();
 
     public int getPending()
     {
@@ -96,6 +99,11 @@ public class ConstantQpsRateLimiter extends SmoothRateLimiter
     public int getMaxBuffered()
     {
       return Integer.MAX_VALUE;
+    }
+
+    public int getNextExecutionDelay(Rate rate)
+    {
+      return _random.nextInt(Math.max(1, (int) (rate.getPeriodRaw() / rate.getEventsRaw())));
     }
   }
 }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
@@ -98,7 +98,6 @@ public class SmoothRateLimiter implements AsyncRateLimiter
    *                           dropping the request might not be backward compatible
    * @param rateLimiterName    Name assigned for logging purposes
    * @param executionTracker   Adjusts the behavior of the rate limiter based on policies/state of RateLimiterExecutionTracker
-
    */
   SmoothRateLimiter(ScheduledExecutorService scheduler, Executor executor, Clock clock, CallbackBuffer pendingCallbacks,
                     BufferOverflowMode bufferOverflowMode, String rateLimiterName, RateLimiterExecutionTracker executionTracker)
@@ -225,6 +224,7 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     private int _permitAvailableCount;
     private int _permitsInTimeFrame;
     private long _nextScheduled;
+    private boolean _wasDelayed;
 
     EventLoop(Clock clock)
     {
@@ -272,6 +272,13 @@ public class SmoothRateLimiter implements AsyncRateLimiter
 
       if (_permitAvailableCount > 0)
       {
+        if (!_wasDelayed)
+        {
+          _wasDelayed = true;
+          _scheduler.schedule(this::loop, _executionTracker.getNextExecutionDelay(_rate), TimeUnit.MILLISECONDS);
+          return;
+        }
+        _wasDelayed = false;
         _permitAvailableCount--;
         Callback<None> callback = null;
         try
@@ -408,6 +415,11 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     public int getMaxBuffered()
     {
       return _maxBuffered;
+    }
+
+    public int getNextExecutionDelay(Rate rate)
+    {
+      return 0;
     }
   }
 }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/RateLimiterExecutionTracker.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/RateLimiterExecutionTracker.java
@@ -53,4 +53,9 @@ public interface RateLimiterExecutionTracker
      * @return maximum number of callbacks that can be stored in the RateLimiter
      */
     int getMaxBuffered();
+
+    /**
+     * @return amount of delay to be incurred before executing the next callback, based on provided rate
+     */
+    int getNextExecutionDelay(Rate rate);
 }

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
@@ -22,6 +22,8 @@ import com.linkedin.r2.transport.http.client.ConstantQpsRateLimiter;
 import com.linkedin.r2.transport.http.client.TestEvictingCircularBuffer;
 import com.linkedin.test.util.ClockedExecutor;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.testng.annotations.Test;
@@ -47,7 +49,7 @@ public class TestConstantQpsRateLimiter
     rateLimiter.setRate(TEST_QPS, ONE_SECOND, UNLIMITED_BURST);
     rateLimiter.setBufferCapacity(1);
 
-    TattlingCallback<None> tattler = new TattlingCallback<>();
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
     rateLimiter.submit(tattler);
     executor.runFor(ONE_SECOND * TEST_NUM_CYCLES);
     Assert.assertTrue(tattler.getInteractCount() > 1);
@@ -62,7 +64,7 @@ public class TestConstantQpsRateLimiter
         new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor));
     rateLimiter.setRate(0.05d, ONE_SECOND, UNLIMITED_BURST);
     rateLimiter.setBufferCapacity(1);
-    TattlingCallback<None> tattler = new TattlingCallback<>();
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
     rateLimiter.submit(tattler);
     executor.runFor(59000);
     Assert.assertTrue(tattler.getInteractCount() == 3);
@@ -77,7 +79,7 @@ public class TestConstantQpsRateLimiter
 
     rateLimiter.setRate(TEST_QPS, ONE_SECOND, UNLIMITED_BURST);
     rateLimiter.setBufferTtl(999, ChronoUnit.MILLIS);
-    TattlingCallback<None> tattler = new TattlingCallback<>();
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
     rateLimiter.submit(tattler);
     executor.runFor(ONE_SECOND * TEST_NUM_CYCLES);
     Assert.assertSame(tattler.getInteractCount(), (int) TEST_QPS);
@@ -88,9 +90,39 @@ public class TestConstantQpsRateLimiter
     Assert.assertSame(executor.getExecutedTaskCount(), prevTaskCount);
   }
 
+  @Test
+  public void ensureRandomButConstantRate()
+  {
+    ClockedExecutor executor = new ClockedExecutor();
+    ConstantQpsRateLimiter rateLimiter =
+        new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(executor));
+    rateLimiter.setRate(200d, ONE_SECOND, 1);
+    rateLimiter.setBufferCapacity(1);
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
+    rateLimiter.submit(tattler);
+    executor.runFor(ONE_SECOND * TEST_NUM_CYCLES);
+    long prevTime = 0;
+    ArrayList<Long> timeDeltas = new ArrayList<>();
+    for (Long stamp : tattler.getOccurrences())
+    {
+      timeDeltas.add(stamp - prevTime);
+      prevTime = stamp;
+    }
+    // Ensure variance up to 10 possible time deltas given a rate of 200 requests per second
+    HashSet<Long> uniqueTimeDeltas = new HashSet<>(timeDeltas);
+    assert(uniqueTimeDeltas.size() > 5 && uniqueTimeDeltas.size() < 11);
+  }
+
   private static class TattlingCallback<T> implements Callback<T>
   {
-    private  AtomicInteger _interactCount = new AtomicInteger();
+    private AtomicInteger _interactCount = new AtomicInteger();
+    private ArrayList<Long> _occurrences = new ArrayList<>();
+    private ClockedExecutor _clock;
+
+    TattlingCallback(ClockedExecutor clock)
+    {
+      _clock = clock;
+    }
 
     @Override
     public void onError(Throwable e) {}
@@ -98,11 +130,17 @@ public class TestConstantQpsRateLimiter
     @Override
     public void onSuccess(T result) {
       _interactCount.incrementAndGet();
+      _occurrences.add(_clock.currentTimeMillis());
     }
 
     public int getInteractCount()
     {
       return _interactCount.intValue();
+    }
+
+    public ArrayList<Long> getOccurrences()
+    {
+      return _occurrences;
     }
   }
 }


### PR DESCRIPTION
This is to address a possibility of creating a thundering herd problem when a large number of replicas running this asynchronous code are simultaneously started or re-configured, such as with the ConstantQpsDarkClusterStrategy use case.