### PR TITLE
Make SmoothRateLimiter setRate idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.22.13] - 2021-11-05
+- Make SmoothRateLimiter setRate idempotent
+
 ## [29.22.12] - 2021-10-28
 - add canaries to service and cluster properties
 
@@ -5123,7 +5126,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.13...master
+[29.22.13]: https://github.com/linkedin/rest.li/compare/v29.22.12...v29.22.13
 [29.22.12]: https://github.com/linkedin/rest.li/compare/v29.22.11...v29.22.12
 [29.22.11]: https://github.com/linkedin/rest.li/compare/v29.22.10...v29.22.11
 [29.22.10]: https://github.com/linkedin/rest.li/compare/v29.22.9...v29.22.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.22.12
+version=29.22.13
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
@@ -25,8 +25,6 @@ import com.linkedin.r2.transport.http.client.ratelimiter.Rate;
 import com.linkedin.util.ArgumentUtil;
 import com.linkedin.util.RateLimitedLogger;
 import com.linkedin.util.clock.Clock;
-import java.time.Instant;
-import java.util.Date;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.concurrent.Executor;
@@ -308,12 +306,6 @@ public class SmoothRateLimiter implements AsyncRateLimiter
         }
         finally
         {
-          if (!_executionTracker.isPaused())
-          {
-            // System.out.println(_clock.currentTimeMillis());
-            Date derp = Date.from(Instant.ofEpochMilli(_clock.currentTimeMillis()));
-            System.out.println(derp.getSeconds());
-          }
           if (!_executionTracker.decrementAndGetPaused())
           {
             _scheduler.execute(this::loop);

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/Rate.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/Rate.java
@@ -118,8 +118,8 @@ public class Rate
     return _period;
   }
 
-  @Override
-  public boolean equals(Object o) {
+  public boolean equals(Object o)
+  {
     if (this == o)
     {
       return true;
@@ -129,8 +129,7 @@ public class Rate
       return false;
     }
     Rate rate = (Rate) o;
-    return Double.compare(rate.getEventsRaw(), getEventsRaw()) == 0
-        && Double.compare(rate.getPeriodRaw(), getPeriodRaw()) == 0;
+    return rate.getEventsRaw() == getEventsRaw() && rate.getPeriodRaw() == getPeriodRaw();
   }
 
   @Override

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/Rate.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/Rate.java
@@ -16,6 +16,9 @@
 
 package com.linkedin.r2.transport.http.client.ratelimiter;
 
+import java.util.Objects;
+
+
 /**
  * An immutable implementation of rate as number of events per period of time in milliseconds.
  * In addition, a {@code burst} parameter is used to indicate the maximum number of permits can
@@ -113,5 +116,26 @@ public class Rate
   public double getPeriodRaw()
   {
     return _period;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+    {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass())
+    {
+      return false;
+    }
+    Rate rate = (Rate) o;
+    return Double.compare(rate.getEventsRaw(), getEventsRaw()) == 0
+        && Double.compare(rate.getPeriodRaw(), getPeriodRaw()) == 0;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(getEventsRaw(), getPeriodRaw());
   }
 }

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
@@ -159,6 +159,7 @@ public class TestConstantQpsRateLimiter
         // Intermix inbound queries while running clock at the defined rate
         for (int x = 0; x < totalRuntime; x = x + ONE_SECOND / LARGE_TEST_INBOUND_QPS_PER_REPLICA)
         {
+          // ensure that calling setRate before submitting a new callback does not detrimentally affect random distribution
           rateLimiter.setRate(TEST_QPS / LARGE_TEST_NUM_REPLICAS, ONE_SECOND, 1);
           rateLimiter.submit(tattler);
           executor.runFor(ONE_SECOND / LARGE_TEST_INBOUND_QPS_PER_REPLICA);

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
@@ -159,6 +159,7 @@ public class TestConstantQpsRateLimiter
         // Intermix inbound queries while running clock at the defined rate
         for (int x = 0; x < totalRuntime; x = x + ONE_SECOND / LARGE_TEST_INBOUND_QPS_PER_REPLICA)
         {
+          rateLimiter.setRate(TEST_QPS / LARGE_TEST_NUM_REPLICAS, ONE_SECOND, 1);
           rateLimiter.submit(tattler);
           executor.runFor(ONE_SECOND / LARGE_TEST_INBOUND_QPS_PER_REPLICA);
         }


### PR DESCRIPTION
Further testing shows benefit in randomness of query distribution over a given period when setRate is idempotent. Current implementation of setRate tends to favor maintaining throughput over maintaining a consistently random distribution over a period.