### PR TITLE
Updating usages of clazz.newInstance

### DIFF
--- a/data-avro/src/main/java/com/linkedin/data/avro/AvroAdapterFinder.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/AvroAdapterFinder.java
@@ -19,6 +19,7 @@ package com.linkedin.data.avro;
 
 import java.lang.reflect.Constructor;
 
+import java.lang.reflect.InvocationTargetException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 
@@ -144,19 +145,10 @@ public class AvroAdapterFinder
     {
       Class<?> clazz = Class.forName(fullName);
       @SuppressWarnings("unchecked")
-      T result = (T) clazz.newInstance();
+      T result = (T) clazz.getDeclaredConstructor().newInstance();
       return result;
-    }
-    catch (ClassNotFoundException e)
-    {
-      throw new IllegalStateException("Unable to construct " + fullName, e);
-    }
-    catch (InstantiationException e)
-    {
-      throw new IllegalStateException("Unable to construct " + fullName, e);
-    }
-    catch (IllegalAccessException e)
-    {
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
+        InvocationTargetException | NoSuchMethodException e) {
       throw new IllegalStateException("Unable to construct " + fullName, e);
     }
   }

--- a/data-avro/src/main/java/com/linkedin/data/avro/AvroOverrideFactory.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/AvroOverrideFactory.java
@@ -17,6 +17,7 @@
 package com.linkedin.data.avro;
 
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import com.linkedin.data.DataMap;
@@ -143,7 +144,7 @@ abstract class AvroOverrideFactory
               try
               {
                 Class<?> translatorClass = Class.forName(customDataTranslatorClassName, true, Thread.currentThread().getContextClassLoader());
-                customDataTranslator = (CustomDataTranslator) translatorClass.newInstance();
+                customDataTranslator = (CustomDataTranslator) translatorClass.getDeclaredConstructor().newInstance();
               }
               catch (ClassCastException e)
               {
@@ -155,12 +156,7 @@ abstract class AvroOverrideFactory
                 emitMessage("%1$s class not found", customDataTranslatorClassName);
                 ok = false;
               }
-              catch (IllegalAccessException e)
-              {
-                emitMessage("%1$s cannot be instantiated due to %2$s", customDataTranslatorClassName, e.getClass().getName());
-                ok = false;
-              }
-              catch (InstantiationException e)
+              catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException e)
               {
                 emitMessage("%1$s cannot be instantiated due to %2$s", customDataTranslatorClassName, e.getClass().getName());
                 ok = false;

--- a/data/src/test/java/com/linkedin/data/template/TestArrayTemplate.java
+++ b/data/src/test/java/com/linkedin/data/template/TestArrayTemplate.java
@@ -26,6 +26,7 @@ import com.linkedin.data.schema.ArrayDataSchema;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -58,7 +59,7 @@ public class TestArrayTemplate
     try
     {
       // constructors and addAll
-      ArrayTemplate array1 = templateClass.newInstance();
+      ArrayTemplate array1 = templateClass.getDeclaredConstructor().newInstance();
       array1.addAll(input);
       assertEquals(input, array1);
 
@@ -134,7 +135,7 @@ public class TestArrayTemplate
       assertEquals(schema1, schema);
 
       // add(E element), get(int index)
-      ArrayTemplate array3 = templateClass.newInstance();
+      ArrayTemplate array3 = templateClass.getDeclaredConstructor().newInstance();
       for (int i = 0; i < adds.size(); ++i)
       {
         E value = adds.get(i);
@@ -147,7 +148,7 @@ public class TestArrayTemplate
       assertEquals(array3, adds);
 
       // add(int index, E element), get(int index)
-      ArrayTemplate array4 = templateClass.newInstance();
+      ArrayTemplate array4 = templateClass.getDeclaredConstructor().newInstance();
       for (int i = 0; i < adds.size(); ++i)
       {
         E value = adds.get(adds.size() - i - 1);
@@ -175,7 +176,7 @@ public class TestArrayTemplate
       for (int i = 0; i <= input.size(); ++i)
       {
         List<E> subList = input.subList(0, i);
-        ArrayTemplate a = templateClass.newInstance();
+        ArrayTemplate a = templateClass.getDeclaredConstructor().newInstance();
         a.addAll(subList);
         if (i == input.size())
         {
@@ -190,7 +191,7 @@ public class TestArrayTemplate
       }
 
       // hashcode()
-      ArrayTemplate array5 = templateClass.newInstance();
+      ArrayTemplate array5 = templateClass.getDeclaredConstructor().newInstance();
       array5.addAll(input);
       assertEquals(array5.hashCode(), array5.data().hashCode());
       array5.addAll(adds);
@@ -209,7 +210,7 @@ public class TestArrayTemplate
       }
 
       // indexOf(Object o), lastIndexOf(Object o)
-      ArrayTemplate array6 = templateClass.newInstance();
+      ArrayTemplate array6 = templateClass.getDeclaredConstructor().newInstance();
       array6.addAll(adds);
       for (E e : adds)
       {
@@ -218,9 +219,9 @@ public class TestArrayTemplate
       }
 
       // remove(int index), subList(int fromIndex, int toIndex)
-      ArrayTemplate array7 = templateClass.newInstance();
+      ArrayTemplate array7 = templateClass.getDeclaredConstructor().newInstance();
       array7.addAll(input);
-      ArrayTemplate array8 = templateClass.newInstance();
+      ArrayTemplate array8 = templateClass.getDeclaredConstructor().newInstance();
       array8.addAll(input);
       for (int i = 0; i < input.size(); ++i)
       {
@@ -234,7 +235,7 @@ public class TestArrayTemplate
       {
         for (int to = from + 1; to <= input.size(); ++to)
         {
-          ArrayTemplate arrayRemove = templateClass.newInstance();
+          ArrayTemplate arrayRemove = templateClass.getDeclaredConstructor().newInstance();
           arrayRemove.addAll(input);
           InternalList<E> reference = new InternalList<>(input);
           arrayRemove.removeRange(from, to);
@@ -244,7 +245,7 @@ public class TestArrayTemplate
       }
 
       // set(int index, E element)
-      ArrayTemplate array9 = templateClass.newInstance();
+      ArrayTemplate array9 = templateClass.getDeclaredConstructor().newInstance();
       array9.addAll(input);
       InternalList<E> reference9 = new InternalList<>(input);
       for (int i = 0; i < input.size() / 2; ++i)
@@ -267,7 +268,7 @@ public class TestArrayTemplate
 
       // clone
       Exception exc = null;
-      ArrayTemplate array10 = templateClass.newInstance();
+      ArrayTemplate array10 = templateClass.getDeclaredConstructor().newInstance();
       array10.addAll(input);
       try
       {
@@ -294,7 +295,7 @@ public class TestArrayTemplate
       assert(exc == null);
 
       // copy
-      ArrayTemplate array10a = templateClass.newInstance();
+      ArrayTemplate array10a = templateClass.getDeclaredConstructor().newInstance();
       array10a.addAll(input);
 
       try
@@ -340,7 +341,7 @@ public class TestArrayTemplate
       // contains
       for (int i = 0; i < input.size(); ++i)
       {
-        ArrayTemplate array = templateClass.newInstance();
+        ArrayTemplate array = templateClass.getDeclaredConstructor().newInstance();
         E v = input.get(i);
         array.add(v);
         for (int k = 0; k < input.size(); ++k)
@@ -353,7 +354,7 @@ public class TestArrayTemplate
       }
 
       // containsAll
-      ArrayTemplate arrayContainsAll = templateClass.newInstance();
+      ArrayTemplate arrayContainsAll = templateClass.getDeclaredConstructor().newInstance();
       arrayContainsAll.addAll(input);
       arrayContainsAll.addAll(adds);
       InternalList<E> referenceContainsAll = new InternalList<>(input);
@@ -381,7 +382,7 @@ public class TestArrayTemplate
       {
         for (int to = from + 1; to <= referenceListRemoveAll.size(); ++to)
         {
-          ArrayTemplate arrayRemoveAll = templateClass.newInstance();
+          ArrayTemplate arrayRemoveAll = templateClass.getDeclaredConstructor().newInstance();
           arrayRemoveAll.addAll(referenceListRemoveAll);
           InternalList<E> referenceRemoveAll = new InternalList<>(referenceListRemoveAll);
 
@@ -402,7 +403,7 @@ public class TestArrayTemplate
       {
         for (int to = from + 1; to <= referenceListRetainAll.size(); ++to)
         {
-          ArrayTemplate arrayRetainAll = templateClass.newInstance();
+          ArrayTemplate arrayRetainAll = templateClass.getDeclaredConstructor().newInstance();
           arrayRetainAll.addAll(referenceListRetainAll);
           InternalList<E> referenceRetainAll = new InternalList<>(referenceListRetainAll);
 
@@ -417,7 +418,7 @@ public class TestArrayTemplate
       }
 
       // Iterator
-      ArrayTemplate arrayIt = templateClass.newInstance();
+      ArrayTemplate arrayIt = templateClass.getDeclaredConstructor().newInstance();
       arrayIt.addAll(input);
       arrayIt.addAll(adds);
       for (Iterator<E> it = arrayIt.iterator(); it.hasNext(); )
@@ -428,7 +429,7 @@ public class TestArrayTemplate
       assertTrue(arrayIt.isEmpty());
 
       // ListIterator hasNext, hasPrevious, next, previous
-      ArrayTemplate arrayListIt = templateClass.newInstance();
+      ArrayTemplate arrayListIt = templateClass.getDeclaredConstructor().newInstance();
       arrayListIt.addAll(input);
       arrayListIt.addAll(adds);
       for (int i = 0; i <= arrayListIt.size(); ++i)
@@ -495,11 +496,7 @@ public class TestArrayTemplate
         assertEquals(arrayListIt.get(i), value);
       }
     }
-    catch (InstantiationException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (IllegalAccessException exc)
+    catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException exc)
     {
       fail("Unexpected exception", exc);
     }
@@ -516,7 +513,7 @@ public class TestArrayTemplate
     try
     {
       Exception exc = null;
-      ArrayTemplate arrayTemplateBad = templateClass.newInstance();
+      ArrayTemplate arrayTemplateBad = templateClass.getDeclaredConstructor().newInstance();
       DataList badDataList = new DataList();
       ArrayTemplate badWrappedArrayTemplate = DataTemplateUtil.wrap(badDataList, schema, templateClass);
 
@@ -734,17 +731,7 @@ public class TestArrayTemplate
         assertTrue(exc != null);
         assertTrue(exc instanceof TemplateOutputCastException);
       }
-    }
-    catch (IllegalAccessException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (InstantiationException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (TemplateOutputCastException exc)
-    {
+    } catch (IllegalAccessException | TemplateOutputCastException | InstantiationException | InvocationTargetException | NoSuchMethodException exc) {
       fail("Unexpected exception", exc);
     }
   }
@@ -759,7 +746,7 @@ public class TestArrayTemplate
     try
     {
       // test insert non-native, converted to element type on set
-      ArrayTemplate array1 = templateClass.newInstance();
+      ArrayTemplate array1 = templateClass.getDeclaredConstructor().newInstance();
       array1.addAll((List<E>) castFrom);
       for (int i = 0; i < castTo.size(); ++i)
       {
@@ -776,11 +763,7 @@ public class TestArrayTemplate
         assertEquals(castTo.get(i), array2.get(i));
       }
     }
-    catch (InstantiationException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (IllegalAccessException exc)
+    catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException exc)
     {
       fail("Unexpected exception", exc);
     }

--- a/data/src/test/java/com/linkedin/data/template/TestMapTemplate.java
+++ b/data/src/test/java/com/linkedin/data/template/TestMapTemplate.java
@@ -26,6 +26,7 @@ import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.MapDataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -66,7 +67,7 @@ public class TestMapTemplate
       Exception exc = null;
 
       // constructor and putall
-      MapTemplate map1 = templateClass.newInstance();
+      MapTemplate map1 = templateClass.getDeclaredConstructor().newInstance();
       map1.putAll(input);
       assertEquals(map1, input);
 
@@ -196,7 +197,7 @@ public class TestMapTemplate
       assertEquals(schema1, schema);
 
       // get(Object key), put(K key, V value, containsKey(Object key), containsValue(Object value), toString
-      MapTemplate map3 = templateClass.newInstance();
+      MapTemplate map3 = templateClass.getDeclaredConstructor().newInstance();
       for (Map.Entry<String, E> e : input.entrySet())
       {
         String key = e.getKey();
@@ -253,7 +254,7 @@ public class TestMapTemplate
       }
 
       // remove(Object key), containsKey(Object key), containsValue(Object value)
-      MapTemplate map4 = templateClass.newInstance();
+      MapTemplate map4 = templateClass.getDeclaredConstructor().newInstance();
       map4.putAll(input);
       int map4Size = map4.size();
       for (Map.Entry<String, E> e : input.entrySet())
@@ -280,7 +281,7 @@ public class TestMapTemplate
 
       // clone
       exc = null;
-      map4 = templateClass.newInstance();
+      map4 = templateClass.getDeclaredConstructor().newInstance();
       map4.putAll(input);
       try
       {
@@ -312,7 +313,7 @@ public class TestMapTemplate
       assert(exc == null);
 
       //copy
-      MapTemplate map4a = templateClass.newInstance();
+      MapTemplate map4a = templateClass.getDeclaredConstructor().newInstance();
       map4a.putAll(input);
       try
       {
@@ -360,7 +361,7 @@ public class TestMapTemplate
       assert(exc == null);
 
       // entrySet, keySet, values, clear
-      MapTemplate map5 = templateClass.newInstance();
+      MapTemplate map5 = templateClass.getDeclaredConstructor().newInstance();
       map5.putAll(input);
       assertEquals(map5.entrySet(), input.entrySet());
       assertCollectionEquals(map5.entrySet(), input.entrySet());
@@ -386,7 +387,7 @@ public class TestMapTemplate
       assertTrue(map5.isEmpty());
 
       // entrySet contains
-      MapTemplate map6 = templateClass.newInstance();
+      MapTemplate map6 = templateClass.getDeclaredConstructor().newInstance();
       Set<Map.Entry<String, E>> entrySet6 = map6.entrySet();
       for (Map.Entry<String, E> e : input.entrySet())
       {
@@ -533,8 +534,8 @@ public class TestMapTemplate
       assertTrue(exc instanceof UnsupportedOperationException);
 
       // entrySet equals, isEmpty
-      MapTemplate map7 = templateClass.newInstance();
-      MapTemplate map8 = templateClass.newInstance();
+      MapTemplate map7 = templateClass.getDeclaredConstructor().newInstance();
+      MapTemplate map8 = templateClass.getDeclaredConstructor().newInstance();
       map8.putAll(input);
       Set<Map.Entry<String, E>> entrySet7 = map7.entrySet();
       assertTrue(entrySet7.isEmpty());
@@ -573,7 +574,7 @@ public class TestMapTemplate
       assertFalse(map7.entrySet().equals(new Object()));
 
       // test Map.Entry.set()
-      MapTemplate map9 = templateClass.newInstance();
+      MapTemplate map9 = templateClass.getDeclaredConstructor().newInstance();
       map9.putAll(input);
       lastValue = null;
       for (Map.Entry<String, E> e : map9.entrySet())
@@ -601,11 +602,7 @@ public class TestMapTemplate
         lastValue = value;
       }
     }
-    catch (IllegalAccessException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (InstantiationException exc)
+    catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException exc)
     {
       fail("Unexpected exception", exc);
     }
@@ -622,13 +619,9 @@ public class TestMapTemplate
     MapTemplate mapTemplateBad = null;
     try
     {
-      mapTemplateBad = templateClass.newInstance();
+      mapTemplateBad = templateClass.getDeclaredConstructor().newInstance();
     }
-    catch (IllegalAccessException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (InstantiationException exc)
+    catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException exc)
     {
       fail("Unexpected exception", exc);
     }
@@ -757,7 +750,7 @@ public class TestMapTemplate
     try
     {
       // test insert non-native, converted to element type on set
-      MapTemplate map1 = templateClass.newInstance();
+      MapTemplate map1 = templateClass.getDeclaredConstructor().newInstance();
       map1.putAll((Map<String, E>) castFrom);
       for (String i : castFrom.keySet())
       {
@@ -800,11 +793,7 @@ public class TestMapTemplate
         lastHash = newHash;
       }
     }
-    catch (IllegalAccessException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (InstantiationException exc)
+    catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException exc)
     {
       fail("Unexpected exception", exc);
     }

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/override/TestRecord.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/override/TestRecord.java
@@ -208,16 +208,12 @@ public class TestRecord
   {
     try
     {
-      T record = recordClass.newInstance();
+      T record = recordClass.getDeclaredConstructor().newInstance();
       RecordDataSchema schema = (RecordDataSchema) DataTemplateUtil.getSchema(recordClass);
       RecordDataSchema schema2 = record.schema();
       assertSame(schema, schema2);
     }
-    catch (IllegalAccessException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (InstantiationException exc)
+    catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException exc)
     {
       fail("Unexpected exception", exc);
     }

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/TestRecord.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/TestRecord.java
@@ -213,16 +213,12 @@ public class TestRecord
   {
     try
     {
-      T record = recordClass.newInstance();
+      T record = recordClass.getDeclaredConstructor().newInstance();
       RecordDataSchema schema = (RecordDataSchema) DataTemplateUtil.getSchema(recordClass);
       RecordDataSchema schema2 = record.schema();
       assertSame(schema, schema2);
     }
-    catch (IllegalAccessException exc)
-    {
-      fail("Unexpected exception", exc);
-    }
-    catch (InstantiationException exc)
+    catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException exc)
     {
       fail("Unexpected exception", exc);
     }

--- a/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/validation/RestLiDataValidator.java
@@ -51,6 +51,7 @@ import com.linkedin.restli.common.util.ProjectionMaskApplier;
 import com.linkedin.restli.restspec.RestSpecAnnotation;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -132,6 +133,8 @@ public class RestLiDataValidator
   private static final String INSTANTIATION_ERROR = "InstantiationException while trying to instantiate the record template class";
   private static final String ILLEGAL_ACCESS_ERROR = "IllegalAccessException while trying to instantiate the record template class";
   private static final String TEMPLATE_RUNTIME_ERROR = "TemplateRuntimeException while trying to find the schema class";
+  private static final String INVOCATION_TARGET_ERROR = "InvocationTargetException while trying to instantiate the record template class";
+  private static final String NO_SUCH_METHOD_ERROR = "NoSuchMethodException while trying to instantiate the record template class";
 
   private static PathMatchesPatternPredicate stringToPredicate(String path, boolean includeDescendants)
   {
@@ -511,7 +514,7 @@ public class RestLiDataValidator
     RecordTemplate entity;
     try
     {
-      entity = _valueClass.newInstance();
+      entity = _valueClass.getDeclaredConstructor().newInstance();
     }
     catch (InstantiationException e)
     {
@@ -520,6 +523,10 @@ public class RestLiDataValidator
     catch (IllegalAccessException e)
     {
       return validationResultWithErrorMessage(ILLEGAL_ACCESS_ERROR);
+    } catch (InvocationTargetException e) {
+      return validationResultWithErrorMessage(INVOCATION_TARGET_ERROR);
+    } catch (NoSuchMethodException e) {
+      return validationResultWithErrorMessage(NO_SUCH_METHOD_ERROR);
     }
     // Apply the patch to the entity and get paths that $set and $delete operations were performed on.
     @SuppressWarnings("unchecked")

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -118,6 +118,7 @@ import com.linkedin.restli.server.resources.unstructuredData.SingleUnstructuredD
 import com.linkedin.util.CustomTypeUtil;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
@@ -313,19 +314,11 @@ public final class RestLiAnnotationReader
     KeyCoercer<?, ?> keyCoercer;
     try
     {
-      keyCoercer = altKeyAnnotation.keyCoercer().newInstance();
-    }
-    catch (InstantiationException e)
-    {
-      throw new ResourceConfigException(String.format("KeyCoercer for alternative key '%s' on resource %s cannot be instantiated, %s",
-                                                      keyName, resourceName, e.getMessage()),
-                                        e);
-    }
-    catch (IllegalAccessException e)
-    {
-      throw new ResourceConfigException(String.format("KeyCoercer for alternative key '%s' on resource %s cannot be instantiated, %s",
-                                                      keyName, resourceName, e.getMessage()),
-                                        e);
+      keyCoercer = altKeyAnnotation.keyCoercer().getDeclaredConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      throw new ResourceConfigException(
+          String.format("KeyCoercer for alternative key '%s' on resource %s cannot be instantiated, %s", keyName,
+              resourceName, e.getMessage()), e);
     }
 
     try
@@ -1747,14 +1740,13 @@ public final class RestLiAnnotationReader
   }
 
   private static TyperefDataSchema getSchemaFromTyperefInfo(Class<? extends TyperefInfo> typerefInfoClass)
-          throws IllegalAccessException, InstantiationException
-  {
+      throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
     if (typerefInfoClass == null)
     {
       return null;
     }
 
-    TyperefInfo typerefInfo = typerefInfoClass.newInstance();
+    TyperefInfo typerefInfo = typerefInfoClass.getDeclaredConstructor().newInstance();
     return typerefInfo.getSchema();
 
   }

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestAsyncMethodInvocationPlanClass.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestAsyncMethodInvocationPlanClass.java
@@ -20,6 +20,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -231,13 +232,9 @@ public class TestAsyncMethodInvocationPlanClass
       {
         try
         {
-          return resourceClass.newInstance();
+          return resourceClass.getDeclaredConstructor().newInstance();
         }
-        catch (InstantiationException e)
-        {
-          throw new RuntimeException(e);
-        }
-        catch (IllegalAccessException e)
+        catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e)
         {
           throw new RuntimeException(e);
         }

--- a/restli-server/src/test/java/com/linkedin/restli/server/multiplexer/TestMultiplexerRunMode.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/multiplexer/TestMultiplexerRunMode.java
@@ -38,6 +38,7 @@ import com.linkedin.restli.server.RestLiServer;
 import com.linkedin.restli.server.resources.ResourceFactory;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -176,13 +177,9 @@ public class TestMultiplexerRunMode
       {
         try
         {
-          return resourceClass.newInstance();
+          return resourceClass.getDeclaredConstructor().newInstance();
         }
-        catch (InstantiationException e)
-        {
-          throw new RuntimeException(e);
-        }
-        catch (IllegalAccessException e)
+        catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e)
         {
           throw new RuntimeException(e);
         }

--- a/restli-tools/src/main/java/com/linkedin/restli/internal/tools/AdditionalDocProvidersUtil.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/internal/tools/AdditionalDocProvidersUtil.java
@@ -23,7 +23,7 @@ final public class AdditionalDocProvidersUtil
       try
       {
         providers.add(
-            (ResourceModelEncoder.DocsProvider) Class.forName("com.linkedin.sbtrestli.tools.scala.ScalaDocsProvider").newInstance());
+            (ResourceModelEncoder.DocsProvider) Class.forName("com.linkedin.sbtrestli.tools.scala.ScalaDocsProvider").getDeclaredConstructor().newInstance());
       }
       catch (ClassNotFoundException | InstantiationException | IllegalAccessException ignored)
       {

--- a/restli-tools/src/main/java/com/linkedin/restli/internal/tools/ClassJarPathUtil.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/internal/tools/ClassJarPathUtil.java
@@ -53,7 +53,7 @@ public class ClassJarPathUtil
       try
       {
         Class<?> handlerClass = Class.forName(className, false, classLoader);
-        SchemaAnnotationHandler handler = (SchemaAnnotationHandler) handlerClass.newInstance();
+        SchemaAnnotationHandler handler = (SchemaAnnotationHandler) handlerClass.getDeclaredConstructor().newInstance();
         handlers.add(handler);
       }
       catch (Exception e)

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/data/PredicateExpressionParser.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/data/PredicateExpressionParser.java
@@ -93,7 +93,7 @@ public class PredicateExpressionParser
       {
         try
         {
-          predicateStack.push(Class.forName(token).asSubclass(Predicate.class).newInstance());
+          predicateStack.push(Class.forName(token).asSubclass(Predicate.class).getDeclaredConstructor().newInstance());
         }
         catch (ClassCastException e)
         {


### PR DESCRIPTION
Java 9+ has deprecated clazz.newInstance().
This PR replaces it with clazz.getDeclaredConstructor().newInstance()