### PR TITLE
Change JSR330Adapter to use getDeclaredConstructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Improve support for JSR330 by allowing package protected constructors annotated with @Inject
 
 ## [29.22.2] - 2021-09-20
 - Add server config support to define supported accept types
@@ -37,7 +38,7 @@ and what APIs have changed, if applicable.
 - Fix a bug in `DataTranslator` where accessing non-existent fields under avro 1.10+ throws an exception.
 
 ## [29.21.4] - 2021-08-30
-- Expose an API to build a URI without query params. Expose a local attr for passing query params for in-process calls. 
+- Expose an API to build a URI without query params. Expose a local attr for passing query params for in-process calls.
 
 ## [29.21.3] - 2021-08-25
 - Fix a bug in `SmoothRateLimiter` where `getEvents` will always return `0`.
@@ -62,7 +63,7 @@ and what APIs have changed, if applicable.
 
 ## [29.19.16] - 2021-08-09
 - Add support for resolving from multiple schema source directories.
-  - This change also introduces the concept of "source" and "resolver" directories when 
+  - This change also introduces the concept of "source" and "resolver" directories when
     creating a `DataSchemaParser`. "Source" directories are used to parse/load the input
     schemas, while the "resolver" directories will only be used for resolving referenced
     schemas.
@@ -86,16 +87,16 @@ serializing/deserializing them for requests that are executed in-process.
 
 ## [29.19.11] - 2021-07-20
 - Add compatibility level config for extension schema compatibility check.
-   - "pegasusPlugin.extensionSchema.compatibility" is the compatibility level config for extension schema compatibility check. 
+   - "pegasusPlugin.extensionSchema.compatibility" is the compatibility level config for extension schema compatibility check.
       It supports following 4 levels:
      - "off": the extension schema compatibility check will not be run.
      - "ignore": the extension schema compatibility check will run, but it allows backward incompatible changes.
      - "backwards": Changes that are considered backwards compatible will pass the check, otherwise changes will fail the check.
      - "equivalent": No changes to extension schemas will pass.
    - If this config is not provided by users, by default the extension schema compatibility check is using "backwards".
-   - How to use it: users could add 'pegasusPlugin.extensionSchema.compatibility=<compatibility level>' in the gradle.properties file 
+   - How to use it: users could add 'pegasusPlugin.extensionSchema.compatibility=<compatibility level>' in the gradle.properties file
      or directly add this property '-PpegasusPlugin.extensionSchema.compatibility=<compatibility level>' to the gradle build.
-   
+
 - Revert "Relax extension schema check to make '@extension' annotation is optional for 1-to-1 injections."
 
 ## [29.19.10] - 2021-07-16
@@ -255,7 +256,7 @@ serializing/deserializing them for requests that are executed in-process.
 - Add `UnionTemplate.memberKeyName()` to directly return the key name for a union member.
 
 ## [29.15.1] - 2021-02-18
-- Cleanup compression code to reduce duplication and minimize memcopies 
+- Cleanup compression code to reduce duplication and minimize memcopies
 
 ## [29.15.0] - 2021-02-17
 - Always enable client compression filter so that responses can be decompressed. If the request already has an accept encoding header set do not overwrite it.

--- a/restli-server/src/main/java/com/linkedin/restli/server/resources/Jsr330Adapter.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/resources/Jsr330Adapter.java
@@ -118,7 +118,7 @@ public class Jsr330Adapter
   private void scanInjectableConstructors(Class<?> beanClazz)
   {
     int annotatedConstructors = 0;
-    for (Constructor<?> constructor : beanClazz.getConstructors())
+    for (Constructor<?> constructor : beanClazz.getDeclaredConstructors())
     {
       Inject injectAnnotation = constructor.getAnnotation(Inject.class);
       if (injectAnnotation != null)
@@ -156,7 +156,7 @@ public class Jsr330Adapter
     {
       try
       {
-        Constructor<?> defaultConstructor = beanClazz.getConstructor();
+        Constructor<?> defaultConstructor = beanClazz.getDeclaredConstructor();
         defaultConstructor.setAccessible(true);
         _constructorParameterDependencies.put(beanClazz,
                                               new InjectableConstructor(defaultConstructor,

--- a/restli-server/src/test/java/com/linkedin/restli/server/resources/TestInjectResourceFactory.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/resources/TestInjectResourceFactory.java
@@ -23,15 +23,18 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.linkedin.restli.server.resources.fixtures.ConstructorArgResource;
+import com.linkedin.restli.server.resources.fixtures.DefaultConstructorArgResource;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.linkedin.restli.internal.server.RestLiInternalException;
 import org.easymock.EasyMock;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.linkedin.restli.internal.server.model.ResourceModel;
-import com.linkedin.restli.server.resources.fixtures.ConstructorArgResource;
+import com.linkedin.restli.server.resources.fixtures.PublicConstructorArgResource;
 import com.linkedin.restli.server.resources.fixtures.SomeDependency1;
 import com.linkedin.restli.server.resources.fixtures.SomeDependency2;
 import com.linkedin.restli.server.resources.fixtures.SomeResource1;
@@ -186,11 +189,11 @@ public class TestInjectResourceFactory
     EasyMock.verify(ctx);
   }
 
-  @Test
-  public void testInjectConstructorArgs()
+  @Test(dataProvider = "constructorClasses")
+  public void testInjectConstructorArgs(Class<? extends ConstructorArgResource> constructorResourceClass)
   {
     Map<String, ResourceModel> pathRootResourceMap =
-            buildResourceModels(ConstructorArgResource.class);
+            buildResourceModels(constructorResourceClass);
 
     // set up mock ApplicationContext
     BeanProvider ctx = createMock(BeanProvider.class);
@@ -211,10 +214,18 @@ public class TestInjectResourceFactory
     factory.setRootResources(pathRootResourceMap);
 
     // #1 happy path
-    ConstructorArgResource r1 = factory.create(ConstructorArgResource.class);
+    ConstructorArgResource r1 = factory.create(constructorResourceClass);
     assertNotNull(r1);
     assertNotNull(r1.getDependency1());
     assertNotNull(r1.getDependency2());
     assertNull(r1.getNonInjectedDependency());
+  }
+
+  @DataProvider(parallel = true)
+  public static Object[] constructorClasses() {
+    return new Object[] {
+        PublicConstructorArgResource.class,
+        DefaultConstructorArgResource.class
+    };
   }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/server/resources/fixtures/ConstructorArgResource.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/resources/fixtures/ConstructorArgResource.java
@@ -1,63 +1,9 @@
-/*
-   Copyright (c) 2012 LinkedIn Corp.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-*/
-
 package com.linkedin.restli.server.resources.fixtures;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+public interface ConstructorArgResource {
+  SomeDependency1 getDependency1();
 
-import com.linkedin.data.template.RecordTemplate;
-import com.linkedin.restli.server.TestRecord;
-import com.linkedin.restli.server.annotations.RestLiCollection;
-import com.linkedin.restli.server.resources.CollectionResourceTemplate;
+  SomeDependency2 getDependency2();
 
-/**
- * @author Josh Walker
- * @version $Revision: $
- */
-@RestLiCollection(name="constructorArgResource",
-                  keyName="key")
-public class ConstructorArgResource extends CollectionResourceTemplate<String, TestRecord>
-{
-  private final SomeDependency1 _dependency1;
-  private final SomeDependency2 _dependency2;
-  private SomeDependency2 _nonInjectedDependency;
-
-
-  @Inject
-  public ConstructorArgResource(@Named("dep1") SomeDependency1 dependency1,
-                                SomeDependency2 dependency2)
-  {
-    _dependency1 = dependency1;
-    _dependency2 = dependency2;
-  }
-
-  public SomeDependency1 getDependency1()
-  {
-    return _dependency1;
-  }
-
-  public SomeDependency2 getDependency2()
-  {
-    return _dependency2;
-  }
-
-  public SomeDependency2 getNonInjectedDependency()
-  {
-    return _nonInjectedDependency;
-  }
-
+  SomeDependency2 getNonInjectedDependency();
 }

--- a/restli-server/src/test/java/com/linkedin/restli/server/resources/fixtures/DefaultConstructorArgResource.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/resources/fixtures/DefaultConstructorArgResource.java
@@ -1,0 +1,63 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.restli.server.resources.fixtures;
+
+import com.linkedin.restli.server.TestRecord;
+import com.linkedin.restli.server.annotations.RestLiCollection;
+import com.linkedin.restli.server.resources.CollectionResourceTemplate;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+
+/**
+ * This exists to ensure that package protected constructors can be used with @Inject
+ * as per JSR330
+ */
+@RestLiCollection(name="defaultConstructorArgResource",
+                  keyName="key")
+public class DefaultConstructorArgResource extends CollectionResourceTemplate<String, TestRecord>
+  implements ConstructorArgResource
+{
+  private final SomeDependency1 _dependency1;
+  private final SomeDependency2 _dependency2;
+  private SomeDependency2 _nonInjectedDependency;
+
+
+  @Inject
+  DefaultConstructorArgResource(@Named("dep1") SomeDependency1 dependency1,
+                                SomeDependency2 dependency2)
+  {
+    _dependency1 = dependency1;
+    _dependency2 = dependency2;
+  }
+
+  public SomeDependency1 getDependency1()
+  {
+    return _dependency1;
+  }
+
+  public SomeDependency2 getDependency2()
+  {
+    return _dependency2;
+  }
+
+  public SomeDependency2 getNonInjectedDependency()
+  {
+    return _nonInjectedDependency;
+  }
+
+}

--- a/restli-server/src/test/java/com/linkedin/restli/server/resources/fixtures/PublicConstructorArgResource.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/resources/fixtures/PublicConstructorArgResource.java
@@ -1,0 +1,64 @@
+/*
+   Copyright (c) 2012 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.restli.server.resources.fixtures;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.restli.server.TestRecord;
+import com.linkedin.restli.server.annotations.RestLiCollection;
+import com.linkedin.restli.server.resources.CollectionResourceTemplate;
+
+/**
+ * @author Josh Walker
+ * @version $Revision: $
+ */
+@RestLiCollection(name="constructorArgResource",
+                  keyName="key")
+public class PublicConstructorArgResource extends CollectionResourceTemplate<String, TestRecord>
+  implements ConstructorArgResource
+{
+  private final SomeDependency1 _dependency1;
+  private final SomeDependency2 _dependency2;
+  private SomeDependency2 _nonInjectedDependency;
+
+
+  @Inject
+  public PublicConstructorArgResource(@Named("dep1") SomeDependency1 dependency1,
+                                SomeDependency2 dependency2)
+  {
+    _dependency1 = dependency1;
+    _dependency2 = dependency2;
+  }
+
+  public SomeDependency1 getDependency1()
+  {
+    return _dependency1;
+  }
+
+  public SomeDependency2 getDependency2()
+  {
+    return _dependency2;
+  }
+
+  public SomeDependency2 getNonInjectedDependency()
+  {
+    return _nonInjectedDependency;
+  }
+
+}


### PR DESCRIPTION
In section 4.1 of JSR 330, there is explicitly a package protected
constructor: https://jcp.org/en/jsr/detail?id=330#orig

This is also consistent with guice and others as well as errorprone:
https://errorprone.info/bugpattern/UnnecessarilyVisible