### PR TITLE
Add a pegasus plugin config to use case sensitive path in datetemplate generation and rest client generation

### DIFF
--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -595,10 +595,10 @@ public class PegasusPlugin implements Plugin<Project>
   // Enable the generation of fluent APIs
   private static final String ENABLE_FLUENT_API = "pegasusPlugin.enableFluentApi";
 
-  // Impact GenerateDataTemplateTask and GenerateRestClientTask;
+  // This config impacts GenerateDataTemplateTask and GenerateRestClientTask;
   // If not set, by default all paths generated in these two tasks will be lower-case.
-  // This is needed because Linux, MacOS, Windows treat case sensitive paths differently,
-  // and we want to be consistent
+  // This default behavior is needed because Linux, MacOS, Windows treat case sensitive paths differently,
+  // and we want to be consistent, so we choose lower-case as default case for path generated
   private static final String CODE_GEN_PATH_CASE_SENSITIVE = "pegasusPlugin.generateCaseSensitivePath";
 
   private static final String PEGASUS_PLUGIN_CONFIGURATION = "pegasusPlugin";

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -595,6 +595,12 @@ public class PegasusPlugin implements Plugin<Project>
   // Enable the generation of fluent APIs
   private static final String ENABLE_FLUENT_API = "pegasusPlugin.enableFluentApi";
 
+  // Impact GenerateDataTemplateTask and GenerateRestClientTask;
+  // If not set, by default all paths generated in these two tasks will be lower-case.
+  // This is needed because Linux, MacOS, Windows treat case sensitive paths differently,
+  // and we want to be consistent
+  private static final String CODE_GEN_PATH_CASE_SENSITIVE = "pegasusPlugin.generateCaseSensitivePath";
+
   private static final String PEGASUS_PLUGIN_CONFIGURATION = "pegasusPlugin";
 
   // Enable the use of generic pegasus schema compatibility checker
@@ -1642,6 +1648,10 @@ public class PegasusPlugin implements Plugin<Project>
           {
             task.setEnableArgFile(true);
           }
+          if (isPropertyTrue(project, CODE_GEN_PATH_CASE_SENSITIVE))
+          {
+            task.setGenerateLowercasePath(false);
+          }
 
           task.onlyIf(t ->
           {
@@ -2017,6 +2027,10 @@ public class PegasusPlugin implements Plugin<Project>
           if (isPropertyTrue(project, ENABLE_ARG_FILE))
           {
             task.setEnableArgFile(true);
+          }
+          if (isPropertyTrue(project, CODE_GEN_PATH_CASE_SENSITIVE))
+          {
+            task.setGenerateLowercasePath(false);
           }
           if (isPropertyTrue(project, ENABLE_FLUENT_API))
           {


### PR DESCRIPTION
In previous PR

https://github.com/linkedin/rest.li/commit/e720a5bf4ff110aa0981c5e5f1ab0f7b01367688#diff-881c39f18a279b2c4590938b0e7eb00edaf336ee6ad1291488f80b7f589d13c9R102

The contributor forgot to add the config into PegasusPlugin so user can opt in or opt out.

This PR is to add that back.