### PR TITLE
Fixed issues with potential duplicate TimingKeys being registered.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5137,7 +5137,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.15...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.16...master
+[29.22.16]: https://github.com/linkedin/rest.li/compare/v29.22.15...v29.22.16
 [29.22.15]: https://github.com/linkedin/rest.li/compare/v29.22.14...v29.22.15
 [29.22.14]: https://github.com/linkedin/rest.li/compare/v29.22.13...v29.22.14
 [29.22.13]: https://github.com/linkedin/rest.li/compare/v29.22.12...v29.22.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.22.16] - 2021-12-03
+- Fixed issues with potential duplicate TimingKeys being registered.
+
 ## [29.22.15] - 2021-11-30
 - Add mock response generator factory for BATCH_FINDER methods.
 - Deprecate `FileFormatDataSchemaParser#new(String, DataSchemaResolver, DataSchemaParserFactory)`. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.22.15
+version=29.22.16
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/filter/TimedRestFilter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/filter/TimedRestFilter.java
@@ -56,13 +56,13 @@ public class TimedRestFilter implements RestFilter
 
     String filterClassName = restFilter.getClass().getSimpleName();
     String timingKeyPrefix = filterClassName + "-";
-    String timingKeyPostfix = ":" + hashCode();
+    String timingKeyPostfix = ":";
 
-    _onRequestTimingKey = TimingKey.registerNewKey(timingKeyPrefix + ON_REQUEST_SUFFIX + timingKeyPostfix,
+    _onRequestTimingKey = TimingKey.registerNewKey(TimingKey.getUniqueName(timingKeyPrefix + ON_REQUEST_SUFFIX + timingKeyPostfix),
         _restFilter.getClass().getSimpleName(), TimingImportance.LOW);
-    _onResponseTimingKey = TimingKey.registerNewKey(timingKeyPrefix + ON_RESPONSE_SUFFIX + timingKeyPostfix,
+    _onResponseTimingKey = TimingKey.registerNewKey(TimingKey.getUniqueName(timingKeyPrefix + ON_RESPONSE_SUFFIX + timingKeyPostfix),
         _restFilter.getClass().getSimpleName(), TimingImportance.LOW);
-    _onErrorTimingKey = TimingKey.registerNewKey(timingKeyPrefix + ON_ERROR_SUFFIX + timingKeyPostfix,
+    _onErrorTimingKey = TimingKey.registerNewKey(TimingKey.getUniqueName(timingKeyPrefix + ON_ERROR_SUFFIX + timingKeyPostfix),
         _restFilter.getClass().getSimpleName(), TimingImportance.LOW);
     _shared = false;
   }

--- a/r2-core/src/main/java/com/linkedin/r2/filter/TimedStreamFilter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/filter/TimedStreamFilter.java
@@ -53,13 +53,13 @@ public class TimedStreamFilter implements StreamFilter
 
     String filterClassName = _streamFilter.getClass().getSimpleName();
     String timingKeyPrefix = filterClassName + "-";
-    String timingKeyPostfix = ":" + hashCode();
+    String timingKeyPostfix = ":";
 
-    _onRequestTimingKey = TimingKey.registerNewKey(timingKeyPrefix + ON_REQUEST_SUFFIX + timingKeyPostfix,
+    _onRequestTimingKey = TimingKey.registerNewKey(TimingKey.getUniqueName(timingKeyPrefix + ON_REQUEST_SUFFIX + timingKeyPostfix),
         filterClassName, TimingImportance.LOW);
-    _onResponseTimingKey = TimingKey.registerNewKey(timingKeyPrefix + ON_RESPONSE_SUFFIX + timingKeyPostfix,
+    _onResponseTimingKey = TimingKey.registerNewKey(TimingKey.getUniqueName(timingKeyPrefix + ON_RESPONSE_SUFFIX + timingKeyPostfix),
         filterClassName, TimingImportance.LOW);
-    _onErrorTimingKey = TimingKey.registerNewKey(timingKeyPrefix + ON_ERROR_SUFFIX + timingKeyPostfix,
+    _onErrorTimingKey = TimingKey.registerNewKey(TimingKey.getUniqueName(timingKeyPrefix + ON_ERROR_SUFFIX + timingKeyPostfix),
         filterClassName, TimingImportance.LOW);
     _shared = false;
   }

--- a/r2-core/src/test/java/com/linkedin/r2/message/timing/TestTimingKey.java
+++ b/r2-core/src/test/java/com/linkedin/r2/message/timing/TestTimingKey.java
@@ -1,0 +1,29 @@
+package com.linkedin.r2.message.timing;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link TimingKey}
+ */
+public class TestTimingKey
+{
+  @Test
+  public void testGetUniqueName()
+  {
+    final Set<String> names = new HashSet<>();
+
+    for (int i = 0; i < 10000; i++) {
+      final String uniqueName = TimingKey.getUniqueName("baseName");
+
+      Assert.assertTrue(uniqueName.contains("baseName"));
+      Assert.assertFalse(names.contains(uniqueName));
+
+      names.add(uniqueName);
+    }
+  }
+
+}


### PR DESCRIPTION
Change to log warning instead of throwing an error when a duplicate timing key name is registered.
Guarantee uniqueness of filter timing key names. 