### PR TITLE
Fix bug in SmoothRateLimiter where executionDelay is not honored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.22.6] - 2021-10-08
+- Fix bug in SmoothRateLimiter where executionDelay is not honored
+
 ## [29.22.5] - 2021-10-08
 - Make PegasusPlugin#getDataSchemaPath public.
 
@@ -5102,7 +5105,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.6...master
+[29.22.6]: https://github.com/linkedin/rest.li/compare/v29.22.5...v29.22.6
 [29.22.5]: https://github.com/linkedin/rest.li/compare/v29.22.4...v29.22.5
 [29.22.4]: https://github.com/linkedin/rest.li/compare/v29.22.3...v29.22.4
 [29.22.3]: https://github.com/linkedin/rest.li/compare/v29.22.2...v29.22.3

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestConstantQpsDarkClusterStrategy.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestConstantQpsDarkClusterStrategy.java
@@ -93,6 +93,7 @@ public class TestConstantQpsDarkClusterStrategy
       ConstantQpsRateLimiter rateLimiter =
         new ConstantQpsRateLimiter(executor, executor, executor, buffer);
       rateLimiter.setBufferCapacity(capacity);
+      rateLimiter.setBufferTtl(Integer.MAX_VALUE, ChronoUnit.DAYS);
       ConstantQpsDarkClusterStrategy strategy = new ConstantQpsDarkClusterStrategy(SOURCE_CLUSTER_NAME,
           DARK_CLUSTER_NAME,
           qps,
@@ -105,8 +106,9 @@ public class TestConstantQpsDarkClusterStrategy
         RestRequest dummyRestRequest = new RestRequestBuilder(URI.create("foo")).build();
         strategy.handleRequest(dummyRestRequest, dummyRestRequest, new RequestContext());
       }
-      executor.runFor(1000);
-      int expectedCount = (int) Math.ceil(((numIterations == 0 ? 0 : 1) * qps * numDarkInstances)/ (double) (numSourceInstances));
+      // must simulate 20 seconds of time in order to collect qps on the low-rate tests.
+      executor.runFor(1000 * 20);
+      int expectedCount = (int) (((numIterations == 0 ? 0 : 1) * qps * numDarkInstances * 20)/ (double) (numSourceInstances));
       int actualCount = baseDispatcher.getRequestCount();
       Assert.assertEquals(actualCount, expectedCount, expectedCount * ERR_PCT, "count not within expected range");
     });

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.22.5
+version=29.22.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
@@ -248,11 +248,6 @@ public class SmoothRateLimiter implements AsyncRateLimiter
       loop();
     }
 
-    private int getRemainingTimeInPeriod()
-    {
-      return (int) (_rate.getPeriod() - (_clock.currentTimeMillis() - _permitTime));
-    }
-
     public void loop()
     {
       // Checks if permits should be refreshed

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
@@ -23,6 +23,7 @@ import com.linkedin.r2.transport.http.client.TestEvictingCircularBuffer;
 import com.linkedin.test.util.ClockedExecutor;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -35,9 +36,16 @@ public class TestConstantQpsRateLimiter
 {
   private static final int TEST_TIMEOUT = 3000;
   private static final float TEST_QPS = 5;
+  private static final float TEST_LOW_FRACTIONAL_QPS = 0.05f;
   private static final int ONE_SECOND = 1000;
-  private static final int TEST_NUM_CYCLES = 10;
+  private static final int TEST_NUM_CYCLES = 100;
   private static final int UNLIMITED_BURST = Integer.MAX_VALUE;
+  private static final int LARGE_TEST_NUM_REPLICAS = 400;
+  private static final int LARGE_TEST_INBOUND_QPS_PER_REPLICA = 10;
+  private static final int LARGE_TEST_MAX_BURST_MULTIPLE = 3;
+  private static final int LARGE_TEST_MAX_BURST_FREQUENCY_COUNT = 5;
+  private static final int LARGE_TEST_MAX_ZERO_FREQUENCY_COUNT = 5;
+  private static final float LARGE_TEST_QUERY_VOLUME_CONSISTENCY_CONFIDENCE = 0.95f;
 
 
   @Test(timeOut = TEST_TIMEOUT)
@@ -60,16 +68,20 @@ public class TestConstantQpsRateLimiter
   @Test(timeOut = TEST_TIMEOUT)
   public void lowNonWholeRate()
   {
-    ClockedExecutor executor = new ClockedExecutor();
-    ClockedExecutor circularBufferExecutor = new ClockedExecutor();
-    ConstantQpsRateLimiter rateLimiter =
-        new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor));
-    rateLimiter.setRate(0.05d, ONE_SECOND, UNLIMITED_BURST);
-    rateLimiter.setBufferCapacity(1);
-    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
-    rateLimiter.submit(tattler);
-    executor.runFor(59000);
-    Assert.assertTrue(tattler.getInteractCount() == 3);
+    for (int i = 0; i < TEST_NUM_CYCLES; i++)
+    {
+      ClockedExecutor executor = new ClockedExecutor();
+      ClockedExecutor circularBufferExecutor = new ClockedExecutor();
+      ConstantQpsRateLimiter rateLimiter =
+          new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor));
+      rateLimiter.setRate(TEST_LOW_FRACTIONAL_QPS, ONE_SECOND, UNLIMITED_BURST);
+      rateLimiter.setBufferCapacity(1);
+      TattlingCallback<None> tattler = new TattlingCallback<>(executor);
+      rateLimiter.submit(tattler);
+      // run for enough time such that 3 queries are sent
+      executor.runFor((int) (((ONE_SECOND / TEST_LOW_FRACTIONAL_QPS) * 3) - 1));
+      Assert.assertTrue(tattler.getInteractCount() == 3);
+    }
   }
 
   @Test(timeOut = TEST_TIMEOUT)
@@ -80,7 +92,7 @@ public class TestConstantQpsRateLimiter
         new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(executor));
 
     rateLimiter.setRate(TEST_QPS, ONE_SECOND, UNLIMITED_BURST);
-    rateLimiter.setBufferTtl(999, ChronoUnit.MILLIS);
+    rateLimiter.setBufferTtl(ONE_SECOND - 1, ChronoUnit.MILLIS);
     TattlingCallback<None> tattler = new TattlingCallback<>(executor);
     rateLimiter.submit(tattler);
     executor.runFor(ONE_SECOND * TEST_NUM_CYCLES);
@@ -116,6 +128,86 @@ public class TestConstantQpsRateLimiter
     assert(uniqueTimeDeltas.size() > 5 && uniqueTimeDeltas.size() < 11);
   }
 
+  @Test
+  public void testLowRateHighlyParallelConsistentRandomness()
+  {
+    // Simulate a large production cluster dispatching a very low rate of traffic.
+    // This test verifies that the resulting qps from a distributed collection of dispatchers
+    // follows a predictable pattern within the defined tolerances.
+    int maxBurstFailCount = 0;
+    int burstFreqFailCount = 0;
+    int zeroFreqFailCount = 0;
+    for (int n = 0; n < TEST_NUM_CYCLES; n++)
+    {
+      // Set simulated test time such that each replica sends exactly one request.
+      int totalRuntime = (int) (ONE_SECOND / (TEST_QPS / LARGE_TEST_NUM_REPLICAS));
+      List<Long> queryTimes = new ArrayList<>();
+      for (int i = 0; i < LARGE_TEST_NUM_REPLICAS; i++)
+      {
+        ClockedExecutor executor = new ClockedExecutor();
+        ConstantQpsRateLimiter rateLimiter =
+            new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(executor));
+        rateLimiter.setBufferTtl(Integer.MAX_VALUE, ChronoUnit.DAYS);
+        rateLimiter.setBufferCapacity(1);
+        // Split an already low TEST_QPS across a large number of replicas
+        rateLimiter.setRate(TEST_QPS / LARGE_TEST_NUM_REPLICAS, ONE_SECOND, 1);
+        TattlingCallback<None> tattler = new TattlingCallback<>(executor);
+        rateLimiter.submit(tattler);
+
+        // Each test replica receives 10 qps, but sends 1 request very infrequently due to the low
+        // target rate shared across the large cluster.
+        // Intermix inbound queries while running clock at the defined rate
+        for (int x = 0; x < totalRuntime; x = x + ONE_SECOND / LARGE_TEST_INBOUND_QPS_PER_REPLICA)
+        {
+          rateLimiter.submit(tattler);
+          executor.runFor(ONE_SECOND / LARGE_TEST_INBOUND_QPS_PER_REPLICA);
+        }
+        for (Long stamp : tattler.getOccurrences())
+        {
+          // totalRuntime includes 1ms of the next window. Exclude any query occurring on the first ms from the next window.
+          // Prefer this over making totalRuntime 1ms shorter since it keeps the math clean
+          if (stamp != totalRuntime) {
+            queryTimes.add(stamp);
+          }
+        }
+      }
+      // each replica should have only sent one request
+      assert (queryTimes.size() == LARGE_TEST_NUM_REPLICAS);
+      int[] queriesPerBucketedSecond = new int[totalRuntime / ONE_SECOND];
+      for (Long stamp : queryTimes)
+      {
+        int idx = (int) (stamp / ONE_SECOND);
+        queriesPerBucketedSecond[idx]++;
+      }
+      // ensure the cluster sent an average of the TEST_QPS
+      assert (Arrays.stream(queriesPerBucketedSecond).average().getAsDouble() == TEST_QPS);
+
+      // Variability of query volume is expected in production, but make sure it stays in check
+      // Ensure our bursts in queries in a given second aren't too high
+      if (Arrays.stream(queriesPerBucketedSecond).max().getAsInt() > TEST_QPS * LARGE_TEST_MAX_BURST_MULTIPLE)
+      {
+        maxBurstFailCount++;
+      };
+      // Make sure though that we don't see too many seconds with high query volume
+      if (Arrays.stream(queriesPerBucketedSecond).filter(
+          a -> a > TEST_QPS * LARGE_TEST_MAX_BURST_MULTIPLE * 0.67).count() > LARGE_TEST_MAX_BURST_FREQUENCY_COUNT)
+      {
+        burstFreqFailCount++;
+      }
+      // Make sure we don't have too many cases of sending zero qps.
+      if (Arrays.stream(queriesPerBucketedSecond).filter(a -> a == 0).count() > LARGE_TEST_MAX_ZERO_FREQUENCY_COUNT)
+      {
+        zeroFreqFailCount++;
+      }
+    }
+    // Query volume stability assertions should be true within the defined confidence value
+    int acceptableFailCount =
+        (int) (TEST_NUM_CYCLES * (1 - LARGE_TEST_QUERY_VOLUME_CONSISTENCY_CONFIDENCE));
+    assert(maxBurstFailCount <= acceptableFailCount);
+    assert(burstFreqFailCount <= acceptableFailCount);
+    assert(zeroFreqFailCount <= acceptableFailCount);
+  }
+
   private static class TattlingCallback<T> implements Callback<T>
   {
     private AtomicInteger _interactCount = new AtomicInteger();
@@ -131,7 +223,8 @@ public class TestConstantQpsRateLimiter
     public void onError(Throwable e) {}
 
     @Override
-    public void onSuccess(T result) {
+    public void onSuccess(T result)
+    {
       _interactCount.incrementAndGet();
       _occurrences.add(_clock.currentTimeMillis());
     }


### PR DESCRIPTION
Previous code tends to not actually introduce randomness before executing callbacks. This is caused by event loop iterations being rapidly scheduled back to back (such as setting the rate), which flip the boolean that tracks whether or not a delay should be incurred. This patch replaces the hasDelayed boolean with a more durable timestamp to compare against.

Most important change is a robust unit test that should accurately simulate production. Let me know if I'm missing something with this test setup. The new test fails spectacularly without the patch to SmoothRateLimiter applied.