### PR TITLE
Update outdated gradle class used in restli-int-server module's buid.gradle

### DIFF
--- a/restli-int-test-server/build.gradle
+++ b/restli-int-test-server/build.gradle
@@ -1,4 +1,4 @@
-import org.apache.tools.ant.types.LogLevel
+import org.gradle.api.logging.LogLevel
 
 
 apply plugin: 'pegasus'


### PR DESCRIPTION
build failed with this message

```
Execution failed for task ':restli-int-test-server:startServer'.
> No signature of method: org.gradle.internal.logging.compatbridge.LoggingManagerInternalCompatibilityBridge.captureStandardOutput() is applicable for argument types: (org.apache.tools.ant.types.LogLevel) values: [info]
  Possible solutions: captureStandardOutput(org.gradle.api.logging.LogLevel)
```