### PR TITLE
ConstantQpsDarkClusterStrategy post-prod fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.21.5] - 2021-08-31
-- DarkClusterConfig's dispatcherOutboundTargetRate: int -> float
+- ConstantQpsDarkClusterStrategy post-prod fixes
+  - DarkClusterConfig's dispatcherOutboundTargetRate: int -> float
+  - ConstantQpsRateLimiter - Introduce randomness while maintaining constant per period rate
 
 ## [29.21.4] - 2021-08-30
 - Expose an API to build a URI without query params. Expose a local attr for passing query params for in-process calls. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and what APIs have changed, if applicable.
 
 ## [29.21.5] - 2021-08-31
 - ConstantQpsDarkClusterStrategy post-prod fixes
-  - DarkClusterConfig's dispatcherOutboundTargetRate: int -> float
+  - Change the type of dispatcherOutboundTargetRate in DarkClusterConfig.pdl from int to float.
   - ConstantQpsRateLimiter - Introduce randomness while maintaining constant per period rate
 
 ## [29.21.4] - 2021-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.21.5] - 2021-08-31
+- DarkClusterConfig's dispatcherOutboundTargetRate: int -> float
+
 ## [29.21.4] - 2021-08-30
 - Expose an API to build a URI without query params. Expose a local attr for passing query params for in-process calls. 
 
@@ -5070,7 +5073,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.5...master
+[29.21.5]: https://github.com/linkedin/rest.li/compare/v29.21.4...v29.21.5
 [29.21.4]: https://github.com/linkedin/rest.li/compare/v29.21.3...v29.21.4
 [29.21.3]: https://github.com/linkedin/rest.li/compare/v29.21.2...v29.21.3
 [29.21.2]: https://github.com/linkedin/rest.li/compare/v29.21.1...v29.21.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.21.6] - 2021-09-09
+- ConstantQpsDarkClusterStrategy post-prod fixes
+   - Change the type of dispatcherOutboundTargetRate in DarkClusterConfig.pdl from int to float.
+   - ConstantQpsRateLimiter - Introduce randomness while maintaining constant per period rate
+
 ## [29.21.5] - 2021-09-09
 - Fix a bug in DataTranslator where accessing non-existent fields under avro 1.10+ throws
 
@@ -5073,7 +5078,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.21.6...master
+[29.21.6]: https://github.com/linkedin/rest.li/compare/v29.21.5...v29.21.6
 [29.21.5]: https://github.com/linkedin/rest.li/compare/v29.21.4...v29.21.5
 [29.21.4]: https://github.com/linkedin/rest.li/compare/v29.21.3...v29.21.4
 [29.21.3]: https://github.com/linkedin/rest.li/compare/v29.21.2...v29.21.3

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/DarkClusterConfig.pdl
@@ -13,7 +13,7 @@ record DarkClusterConfig {
   /**
    * Desired query rate to be maintained to the dark cluster per dark cluster host by the CONSTANT_QPS strategy. Measured in qps.
    */
-  dispatcherOutboundTargetRate: int = 0
+  dispatcherOutboundTargetRate: float = 0
 
   /**
    * Number of requests to store in the circular buffer used for asynchronous dispatching by the CONSTANT_QPS strategy.

--- a/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/config/DarkClustersConverter.java
@@ -126,7 +126,7 @@ public class DarkClustersConverter
       if (props.containsKey(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE))
       {
         darkClusterConfig.setDispatcherOutboundTargetRate(
-            PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE), Integer.class));
+            PropertyUtil.coerce(props.get(PropertyKeys.DARK_CLUSTER_OUTBOUND_TARGET_RATE), Float.class));
       }
       else
       {

--- a/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/config/DarkClustersConverterTest.java
@@ -104,7 +104,7 @@ public class DarkClustersConverterTest
 
     DarkClusterConfig resultConfig = DarkClustersConverter.toConfig(DarkClustersConverter.toProperties(configMap)).get(DARK_CLUSTER_KEY);
     Assert.assertEquals(resultConfig.getMultiplier(), DARK_CLUSTER_DEFAULT_MULTIPLIER);
-    Assert.assertEquals((int)resultConfig.getDispatcherOutboundTargetRate(), DARK_CLUSTER_DEFAULT_TARGET_RATE);
+    Assert.assertEquals(resultConfig.getDispatcherOutboundTargetRate(), DARK_CLUSTER_DEFAULT_TARGET_RATE);
     Assert.assertEquals((int)resultConfig.getDispatcherMaxRequestsToBuffer(), DARK_CLUSTER_DEFAULT_MAX_REQUESTS_TO_BUFFER);
     Assert.assertEquals((int)resultConfig.getDispatcherBufferedRequestExpiryInSeconds(), DARK_CLUSTER_DEFAULT_BUFFERED_REQUEST_EXPIRY_IN_SECONDS);
     Assert.assertEquals(resultConfig.getDarkClusterStrategyPrioritizedList().size(), 1, "default strategy list should be size 1");

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/ConstantQpsDarkClusterStrategy.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/ConstantQpsDarkClusterStrategy.java
@@ -49,7 +49,7 @@ public class ConstantQpsDarkClusterStrategy implements DarkClusterStrategy
 {
   private final String _originalClusterName;
   private final String _darkClusterName;
-  private final Integer _darkClusterPerHostQps;
+  private final Float _darkClusterPerHostQps;
   private final BaseDarkClusterDispatcher _baseDarkClusterDispatcher;
   private final Notifier _notifier;
   private final ClusterInfoProvider _clusterInfoProvider;
@@ -59,7 +59,7 @@ public class ConstantQpsDarkClusterStrategy implements DarkClusterStrategy
   private static final int NUM_REQUESTS_TO_SEND_PER_RATE_LIMITER_CYCLE = 1;
 
   public ConstantQpsDarkClusterStrategy(@Nonnull String originalClusterName, @Nonnull String darkClusterName,
-      @Nonnull Integer darkClusterPerHostQps, @Nonnull BaseDarkClusterDispatcher baseDarkClusterDispatcher,
+      @Nonnull Float darkClusterPerHostQps, @Nonnull BaseDarkClusterDispatcher baseDarkClusterDispatcher,
       @Nonnull Notifier notifier, @Nonnull ClusterInfoProvider clusterInfoProvider, @Nonnull ConstantQpsRateLimiter rateLimiter)
   {
     _originalClusterName = originalClusterName;
@@ -132,7 +132,7 @@ public class ConstantQpsDarkClusterStrategy implements DarkClusterStrategy
       int numSourceClusterInstances = _clusterInfoProvider.getHttpsClusterCount(_originalClusterName);
       if (numSourceClusterInstances != 0)
       {
-        return (float) (numDarkClusterInstances * _darkClusterPerHostQps) / numSourceClusterInstances;
+        return (numDarkClusterInstances * _darkClusterPerHostQps) / numSourceClusterInstances;
       }
 
       return 0F;

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestConstantQpsDarkClusterStrategy.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestConstantQpsDarkClusterStrategy.java
@@ -60,6 +60,7 @@ public class TestConstantQpsDarkClusterStrategy
         {1000, 100, 10, 10},
         {1000, 150, 10, 10},
         {100, 200, 10, 10},
+        {1000, 9.5f, 400, 10},
         // now test typical case of differing qps with different instance sizes
         {1000, 100, 10, 1},
         {1000, 90, 10, 1},
@@ -74,7 +75,7 @@ public class TestConstantQpsDarkClusterStrategy
   }
 
   @Test(dataProvider = "qpsKeys")
-  public void testStrategy(int numIterations, int qps, int numSourceInstances, int numDarkInstances)
+  public void testStrategy(int numIterations, float qps, int numSourceInstances, int numDarkInstances)
   {
     IntStream.of(1, 1000, 1000000).forEach(capacity ->
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.21.5
+version=29.21.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.21.4
+version=29.21.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ConstantQpsRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ConstantQpsRateLimiter.java
@@ -16,9 +16,11 @@
 
 package com.linkedin.r2.transport.http.client;
 
+import com.linkedin.r2.transport.http.client.ratelimiter.Rate;
 import com.linkedin.r2.transport.http.client.ratelimiter.RateLimiterExecutionTracker;
 import com.linkedin.util.clock.Clock;
 import java.time.temporal.ChronoUnit;
+import java.util.Random;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -67,6 +69,7 @@ public class ConstantQpsRateLimiter extends SmoothRateLimiter
   private static class UnboundedRateLimiterExecutionTracker implements RateLimiterExecutionTracker
   {
     private final AtomicBoolean _paused = new AtomicBoolean(true);
+    private final Random _random = new Random();
 
     public int getPending()
     {
@@ -96,6 +99,11 @@ public class ConstantQpsRateLimiter extends SmoothRateLimiter
     public int getMaxBuffered()
     {
       return Integer.MAX_VALUE;
+    }
+
+    public int getNextExecutionDelay(Rate rate)
+    {
+      return _random.nextInt(Math.max(1, (int) (rate.getPeriodRaw() / rate.getEventsRaw())));
     }
   }
 }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
@@ -98,7 +98,6 @@ public class SmoothRateLimiter implements AsyncRateLimiter
    *                           dropping the request might not be backward compatible
    * @param rateLimiterName    Name assigned for logging purposes
    * @param executionTracker   Adjusts the behavior of the rate limiter based on policies/state of RateLimiterExecutionTracker
-
    */
   SmoothRateLimiter(ScheduledExecutorService scheduler, Executor executor, Clock clock, CallbackBuffer pendingCallbacks,
                     BufferOverflowMode bufferOverflowMode, String rateLimiterName, RateLimiterExecutionTracker executionTracker)
@@ -225,6 +224,7 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     private int _permitAvailableCount;
     private int _permitsInTimeFrame;
     private long _nextScheduled;
+    private boolean _wasDelayed;
 
     EventLoop(Clock clock)
     {
@@ -272,6 +272,13 @@ public class SmoothRateLimiter implements AsyncRateLimiter
 
       if (_permitAvailableCount > 0)
       {
+        if (!_wasDelayed)
+        {
+          _wasDelayed = true;
+          _scheduler.schedule(this::loop, _executionTracker.getNextExecutionDelay(_rate), TimeUnit.MILLISECONDS);
+          return;
+        }
+        _wasDelayed = false;
         _permitAvailableCount--;
         Callback<None> callback = null;
         try
@@ -408,6 +415,11 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     public int getMaxBuffered()
     {
       return _maxBuffered;
+    }
+
+    public int getNextExecutionDelay(Rate rate)
+    {
+      return 0;
     }
   }
 }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
@@ -224,7 +224,7 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     private int _permitAvailableCount;
     private int _permitsInTimeFrame;
     private long _nextScheduled;
-    private boolean _wasDelayed;
+    private boolean _wasDelayed = false;
 
     EventLoop(Clock clock)
     {

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
@@ -416,10 +416,5 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     {
       return _maxBuffered;
     }
-
-    public int getNextExecutionDelay(Rate rate)
-    {
-      return 0;
-    }
   }
 }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/RateLimiterExecutionTracker.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/RateLimiterExecutionTracker.java
@@ -53,4 +53,9 @@ public interface RateLimiterExecutionTracker
      * @return maximum number of callbacks that can be stored in the RateLimiter
      */
     int getMaxBuffered();
+
+    /**
+     * @return amount of delay to be incurred before executing the next callback, based on provided rate
+     */
+    int getNextExecutionDelay(Rate rate);
 }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/RateLimiterExecutionTracker.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/RateLimiterExecutionTracker.java
@@ -57,5 +57,7 @@ public interface RateLimiterExecutionTracker
     /**
      * @return amount of delay to be incurred before executing the next callback, based on provided rate
      */
-    int getNextExecutionDelay(Rate rate);
+    default int getNextExecutionDelay(Rate rate) {
+        return 0;
+    }
 }

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
@@ -96,8 +96,9 @@ public class TestConstantQpsRateLimiter
   public void ensureRandomButConstantRate()
   {
     ClockedExecutor executor = new ClockedExecutor();
+    ClockedExecutor circularBufferExecutor = new ClockedExecutor();
     ConstantQpsRateLimiter rateLimiter =
-        new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(executor));
+        new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor));
     rateLimiter.setRate(200d, ONE_SECOND, 1);
     rateLimiter.setBufferCapacity(1);
     TattlingCallback<None> tattler = new TattlingCallback<>(executor);

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
@@ -22,6 +22,8 @@ import com.linkedin.r2.transport.http.client.ConstantQpsRateLimiter;
 import com.linkedin.r2.transport.http.client.TestEvictingCircularBuffer;
 import com.linkedin.test.util.ClockedExecutor;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.testng.annotations.Test;
@@ -47,7 +49,7 @@ public class TestConstantQpsRateLimiter
     rateLimiter.setRate(TEST_QPS, ONE_SECOND, UNLIMITED_BURST);
     rateLimiter.setBufferCapacity(1);
 
-    TattlingCallback<None> tattler = new TattlingCallback<>();
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
     rateLimiter.submit(tattler);
     executor.runFor(ONE_SECOND * TEST_NUM_CYCLES);
     Assert.assertTrue(tattler.getInteractCount() > 1);
@@ -62,7 +64,7 @@ public class TestConstantQpsRateLimiter
         new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor));
     rateLimiter.setRate(0.05d, ONE_SECOND, UNLIMITED_BURST);
     rateLimiter.setBufferCapacity(1);
-    TattlingCallback<None> tattler = new TattlingCallback<>();
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
     rateLimiter.submit(tattler);
     executor.runFor(59000);
     Assert.assertTrue(tattler.getInteractCount() == 3);
@@ -77,7 +79,7 @@ public class TestConstantQpsRateLimiter
 
     rateLimiter.setRate(TEST_QPS, ONE_SECOND, UNLIMITED_BURST);
     rateLimiter.setBufferTtl(999, ChronoUnit.MILLIS);
-    TattlingCallback<None> tattler = new TattlingCallback<>();
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
     rateLimiter.submit(tattler);
     executor.runFor(ONE_SECOND * TEST_NUM_CYCLES);
     Assert.assertSame(tattler.getInteractCount(), (int) TEST_QPS);
@@ -88,9 +90,39 @@ public class TestConstantQpsRateLimiter
     Assert.assertSame(executor.getExecutedTaskCount(), prevTaskCount);
   }
 
+  @Test
+  public void ensureRandomButConstantRate()
+  {
+    ClockedExecutor executor = new ClockedExecutor();
+    ConstantQpsRateLimiter rateLimiter =
+        new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(executor));
+    rateLimiter.setRate(200d, ONE_SECOND, 1);
+    rateLimiter.setBufferCapacity(1);
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
+    rateLimiter.submit(tattler);
+    executor.runFor(ONE_SECOND * TEST_NUM_CYCLES);
+    long prevTime = 0;
+    ArrayList<Long> timeDeltas = new ArrayList<>();
+    for (Long stamp : tattler.getOccurrences())
+    {
+      timeDeltas.add(stamp - prevTime);
+      prevTime = stamp;
+    }
+    // Ensure variance up to 10 possible time deltas given a rate of 200 requests per second
+    HashSet<Long> uniqueTimeDeltas = new HashSet<>(timeDeltas);
+    assert(uniqueTimeDeltas.size() > 5 && uniqueTimeDeltas.size() < 11);
+  }
+
   private static class TattlingCallback<T> implements Callback<T>
   {
-    private  AtomicInteger _interactCount = new AtomicInteger();
+    private AtomicInteger _interactCount = new AtomicInteger();
+    private ArrayList<Long> _occurrences = new ArrayList<>();
+    private ClockedExecutor _clock;
+
+    TattlingCallback(ClockedExecutor clock)
+    {
+      _clock = clock;
+    }
 
     @Override
     public void onError(Throwable e) {}
@@ -98,11 +130,17 @@ public class TestConstantQpsRateLimiter
     @Override
     public void onSuccess(T result) {
       _interactCount.incrementAndGet();
+      _occurrences.add(_clock.currentTimeMillis());
     }
 
     public int getInteractCount()
     {
       return _interactCount.intValue();
+    }
+
+    public ArrayList<Long> getOccurrences()
+    {
+      return _occurrences;
     }
   }
 }

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
@@ -24,6 +24,8 @@ import com.linkedin.test.util.ClockedExecutor;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.testng.annotations.Test;
@@ -102,21 +104,21 @@ public class TestConstantQpsRateLimiter
     rateLimiter.submit(tattler);
     executor.runFor(ONE_SECOND * TEST_NUM_CYCLES);
     long prevTime = 0;
-    ArrayList<Long> timeDeltas = new ArrayList<>();
+    List<Long> timeDeltas = new ArrayList<>();
     for (Long stamp : tattler.getOccurrences())
     {
       timeDeltas.add(stamp - prevTime);
       prevTime = stamp;
     }
     // Ensure variance up to 10 possible time deltas given a rate of 200 requests per second
-    HashSet<Long> uniqueTimeDeltas = new HashSet<>(timeDeltas);
+    Set<Long> uniqueTimeDeltas = new HashSet<>(timeDeltas);
     assert(uniqueTimeDeltas.size() > 5 && uniqueTimeDeltas.size() < 11);
   }
 
   private static class TattlingCallback<T> implements Callback<T>
   {
     private AtomicInteger _interactCount = new AtomicInteger();
-    private ArrayList<Long> _occurrences = new ArrayList<>();
+    private List<Long> _occurrences = new ArrayList<>();
     private ClockedExecutor _clock;
 
     TattlingCallback(ClockedExecutor clock)
@@ -138,7 +140,7 @@ public class TestConstantQpsRateLimiter
       return _interactCount.intValue();
     }
 
-    public ArrayList<Long> getOccurrences()
+    public List<Long> getOccurrences()
     {
       return _occurrences;
     }


### PR DESCRIPTION
- DarkClusterConfig's dispatcherOutboundTargetRate: int -> float
This change enables low qps use cases to more finely configure their per-host inbound dark qps.

- ConstantQpsRateLimiter - Introduce randomness while maintaining constant per period rate
This addresses a thundering herd problem resulting from a central signaling of many replicas simultaneously running ConstantQpsRateLimiter.