### PR TITLE
Make DarkGateKeeper configurable given a dark cluster name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.29.1] - 2022-02-10
+- Make DarkGateKeeper configurable for different dark clusters
+
 ## [29.29.0] - 2022-02-09
 - Revert avro update introduced in 29.27.0
 
@@ -5179,7 +5182,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.29.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.29.1...master
+[29.29.1]: https://github.com/linkedin/rest.li/compare/v29.29.0...v29.29.1
 [29.29.0]: https://github.com/linkedin/rest.li/compare/v29.28.0...v29.29.0
 [29.28.0]: https://github.com/linkedin/rest.li/compare/v29.27.0...v29.28.0
 [29.27.0]: https://github.com/linkedin/rest.li/compare/v29.26.4...v29.27.0

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/api/DarkGateKeeper.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/api/DarkGateKeeper.java
@@ -7,14 +7,31 @@ import com.linkedin.r2.message.rest.RestRequest;
 /**
  * Interface that lets users define custom logic to determine if a given request is to be dispatched to dark cluster or not.
  */
-@FunctionalInterface
 public interface DarkGateKeeper
 {
+  DarkGateKeeper NO_OP_DARK_GATE_KEEPER = new DarkGateKeeper() { };
+
   /**
    * Determine if the request is to be dispatched or not
    * @param request original request
    * @param requestContext original request context
    * @return true if request should be dispatched, false otherwise
    */
-  boolean shouldDispatchToDark(RestRequest request, RequestContext requestContext);
+  @Deprecated
+  default boolean shouldDispatchToDark(RestRequest request, RequestContext requestContext)
+  {
+    return true;
+  }
+
+  /**
+   * Determine if the request is to be dispatched or not given dark cluster name
+   * @param request original request
+   * @param requestContext original request context
+   * @param darkClusterName name of the dark cluster
+   * @return true if request should be dispatched, false otherwise
+   */
+  default boolean shouldDispatchToDark(RestRequest request, RequestContext requestContext, String darkClusterName)
+  {
+    return shouldDispatchToDark(request, requestContext);
+  }
 }

--- a/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterManager.java
+++ b/darkcluster/src/test/java/com/linkedin/darkcluster/TestDarkClusterManager.java
@@ -17,6 +17,7 @@ import com.linkedin.r2.message.rest.RestRequestBuilder;
 
 import static com.linkedin.darkcluster.DarkClusterTestUtil.createRelativeTrafficMultiplierConfig;
 import static com.linkedin.darkcluster.TestDarkClusterStrategyFactory.DARK_CLUSTER_NAME;
+import static com.linkedin.darkcluster.TestDarkClusterStrategyFactory.DARK_CLUSTER_NAME2;
 import static com.linkedin.darkcluster.TestDarkClusterStrategyFactory.SOURCE_CLUSTER_NAME;
 
 import java.util.Collections;
@@ -34,7 +35,13 @@ public class TestDarkClusterManager
   @DataProvider
   public Object[][] provideKeys()
   {
-    DarkGateKeeper darkGateKeeper = (request, requestContext) -> false;
+    DarkGateKeeper darkGateKeeper = new DarkGateKeeper() {
+      @Override
+      public boolean shouldDispatchToDark(RestRequest request, RequestContext requestContext, String darkClusterName) {
+        return false;
+      }
+    };
+
     return new Object[][] {
       // whitelist, blacklist, httpMethod, darkGateKeeper, expected white count, expected black count
       {null, null, METHOD_SAFE, null, 1, 1},
@@ -86,6 +93,54 @@ public class TestDarkClusterManager
     Assert.assertEquals(blackStatus, expectedBlackCount > 0, "black uri requests not as expected");
     Assert.assertEquals(strategyFactory.strategyGetOrCreateCount, expectedWhiteCount + expectedBlackCount,
                         "unexpected strategy GetOrCreateCount");
+  }
+
+  @Test
+  public void testDarkGateKeeper()
+  {
+    DarkGateKeeper darkGateKeeper = new DarkGateKeeper() {
+      @Override
+      public boolean shouldDispatchToDark(RestRequest request, RequestContext requestContext, String darkClusterName) {
+        return darkClusterName.equals(DARK_CLUSTER_NAME);
+      }
+    };
+
+    MockClusterInfoProvider clusterInfoProvider = new MockClusterInfoProvider();
+    Facilities facilities = new MockFacilities(clusterInfoProvider);
+    MockStrategyFactory strategyFactory = new MockStrategyFactory();
+    DarkClusterManager darkClusterManager = new DarkClusterManagerImpl(SOURCE_CLUSTER_NAME,
+        facilities,
+        strategyFactory,
+        null,
+        null,
+        new DoNothingNotifier(),
+        darkGateKeeper);
+
+    strategyFactory.start();
+
+    // This configuration will choose the RelativeTrafficMultiplierDarkClusterStrategy
+    DarkClusterConfig darkClusterConfig = createRelativeTrafficMultiplierConfig(1.0f);
+    clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, DARK_CLUSTER_NAME2, darkClusterConfig);
+
+    RestRequest restRequest1 = new RestRequestBuilder(URI.create("/white")).setMethod(METHOD_SAFE).build();
+    boolean whiteStatus = darkClusterManager.handleDarkRequest(restRequest1, new RequestContext());
+    RestRequest restRequest2 = new RestRequestBuilder(URI.create("/black")).setMethod(METHOD_SAFE).build();
+    boolean blackStatus = darkClusterManager.handleDarkRequest(restRequest2, new RequestContext());
+
+    Assert.assertFalse(whiteStatus, "white uri requests not as expected");
+    Assert.assertFalse(blackStatus, "black uri requests not as expected");
+    Assert.assertEquals(strategyFactory.strategyGetOrCreateCount, 0,
+        "unexpected strategy GetOrCreateCount");
+
+    clusterInfoProvider.addDarkClusterConfig(SOURCE_CLUSTER_NAME, DARK_CLUSTER_NAME, darkClusterConfig);
+
+    boolean whiteStatus1 = darkClusterManager.handleDarkRequest(restRequest1, new RequestContext());
+    boolean blackStatus1 = darkClusterManager.handleDarkRequest(restRequest2, new RequestContext());
+
+    Assert.assertTrue(whiteStatus1, "white uri requests not as expected");
+    Assert.assertTrue(blackStatus1, "black uri requests not as expected");
+    Assert.assertEquals(strategyFactory.strategyGetOrCreateCount, 2,
+        "unexpected strategy GetOrCreateCount");
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.29.0
+version=29.29.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Previously, DarkGateKeeper can only apply to all dark clusters. Exposing an API to make it configurable for each dark cluster