### PR TITLE
Fix a bug during documentation rendering where it does not account for api-name in the path when searching for restepec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.32.2] - 2022-03-17
 - Fix documentation renderer's doc string rendering failure for restspec filename that has api-name prefix
 
 ## [29.32.1] - 2022-03-15
@@ -5198,7 +5200,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.32.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.32.2...master
+[29.32.2]: https://github.com/linkedin/rest.li/compare/v29.32.1...v29.32.2
 [29.32.1]: https://github.com/linkedin/rest.li/compare/v29.31.0...v29.31.1
 [29.32.0]: https://github.com/linkedin/rest.li/compare/v29.31.0...v29.32.0
 [29.31.0]: https://github.com/linkedin/rest.li/compare/v29.30.0...v29.31.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Fix documentation renderer's doc string rendering failure for restspec filename that has api-name prefix
 
 ## [29.32.1] - 2022-03-15
 - Support failouts in ClusterStoreProperties.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.32.1
+version=29.32.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
@@ -112,6 +112,7 @@ public class ResourceModelEncoder
   public static final String DEPRECATED_ANNOTATION_DOC_FIELD = "doc";
   public static final String COMPOUND_KEY_TYPE_NAME = "CompoundKey";
 
+  private static final String REST_SPEC_JSON_SUFFIX = "restspec.json";
   private static final Pattern UNNECESSARY_WHITESPACE_PATTERN = Pattern.compile("[ \\t]+");
 
   private final DataCodec codec = new JacksonDataCodec();
@@ -340,7 +341,6 @@ public class ResourceModelEncoder
 
   private InputStream getResourceStreamBySearchingRestSpec(String resourceName, ClassLoader... classLoaders)
   {
-    final String REST_SPEC_JSON_SUFFIX = "restspec.json";
     if (!resourceName.endsWith(REST_SPEC_JSON_SUFFIX))
     {
       return null;

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
@@ -340,6 +340,11 @@ public class ResourceModelEncoder
 
   private InputStream getResourceStreamBySearchingRestSpec(String resourceName, ClassLoader... classLoaders)
   {
+    final String REST_SPEC_JSON_SUFFIX = "restspec.json";
+    if (!resourceName.endsWith(REST_SPEC_JSON_SUFFIX))
+    {
+      return null;
+    }
     if (_restSpecToClassLoaderMap == null)
     {
       _restSpecToClassLoaderMap = new HashMap<>();
@@ -356,7 +361,7 @@ public class ResourceModelEncoder
           {
             JarInputStream jarIn = new JarInputStream(url.openStream());
             for (JarEntry e = jarIn.getNextJarEntry(); e != null; e = jarIn.getNextJarEntry()) {
-              if (!e.isDirectory() && e.getName().contains("restspec.json"))
+              if (!e.isDirectory() && e.getName().endsWith(REST_SPEC_JSON_SUFFIX))
               {
                 _restSpecToClassLoaderMap.put(e.getName(), classLoader);
               }
@@ -372,7 +377,7 @@ public class ResourceModelEncoder
 
     for (Map.Entry<String, ClassLoader> entry : _restSpecToClassLoaderMap.entrySet())
     {
-      if (entry.getKey().contains(resourceName))
+      if (entry.getKey().endsWith("-" + resourceName))
       {
         return entry.getValue().getResourceAsStream(entry.getKey());
       }


### PR DESCRIPTION
Our documentationRender would respond to Options calls by checking the restspec json files from class path using a direct resource name as the file name. 

But some cusomters added a prefix as api-name to pegasus plugin's idl options when generating the idl files, therefore the idl file in class path will have that prefix and documentationRender will not find it for option calls.

This change, is to fix this case by searching for all restspec.json files in the classpath, so that the restspec.json which prefixed by api-names are also taken into account.



Tested by local optionss call, e.g.
`curl "localhost:9000/<service-name>/<resource-name>" -X OPTIONS`