### PR TITLE
Fix for SI-24257 (NPS from PropertyEventBusImpl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.26.2] - 2022-01-13
+- Fix for null pointer exception when registering listener on event bus before publisher is set.
+
 ## [29.26.1] - 2022-01-13
 - Fail documentation requests while renderers are being lazily initialized (rather than block threads until complete).
 
@@ -5161,7 +5164,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.26.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.26.2...master
+[29.26.2]: https://github.com/linkedin/rest.li/compare/v29.26.1...v29.26.2
 [29.26.1]: https://github.com/linkedin/rest.li/compare/v29.26.0...v29.26.1
 [29.26.0]: https://github.com/linkedin/rest.li/compare/v29.25.0...v29.26.0
 [29.25.0]: https://github.com/linkedin/rest.li/compare/v29.24.0...v29.25.0

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/PropertyEventBusImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/PropertyEventBusImpl.java
@@ -121,7 +121,7 @@ public class PropertyEventBusImpl<T> implements PropertyEventBus<T>
           {
             subscriber.onInitialize(prop, _properties.get(prop));
           }
-          if (notifyPublisher)
+          if (notifyPublisher && _publisher != null)
           {
             _publisher.startPublishing(prop);
           }
@@ -147,7 +147,10 @@ public class PropertyEventBusImpl<T> implements PropertyEventBus<T>
             if (subscribers.isEmpty())
             {
               _properties.remove(prop);
-              _publisher.stopPublishing(prop);
+              if (_publisher != null)
+              {
+                _publisher.stopPublishing(prop);
+              }
             }
           }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.26.1
+version=29.26.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Fix for SI-24257, where NPS is thrown when registering listener before publisher exists on an event bus.

Some event buses are created without a publisher, as a publisher can be set later via setPublisher. However the register listener function assumes that a publisher exists when a first listener is added for a property name, and attempts to tell it to start publishing. Fix is to simply check for a null publisher. Same issue potentially exists in unregister. setPublisher already correctly handles starting publishing if listeners are already registered.