### PR TITLE
Fix an issue in StateUpdater to force update PartitionState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.22.11] - 2021-10-25
+- Fix an issue in D2 StateUpdater to force update PartitionState
+
 ## [29.22.10] - 2021-10-20
 - SmoothRateLimiter - do not double-count execution delays on setRate
 
@@ -5117,7 +5120,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.11...master
+[29.22.11]: https://github.com/linkedin/rest.li/compare/v29.22.10...v29.22.11
 [29.22.10]: https://github.com/linkedin/rest.li/compare/v29.22.9...v29.22.10
 [29.22.9]: https://github.com/linkedin/rest.li/compare/v29.22.8...v29.22.9
 [29.22.8]: https://github.com/linkedin/rest.li/compare/v29.22.7...v29.22.8

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/QuarantineManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/QuarantineManager.java
@@ -286,9 +286,7 @@ public class QuarantineManager {
     }
     else if (trackerClientState.isUnhealthy() || trackerClientState.getHealthScore() > FAST_RECOVERY_HEALTH_SCORE_THRESHOLD)
     {
-      /**
-       * Remove the client from the map if the client is unhealthy or he health score is beyond 0.5
-       */
+      // Remove the client from the map if the client is unhealthy or the health score is beyond 0.5
       recoverySet.remove(trackerClient);
     }
   }
@@ -380,7 +378,8 @@ public class QuarantineManager {
     // Also enroll new client into the recovery set if slow start is enabled
     if (!recoverySet.contains(trackerClient)
         && !oldPartitionState.getTrackerClients().contains(trackerClient)
-        && _slowStartEnabled)
+        && _slowStartEnabled
+        && !trackerClient.doNotSlowStart())
     {
       recoverySet.add(trackerClient);
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
@@ -130,9 +130,10 @@ public class SubsettingState
           Map<Integer, Map<URI, TrackerClient>> serviceWeightedSubset = new HashMap<>();
           servicePotentialClients.put(partitionId, potentialClients.keySet());
           serviceWeightedSubset.put(partitionId, subsetClients);
+          subsetCache = new SubsetCache(version, metadata.getPeerClusterVersion(),
+              minClusterSubsetSize, servicePotentialClients, serviceWeightedSubset);
 
-          _subsetCache.put(serviceName, new SubsetCache(version, metadata.getPeerClusterVersion(),
-              minClusterSubsetSize, servicePotentialClients, serviceWeightedSubset));
+          _subsetCache.put(serviceName, subsetCache);
         }
 
         LOG.debug("Subset cache updated for service " + serviceName + ": " + subsetCache);

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -446,7 +446,7 @@ public class StateUpdaterTest
     Set<TrackerClient> newTrackerClientSet = new HashSet<>();
     newTrackerClientSet.add(trackerClients.get(0));
     newTrackerClientSet.add(trackerClients.get(1));
-    _stateUpdater.updateStateForPartition(newTrackerClientSet, DEFAULT_PARTITION_ID, state, 1L);
+    _stateUpdater.updateStateForPartition(newTrackerClientSet, DEFAULT_PARTITION_ID, state, 1L, false);
 
     Map<URI, Integer> pointsMap = _stateUpdater.getPointsMap(DEFAULT_PARTITION_ID);
     assertEquals(pointsMap.size(), 2, "There should only be 2 uris after cluster id change");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.22.10
+version=29.22.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Minor bug fixes for subsetting and d2 recovery:
1. Do not put a host into recovery set if doNotSlowStart is specified
2. If `shouldForceUpdate` is true, we should check for host changes in state updater
3. Minor style fixes