### PR TITLE
update DefaultSymbolTableProvider to take default headers as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.23.3] - 2021-12-09
+- Take default headers as input to fetch remote symbol table in `DefaultSymbolTableProvider`
+
 ## [29.23.2] - 2021-12-09
 - Observability enhancements for D2 announcer.
 
@@ -5146,7 +5149,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.23.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.23.3...master
+[29.23.3]: https://github.com/linkedin/rest.li/compare/v29.23.2...v29.23.3
 [29.23.2]: https://github.com/linkedin/rest.li/compare/v29.23.1...v29.23.2
 [29.23.1]: https://github.com/linkedin/rest.li/compare/v29.23.0...v29.23.1
 [29.23.0]: https://github.com/linkedin/rest.li/compare/v29.22.16...v29.23.0

--- a/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
+++ b/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import org.slf4j.Logger;
@@ -74,6 +75,11 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
   private static SSLSocketFactory SSL_SOCKET_FACTORY;
 
   /**
+   * Default request headers to fetch remote symbol table if any.
+   */
+  private static Map<String, String> DEFAULT_HEADERS;
+
+  /**
    * Cache storing mapping from symbol table name to symbol table.
    */
   private final Cache<String, SymbolTable> _cache;
@@ -83,6 +89,13 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
    */
   public static void setSSLSocketFactory(SSLSocketFactory socketFactory) {
     SSL_SOCKET_FACTORY = socketFactory;
+  }
+
+  /**
+   * Set Default headers to fetch remote symbol table
+   */
+  public static void setDefaultHeaders(Map<String, String> defaultHeaders) {
+    DEFAULT_HEADERS = defaultHeaders;
   }
 
   /**
@@ -138,6 +151,10 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
       HttpURLConnection connection = openConnection(url);
       try
       {
+        if (DEFAULT_HEADERS != null)
+        {
+          DEFAULT_HEADERS.entrySet().forEach(entry -> connection.setRequestProperty(entry.getKey(), entry.getValue()));
+        }
         connection.setRequestProperty(ACCEPT_HEADER, ProtobufDataCodec.DEFAULT_HEADER);
         connection.setRequestProperty(SYMBOL_TABLE_HEADER, Boolean.toString(true));
         int responseCode = connection.getResponseCode();

--- a/data/src/test/java/com/linkedin/data/codec/symbol/TestDefaultSymbolTableProvider.java
+++ b/data/src/test/java/com/linkedin/data/codec/symbol/TestDefaultSymbolTableProvider.java
@@ -22,6 +22,8 @@ import java.net.HttpURLConnection;
 import static org.mockito.Mockito.*;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -34,16 +36,20 @@ public class TestDefaultSymbolTableProvider
   @Test
   public void testRemoteSymbolTableSuccess() throws Exception
   {
+    Map<String, String> defaultHeader = new HashMap<>();
+    defaultHeader.put("test", "test");
     ByteString serializedTable = SymbolTableSerializer.toByteString(DefaultSymbolTableProvider.CODEC, _symbolTable);
 
     HttpURLConnection connection = mock(HttpURLConnection.class);
     DefaultSymbolTableProvider provider = spy(new DefaultSymbolTableProvider());
+    provider.setDefaultHeaders(defaultHeader);
     doReturn(connection).when(provider).openConnection(eq("https://someservice:100/symbolTable/tableName"));
     when(connection.getResponseCode()).thenReturn(200);
     when(connection.getInputStream()).thenReturn(serializedTable.asInputStream());
 
     SymbolTable remoteTable = provider.getSymbolTable(_symbolTableName);
     verify(connection).setRequestProperty(eq("Accept"), eq(ProtobufDataCodec.DEFAULT_HEADER));
+    verify(connection).setRequestProperty(eq("test"), eq("test"));
     verify(connection).disconnect();
 
     // Verify table is deserialized correctly.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.23.2
+version=29.23.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This is required to add any static headers required for the application downstream calls