### PR TITLE
Logging and JMX enhancements for D2 ZooKeeper backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.23.2] - 2021-12-09
+- Observability enhancements for D2 announcer.
+
 ## [29.23.1] - 2021-12-08
 - Add support for a rate limiter supplier to enable multiple dark clusters with the CONSTANT_QPS strategy
 
@@ -5143,7 +5146,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.23.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.23.2...master
+[29.23.2]: https://github.com/linkedin/rest.li/compare/v29.23.1...v29.23.2
 [29.23.1]: https://github.com/linkedin/rest.li/compare/v29.23.0...v29.23.1
 [29.23.0]: https://github.com/linkedin/rest.li/compare/v29.22.16...v29.23.0
 [29.22.16]: https://github.com/linkedin/rest.li/compare/v29.22.15...v29.22.16

--- a/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.jmx;
 
 import com.linkedin.d2.balancer.servers.ZooKeeperAnnouncer;
+import com.linkedin.d2.balancer.servers.ZooKeeperConnectionManager;
 import com.linkedin.d2.balancer.servers.ZooKeeperServer;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancer;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
@@ -138,6 +139,14 @@ public class JmxManager
                                                             ZooKeeperAnnouncer announcer)
   {
     checkReg(new ZooKeeperAnnouncerJmx(announcer), name);
+
+    return this;
+  }
+
+  public synchronized JmxManager registerZooKeeperConnectionManager(String name,
+      ZooKeeperConnectionManager connectionManager)
+  {
+    checkReg(new ZooKeeperConnectionManagerJmx(connectionManager), name);
 
     return this;
   }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmx.java
@@ -178,4 +178,9 @@ public class ZooKeeperAnnouncerJmx implements ZooKeeperAnnouncerJmxMXBean
   {
     return _announcer.getPartitionData();
   }
+
+  @Override
+  public boolean isMarkUpFailed() {
+    return _announcer.isMarkUpFailed();
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmxMXBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmxMXBean.java
@@ -70,4 +70,6 @@ public interface ZooKeeperAnnouncerJmxMXBean
       throws IOException;
 
   void setPartitionData(Map<Integer, PartitionData> partitionData);
+
+  boolean isMarkUpFailed();
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperConnectionManagerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperConnectionManagerJmx.java
@@ -1,0 +1,70 @@
+package com.linkedin.d2.jmx;
+
+import com.linkedin.common.callback.FutureCallback;
+import com.linkedin.common.util.None;
+import com.linkedin.d2.balancer.servers.ZooKeeperConnectionManager;
+import com.linkedin.d2.discovery.stores.PropertyStoreException;
+import java.util.concurrent.TimeUnit;
+
+
+public class ZooKeeperConnectionManagerJmx implements ZooKeeperConnectionManagerJmxMBean
+{
+  private final ZooKeeperConnectionManager _connectionManager;
+
+  public ZooKeeperConnectionManagerJmx(ZooKeeperConnectionManager connectionManager)
+  {
+    _connectionManager = connectionManager;
+  }
+
+  @Override
+  public void markUpAllServers() throws PropertyStoreException
+  {
+    FutureCallback<None> callback = new FutureCallback<>();
+    _connectionManager.markUpAllServers(callback);
+    try
+    {
+      callback.get(10, TimeUnit.SECONDS);
+    }
+    catch (Exception e)
+    {
+      throw new PropertyStoreException(e);
+    }
+  }
+
+  @Override
+  public void markDownAllServers() throws PropertyStoreException
+  {
+    FutureCallback<None> callback = new FutureCallback<>();
+    _connectionManager.markDownAllServers(callback);
+    try
+    {
+      callback.get(10, TimeUnit.SECONDS);
+    }
+    catch (Exception e)
+    {
+      throw new PropertyStoreException(e);
+    }
+  }
+
+  @Override
+  public boolean isSessionEstablished()
+  {
+    return _connectionManager.isSessionEstablished();
+  }
+
+  @Override
+  public String getZooKeeperConnectString()
+  {
+    return _connectionManager.getZooKeeperConnectString();
+  }
+
+  @Override
+  public String getZooKeeperBasePath() {
+    return _connectionManager.getZooKeeperBasePath();
+  }
+
+  @Override
+  public int getZooKeeperSessionTimeout() {
+    return _connectionManager.getZooKeeperSessionTimeout();
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperConnectionManagerJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperConnectionManagerJmxMBean.java
@@ -1,0 +1,19 @@
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.discovery.stores.PropertyStoreException;
+
+
+public interface ZooKeeperConnectionManagerJmxMBean
+{
+  void markUpAllServers() throws PropertyStoreException;
+
+  void markDownAllServers() throws PropertyStoreException;
+
+  boolean isSessionEstablished();
+
+  String getZooKeeperConnectString();
+
+  String getZooKeeperBasePath();
+
+  int getZooKeeperSessionTimeout();
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.23.1
+version=29.23.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Ensures that errors that occur during the announcement are captured to log and that the state of
the announcer's success is visible to monitoring. Adds mbean for the ZooKeeperConnectionManager.