### PR TITLE
Make extensions directory as the resource root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-- Add a pegasus plugin config to use case sensitive path in dataTemplate generation and rest client generation
 
+
+## [29.22.1] - 2021-09-13
+- Mark the `extensions` directory as a resource root in the Gradle plugin.
+- Add a pegasus plugin config to use case sensitive path in dataTemplate generation and rest client generation
 
 ## [29.22.0] - 2021-09-09
 - Allow customizing `MethodAdapterRegistry` (now called `MethodAdapterProvider`) via `RestLiConfig`.
@@ -5087,7 +5090,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.1...master
+[29.22.1]: https://github.com/linkedin/rest.li/compare/v29.22.0...v29.22.1
 [29.22.0]: https://github.com/linkedin/rest.li/compare/v29.21.5...v29.22.0
 [29.21.5]: https://github.com/linkedin/rest.li/compare/v29.21.4...v29.21.5
 [29.21.4]: https://github.com/linkedin/rest.li/compare/v29.21.3...v29.21.4

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -2296,11 +2296,18 @@ public class PegasusPlugin implements Plugin<Project>
       sourceDirectorySet.srcDir(dataSchemaPath);
       project.getLogger().info("Adding resource root '{}'", dataSchemaPath);
 
-      // Exclude the data schema directory from being copied into the default Jar task
+      final String extensionsSchemaPath = getExtensionSchemaPath(project, sourceSet);
+      final File extensionsSchemaRoot = project.file(extensionsSchemaPath);
+      sourceDirectorySet.srcDir(extensionsSchemaPath);
+      project.getLogger().info("Adding resource root '{}'", extensionsSchemaPath);
+
+      // Exclude the data schema and extensions schema directory from being copied into the default Jar task
       sourceDirectorySet.getFilter().exclude(fileTreeElement -> {
         final File file = fileTreeElement.getFile();
         // Traversal starts with the children of a resource root, so checking the direct parent is sufficient
-        final boolean exclude = dataSchemaRoot.equals(file.getParentFile());
+        final boolean underDataSchemaRoot = dataSchemaRoot.equals(file.getParentFile());
+        final boolean underExtensionsSchemaRoot = extensionsSchemaRoot.equals(file.getParentFile());
+        final boolean exclude = (underDataSchemaRoot || underExtensionsSchemaRoot);
         if (exclude)
         {
           project.getLogger().info("Excluding resource directory '{}'", file);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.22.0
+version=29.22.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This change is making /extensions directory as the resource root. It was a miss when we introduced /extensions directory.

Tested the snapshot in a MP.