### PR TITLE
Add mock response generator factory for BATCH_FINDER methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add mock response generator factory for BATCH_FINDER methods.
 
 ## [29.22.13] - 2021-11-05
 - Make SmoothRateLimiter setRate idempotent

--- a/restli-client-testutils/src/main/java/com/linkedin/restli/client/testutils/MockBatchCollectionResponseFactory.java
+++ b/restli-client-testutils/src/main/java/com/linkedin/restli/client/testutils/MockBatchCollectionResponseFactory.java
@@ -1,0 +1,86 @@
+package com.linkedin.restli.client.testutils;
+
+import com.linkedin.data.DataList;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.DataMapBuilder;
+import com.linkedin.data.collections.CheckedUtil;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.restli.common.BatchCollectionResponse;
+import com.linkedin.restli.common.CollectionMetadata;
+import com.linkedin.restli.common.CollectionResponse;
+import com.linkedin.restli.internal.common.BatchFinderCriteriaResultDecoder;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ * Factory for creating mock {@link BatchCollectionResponse}s that can be used on tests.
+ */
+public class MockBatchCollectionResponseFactory {
+  private MockBatchCollectionResponseFactory() { }
+
+  /**
+   * Creates a {@link BatchCollectionResponse} with the specified mock data.
+   *
+   * @param entryClass  the class of elements to be stored in {@link BatchCollectionResponse}
+   * @param elementsList A list of list containing the instances of type `entryClass`
+   * @param <T> the type of elements to be stored in {@link BatchCollectionResponse}
+   * @return An instance of {@link BatchCollectionResponse} created with the specified mock data
+   */
+  public static <T extends RecordTemplate> BatchCollectionResponse<T> create(
+      Class<T> entryClass, List<List<T>> elementsList) {
+    return create(entryClass, elementsList, Collections.emptyList(), Collections.emptyList());
+  }
+
+  /**
+   * Creates a {@link BatchCollectionResponse} with the specified mock data. Make sure the size of the specified lists
+   * are the same as the entries at the same index will be used for generating the instances of
+   * {@link com.linkedin.restli.common.BatchFinderCriteriaResult} that goes into the final {@link BatchCollectionResponse}.
+   * The specified paging and metadata list can contain null entries if the corresponding criteria result instance must
+   * not have the paging and/or metadata set.
+   *
+   * @param entryClass  the class of elements to be stored in {@link BatchCollectionResponse}
+   * @param elementsList A list of list containing the instances of type `entryClass`
+   * @param pagingList A list of {@link CollectionMetadata} for paging
+   * @param metadataList A list of {@link DataMap} for custom metadata
+   * @param <T> the type of elements to be stored in {@link BatchCollectionResponse}
+   * @return An instance of {@link BatchCollectionResponse} created with the specified mock data
+   */
+  public static <T extends RecordTemplate> BatchCollectionResponse<T> create(
+      Class<T> entryClass, List<List<T>> elementsList,
+      List<CollectionMetadata> pagingList, List<DataMap> metadataList) {
+
+    DataList batchedCollectionResponse = new DataList(DataMapBuilder.getOptimumHashMapCapacityFromSize(elementsList.size()));
+    for (int i = 0; i < elementsList.size(); i++) {
+      Collection<T> recordElements = elementsList.get(i);
+
+      DataList elements = recordElements.stream().map(RecordTemplate::data).collect(Collectors.toCollection(DataList::new));
+
+      DataMap collectionResponse = new DataMap();
+      collectionResponse.put(CollectionResponse.ELEMENTS, elements);
+
+      if (!pagingList.isEmpty()) {
+        CollectionMetadata paging = pagingList.get(i);
+        if (paging != null) {
+          collectionResponse.put(CollectionResponse.PAGING, paging.data());
+        }
+      }
+
+      if (!metadataList.isEmpty()) {
+        DataMap metadata = metadataList.get(i);
+        if (metadata != null) {
+          collectionResponse.put(CollectionResponse.METADATA, metadata);
+        }
+      }
+
+      batchedCollectionResponse.add(collectionResponse);
+    }
+
+    DataMap batchResponse = new DataMap(DataMapBuilder.getOptimumHashMapCapacityFromSize(1));
+    CheckedUtil.putWithoutCheckingOrChangeNotification(batchResponse, CollectionResponse.ELEMENTS, batchedCollectionResponse);
+
+    return new BatchCollectionResponse<>(batchResponse, new BatchFinderCriteriaResultDecoder<>(entryClass));
+  }
+}

--- a/restli-client-testutils/src/main/java/com/linkedin/restli/client/testutils/MockBatchCollectionResponseFactory.java
+++ b/restli-client-testutils/src/main/java/com/linkedin/restli/client/testutils/MockBatchCollectionResponseFactory.java
@@ -18,7 +18,8 @@ import java.util.stream.Collectors;
 /**
  * Factory for creating mock {@link BatchCollectionResponse}s that can be used on tests.
  */
-public class MockBatchCollectionResponseFactory {
+public class MockBatchCollectionResponseFactory
+{
   private MockBatchCollectionResponseFactory() { }
 
   /**
@@ -30,7 +31,8 @@ public class MockBatchCollectionResponseFactory {
    * @return An instance of {@link BatchCollectionResponse} created with the specified mock data
    */
   public static <T extends RecordTemplate> BatchCollectionResponse<T> create(
-      Class<T> entryClass, List<List<T>> elementsList) {
+      Class<T> entryClass, List<List<T>> elementsList)
+  {
     return create(entryClass, elementsList, Collections.emptyList(), Collections.emptyList());
   }
 
@@ -50,32 +52,38 @@ public class MockBatchCollectionResponseFactory {
    */
   public static <T extends RecordTemplate> BatchCollectionResponse<T> create(
       Class<T> entryClass, List<List<T>> elementsList,
-      List<CollectionMetadata> pagingList, List<DataMap> metadataList) {
+      List<CollectionMetadata> pagingList, List<DataMap> metadataList)
+  {
 
     DataList batchedCollectionResponse = new DataList(DataMapBuilder.getOptimumHashMapCapacityFromSize(elementsList.size()));
-    for (int i = 0; i < elementsList.size(); i++) {
+    for (int i = 0; i < elementsList.size(); i++)
+    {
       Collection<T> recordElements = elementsList.get(i);
 
       DataList elements = recordElements.stream().map(RecordTemplate::data).collect(Collectors.toCollection(DataList::new));
 
-      DataMap collectionResponse = new DataMap();
-      collectionResponse.put(CollectionResponse.ELEMENTS, elements);
+      DataMap collectionResponse = new DataMap(DataMapBuilder.getOptimumHashMapCapacityFromSize(3));
+      CheckedUtil.putWithoutCheckingOrChangeNotification(collectionResponse, CollectionResponse.ELEMENTS, elements);
 
-      if (!pagingList.isEmpty()) {
+      if (!pagingList.isEmpty())
+      {
         CollectionMetadata paging = pagingList.get(i);
-        if (paging != null) {
-          collectionResponse.put(CollectionResponse.PAGING, paging.data());
+        if (paging != null)
+        {
+          CheckedUtil.putWithoutCheckingOrChangeNotification(collectionResponse, CollectionResponse.PAGING, paging.data());
         }
       }
 
-      if (!metadataList.isEmpty()) {
+      if (!metadataList.isEmpty())
+      {
         DataMap metadata = metadataList.get(i);
-        if (metadata != null) {
-          collectionResponse.put(CollectionResponse.METADATA, metadata);
+        if (metadata != null)
+        {
+          CheckedUtil.putWithoutCheckingOrChangeNotification(collectionResponse, CollectionResponse.METADATA, metadata);
         }
       }
 
-      batchedCollectionResponse.add(collectionResponse);
+      CheckedUtil.addWithoutChecking(batchedCollectionResponse, collectionResponse);
     }
 
     DataMap batchResponse = new DataMap(DataMapBuilder.getOptimumHashMapCapacityFromSize(1));

--- a/restli-client-testutils/src/test/java/com/linkedin/restli/client/testutils/test/TestMockBatchCollectionResponseFactory.java
+++ b/restli-client-testutils/src/test/java/com/linkedin/restli/client/testutils/test/TestMockBatchCollectionResponseFactory.java
@@ -1,0 +1,92 @@
+package com.linkedin.restli.client.testutils.test;
+
+import com.linkedin.data.DataMap;
+import com.linkedin.restli.client.testutils.MockBatchCollectionResponseFactory;
+import com.linkedin.restli.common.BatchCollectionResponse;
+import com.linkedin.restli.common.BatchFinderCriteriaResult;
+import com.linkedin.restli.common.CollectionMetadata;
+import com.linkedin.restli.examples.greetings.api.Greeting;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestMockBatchCollectionResponseFactory
+{
+  @Test
+  public void testCreate()
+  {
+    Greeting g1 = new Greeting().setId(1L).setMessage("g1");
+    Greeting g2 = new Greeting().setId(2L).setMessage("g2");
+
+    List<Greeting> greetings1 = Collections.singletonList(g1);
+    List<Greeting> greetings2 = Collections.singletonList(g2);
+
+    List<List<Greeting>> greetingsList = new ArrayList<>();
+    greetingsList.add(greetings1);
+    greetingsList.add(greetings2);
+
+    BatchCollectionResponse<Greeting> batchCollectionResponse = MockBatchCollectionResponseFactory.create(
+        Greeting.class, greetingsList, Collections.emptyList(), Collections.emptyList());
+
+    List<BatchFinderCriteriaResult<Greeting>> elements = batchCollectionResponse.getResults();
+    Assert.assertEquals(elements.size(), 2);
+
+    BatchFinderCriteriaResult<Greeting> criteriaResult1 = elements.get(0);
+    Assert.assertEquals(criteriaResult1.getElements(), greetings1);
+    Assert.assertNull(criteriaResult1.getPaging());
+    Assert.assertNull(criteriaResult1.getMetadataRaw());
+
+    BatchFinderCriteriaResult<Greeting> criteriaResult2 = elements.get(1);
+    Assert.assertEquals(criteriaResult2.getElements(), greetings2);
+    Assert.assertNull(criteriaResult2.getPaging());
+    Assert.assertNull(criteriaResult2.getMetadataRaw());
+  }
+
+  @Test
+  public void testCreateWithPagingAndMetadata()
+  {
+    List<List<Greeting>> greetingsList = new ArrayList<>();
+
+    Greeting g1 = new Greeting().setId(1L).setMessage("g1");
+    List<Greeting> greetings1 = Collections.singletonList(g1);
+    greetingsList.add(greetings1);
+
+    Greeting g2 = new Greeting().setId(2L).setMessage("g2");
+    List<Greeting> greetings2 = Collections.singletonList(g2);
+    greetingsList.add(greetings2);
+
+    List<CollectionMetadata> pagingList = new ArrayList<>();
+
+    CollectionMetadata paging1 = new CollectionMetadata().setCount(2).setStart(0).setTotal(2);
+    pagingList.add(paging1);
+
+    pagingList.add(null);
+
+    List<DataMap> metadataList = new ArrayList<>();
+
+    metadataList.add(null);
+
+    DataMap customMetadata2 = new DataMap();
+    customMetadata2.put("foo", "bar");
+    metadataList.add(customMetadata2);
+
+    BatchCollectionResponse<Greeting> batchCollectionResponse = MockBatchCollectionResponseFactory.create(
+        Greeting.class, greetingsList, pagingList, metadataList);
+
+    List<BatchFinderCriteriaResult<Greeting>> elements = batchCollectionResponse.getResults();
+    Assert.assertEquals(elements.size(), 2);
+
+    BatchFinderCriteriaResult<Greeting> criteriaResult1 = elements.get(0);
+    Assert.assertEquals(criteriaResult1.getElements(), greetings1);
+    Assert.assertEquals(criteriaResult1.getPaging(), paging1);
+    Assert.assertNull(criteriaResult1.getMetadataRaw());
+
+    BatchFinderCriteriaResult<Greeting> criteriaResult2 = elements.get(1);
+    Assert.assertEquals(criteriaResult2.getElements(), greetings2);
+    Assert.assertNull(criteriaResult2.getPaging());
+    Assert.assertEquals(criteriaResult2.getMetadataRaw(), customMetadata2);
+  }
+}


### PR DESCRIPTION
Rest.li's testutils currently doesn't have support for generating mock BATCH_FINDER method responses. This PR adds support for that.