### PR TITLE
Fail documentation requests while renderers are being lazily initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.26.1] - 2022-01-13
+- Fail documentation requests while renderers are being lazily initialized (rather than block threads until complete).
+
 ## [29.26.0] - 2022-01-10
 - Add header provider to generate required request to fetch default remote symbol table
 
@@ -5158,7 +5161,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.26.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.26.1...master
+[29.26.1]: https://github.com/linkedin/rest.li/compare/v29.26.0...v29.26.1
 [29.26.0]: https://github.com/linkedin/rest.li/compare/v29.25.0...v29.26.0
 [29.25.0]: https://github.com/linkedin/rest.li/compare/v29.24.0...v29.25.0
 [29.24.0]: https://github.com/linkedin/rest.li/compare/v29.23.3...v29.24.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.26.0
+version=29.26.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
In `DefaultDocumentationRequestHandler`, the documentation renderers are lazily initialized. Request threads will block on the completion of this initialization, which could cause problems if it takes too long. This changes that, as request threads will simply fail if it's not complete.