### PR TITLE
Add server config support to define supported accept types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.22.2] - 2021-09-20
+- Add server config support to define supported accept types
 
 ## [29.22.1] - 2021-09-13
 - Mark the `extensions` directory as a resource root in the Gradle plugin.
@@ -5090,7 +5092,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.2...master
+[29.22.2]: https://github.com/linkedin/rest.li/compare/v29.22.1...v29.22.2
 [29.22.1]: https://github.com/linkedin/rest.li/compare/v29.22.0...v29.22.1
 [29.22.0]: https://github.com/linkedin/rest.li/compare/v29.21.5...v29.22.0
 [29.21.5]: https://github.com/linkedin/rest.li/compare/v29.21.4...v29.21.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.22.1
+version=29.22.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/util/RestUtils.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/util/RestUtils.java
@@ -229,9 +229,9 @@ public class RestUtils
         return RestConstants.HEADER_VALUE_APPLICATION_JSON;
       }
 
-      return MIMEParse.bestMatch(supportedAcceptTypes != null ? supportedAcceptTypes.stream() :
-              Stream.concat(customMimeTypesSupported.stream(), RestConstants.SUPPORTED_MIME_TYPES.stream()),
-              acceptHeader);
+      return MIMEParse.bestMatch(supportedAcceptTypes != null && supportedAcceptTypes.isEmpty() ? supportedAcceptTypes.stream() :
+          Stream.concat(customMimeTypesSupported.stream(), RestConstants.SUPPORTED_MIME_TYPES.stream()),
+          acceptHeader);
     }
 
     // Handle the case when an accept MIME type that was passed in along with the
@@ -239,7 +239,7 @@ public class RestUtils
     catch (InvalidMimeTypeException e)
     {
       throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, String
-              .format("Encountered invalid MIME type '%s' in accept header.", e.getType()));
+        .format("Encountered invalid MIME type '%s' in accept header.", e.getType()));
     }
   }
 

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/util/RestUtils.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/util/RestUtils.java
@@ -46,14 +46,11 @@ import com.linkedin.restli.server.ProjectionMode;
 import com.linkedin.restli.server.ResourceContext;
 import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.server.RoutingException;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 
@@ -212,6 +209,11 @@ public class RestUtils
 
   public static String pickBestEncoding(String acceptHeader, Set<String> customMimeTypesSupported)
   {
+    return pickBestEncoding(acceptHeader, null, customMimeTypesSupported);
+  }
+
+  public static String pickBestEncoding(String acceptHeader, List<String> supportedAcceptTypes, Set<String> customMimeTypesSupported)
+  {
     if (acceptHeader == null || acceptHeader.isEmpty())
     {
       return RestConstants.HEADER_VALUE_APPLICATION_JSON;
@@ -227,9 +229,9 @@ public class RestUtils
         return RestConstants.HEADER_VALUE_APPLICATION_JSON;
       }
 
-      return MIMEParse.bestMatch(
-          Stream.concat(customMimeTypesSupported.stream(), RestConstants.SUPPORTED_MIME_TYPES.stream()),
-          acceptHeader);
+      return MIMEParse.bestMatch(supportedAcceptTypes != null ? supportedAcceptTypes.stream() :
+              Stream.concat(customMimeTypesSupported.stream(), RestConstants.SUPPORTED_MIME_TYPES.stream()),
+              acceptHeader);
     }
 
     // Handle the case when an accept MIME type that was passed in along with the
@@ -237,7 +239,7 @@ public class RestUtils
     catch (InvalidMimeTypeException e)
     {
       throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, String
-          .format("Encountered invalid MIME type '%s' in accept header.", e.getType()));
+              .format("Encountered invalid MIME type '%s' in accept header.", e.getType()));
     }
   }
 
@@ -342,6 +344,26 @@ public class RestUtils
                                                                     ServerResourceContext resourceContext,
                                                                     RequestContext requestContext)
   {
+    validateRequestHeadersAndUpdateResourceContext(headers, null, customMimeTypesSupported, resourceContext, requestContext);
+  }
+
+  /**
+   * Validate request headers and set response mime type in the server resource context.
+   *
+   * @param headers                    Request headers.
+   * @param supportedAcceptTypes       List of supported content type header keys for response payload.
+   * @param customMimeTypesSupported   Set of supported custom mime types.
+   * @param resourceContext            Server resource context.
+   * @param requestContext             Incoming request context.
+   *
+   * @throws RestLiServiceException if any of the headers are invalid.
+   */
+  public static void validateRequestHeadersAndUpdateResourceContext(final Map<String, String> headers,
+                                                                    final List<String> supportedAcceptTypes,
+                                                                    final Set<String> customMimeTypesSupported,
+                                                                    ServerResourceContext resourceContext,
+                                                                    RequestContext requestContext)
+  {
     // In process requests don't serialize the response, so just set response mime-type to JSON.
     if (Boolean.TRUE.equals(requestContext.getLocalAttr(ServerResourceContext.CONTEXT_IN_PROCESS_RESOLUTION_KEY))) {
       resourceContext.setResponseMimeType(ContentType.JSON.getHeaderKey());
@@ -350,7 +372,7 @@ public class RestUtils
 
     // Validate whether the accept headers have at least one type that we support.
     // Fail the validation if we will be unable to support the requested accept type.
-    String mimeType = pickBestEncoding(headers.get(RestConstants.HEADER_ACCEPT), customMimeTypesSupported);
+    String mimeType = pickBestEncoding(headers.get(RestConstants.HEADER_ACCEPT), supportedAcceptTypes, customMimeTypesSupported);
     if (StringUtils.isEmpty(mimeType))
     {
       throw new RestLiServiceException(HttpStatus.S_406_NOT_ACCEPTABLE,

--- a/restli-server/src/main/java/com/linkedin/restli/server/BaseRestLiServer.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/BaseRestLiServer.java
@@ -69,6 +69,7 @@ abstract class BaseRestLiServer
   private final ErrorResponseBuilder _errorResponseBuilder;
   private final List<Filter> _filters;
   private final Set<String> _customContentTypes;
+  private final List<String> _supportedAcceptTypes;
   private final ResourceMethodConfigProvider _methodConfigProvider;
   private final boolean _fillInDefaultValueConfigured;
   private final MethodAdapterProvider _methodAdapterProvider;
@@ -81,6 +82,7 @@ abstract class BaseRestLiServer
     _customContentTypes = config.getCustomContentTypes().stream()
         .map(ContentType::getHeaderKey)
         .collect(Collectors.toSet());
+    _supportedAcceptTypes = config.getSupportedAcceptTypes();
 
     _router = new RestLiRouter(rootResources, config);
     resourceFactory.setRootResources(rootResources);
@@ -110,6 +112,7 @@ abstract class BaseRestLiServer
     _customContentTypes = config.getCustomContentTypes().stream()
         .map(ContentType::getHeaderKey)
         .collect(Collectors.toSet());
+    _supportedAcceptTypes = config.getSupportedAcceptTypes();
 
     _router = new RestLiRouter(rootResources, config);
     resourceFactory.setRootResources(rootResources);
@@ -172,8 +175,8 @@ abstract class BaseRestLiServer
     try
     {
       ServerResourceContext context = new ResourceContextImpl(new PathKeysImpl(), request, requestContext);
-      RestUtils.validateRequestHeadersAndUpdateResourceContext(
-          request.getHeaders(), _customContentTypes, context, requestContext);
+      RestUtils.validateRequestHeadersAndUpdateResourceContext(request.getHeaders(), _supportedAcceptTypes,
+              _customContentTypes, context, requestContext);
 
       ResourceMethodDescriptor method = _router.process(context);
       ResourceMethodConfig methodConfig = _methodConfigProvider.apply(method);

--- a/restli-server/src/main/java/com/linkedin/restli/server/BaseRestLiServer.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/BaseRestLiServer.java
@@ -176,7 +176,7 @@ abstract class BaseRestLiServer
     {
       ServerResourceContext context = new ResourceContextImpl(new PathKeysImpl(), request, requestContext);
       RestUtils.validateRequestHeadersAndUpdateResourceContext(request.getHeaders(), _supportedAcceptTypes,
-              _customContentTypes, context, requestContext);
+          _customContentTypes, context, requestContext);
 
       ResourceMethodDescriptor method = _router.process(context);
       ResourceMethodConfig methodConfig = _methodConfigProvider.apply(method);

--- a/restli-server/src/main/java/com/linkedin/restli/server/RestLiConfig.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/RestLiConfig.java
@@ -91,6 +91,7 @@ public class RestLiConfig
   private MultiplexerSingletonFilter _multiplexerSingletonFilter;
   private MultiplexerRunMode _multiplexerRunMode = MultiplexerRunMode.MULTIPLE_PLANS;
   private final List<ContentType> _customContentTypes = new LinkedList<>();
+  private List<String> _supportedAcceptTypes;
   private final List<ResourceDefinitionListener> _resourceDefinitionListeners = new ArrayList<>();
   private boolean _useStreamCodec = false;
 
@@ -617,5 +618,23 @@ public class RestLiConfig
   {
     return Optional.ofNullable(_methodAdapterProvider)
             .orElse(new DefaultMethodAdapterProvider(new ErrorResponseBuilder(_errorResponseFormat)));
+  }
+
+  /**
+   * Get list of supported mime types for response serialization.
+   * @return list of mime types.
+   */
+  public List<String> getSupportedAcceptTypes()
+  {
+    return _supportedAcceptTypes;
+  }
+
+  /**
+   * Sets list of supported mime types for response serialization.
+   * @param supportedAcceptTypes list of mime types.
+   */
+  public void setSupportedAcceptTypes(List<String> supportedAcceptTypes)
+  {
+    _supportedAcceptTypes = supportedAcceptTypes;
   }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/util/TestRestUtils.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/util/TestRestUtils.java
@@ -40,10 +40,12 @@ import com.linkedin.restli.internal.server.ServerResourceContext;
 import com.linkedin.restli.server.LinkedListNode;
 import com.linkedin.restli.server.RestLiServiceException;
 import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -68,6 +70,7 @@ public class TestRestUtils
   private static final String UNKNOWN_TYPE_HEADER_WITH_INVALID_PARAMS_JSON = "foo/bar; baz, application/json";
   private static final String UNKNOWN_TYPE_HEADER_WITH_UNKNOWN_PARAMS_JSON = "foo/bar; baz=bark, application/json";
   private static final String UNKNOWN_TYPE_HEADER_WITH_VALID_PARAMS_JSON = "foo/bar; level=1, application/json";
+  private static final String PSON_TYPE_HEADER_WITH_VALID_PARAMS_JSON = "application/x-pson; level=1, application/json";
   private static final String JSON_HEADER = "application/json";
   private static final String PSON_HEADER = "application/x-pson";
   private static final String INVALID_TYPE_HEADER_1 = "foo";
@@ -94,7 +97,8 @@ public class TestRestUtils
         { UNKNOWN_TYPE_HEADER_WITH_INVALID_PARAMS_JSON, JSON_TYPE },
         { UNKNOWN_TYPE_HEADER_WITH_UNKNOWN_PARAMS_JSON, JSON_TYPE },
         { UNKNOWN_TYPE_HEADER_WITH_VALID_PARAMS_JSON, JSON_TYPE },
-        { MULTIPART_MIME_RELATED_TYPE, JSON_TYPE}
+        { MULTIPART_MIME_RELATED_TYPE, JSON_TYPE},
+        { PSON_TYPE_HEADER_WITH_VALID_PARAMS_JSON, PSON_TYPE }
     };
   }
 
@@ -114,6 +118,13 @@ public class TestRestUtils
   public void testPickBestEncodingWithValidMimeTypes(String header, String result)
   {
     Assert.assertEquals(RestUtils.pickBestEncoding(header, Collections.emptySet()), result);
+  }
+
+  @Test
+  public void testPickBestEncodingWithSupportedMimeTypes()
+  {
+    Assert.assertEquals(RestUtils.pickBestEncoding(PSON_TYPE_HEADER_WITH_VALID_PARAMS_JSON, Arrays.asList(JSON_HEADER),Collections.emptySet()), JSON_HEADER);
+    Assert.assertEquals(RestUtils.pickBestEncoding(PSON_TYPE_HEADER_WITH_VALID_PARAMS_JSON, Collections.EMPTY_LIST,Collections.emptySet()), PSON_HEADER);
   }
 
   @Test


### PR DESCRIPTION
Add server config support to define supported accept types
1) if this is set server will support only the accept types defined in list and if non of accept type requested by client is supported it will default to empty type ie json
2) if not set server will support all supported content types ie. custom or defined within restli.