### PR TITLE
Throw an exception when an entity-level action would be invoked witho…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- For entity level action request builders, issue a sensible error if the id is null.
 
 ## [29.22.10] - 2021-10-20
 - SmoothRateLimiter - do not double-count execution delays on setRate

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/handler/http2/Http2ProtocolUpgradeHandler.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/handler/http2/Http2ProtocolUpgradeHandler.java
@@ -78,7 +78,7 @@ public class Http2ProtocolUpgradeHandler extends ChannelDuplexHandler
 
   public static void processChannelActive(ChannelHandlerContext ctx, Logger log, ChannelPromise upgradePromise)
   {
-    // For an upgrade request, clients should use an OPTIONS request for path “*” or a HEAD request for “/”.
+    // For an upgrade request, clients should use an OPTIONS request for path "*" or a HEAD request for "/".
     // RFC: https://tools.ietf.org/html/rfc7540#section-3.2
     // Implementation detail: https://http2.github.io/faq/#can-i-implement-http2-without-implementing-http11
     final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "*");

--- a/restli-client/src/main/java/com/linkedin/restli/client/ActionRequestBuilder.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/ActionRequestBuilder.java
@@ -241,6 +241,11 @@ public class ActionRequestBuilder<K, V> extends AbstractRequestBuilder<K, V, Act
 
   }
 
+  protected boolean hasId()
+  {
+    return _id != null;
+  }
+
   private Map<FieldDef<?>, Object> buildReadOnlyActionParameters()
   {
     return buildReadOnlyActionParameters(_actionParams);

--- a/restli-client/src/main/java/com/linkedin/restli/client/base/EntityActionRequestBuilderBase.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/base/EntityActionRequestBuilderBase.java
@@ -1,0 +1,47 @@
+/*
+   Copyright (c) 2021 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/**
+ * $Id: $
+ */
+
+package com.linkedin.restli.client.base;
+
+import com.linkedin.restli.client.ActionRequest;
+import com.linkedin.restli.client.RestliRequestOptions;
+import com.linkedin.restli.common.ResourceSpec;
+
+/**
+ * The abstract base class for all generated request builders classes for entity-level actions.
+ */
+public abstract class EntityActionRequestBuilderBase<K, V, RB extends ActionRequestBuilderBase<K, V, RB>>
+        extends ActionRequestBuilderBase<K, V, RB>
+{
+    protected EntityActionRequestBuilderBase(String baseUriTemplate, Class<V> elementClass, ResourceSpec resourceSpec,
+        RestliRequestOptions requestOptions)
+    {
+      super(baseUriTemplate, elementClass, resourceSpec, requestOptions);
+    }
+
+    @Override
+    public ActionRequest<V> build() {
+      if (!hasId())
+      {
+        throw new IllegalStateException("Entity-level action request is missing required id value.");
+      }
+      return super.build();
+    }
+}

--- a/restli-client/src/main/java/com/linkedin/restli/client/base/EntityActionRequestBuilderBase.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/base/EntityActionRequestBuilderBase.java
@@ -14,10 +14,6 @@
    limitations under the License.
 */
 
-/**
- * $Id: $
- */
-
 package com.linkedin.restli.client.base;
 
 import com.linkedin.restli.client.ActionRequest;
@@ -26,6 +22,11 @@ import com.linkedin.restli.common.ResourceSpec;
 
 /**
  * The abstract base class for all generated request builders classes for entity-level actions.
+ *
+ * For entity-level actions the action is being performed against a specific record which means
+ * that the key/id must be present in the request to identify which record to perform the action
+ * on. This class adds validation when the request is built that the id was set to a non-null
+ * value.
  */
 public abstract class EntityActionRequestBuilderBase<K, V, RB extends ActionRequestBuilderBase<K, V, RB>>
         extends ActionRequestBuilderBase<K, V, RB>

--- a/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.greeting.restspec.json
+++ b/restli-int-test-api/src/main/idl/com.linkedin.restli.examples.greetings.client.greeting.restspec.json
@@ -28,6 +28,22 @@
       } ],
       "returns" : "int"
     }, {
+      "name" : "exampleActionThatIsExplicitlyAnyLevel",
+      "doc" : "An example action on the greeting which is explicitly set to any-level.",
+      "parameters" : [ {
+        "name" : "param1",
+        "type" : "int"
+      } ],
+      "returns" : "int"
+    }, {
+      "name" : "exampleActionThatIsExplicitlyEntityLevel",
+      "doc" : "An example action on the greeting which is explicitly set to entity-level.",
+      "parameters" : [ {
+        "name" : "param1",
+        "type" : "int"
+      } ],
+      "returns" : "int"
+    }, {
       "name" : "exceptionTest",
       "doc" : "An example action throwing an exception."
     } ],

--- a/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.greeting.snapshot.json
+++ b/restli-int-test-api/src/main/snapshot/com.linkedin.restli.examples.greetings.client.greeting.snapshot.json
@@ -58,6 +58,22 @@
         } ],
         "returns" : "int"
       }, {
+        "name" : "exampleActionThatIsExplicitlyAnyLevel",
+        "doc" : "An example action on the greeting which is explicitly set to any-level.",
+        "parameters" : [ {
+          "name" : "param1",
+          "type" : "int"
+        } ],
+        "returns" : "int"
+      }, {
+        "name" : "exampleActionThatIsExplicitlyEntityLevel",
+        "doc" : "An example action on the greeting which is explicitly set to entity-level.",
+        "parameters" : [ {
+          "name" : "param1",
+          "type" : "int"
+        } ],
+        "returns" : "int"
+      }, {
         "name" : "exceptionTest",
         "doc" : "An example action throwing an exception."
       } ],

--- a/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/RootSimpleResource.java
+++ b/restli-int-test-server/src/main/java/com/linkedin/restli/examples/greetings/server/RootSimpleResource.java
@@ -22,6 +22,7 @@ import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.common.PatchRequest;
 import com.linkedin.restli.examples.greetings.api.Greeting;
 import com.linkedin.restli.examples.greetings.api.Tone;
+import com.linkedin.restli.server.ResourceLevel;
 import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.server.UpdateResponse;
 import com.linkedin.restli.server.annotations.Action;
@@ -94,6 +95,24 @@ public class RootSimpleResource extends SimpleResourceTemplate<Greeting>
   public int exampleAction(@ActionParam("param1") int param1)
   {
     return param1 * 10;
+  }
+
+  /**
+   * An example action on the greeting which is explicitly set to entity-level.
+   */
+  @Action(name="exampleActionThatIsExplicitlyEntityLevel", resourceLevel=ResourceLevel.ENTITY)
+  public int exampleActionThatIsExplicitlyEntityLevel(@ActionParam("param1") int param1)
+  {
+    return param1 * 11;
+  }
+
+  /**
+   * An example action on the greeting which is explicitly set to any-level.
+   */
+  @Action(name="exampleActionThatIsExplicitlyAnyLevel", resourceLevel=ResourceLevel.ANY)
+  public int exampleActionThatIsExplicitlyAnyLevel(@ActionParam("param1") int param1)
+  {
+    return param1 * 12;
   }
 
   /**

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestGreetingsClient.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestGreetingsClient.java
@@ -121,6 +121,14 @@ public class TestGreetingsClient extends RestLiIntegrationTest
     Assert.assertEquals(request.getRequestOptions(), builders.getRequestOptions());
   }
 
+  @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestBuilderDataProvider",
+    expectedExceptions = { IllegalStateException.class },
+    expectedExceptionsMessageRegExp = "Entity-level action request is missing required id value\\.")
+  public void testEntityActionRequiresIdInBuild(RootBuilderWrapper<Long, Greeting> builders)
+  {
+    builders.action("SomeAction").build();
+  }
+
   @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestBuilderDataProvider")
   public void testGetRequestOptionsPropagation(RootBuilderWrapper<Long, Greeting> builders)
   {

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestSimpleResourceHierarchy.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestSimpleResourceHierarchy.java
@@ -161,6 +161,24 @@ public class TestSimpleResourceHierarchy extends RestLiIntegrationTest
   }
 
   @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestBuilderDataProvider")
+  public void testRootSimpleResourceEntityAction(RootBuilderWrapper<Void, Greeting> builders) throws RemoteInvocationException
+  {
+    Request<Integer> request = builders.<Integer>action("ExampleActionThatIsExplicitlyEntityLevel").setActionParam("Param1", 3).build();
+    ResponseFuture<Integer> responseFuture = getClient().sendRequest(request);
+    Assert.assertEquals(responseFuture.getResponse().getStatus(), 200);
+    Assert.assertEquals(responseFuture.getResponse().getEntity().intValue(), 33);
+  }
+
+  @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestBuilderDataProvider")
+  public void testRootSimpleResourceAnyAction(RootBuilderWrapper<Void, Greeting> builders) throws RemoteInvocationException
+  {
+    Request<Integer> request = builders.<Integer>action("ExampleActionThatIsExplicitlyAnyLevel").setActionParam("Param1", 3).build();
+    ResponseFuture<Integer> responseFuture = getClient().sendRequest(request);
+    Assert.assertEquals(responseFuture.getResponse().getStatus(), 200);
+    Assert.assertEquals(responseFuture.getResponse().getEntity().intValue(), 36);
+  }
+
+  @Test(dataProvider = com.linkedin.restli.internal.common.TestConstants.RESTLI_PROTOCOL_1_2_PREFIX + "requestBuilderDataProvider")
   public void testRootSimpleResourceActionException(RootBuilderWrapper<Void, Greeting> builders) throws RemoteInvocationException
   {
     try

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/JavaRequestBuilderGenerator.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/JavaRequestBuilderGenerator.java
@@ -42,6 +42,7 @@ import com.linkedin.pegasus.generator.JavaCodeUtil;
 import com.linkedin.pegasus.generator.JavaDataTemplateGenerator;
 import com.linkedin.pegasus.generator.TemplateSpecGenerator;
 import com.linkedin.pegasus.generator.spec.ClassTemplateSpec;
+import com.linkedin.restli.client.ActionRequestBuilder;
 import com.linkedin.restli.client.OptionsRequestBuilder;
 import com.linkedin.restli.client.RestliRequestOptions;
 import com.linkedin.restli.client.base.ActionRequestBuilderBase;
@@ -57,6 +58,7 @@ import com.linkedin.restli.client.base.BuilderBase;
 import com.linkedin.restli.client.base.CreateIdEntityRequestBuilderBase;
 import com.linkedin.restli.client.base.CreateIdRequestBuilderBase;
 import com.linkedin.restli.client.base.DeleteRequestBuilderBase;
+import com.linkedin.restli.client.base.EntityActionRequestBuilderBase;
 import com.linkedin.restli.client.base.FindRequestBuilderBase;
 import com.linkedin.restli.client.base.GetAllRequestBuilderBase;
 import com.linkedin.restli.client.base.GetRequestBuilderBase;
@@ -1378,7 +1380,9 @@ public class JavaRequestBuilderGenerator extends JavaCodeGeneratorBase
     {
       for (ActionSchema action : resourceActions)
       {
-        generateActionMethod(facadeClass, baseUriExpr, _voidClass, action, resourceSpecField, resourceName, pathKeys, pathKeyTypes, assocKeyTypes, pathToAssocKeys, requestOptionsExpr, rootPath);
+        generateActionMethod(facadeClass, baseUriExpr, _voidClass, ActionRequestBuilderBase.class, action,
+            resourceSpecField, resourceName, pathKeys, pathKeyTypes, assocKeyTypes, pathToAssocKeys, requestOptionsExpr,
+            rootPath);
       }
     }
 
@@ -1386,7 +1390,9 @@ public class JavaRequestBuilderGenerator extends JavaCodeGeneratorBase
     {
       for (ActionSchema action : entityActions)
       {
-        generateActionMethod(facadeClass, baseUriExpr, keyClass, action, resourceSpecField, resourceName, pathKeys, pathKeyTypes, assocKeyTypes, pathToAssocKeys, requestOptionsExpr, rootPath);
+        generateActionMethod(facadeClass, baseUriExpr, keyClass, EntityActionRequestBuilderBase.class, action,
+            resourceSpecField, resourceName, pathKeys, pathKeyTypes, assocKeyTypes, pathToAssocKeys, requestOptionsExpr,
+            rootPath);
       }
     }
   }
@@ -1394,6 +1400,7 @@ public class JavaRequestBuilderGenerator extends JavaCodeGeneratorBase
   private void generateActionMethod(JDefinedClass facadeClass,
                                     JExpression baseUriExpr,
                                     JClass keyClass,
+                                    Class<?> builderParentClass,
                                     ActionSchema action,
                                     JVar resourceSpecField,
                                     String resourceName,
@@ -1406,7 +1413,7 @@ public class JavaRequestBuilderGenerator extends JavaCodeGeneratorBase
       throws JClassAlreadyExistsException
   {
     final JClass returnType = getActionReturnType(facadeClass, action.getReturns());
-    final JClass vanillaActionBuilderClass = getCodeModel().ref(ActionRequestBuilderBase.class).narrow(keyClass, returnType);
+    final JClass vanillaActionBuilderClass = getCodeModel().ref(builderParentClass).narrow(keyClass, returnType);
     final String actionName = action.getName();
 
     final String actionBuilderClassName = CodeUtil.capitalize(resourceName) + "Do" + CodeUtil.capitalize(actionName) + METHOD_BUILDER_SUFFIX.get(_version);


### PR DESCRIPTION
…ut an id.

Entity-level actions are performed on a specific resource, and so the id value
in the request is mandatory. Today, if the client forgets to call .id(...) to
supply a value the request can be built and sent to the server where it will
cause an error with a mysterious error message that implies that there is no
action of that name, i.e.
"POST operation named myAction not supported on resource '...' URI: '...'"

Here we fix that so that
a) The problem is caught on the client side during the RequestBuilder.build()
   method call so that the request cannot be sent to the server.
b) A sensible error message is given where the stack trace's line number will
   lead the developer straight to the root of the problem:
   "Missing or null id value; we cannot invoke this entity-level action."

**Summary**

When invoking an entity-level action, if your code passes null to the request builder's id setter, then the request will fail with an error saying that the action does not exist. I propose a performant way to provide a better error message saying that because it is an entity-level action (as opposed to a collection-level action) a value for the key is required.

**Problem statement**

Suppose that we have "myResource" generated from net.hotelling.harold.restli.MyResource with entity-level action "myAction". For an entity level action, the following request will always fail:

```
    restClient.sendRequest(new MyResourceRequestBuilders().actionMyAction()
      .id(null)
      .build());
```

This is an easier bug to introduce if the id is supplied by a nullable variable where there may be some unintended code path that

```
    // Bad code path results in key == null here:
    restClient.sendRequest(new MyResourceRequestBuilders().actionMyAction()
      .id(key)
      .build());
```

Unfortunately, the error message that occurs in this scenario implies that the action does not exist, which should never happen because the action was invoked using client code generated from the server-side resource class.

 `com.linkedin.restli.server.RoutingException: POST operation named myAction not supported on resource 'net.hotelling.harold.resources.restli.MyResource' URI: 'http://localhost/myResource?action=myAction'`

The error message is coming from this logic on the server side:
https://github.com/linkedin/rest.li/blob/b1ac6f103e0248450f35bc618401166dcd38c830/restli-server/src/main/java/com/linkedin/restli/internal/server/RestLiRouter.java#L254

**Proposed solution**

For entity-level actions, add a null check for the _id during the #build() that takes the RequestBuilder and creates an ActionRequest. If the _id is null, then throw a meaningful error message. Add the check by having the generated RequestBuilder class that models an entity level action subclass a new layer in the inheritance hierarchy. The new class will be EntityActionRequestBuilderBase which exists only to perform this check. Collection level actions will continue to subclass ActionRequestBuilderBase.

**How is the proposed solution performant?**

It will also perform the check in the Rest.li client side to save on unnecessary network traffic.
The additional logic will only exist for RequestBuilders classes for entity-level actions.
The additional null check is trivial in cost compared to other per-request logic already being performed in `com.linkedin.restli.client.AbstractRequestBuilder#getReadOnlyOrCopyKeyObject`, for example the two `instanceof` checks.

**In our design do we need to consider a case where the same action name exists for both a collection and entity level action?**

Code gen logic builds a class name that would be the same for an entity-level and collection-level action with the same action name, so we know that this cannot happen.
Doesn't matter anyway - we generate separate action request builder classes.

**Are there alternative approaches?**

After looking for a matching method if there is no match, loop again to see if there is a name-only match.
Or, since we know that there can only be one action with a given name:

```
    // https://github.com/linkedin/rest.li/blob/b1ac6f103e0248450f35bc618401166dcd38c830/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java#L428
    for (ResourceMethodDescriptor methodDescriptor : _resourceMethodDescriptors)
    {
      if (methodDescriptor.getType().equals(ResourceMethod.ACTION)
              && actionName.equals(methodDescriptor.getActionName()))
      {
        if (methodDescriptor.getActionResourceLevel().equals(resourceLevel)) {
          return methodDescriptor;
        } else {
          // TODO: return some meaningful error saying the action exists but the ResourceLevel does not match...
        }
      }
    }
```
