### PR TITLE
Fix a race condition where TransportClient is shutdown while subset cache still holds reference to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.25.0] - 2022-01-06
+- Fix a race condition where TransportClient is shutdown while subset cache still holds reference to it
+
 ## [29.24.0] - 2021-12-09
 - bump minor version for the new public method added in 29.23.3
 
@@ -5152,7 +5155,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.24.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.25.0...master
+[29.25.0]: https://github.com/linkedin/rest.li/compare/v29.24.0...v29.25.0
 [29.24.0]: https://github.com/linkedin/rest.li/compare/v29.23.3...v29.24.0
 [29.23.3]: https://github.com/linkedin/rest.li/compare/v29.23.2...v29.23.3
 [29.23.2]: https://github.com/linkedin/rest.li/compare/v29.23.1...v29.23.2

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
@@ -29,6 +29,7 @@ import com.linkedin.d2.discovery.event.PropertyEventThread.PropertyEventShutdown
 import com.linkedin.r2.transport.common.bridge.client.TransportClient;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -95,10 +96,10 @@ public interface LoadBalancerState
   default SubsettingState.SubsetItem getClientsSubset(String serviceName,
                                                    int minClusterSubsetSize,
                                                    int partitionId,
-                                                   Map<URI, TrackerClient> potentialClients,
+                                                   Map<URI, Double> possibleUris,
                                                    long version)
   {
-    return new SubsettingState.SubsetItem(false, potentialClients);
+    return new SubsettingState.SubsetItem(false, possibleUris, Collections.emptySet());
   }
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -1029,14 +1029,20 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
             {
               warn(_log, "Failed to shut down old ", serviceName, " TransportClient with scheme = ", entry.getKey()
                 , e);
-              _subsettingState.invalidateCache(serviceName);
+              if (_subsettingState != null)
+              {
+                _subsettingState.invalidateCache(serviceName);
+              }
             }
 
             @Override
             public void onSuccess(None result)
             {
               info(_log, "Shut down old ", serviceName, " TransportClient with scheme = ", entry.getKey());
-              _subsettingState.invalidateCache(serviceName);
+              if (_subsettingState != null)
+              {
+                _subsettingState.invalidateCache(serviceName);
+              }
             }
           };
           entry.getValue().shutdown(callback);

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -672,24 +672,24 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
   public SubsettingState.SubsetItem getClientsSubset(String serviceName,
                                                   int minClusterSubsetSize,
                                                   int partitionId,
-                                                  Map<URI, TrackerClient> potentialClients,
+                                                  Map<URI, Double> possibleUris,
                                                   long version)
   {
     if (_subsettingState == null)
     {
-      return new SubsettingState.SubsetItem(false, potentialClients);
+      return new SubsettingState.SubsetItem(false, possibleUris, Collections.emptySet());
     }
     else
     {
       SubsettingState.SubsetItem subsetItem = _subsettingState
-          .getClientsSubset(serviceName, minClusterSubsetSize, partitionId, potentialClients, version, this);
+          .getClientsSubset(serviceName, minClusterSubsetSize, partitionId, possibleUris, version, this);
 
       debug(_log, "get cluster subset for service ", serviceName, ": [",
-          subsetItem.getWeightedSubset().values().stream()
+          subsetItem.getWeightedUriSubset().entrySet().stream()
               .limit(LOG_SUBSET_MAX_SIZE)
-              .map(client -> client.getUri() + ":" + client.getSubsetWeight(partitionId))
+              .map(uri -> uri.getKey() + ":" + uri.getValue())
               .collect(Collectors.joining(",")),
-          " (total ", subsetItem.getWeightedSubset().size(), ")], shouldForceUpdate = ", subsetItem.shouldForceUpdate()
+          " (total ", subsetItem.getWeightedUriSubset().size(), ")], shouldForceUpdate = ", subsetItem.shouldForceUpdate()
       );
 
       return subsetItem;
@@ -1029,12 +1029,14 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
             {
               warn(_log, "Failed to shut down old ", serviceName, " TransportClient with scheme = ", entry.getKey()
                 , e);
+              _subsettingState.invalidateCache(serviceName);
             }
 
             @Override
             public void onSuccess(None result)
             {
               info(_log, "Shut down old ", serviceName, " TransportClient with scheme = ", entry.getKey());
+              _subsettingState.invalidateCache(serviceName);
             }
           };
           entry.getValue().shutdown(callback);

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
@@ -21,11 +21,11 @@ import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +57,7 @@ public class SubsettingState
   public SubsetItem getClientsSubset(String serviceName,
       int minClusterSubsetSize,
       int partitionId,
-      Map<URI, TrackerClient> potentialClients,
+      Map<URI, Double> possibleUris,
       long version,
       SimpleLoadBalancerState state)
   {
@@ -65,14 +65,14 @@ public class SubsettingState
 
     if (subsettingStrategy == null)
     {
-      return new SubsetItem(false, potentialClients);
+      return new SubsetItem(false, possibleUris, Collections.emptySet());
     }
 
     DeterministicSubsettingMetadata metadata = _subsettingMetadataProvider.getSubsettingMetadata(state);
 
     if (metadata == null)
     {
-      return new SubsetItem(false, potentialClients);
+      return new SubsetItem(false, possibleUris, Collections.emptySet());
     }
 
     synchronized (_lockMap.computeIfAbsent(serviceName, name -> new Object()))
@@ -82,63 +82,52 @@ public class SubsettingState
       {
         if (subsetCache.getWeightedSubsets().containsKey(partitionId))
         {
-          return new SubsetItem(false, subsetCache.getWeightedSubsets().get(partitionId));
+          return new SubsetItem(false, subsetCache.getWeightedSubsets().get(partitionId), Collections.emptySet());
         }
       }
 
-      Map<URI, Double> weightMap = potentialClients.entrySet().stream()
-          .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getPartitionWeight(partitionId)));
-      Map<URI, Double> subsetMap = subsettingStrategy.getWeightedSubset(weightMap, metadata);
+      Map<URI, Double> subsetMap = subsettingStrategy.getWeightedSubset(possibleUris, metadata);
 
       if (subsetMap == null)
       {
-        return new SubsetItem(false, potentialClients);
+        return new SubsetItem(false, possibleUris, Collections.emptySet());
       }
       else
       {
-        Set<URI> oldPotentialClients = Collections.emptySet();
+        LOG.info("Force updating subset cache for service " + serviceName);
+        Set<URI> doNotSlowStartUris = new HashSet<>();
 
         if (subsetCache != null)
         {
-          oldPotentialClients = subsetCache.getPotentialClients().getOrDefault(partitionId, Collections.emptySet());
-        }
-
-        Map<URI, TrackerClient> subsetClients = new HashMap<>();
-        for (Map.Entry<URI, Double> entry: subsetMap.entrySet())
-        {
-          URI uri = entry.getKey();
-          TrackerClient client = potentialClients.get(uri);
-          if (oldPotentialClients.contains(uri))
+          Set<URI> oldPossibleUris = subsetCache.getPossibleUris().getOrDefault(partitionId, Collections.emptySet());
+          for (URI uri : subsetMap.keySet())
           {
-            client.setDoNotSlowStart(true);
+            if (oldPossibleUris.contains(uri))
+            {
+              doNotSlowStartUris.add(uri);
+            }
           }
-          client.setSubsetWeight(partitionId, entry.getValue());
-          subsetClients.put(uri, client);
-        }
-
-        if (subsetCache != null)
-        {
           subsetCache.setVersion(version);
           subsetCache.setPeerClusterVersion(metadata.getPeerClusterVersion());
           subsetCache.setMinClusterSubsetSize(minClusterSubsetSize);
-          subsetCache.getPotentialClients().put(partitionId, potentialClients.keySet());
-          subsetCache.getWeightedSubsets().put(partitionId, subsetClients);
+          subsetCache.getPossibleUris().put(partitionId, possibleUris.keySet());
+          subsetCache.getWeightedSubsets().put(partitionId, subsetMap);
         }
         else
         {
-          Map<Integer, Set<URI>> servicePotentialClients = new HashMap<>();
-          Map<Integer, Map<URI, TrackerClient>> serviceWeightedSubset = new HashMap<>();
-          servicePotentialClients.put(partitionId, potentialClients.keySet());
-          serviceWeightedSubset.put(partitionId, subsetClients);
+          Map<Integer, Set<URI>> servicePossibleUris = new HashMap<>();
+          Map<Integer, Map<URI, Double>> serviceWeightedSubset = new HashMap<>();
+          servicePossibleUris.put(partitionId, possibleUris.keySet());
+          serviceWeightedSubset.put(partitionId, subsetMap);
           subsetCache = new SubsetCache(version, metadata.getPeerClusterVersion(),
-              minClusterSubsetSize, servicePotentialClients, serviceWeightedSubset);
+              minClusterSubsetSize, servicePossibleUris, serviceWeightedSubset);
 
           _subsetCache.put(serviceName, subsetCache);
         }
 
         LOG.debug("Subset cache updated for service " + serviceName + ": " + subsetCache);
 
-        return new SubsetItem(true, subsetClients);
+        return new SubsetItem(true, subsetMap, doNotSlowStartUris);
       }
     }
   }
@@ -150,21 +139,30 @@ public class SubsettingState
         minClusterSubsetSize == subsetCache.getMinClusterSubsetSize();
   }
 
+  public void invalidateCache(String serviceName)
+  {
+    synchronized (_lockMap.computeIfAbsent(serviceName, name -> new Object()))
+    {
+      LOG.info("Invalidating subset cache for service " + serviceName);
+      _subsetCache.remove(serviceName);
+    }
+  }
+
   private static class SubsetCache
   {
     private long _version;
     private long _peerClusterVersion;
     private int _minClusterSubsetSize;
-    private final Map<Integer, Set<URI>> _potentialClients;
-    private final Map<Integer, Map<URI, TrackerClient>> _weightedSubsets;
+    private final Map<Integer, Set<URI>> _possibleUris;
+    private final Map<Integer, Map<URI, Double>> _weightedSubsets;
 
     SubsetCache(long version, long peerClusterVersion, int minClusterSubsetSize,
-        Map<Integer, Set<URI>> potentialClients, Map<Integer, Map<URI, TrackerClient>> weightedSubsets)
+        Map<Integer, Set<URI>> possibleUris, Map<Integer, Map<URI, Double>> weightedSubsets)
     {
       _version = version;
       _peerClusterVersion = peerClusterVersion;
       _minClusterSubsetSize = minClusterSubsetSize;
-      _potentialClients = potentialClients;
+      _possibleUris = possibleUris;
       _weightedSubsets = weightedSubsets;
     }
 
@@ -183,12 +181,12 @@ public class SubsettingState
       return _minClusterSubsetSize;
     }
 
-    public Map<Integer, Set<URI>> getPotentialClients()
+    public Map<Integer, Set<URI>> getPossibleUris()
     {
-      return _potentialClients;
+      return _possibleUris;
     }
 
-    public Map<Integer, Map<URI, TrackerClient>> getWeightedSubsets()
+    public Map<Integer, Map<URI, Double>> getWeightedSubsets()
     {
       return _weightedSubsets;
     }
@@ -211,20 +209,35 @@ public class SubsettingState
     @Override
     public String toString() {
       return "SubsetCache{" + "_version=" + _version + ", _peerClusterVersion=" + _peerClusterVersion
-          + ", _minClusterSubsetSize=" + _minClusterSubsetSize + ", _potentialClients=" + _potentialClients
+          + ", _minClusterSubsetSize=" + _minClusterSubsetSize + ", _possibleUris=" + _possibleUris
           + ", _weightedSubsets=" + _weightedSubsets + '}';
     }
   }
 
+  /**
+   * Encapsulates the result of subsetting
+   */
   public static class SubsetItem
   {
     private final boolean _shouldForceUpdate;
-    private final Map<URI, TrackerClient> _weightedSubset;
+    private final Map<URI, Double> _weightedUriSubset;
+    private final Set<URI> _doNotSlowStartUris;
+    private final Map<URI, TrackerClient> _weightedClientSubset;
 
-    public SubsetItem(boolean shouldForceUpdate, Map<URI, TrackerClient> weightedSubset)
+    public SubsetItem(boolean shouldForceUpdate, Map<URI, Double> weightedUriSubset, Set<URI> doNotSlowStartUris)
     {
       _shouldForceUpdate = shouldForceUpdate;
-      _weightedSubset = weightedSubset;
+      _weightedUriSubset = weightedUriSubset;
+      _doNotSlowStartUris = doNotSlowStartUris;
+      _weightedClientSubset = null;
+    }
+
+    public SubsetItem(SubsetItem subsetItem, Map<URI, TrackerClient> weightedClientSubset)
+    {
+      _shouldForceUpdate = subsetItem.shouldForceUpdate();
+      _weightedUriSubset = subsetItem.getWeightedUriSubset();
+      _doNotSlowStartUris = subsetItem.getDoNotSlowStartUris();
+      _weightedClientSubset = weightedClientSubset;
     }
 
     public boolean shouldForceUpdate()
@@ -232,9 +245,19 @@ public class SubsettingState
       return _shouldForceUpdate;
     }
 
+    public Map<URI, Double> getWeightedUriSubset()
+    {
+      return _weightedUriSubset;
+    }
+
+    public Set<URI> getDoNotSlowStartUris()
+    {
+      return _doNotSlowStartUris;
+    }
+
     public Map<URI, TrackerClient> getWeightedSubset()
     {
-      return _weightedSubset;
+      return _weightedClientSubset;
     }
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.d2.balancer.subsetting;
 
-import com.linkedin.d2.balancer.clients.TrackerClient;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
 import java.net.URI;
 import java.util.Collections;
@@ -222,22 +221,12 @@ public class SubsettingState
     private final boolean _shouldForceUpdate;
     private final Map<URI, Double> _weightedUriSubset;
     private final Set<URI> _doNotSlowStartUris;
-    private final Map<URI, TrackerClient> _weightedClientSubset;
 
     public SubsetItem(boolean shouldForceUpdate, Map<URI, Double> weightedUriSubset, Set<URI> doNotSlowStartUris)
     {
       _shouldForceUpdate = shouldForceUpdate;
       _weightedUriSubset = weightedUriSubset;
       _doNotSlowStartUris = doNotSlowStartUris;
-      _weightedClientSubset = null;
-    }
-
-    public SubsetItem(SubsetItem subsetItem, Map<URI, TrackerClient> weightedClientSubset)
-    {
-      _shouldForceUpdate = subsetItem.shouldForceUpdate();
-      _weightedUriSubset = subsetItem.getWeightedUriSubset();
-      _doNotSlowStartUris = subsetItem.getDoNotSlowStartUris();
-      _weightedClientSubset = weightedClientSubset;
     }
 
     public boolean shouldForceUpdate()
@@ -253,11 +242,6 @@ public class SubsettingState
     public Set<URI> getDoNotSlowStartUris()
     {
       return _doNotSlowStartUris;
-    }
-
-    public Map<URI, TrackerClient> getWeightedSubset()
-    {
-      return _weightedClientSubset;
     }
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -46,7 +46,7 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
   private final Object _lock = new Object();
 
   @GuardedBy("_lock")
-  private long _peerCluserVersion = -1;
+  private long _peerClusterVersion = -1;
   @GuardedBy("_lock")
   private DeterministicSubsettingMetadata _subsettingMetadata;
 
@@ -72,9 +72,9 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
 
       synchronized (_lock)
       {
-        if (uriItem.getVersion() != _peerCluserVersion)
+        if (uriItem.getVersion() != _peerClusterVersion)
         {
-          _peerCluserVersion = uriItem.getVersion();
+          _peerClusterVersion = uriItem.getVersion();
           UriProperties uriProperties = uriItem.getProperty();
           if (uriProperties != null)
           {
@@ -89,7 +89,8 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
 
             if (instanceId >= 0)
             {
-              _subsettingMetadata = new DeterministicSubsettingMetadata(instanceId, sortedHosts.size(), _peerCluserVersion);
+              _subsettingMetadata = new DeterministicSubsettingMetadata(instanceId, sortedHosts.size(),
+                  _peerClusterVersion);
             }
             else
             {

--- a/d2/src/test/java/com/linkedin/d2/balancer/clients/RetryClientTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clients/RetryClientTest.java
@@ -431,7 +431,7 @@ public class RetryClientTest
       final URI foo = URI.create(uri);
       Map<Integer, PartitionData> foo1Data = new HashMap<>();
       // ensure that we first route to the retry uris before the good uris
-      double weight = uri.contains("good") ? 0.0001 : 1.0;
+      double weight = uri.contains("good") ? 0.1 : 1.0;
       foo1Data.put(0, new PartitionData(weight));
       partitionDescriptions.put(foo, foo1Data);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.24.0
+version=29.25.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This PR is a critical bug fix that addresses a race condition in D2 subsetting cache.

The sequence that triggers the race condition is as follows:
1. D2 receives a `ServiceProperties` update, and in the new config, D2 subsetting is enabled.
2. In `handlePut()` of `ServiceLoadBalancerSubscriber`, the new `ServiceProperties` is put into the `SimpleLoadBalancerState`.
3. Another thread jumps in, reads the new `ServiceProperties` and updates the D2 subset cache with the TrackerClient map.
4. `handlePut()` continues and calls `_state.refreshClients()`. New TransportClients and TrackerClients are created and the old ones are shutdown.
5. But in the subset cache, it still holds on to the old TrackerClient, while the underlying TransportClient has already been shutdown.
6. All the subsequent calls will fail, until the subset cache is updated again (which is triggered only by cluster URI changes).

This PR fixes the bug by not having subset cache hold on to TrackerClient objects. Instead, the cache now only stores the stateless URI information. This makes sure that now all the TrackerClients used by the `SimpleLoadBalancer` are the latest ones stored in the `SimpleLoadBalancerState`.

This PR bumps the minor version of Pegasus.