### PR TITLE
Add dummy trace header to fetch default remote symbol table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.26.0] - 2022-01-10
+- Add header provider to generate required request to fetch default remote symbol table
+
 ## [29.25.0] - 2022-01-06
 - Fix a race condition where TransportClient is shutdown while subset cache still holds reference to it
 
@@ -5155,7 +5158,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.25.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.26.0...master
+[29.26.0]: https://github.com/linkedin/rest.li/compare/v29.25.0...v29.26.0
 [29.25.0]: https://github.com/linkedin/rest.li/compare/v29.24.0...v29.25.0
 [29.24.0]: https://github.com/linkedin/rest.li/compare/v29.23.3...v29.24.0
 [29.23.3]: https://github.com/linkedin/rest.li/compare/v29.23.2...v29.23.3

--- a/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
+++ b/data/src/main/java/com/linkedin/data/codec/symbol/DefaultSymbolTableProvider.java
@@ -25,12 +25,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Base64;
 import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import org.slf4j.Logger;
@@ -52,16 +47,6 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
    * Accept header
    */
   private static final String ACCEPT_HEADER = "Accept";
-
-  /**
-   * IC header key
-   */
-  private static final String IC_HEADER = "X-LI-R2-W-IC-1";
-
-  /**
-   * Default IC header
-   */
-  private static final String DEFAULT_IC_HEADER = "serviceCallTraceData=%7B%22caller%22%3A%7B%22container%22%3A%22container%22%2C%22service%22%3A%22restli%22%2C%22env%22%3A%22env%22%2C%22instance%22%3A%22inst%22%2C%22machine%22%3A%22machine.linkedin.biz%22%2C%22version%22%3A%220.0.1%22%7D%2C%22treeId%22%3A%22{}%22%2C%22context%22%3A%7B%22source%22%3A%22restli%22%2C%22forceTraceEnabled%22%3A%22false%22%2C%22debugEnabled%22%3A%22false%22%2C%22traceGroupingKey%22%3A%22restli-default-symboltable%22%7D%7D,com.linkedin.container.rpc.trace.rpcTrace=(machine.linkedin.biz,restli,1970/01/01 01:00:00.000)";
 
   /**
    * Symbol table request header
@@ -95,6 +80,11 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
   private static Map<String, String> DEFAULT_HEADERS;
 
   /**
+   * Request headers provider to generate headers required to fetch remote symbol table if any.
+   */
+  private static HeaderProvider HEADER_PROVIDER;
+
+  /**
    * Cache storing mapping from symbol table name to symbol table.
    */
   private final Cache<String, SymbolTable> _cache;
@@ -109,8 +99,17 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
   /**
    * Set Default headers to fetch remote symbol table
    */
-  public static void setDefaultHeaders(Map<String, String> defaultHeaders) {
+  public static void setDefaultHeaders(Map<String, String> defaultHeaders)
+  {
     DEFAULT_HEADERS = defaultHeaders;
+  }
+
+  /**
+   * Set request headers provider to fetch remote symbol table
+   */
+  public static void setHeaderProvider(HeaderProvider headerProvider)
+  {
+    HEADER_PROVIDER = headerProvider;
   }
 
   /**
@@ -170,8 +169,10 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
         {
           DEFAULT_HEADERS.entrySet().forEach(entry -> connection.setRequestProperty(entry.getKey(), entry.getValue()));
         }
-        connection.setRequestProperty(IC_HEADER,
-                DEFAULT_IC_HEADER.replaceAll("\\{}", Base64.getEncoder().encodeToString(getTreeId(Instant.now()))));
+        if (HEADER_PROVIDER != null)
+        {
+          HEADER_PROVIDER.getHeaders().entrySet().forEach(entry -> connection.setRequestProperty(entry.getKey(), entry.getValue()));
+        }
         connection.setRequestProperty(ACCEPT_HEADER, ProtobufDataCodec.DEFAULT_HEADER);
         connection.setRequestProperty(SYMBOL_TABLE_HEADER, Boolean.toString(true));
         int responseCode = connection.getResponseCode();
@@ -219,37 +220,7 @@ public class DefaultSymbolTableProvider implements SymbolTableProvider
     return connection;
   }
 
-
-  private final static int TREE_ID_RESERVED_LENGTH = 1;
-  private final static int TREE_ID_LENGTH = 16;
-  private final static int TREE_ID_RANDOM_LENGTH = 8;
-  // TreeId only support version 0~3
-  private final static byte TREE_ID_RESERVED_VERSION_MASK = 0x03;
-
-  // Below are config specific for treeId_v0
-  private final static byte TREE_ID_RESERVED_UNUSED = 0x00;
-  private final static byte TREE_ID_RESERVED_EXCLUDE_VERSION_MASK = (byte) 0xfc;
-  private final static int TREE_ID_VERSION = 0x00; // current version = 0
-  // 6 bits unused + 2 bit version
-  private final static byte TREE_ID_RESERVED = (TREE_ID_RESERVED_UNUSED & TREE_ID_RESERVED_EXCLUDE_VERSION_MASK)
-          | (TREE_ID_VERSION & TREE_ID_RESERVED_VERSION_MASK);
-
-  private byte[] getTreeId(Instant instant) {
-    final byte[] treeId = new byte[TREE_ID_LENGTH];
-    final byte[] random = new byte[TREE_ID_RANDOM_LENGTH];
-
-    // assign reserved to treeId
-    treeId[0] = TREE_ID_RESERVED;
-    // assign micro-second epoch time to treeId
-    long currentTimeUs = ChronoUnit.MICROS.between(Instant.EPOCH, instant);
-    for (int i = TREE_ID_LENGTH - TREE_ID_RANDOM_LENGTH - 1; i >= TREE_ID_RESERVED_LENGTH; i--) {
-      treeId[i] = (byte) (currentTimeUs & 0xFF);
-      currentTimeUs >>= Byte.SIZE;
-    }
-    // assign random to treeId
-    ThreadLocalRandom.current().nextBytes(random);
-    System.arraycopy(random, 0, treeId, TREE_ID_LENGTH - TREE_ID_RANDOM_LENGTH, TREE_ID_RANDOM_LENGTH);
-
-    return treeId;
+  public interface HeaderProvider {
+    Map<String, String> getHeaders();
   }
 }

--- a/data/src/test/java/com/linkedin/data/codec/symbol/TestDefaultSymbolTableProvider.java
+++ b/data/src/test/java/com/linkedin/data/codec/symbol/TestDefaultSymbolTableProvider.java
@@ -43,6 +43,7 @@ public class TestDefaultSymbolTableProvider
     HttpURLConnection connection = mock(HttpURLConnection.class);
     DefaultSymbolTableProvider provider = spy(new DefaultSymbolTableProvider());
     provider.setDefaultHeaders(defaultHeader);
+    provider.setHeaderProvider(new MockSymbolTableHeaderProvider());
     doReturn(connection).when(provider).openConnection(eq("https://someservice:100/symbolTable/tableName"));
     when(connection.getResponseCode()).thenReturn(200);
     when(connection.getInputStream()).thenReturn(serializedTable.asInputStream());
@@ -50,7 +51,7 @@ public class TestDefaultSymbolTableProvider
     SymbolTable remoteTable = provider.getSymbolTable(_symbolTableName);
     verify(connection).setRequestProperty(eq("Accept"), eq(ProtobufDataCodec.DEFAULT_HEADER));
     verify(connection).setRequestProperty(eq("test"), eq("test"));
-    verify(connection).setRequestProperty(eq("X-LI-R2-W-IC-1"), anyString());
+    verify(connection).setRequestProperty(eq("Header"), eq("test"));
     verify(connection).disconnect();
 
     // Verify table is deserialized correctly.
@@ -111,5 +112,17 @@ public class TestDefaultSymbolTableProvider
   {
     DefaultSymbolTableProvider provider = new DefaultSymbolTableProvider();
     provider.getSymbolTable("random");
+  }
+
+  class MockSymbolTableHeaderProvider implements DefaultSymbolTableProvider.HeaderProvider
+  {
+
+    @Override
+    public Map<String, String> getHeaders()
+    {
+      Map<String, String> headers = new HashMap<>();
+      headers.put("Header", "test");
+      return headers;
+    }
   }
 }

--- a/data/src/test/java/com/linkedin/data/codec/symbol/TestDefaultSymbolTableProvider.java
+++ b/data/src/test/java/com/linkedin/data/codec/symbol/TestDefaultSymbolTableProvider.java
@@ -50,6 +50,7 @@ public class TestDefaultSymbolTableProvider
     SymbolTable remoteTable = provider.getSymbolTable(_symbolTableName);
     verify(connection).setRequestProperty(eq("Accept"), eq(ProtobufDataCodec.DEFAULT_HEADER));
     verify(connection).setRequestProperty(eq("test"), eq("test"));
+    verify(connection).setRequestProperty(eq("X-LI-R2-W-IC-1"), anyString());
     verify(connection).disconnect();
 
     // Verify table is deserialized correctly.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.25.0
+version=29.26.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This change fixes missing header required for LI internal tracing which couldn't be injected at boot time because dynamic tree id required in trace.