### PR TITLE
Add file existence check before performing compatibility report check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.22.15] - 2021-11-30
 - Deprecate `FileFormatDataSchemaParser#new(String, DataSchemaResolver, DataSchemaParserFactory)`. 
+- Write empty compatibility check report during snapshot check when there is not file to be processed
 
 ## [29.22.14] - 2021-11-24
 - Fix bug where content type was not set for stream requests
@@ -5130,7 +5133,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.14...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.15...master
+[29.22.15]: https://github.com/linkedin/rest.li/compare/v29.22.14...v29.22.15
 [29.22.14]: https://github.com/linkedin/rest.li/compare/v29.22.13...v29.22.14
 [29.22.13]: https://github.com/linkedin/rest.li/compare/v29.22.12...v29.22.13
 [29.22.12]: https://github.com/linkedin/rest.li/compare/v29.22.11...v29.22.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and what APIs have changed, if applicable.
 ## [29.22.15] - 2021-11-30
 - Add mock response generator factory for BATCH_FINDER methods.
 - Deprecate `FileFormatDataSchemaParser#new(String, DataSchemaResolver, DataSchemaParserFactory)`. 
-- Write empty compatibility check report during snapshot check when there is not file to be processed
+- Add file existence check before performing compatibility report check during snapshot and restmodel publishing
 
 ## [29.22.14] - 2021-11-24
 - Fix bug where content type was not set for stream requests

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -1375,11 +1375,13 @@ public class PegasusPlugin implements Plugin<Project>
                       (
                          isPropertyTrue(project, SKIP_IDL_CHECK) &&
                          isTaskSuccessful(checkSnapshotTask) &&
+                         checkSnapshotTask.getSummaryTarget().exists() &&
                          !isResultEquivalent(checkSnapshotTask.getSummaryTarget())
                       ) ||
                       (
                         !isPropertyTrue(project, SKIP_IDL_CHECK) &&
                         isTaskSuccessful(checkRestModelTask) &&
+                         checkRestModelTask.getSummaryTarget().exists() &&
                         !isResultEquivalent(checkRestModelTask.getSummaryTarget())
                       )
                     ));
@@ -1398,13 +1400,18 @@ public class PegasusPlugin implements Plugin<Project>
                       (
                          isPropertyTrue(project, SKIP_IDL_CHECK) &&
                          isTaskSuccessful(checkSnapshotTask) &&
+                         checkSnapshotTask.getSummaryTarget().exists() &&
                          !isResultEquivalent(checkSnapshotTask.getSummaryTarget(), true)
                       ) ||
                       (
                          !isPropertyTrue(project, SKIP_IDL_CHECK) &&
                          (
-                            (isTaskSuccessful(checkRestModelTask) && !isResultEquivalent(checkRestModelTask.getSummaryTarget(), true)) ||
-                            (isTaskSuccessful(checkIdlTask) && !isResultEquivalent(checkIdlTask.getSummaryTarget()))
+                            (isTaskSuccessful(checkRestModelTask) &&
+                                checkRestModelTask.getSummaryTarget().exists() &&
+                                !isResultEquivalent(checkRestModelTask.getSummaryTarget(), true)) ||
+                            (isTaskSuccessful(checkIdlTask) &&
+                                checkIdlTask.getSummaryTarget().exists() &&
+                                !isResultEquivalent(checkIdlTask.getSummaryTarget()))
                          )
                       )
                     ));

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckSnapshotTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckSnapshotTask.java
@@ -53,7 +53,6 @@ public class CheckSnapshotTask extends DefaultTask
 
     if (argFiles.isEmpty())
     {
-      IOUtil.writeText(_summaryTarget,"");
       return;
     }
 

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckSnapshotTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckSnapshotTask.java
@@ -53,6 +53,7 @@ public class CheckSnapshotTask extends DefaultTask
 
     if (argFiles.isEmpty())
     {
+      IOUtil.writeText(_summaryTarget,"");
       return;
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.22.14
+version=29.22.15
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Previously we didn't write any compatibility report if no files found. 

That case typically happens for the "test" sourceSet. Since normally Gradle process "main" sourceset first and then "test" sourceset, therefore this bug is not causing trouble since "test" sourceset just reuse "main" sourceset result.

But it will cause IOException in some corner cases, such as user directly try to process test sourceset.

This change add an additional check. As a result, if no files found, no compatibility report will be return and no compatibility report will be checked