### PR TITLE
Introduce d2ServiceName annotation on rest.li resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.23.0] - 2021-12-06
+- Introduce d2ServiceName annotation on rest.li resources. This is an optional param that is meant to be populated by resources for whom the resource name is not the same as d2 service name
+
 ## [29.22.16] - 2021-12-03
 - Fixed issues with potential duplicate TimingKeys being registered.
 
@@ -5137,7 +5140,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.22.16...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.23.0...master
+[29.23.0]: https://github.com/linkedin/rest.li/compare/v29.22.16...v29.23.0
 [29.22.16]: https://github.com/linkedin/rest.li/compare/v29.22.15...v29.22.16
 [29.22.15]: https://github.com/linkedin/rest.li/compare/v29.22.14...v29.22.15
 [29.22.14]: https://github.com/linkedin/rest.li/compare/v29.22.13...v29.22.14

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.22.16
+version=29.23.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/pegasus/com/linkedin/restli/restspec/ResourceSchema.pdl
+++ b/restli-common/src/main/pegasus/com/linkedin/restli/restspec/ResourceSchema.pdl
@@ -16,6 +16,16 @@ record ResourceSchema includes CustomAnnotationSchema {
   `namespace`: optional string
 
   /**
+   * d2 service name of the resource. Should be set only if the d2 service name is not the same as
+   * the Rest.li resource name.
+   *
+   * This is meant to be a hint to D2 based routing solutions, and is NOT directly used anywhere by
+   * the rest.li framework, apart from enforcing that this value once set, cannot be changed for backward
+   * compatibility reasons.
+   */
+  d2ServiceName: optional string
+
+  /**
    * URI template for accessing the resource
    */
   path: string

--- a/restli-docgen/src/main/java/com/linkedin/restli/docgen/examplegen/ExampleRequestResponseGenerator.java
+++ b/restli-docgen/src/main/java/com/linkedin/restli/docgen/examplegen/ExampleRequestResponseGenerator.java
@@ -1220,6 +1220,7 @@ public class ExampleRequestResponseGenerator
         null,
         resourceSchema.getName(),
         null,
-        resourceSchema.getNamespace());
+        resourceSchema.getNamespace(),
+        null);
   }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java
@@ -57,6 +57,7 @@ public class ResourceModel implements ResourceDefinition
 
   private final String                          _name;
   private final String                          _namespace;
+  private final String                          _d2ServiceName;
 
   private final Class<?>                        _resourceClass;
   private final ResourceType                    _resourceType;
@@ -114,6 +115,39 @@ public class ResourceModel implements ResourceDefinition
                        final ResourceType resourceType,
                        final String namespace)
   {
+    this(primaryKey, keyKeyClass, keyParamsClass, keys, valueClass, resourceClass, parentResourceClass, name,
+        resourceType, namespace, null);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param primaryKey the primary {@link Key} of this resource
+   * @param keyKeyClass class of the key part of a {@link ComplexResourceKey} if this is a
+   *          {@link ComplexKeyResource}
+   * @param keyParamsClass class of the param part of a {@link ComplexResourceKey} if this
+   *          is a {@link ComplexKeyResource}
+   * @param keys set of resource keys
+   * @param valueClass resource value class
+   * @param resourceClass resource class
+   * @param parentResourceClass parent resource class
+   * @param name resource name
+   * @param resourceType {@link ResourceType}
+   * @param namespace namespace
+   * @param d2ServiceName The d2 service name for the resource
+   */
+  public ResourceModel(final Key primaryKey,
+      final Class<? extends RecordTemplate> keyKeyClass,
+      final Class<? extends RecordTemplate> keyParamsClass,
+      final Set<Key> keys,
+      final Class<? extends RecordTemplate> valueClass,
+      final Class<?> resourceClass,
+      final Class<?> parentResourceClass,
+      final String name,
+      final ResourceType resourceType,
+      final String namespace,
+      final String d2ServiceName)
+  {
     _keyKeyClass = keyKeyClass;
     _keyParamsClass = keyParamsClass;
     _keys = keys;
@@ -126,6 +160,7 @@ public class ResourceModel implements ResourceDefinition
     _resourceClass = resourceClass;
     _name = name;
     _namespace = namespace;
+    _d2ServiceName = d2ServiceName;
     _root = (parentResourceClass == null);
     _parentResourceClass = parentResourceClass;
     _resourceMethodDescriptors = new ArrayList<>(5);
@@ -143,7 +178,6 @@ public class ResourceModel implements ResourceDefinition
    * @param name resource name
    * @param resourceType {@link ResourceType}
    * @param namespace namespace
-   *
    */
   public ResourceModel(final Class<? extends RecordTemplate> valueClass,
                        final Class<?> resourceClass,
@@ -162,6 +196,38 @@ public class ResourceModel implements ResourceDefinition
          name,
          resourceType,
          namespace);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param valueClass resource value class
+   * @param resourceClass resource class
+   * @param parentResourceClass parent resource class
+   * @param name resource name
+   * @param resourceType {@link ResourceType}
+   * @param namespace namespace
+   * @param d2ServiceName The d2 service name for the resource
+   */
+  public ResourceModel(final Class<? extends RecordTemplate> valueClass,
+      final Class<?> resourceClass,
+      final Class<?> parentResourceClass,
+      final String name,
+      final ResourceType resourceType,
+      final String namespace,
+      final String d2ServiceName)
+  {
+    this(null,
+        null,
+        null,
+        Collections.<Key>emptySet(),
+        valueClass,
+        resourceClass,
+        parentResourceClass,
+        name,
+        resourceType,
+        namespace,
+        d2ServiceName);
   }
 
   public ResourceType getResourceType()
@@ -349,6 +415,12 @@ public class ResourceModel implements ResourceDefinition
   public String getNamespace()
   {
     return _namespace;
+  }
+
+  @Override
+  public String getD2ServiceName()
+  {
+    return _d2ServiceName;
   }
 
   @Override

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
@@ -297,7 +297,7 @@ public class ResourceModelEncoder
       InputStream stream = getResourceStream(resourceFilePath.toString(),
         this.getClass().getClassLoader(),
         Thread.currentThread().getContextClassLoader());
-      if(stream == null)
+      if (stream == null)
       {
         // restspec.json file not found, building one instead
         return buildResourceSchema(resourceModel);
@@ -453,6 +453,13 @@ public class ResourceModelEncoder
     {
       resourceSchema.setNamespace(resourceModel.getNamespace());
     }
+
+    // Set the D2 service name only IF it is not null to avoid unnecessary IDL changes.
+    if (resourceModel.getD2ServiceName() != null)
+    {
+      resourceSchema.setD2ServiceName(resourceModel.getD2ServiceName());
+    }
+
     resourceSchema.setPath(buildPath(resourceModel));
 
     final Class<?> valueClass = resourceModel.getValueClass();

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationData.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationData.java
@@ -40,6 +40,7 @@ public class RestLiAnnotationData
   private final Key[]    _keys;
   private final String   _keyName;
   private final Class<? extends TyperefInfo> _typerefInfoClass;
+  private final String   _d2ServiceName;
 
   /**
    * @param collectionAnno {@link RestLiCollection} annotation
@@ -52,6 +53,7 @@ public class RestLiAnnotationData
     _keys = null;
     _keyName = RestAnnotations.DEFAULT.equals(collectionAnno.keyName()) ? null : collectionAnno.keyName();
     _typerefInfoClass = RestAnnotations.NULL_TYPEREF_INFO.class.equals(collectionAnno.keyTyperefClass()) ? null : collectionAnno.keyTyperefClass();
+    _d2ServiceName = RestAnnotations.DEFAULT.equals(collectionAnno.d2ServiceName()) ? null : collectionAnno.d2ServiceName();
   }
 
   /**
@@ -65,6 +67,7 @@ public class RestLiAnnotationData
     _keys = associationAnno.assocKeys();
     _keyName = RestAnnotations.DEFAULT.equals(associationAnno.keyName()) ? null : associationAnno.keyName();
     _typerefInfoClass = null;
+    _d2ServiceName = RestAnnotations.DEFAULT.equals(associationAnno.d2ServiceName()) ? null : associationAnno.d2ServiceName();
   }
 
   /**
@@ -78,6 +81,7 @@ public class RestLiAnnotationData
     _keys = null;
     _keyName = null;
     _typerefInfoClass = null;
+    _d2ServiceName = RestAnnotations.DEFAULT.equals(simpleResourceAnno.d2ServiceName()) ? null : simpleResourceAnno.d2ServiceName();
   }
 
   /**
@@ -125,4 +129,11 @@ public class RestLiAnnotationData
     return _typerefInfoClass;
   }
 
+  /**
+   * @return d2 service name
+   */
+  public String d2ServiceName()
+  {
+    return _d2ServiceName;
+  }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -631,7 +631,8 @@ public final class RestLiAnnotationReader
                           parentResourceClass,
                           name,
                           resourceType,
-                          namespace);
+                          namespace,
+                          annotationData.d2ServiceName());
 
     collectionModel.setParentResourceModel(parentResourceModel);
 
@@ -644,7 +645,6 @@ public final class RestLiAnnotationReader
 
   private static RestLiAnnotationData getRestLiAnnotationData(Class<?> resourceClass)
   {
-    RestLiAnnotationData annotationData;
     if (resourceClass.isAnnotationPresent(RestLiCollection.class))
     {
       return new RestLiAnnotationData(resourceClass.getAnnotation(RestLiCollection.class));
@@ -692,7 +692,8 @@ public final class RestLiAnnotationReader
                           parentResourceClass,
                           name,
                           resourceType,
-                          namespace);
+                          namespace,
+                          annotationData.d2ServiceName());
 
     resourceModel.setParentResourceModel(parentResource);
 
@@ -2712,6 +2713,8 @@ public final class RestLiAnnotationReader
 
     String namespace = actionsAnno.namespace();
 
+    String d2ServiceName = RestAnnotations.DEFAULT.equals(actionsAnno.d2ServiceName()) ? null : actionsAnno.d2ServiceName();
+
     ResourceModel actionResourceModel = new ResourceModel(null, // primary key
                                                           null, // key key class
                                                           null, // key params class
@@ -2721,7 +2724,8 @@ public final class RestLiAnnotationReader
                                                           null, // parent resource class
                                                           name, // name
                                                           ResourceType.ACTIONS, // resource type
-                                                          namespace); // namespace
+                                                          namespace, // namespace
+                                                          d2ServiceName); // d2 service name
 
     actionResourceModel.setParentResourceModel(parentResourceModel);
 

--- a/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
@@ -42,6 +42,17 @@ public interface ResourceDefinition
   String getNamespace();
 
   /**
+   * Gets the D2 service name. This is null unless explicitly annotated by the resource owner in the resource.
+   *
+   * <p>This is meant to be a hint to D2 based routing solutions, and is NOT directly used anywhere by
+   * the rest.li framework, apart from enforcing that this value once set, cannot be changed for backward
+   * compatibility reasons.</p>
+   *
+   * @return the d2 service name
+   */
+  String getD2ServiceName();
+
+  /**
    * Gets the rest.li resource java class.
    *
    * @return java class for this rest.li resource.

--- a/restli-server/src/main/java/com/linkedin/restli/server/annotations/RestLiActions.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/annotations/RestLiActions.java
@@ -32,9 +32,23 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface RestLiActions
 {
+  /**
+   * The name of the resource.
+   */
   String name();
 
-  /** The namespace of the resource, used to qualify the IDL name*/
+  /**
+   * The namespace of the resource, used to qualify the IDL name
+   */
   String namespace() default "";
 
+  /**
+   * The d2 service name for this resource. Should be set only if the d2 service name is not the same as
+   * the Rest.li resource name.
+   *
+   * <p>This is meant to be a hint to D2 based routing solutions, and is NOT directly used anywhere by
+   * the rest.li framework, apart from enforcing that this value once set, cannot be changed for backward
+   * compatibility reasons.</p>
+   */
+  String d2ServiceName() default RestAnnotations.DEFAULT;
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/annotations/RestLiAssociation.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/annotations/RestLiAssociation.java
@@ -42,19 +42,39 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface RestLiAssociation
 {
-  /** The parent resource class.  Optional - if not specified, this resource will be a
-   * root resource */
+  /**
+   * The parent resource class.  Optional - if not specified, this resource will be a
+   * root resource
+   */
   Class<?> parent() default RestAnnotations.ROOT.class;
 
-  /** Path is only set for root resources. The path of subresources is implied by the resource hierarchy */
+  /**
+   * Path is only set for root resources. The path of subresources is implied by the resource hierarchy
+   */
   String name();
 
-  /** The namespace of the resource, used to qualify the IDL name*/
+  /**
+   * The namespace of the resource, used to qualify the IDL name
+   */
   String namespace() default "";
 
-  /** The symbolic name of the key for this resource e.g. 'groupID'. Optional, defaults to "[resourceName]id" */
+  /**
+   * The symbolic name of the key for this resource e.g. 'groupID'. Optional, defaults to "[resourceName]id"
+   */
   String keyName() default RestAnnotations.DEFAULT;
 
-  /** An ordered list of associative keys used in this association (required) */
+  /**
+   * An ordered list of associative keys used in this association (required)
+   */
   Key[] assocKeys();
+
+  /**
+   * The d2 service name for this resource. Should be set only if the d2 service name is not the same as
+   * the Rest.li resource name.
+   *
+   * <p>This is meant to be a hint to D2 based routing solutions, and is NOT directly used anywhere by
+   * the rest.li framework, apart from enforcing that this value once set, cannot be changed for backward
+   * compatibility reasons.</p>
+   */
+  String d2ServiceName() default RestAnnotations.DEFAULT;
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/annotations/RestLiCollection.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/annotations/RestLiCollection.java
@@ -34,17 +34,36 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface RestLiCollection
 {
-  /** The parent resource class.  Optional - if not specified, this resource will be a
-   * root resource */
+  /**
+   * The parent resource class.  Optional - if not specified, this resource will be a
+   * root resource
+   */
   Class<?> parent() default RestAnnotations.ROOT.class;
 
+  /**
+   * The name of the resource.
+   */
   String name();
 
-  /** The namespace of the resource, used to qualify the IDL name*/
+  /**
+   * The namespace of the resource, used to qualify the IDL name
+   */
   String namespace() default "";
 
-  /** The symbolic name of the key for this resource e.g. 'groupID'. Optional, defaults to "[resourceName]id" */
+  /**
+   * The symbolic name of the key for this resource e.g. 'groupID'. Optional, defaults to "[resourceName]id"
+   */
   String keyName() default RestAnnotations.DEFAULT;
 
   Class<? extends TyperefInfo> keyTyperefClass() default RestAnnotations.NULL_TYPEREF_INFO.class;
+
+  /**
+   * The d2 service name for this resource. Should be set only if the d2 service name is not the same as
+   * the Rest.li resource name.
+   *
+   * <p>This is meant to be a hint to D2 based routing solutions, and is NOT directly used anywhere by
+   * the rest.li framework, apart from enforcing that this value once set, cannot be changed for backward
+   * compatibility reasons.</p>
+   */
+  String d2ServiceName() default RestAnnotations.DEFAULT;
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/annotations/RestLiSimpleResource.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/annotations/RestLiSimpleResource.java
@@ -45,4 +45,14 @@ public @interface RestLiSimpleResource
    * The namespace of the resource, used to qualify the IDL name
    */
   String namespace() default "";
+
+  /**
+   * The d2 service name for this resource. Should be set only if the d2 service name is not the same as
+   * the Rest.li resource name.
+   *
+   * <p>This is meant to be a hint to D2 based routing solutions, and is NOT directly used anywhere by
+   * the rest.li framework, apart from enforcing that this value once set, cannot be changed for backward
+   * compatibility reasons.</p>
+   */
+  String d2ServiceName() default RestAnnotations.DEFAULT;
 }

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/SampleResources.java
@@ -152,13 +152,13 @@ class SampleResources
    * The following resources are used by {@link TestRestLiApiBuilder}.
    */
 
-  @RestLiCollection(name = "foo")
+  @RestLiCollection(name = "foo", d2ServiceName = "foo1")
   static class FooResource1 extends CollectionResourceTemplate<Long, EmptyRecord> {}
 
   @RestLiCollection(name = "foo")
   static class FooResource2 extends CollectionResourceTemplate<Long, EmptyRecord> {}
 
-  @RestLiSimpleResource(name = "foo")
+  @RestLiSimpleResource(name = "foo", d2ServiceName = "foo3")
   static class FooResource3 extends SimpleResourceTemplate<EmptyRecord> {}
 
   @RestLiActions(name = "foo")
@@ -848,7 +848,8 @@ class SampleResources
    */
   @RestLiActions(
       name = "actionsMethod",
-      namespace = "com.linkedin.model.actions"
+      namespace = "com.linkedin.model.actions",
+      d2ServiceName = "actionsService"
   )
   public static class ActionsOnlyResource {
 

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestResourceModel.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestResourceModel.java
@@ -119,7 +119,8 @@ public class TestResourceModel
                                                           null,
                                                           "collectionCollection",
                                                           ResourceType.COLLECTION,
-                                                          "com.linkedin.restli.internal.server.model");
+                                                          "com.linkedin.restli.internal.server.model",
+                                                          "collectionCollection");
 
     // Add resource-level service errors
     if (resourceLevelServiceErrors == null)

--- a/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiAnnotationReader.java
+++ b/restli-server/src/test/java/com/linkedin/restli/internal/server/model/TestRestLiAnnotationReader.java
@@ -70,6 +70,7 @@ public class TestRestLiAnnotationReader
   {
     final String expectedNamespace = "com.linkedin.model.actions";
     final String expectedName = "actionsMethod";
+    final String expectedD2ServiceName = "actionsService";
 
     final ResourceModel model = RestLiAnnotationReader.processResource(ActionsOnlyResource.class);
 
@@ -78,6 +79,7 @@ public class TestRestLiAnnotationReader
     Assert.assertTrue(model.isRoot());
     Assert.assertEquals(expectedName, model.getName());
     Assert.assertEquals(expectedNamespace, model.getNamespace());
+    Assert.assertEquals(expectedD2ServiceName, model.getD2ServiceName());
 
     Assert.assertNull(model.getParentResourceClass());
     Assert.assertNull(model.getParentResourceModel());
@@ -156,6 +158,7 @@ public class TestRestLiAnnotationReader
     Assert.assertTrue(model.isRoot());
     Assert.assertEquals(expectedName, model.getName());
     Assert.assertEquals(expectedNamespace, model.getNamespace());
+    Assert.assertNull(model.getD2ServiceName());
 
     Assert.assertNull(model.getParentResourceClass());
     Assert.assertNull(model.getParentResourceModel());
@@ -208,6 +211,9 @@ public class TestRestLiAnnotationReader
     final String expectedNamespace = "";
 
     final String expectedName = "foo";
+
+    final String expectedD2ServiceName = "foo1";
+
     final Class<? extends RecordTemplate> expectedValueClass = EmptyRecord.class;
 
     final String expectedKeyName = "fooId";
@@ -220,6 +226,7 @@ public class TestRestLiAnnotationReader
     Assert.assertTrue(model.isRoot());
     Assert.assertEquals(expectedName, model.getName());
     Assert.assertEquals(expectedNamespace, model.getNamespace());
+    Assert.assertEquals(expectedD2ServiceName, model.getD2ServiceName());
 
     Assert.assertNull(model.getParentResourceClass());
     Assert.assertNull(model.getParentResourceModel());
@@ -401,6 +408,9 @@ public class TestRestLiAnnotationReader
     final String expectedNamespace = "";
 
     final String expectedName = "foo";
+
+    final String expectedD2ServiceName = "foo3";
+
     final Class<? extends RecordTemplate> expectedValueClass = EmptyRecord.class;
 
     final ResourceModel model = RestLiAnnotationReader.processResource(FooResource3.class);
@@ -410,6 +420,7 @@ public class TestRestLiAnnotationReader
     Assert.assertTrue(model.isRoot());
     Assert.assertEquals(expectedName, model.getName());
     Assert.assertEquals(expectedNamespace, model.getNamespace());
+    Assert.assertEquals(expectedD2ServiceName, model.getD2ServiceName());
 
     Assert.assertNull(model.getParentResourceClass());
     Assert.assertNull(model.getParentResourceModel());

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/ResourceCompatibilityChecker.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/ResourceCompatibilityChecker.java
@@ -70,6 +70,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 
@@ -222,6 +223,20 @@ public class ResourceCompatibilityChecker
     }
 
     return true;
+  }
+
+  private boolean checkD2ServiceName(String prevData, String currData) {
+    if (prevData == null && currData == null) {
+      return true;
+    }
+
+    if (prevData != null && prevData.equals(currData)) {
+      return true;
+    }
+
+    _infoMap.addRestSpecInfo("d2ServiceName", CompatibilityInfo.Type.VALUE_NOT_EQUAL, _infoPath,
+        prevData, currData);
+    return false;
   }
 
   private boolean checkDoc(RecordDataSchema.Field field, Object prevData, Object currData)
@@ -685,6 +700,8 @@ public class ResourceCompatibilityChecker
     checkEqualSingleValue(prevRec.schema().getField("namespace"),
                           prevRec.getNamespace(GetMode.DEFAULT),
                           currRec.getNamespace(GetMode.DEFAULT));
+
+    checkD2ServiceName(prevRec.getD2ServiceName(GetMode.DEFAULT), currRec.getD2ServiceName(GetMode.DEFAULT));
 
     checkEqualSingleValue(prevRec.schema().getField("path"),
                           prevRec.getPath(GetMode.DEFAULT),

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/compatibility/TestResourceCompatibilityChecker.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/compatibility/TestResourceCompatibilityChecker.java
@@ -355,6 +355,8 @@ public class TestResourceCompatibilityChecker
 
     final Collection<CompatibilityInfo> resourceTestErrors = new HashSet<>();
     final Collection<CompatibilityInfo> modelTestErrors = new HashSet<>();
+    resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "d2ServiceName"),
+        CompatibilityInfo.Type.VALUE_NOT_EQUAL, null, "greetingsD2"));
     resourceTestErrors.add(
       new CompatibilityInfo(Arrays.asList("", "collection", "identifier", "params"),
                             CompatibilityInfo.Type.TYPE_ERROR, "schema type changed from string to long"));
@@ -426,7 +428,7 @@ public class TestResourceCompatibilityChecker
                             "schema type changed from long to string"));
 
     final ResourceSchema prevResource = idlToResource(IDLS_SUFFIX + PREV_COLL_FILE);
-    final  ResourceSchema currResource = idlToResource(IDLS_SUFFIX + CURR_COLL_FAIL_FILE);
+    final ResourceSchema currResource = idlToResource(IDLS_SUFFIX + CURR_COLL_FAIL_FILE);
 
     ResourceCompatibilityChecker checker = new ResourceCompatibilityChecker(prevResource, prevSchemaResolver,
                                                                             currResource, incompatSchemaResolver);
@@ -461,6 +463,9 @@ public class TestResourceCompatibilityChecker
     prevAssocKey.setType("string");
 
     final Collection<CompatibilityInfo> testErrors = new HashSet<>();
+    testErrors.add(new CompatibilityInfo(Arrays.asList("", "d2ServiceName"),
+                                         CompatibilityInfo.Type.VALUE_NOT_EQUAL,
+                             "oldD2Assoc", "newD2Assoc"));
     testErrors.add(new CompatibilityInfo(Arrays.asList("", "association", "assocKeys"),
                                          CompatibilityInfo.Type.ARRAY_NOT_EQUAL,
                                          new AssocKeySchemaArray(prevAssocKey)));
@@ -501,6 +506,9 @@ public class TestResourceCompatibilityChecker
     final Collection<CompatibilityInfo> resourceTestErrors = new HashSet<>();
     final Collection<CompatibilityInfo> modelTestErrors = new HashSet<>();
 
+    resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "d2ServiceName"),
+                                                 CompatibilityInfo.Type.VALUE_NOT_EQUAL,
+                                                 null, "greetingSimpleD2"));
     resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "simple", "supports"),
                                                  CompatibilityInfo.Type.ARRAY_NOT_CONTAIN,
                                                  new StringArray("delete", "get")));
@@ -558,6 +566,9 @@ public class TestResourceCompatibilityChecker
   public void testFailActionsSetFile() throws IOException
   {
     final Collection<CompatibilityInfo> testErrors = new HashSet<>();
+    testErrors.add(new CompatibilityInfo(Arrays.asList("", "d2ServiceName"),
+                                         CompatibilityInfo.Type.VALUE_NOT_EQUAL,
+                             null, "asD2"));
     testErrors.add(new CompatibilityInfo(Arrays.asList(""),
                                          CompatibilityInfo.Type.VALUE_WRONG_OPTIONALITY, "actionsSet"));
 

--- a/restli-tools/src/test/resources/idls/curr-greeting-simple-fail.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greeting-simple-fail.restspec.json
@@ -1,5 +1,6 @@
 {
   "name" : "greeting",
+  "d2ServiceName": "greetingSimpleD2",
   "path" : "/greeting",
   "schema" : "com.linkedin.greetings.api.Greeting",
   "doc" : "A simple greeting resource",

--- a/restli-tools/src/test/resources/idls/curr-greetings-as-fail.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greetings-as-fail.restspec.json
@@ -2,5 +2,6 @@
   "name" : "greetings",
   "path" : "/greetings",
   "schema" : "com.linkedin.greetings.api.Greeting",
+  "d2ServiceName" : "asD2",
   "doc" : "A richer \"Hello world\" example"
 }

--- a/restli-tools/src/test/resources/idls/curr-greetings-assoc-fail.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greetings-assoc-fail.restspec.json
@@ -1,6 +1,7 @@
 {
   "name" : "greetings",
   "namespace": "com.linkedin.restli.greetings",
+  "d2ServiceName": "newD2Assoc",
   "path" : "/greetings",
   "schema" : "com.linkedin.greetings.api.Greeting",
   "doc" : "A richer \"Hello world\" example, demonstrating a full array of methods, finders and actions",

--- a/restli-tools/src/test/resources/idls/curr-greetings-assoc-pass.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greetings-assoc-pass.restspec.json
@@ -1,6 +1,7 @@
 {
   "name" : "greetings",
   "namespace": "com.linkedin.restli.greetings",
+  "d2ServiceName": "oldD2Assoc",
   "path" : "/greetings",
   "schema" : "com.linkedin.greetings.api.Greeting",
   "doc" : "A richer \"Hello world\" example, demonstrating a full array of methods, finders and actions",

--- a/restli-tools/src/test/resources/idls/curr-greetings-coll-fail.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greetings-coll-fail.restspec.json
@@ -1,5 +1,6 @@
 {
   "name" : "greetings",
+  "d2ServiceName": "greetingsD2",
   "path" : "/greetings",
   "schema" : "com.linkedin.greetings.api.Greeting",
   "entityType" : "UNSTRUCTURED_DATA",

--- a/restli-tools/src/test/resources/idls/prev-greetings-assoc.restspec.json
+++ b/restli-tools/src/test/resources/idls/prev-greetings-assoc.restspec.json
@@ -1,6 +1,7 @@
 {
   "name" : "greetings",
   "namespace": "com.linkedin.restli.greetings",
+  "d2ServiceName": "oldD2Assoc",
   "path" : "/greetings",
   "schema" : "com.linkedin.greetings.api.Greeting",
   "entityType" : "STRUCTURED_DATA",


### PR DESCRIPTION
This is an optional param that is meant to be populated by resources for whom the resource name is not the same as d2 service name (if not populated we default to null). This is useful for situations like generating routing hints for graphQL.

This value is also emitted into the IDL. Any changes to this value are considered backward incompatible.