### PR TITLE
Bugfix for Avro schema translation for schemas with partial record default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.33.1] - 2022-04-12
+- Fix a bug where optional fields in a partial default record are not treated properly.
+
 ## [29.33.0] - 2022-03-28
 - Add Support for ByteString[] Query Parameters
 
@@ -5212,7 +5215,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.33.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.33.1...master
+[29.33.1]: https://github.com/linkedin/rest.li/compare/v29.33.0...v29.33.1
 [29.33.0]: https://github.com/linkedin/rest.li/compare/v29.32.5...v29.33.0
 [29.32.5]: https://github.com/linkedin/rest.li/compare/v29.32.4...v29.32.5
 [29.32.4]: https://github.com/linkedin/rest.li/compare/v29.32.3...v29.32.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.33.1] - 2022-04-12
-- Fix a bug where optional fields in a partial default record are not treated properly.
+- Fix an Avro translation bug where optional fields in a partial default record are not treated properly.
 
 ## [29.33.0] - 2022-03-28
 - Add Support for ByteString[] Query Parameters

--- a/data-avro/src/main/java/com/linkedin/data/avro/DefaultAvroToDataConvertCallback.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DefaultAvroToDataConvertCallback.java
@@ -75,7 +75,7 @@ class DefaultAvroToDataConvertCallback extends AbstractDefaultDataTranslator imp
     DataSchema fieldDataSchema = field.getType();
     boolean isOptional = field.getOptional();
     Object result;
-    if (isOptional && ((fieldValue == null) || (fieldValue == Data.NULL)))
+    if (isOptional && (fieldValue == null || fieldValue == Data.NULL))
     {
       // for optional fields,
       // null union members have been removed from translated union schema

--- a/data-avro/src/main/java/com/linkedin/data/avro/DefaultAvroToDataConvertCallback.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DefaultAvroToDataConvertCallback.java
@@ -75,7 +75,7 @@ class DefaultAvroToDataConvertCallback extends AbstractDefaultDataTranslator imp
     DataSchema fieldDataSchema = field.getType();
     boolean isOptional = field.getOptional();
     Object result;
-    if (isOptional && fieldValue == Data.NULL)
+    if (isOptional && ((fieldValue == null) || (fieldValue == Data.NULL)))
     {
       // for optional fields,
       // null union members have been removed from translated union schema

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -3324,6 +3324,56 @@ public class TestSchemaTranslator
     assertEquals(actual, expected);
   }
 
+  @Test
+  public void testAvroPartialDefaultFields() throws IOException
+  {
+    String schemaWithPartialDefaultFields = "{" +
+        "  \"type\": \"record\"," +
+        "  \"name\": \"testRecord\"," +
+        "  \"fields\": [" +
+        "    {" +
+        "      \"name\": \"recordFieldWithDefault\"," +
+        "      \"type\": {" +
+        "        \"type\": \"record\"," +
+        "        \"name\": \"recordType\"," +
+        "        \"fields\": [" +
+        "          {" +
+        "            \"name\": \"mapField\"," +
+        "            \"type\": {" +
+        "              \"type\": \"map\"," +
+        "              \"values\": \"string\"" +
+        "            }" +
+        "          }," +
+        "          {" +
+        "            \"name\": \"optionalRecordField\"," +
+        "            \"type\": [" +
+        "              \"null\"," +
+        "              {" +
+        "                \"type\": \"record\"," +
+        "                \"name\": \"simpleRecordType\"," +
+        "                \"fields\": [" +
+        "                  {" +
+        "                    \"name\": \"stringField\"," +
+        "                    \"type\": \"string\"" +
+        "                  }" + "                ]" +
+        "              }" +
+        "            ]," +
+        "            \"default\": null" +
+        "          }" +
+        "        ]" +
+        "      }," +
+        "      \"default\": {" +
+        "        \"mapField\": {}" +
+        "      }" +
+        "    }" +
+        "  ]" +
+        "}";
+
+    Schema schema = Schema.parse(schemaWithPartialDefaultFields);
+    DataSchema dataSchema = SchemaTranslator.avroToDataSchema(schema);
+    Assert.assertNotNull(dataSchema);
+  }
+
   /*
    * This test will fail in versions below 29.32.2 since AbstractSchemaParser.extractProperties throws exception
    * if value is null in a schema

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.33.0
+version=29.33.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This commit fixes a bug for record default values that do not specify default values for each field. If a field is optional and is missing a default value in the record default value, `fieldValue` in `translateField()` will be `null` instead of `Data.NULL`.

Without this fix, Avro schema translation will fail with a `NullPointerException`.

```
java.lang.NullPointerException
	at com.linkedin.data.avro.AbstractDefaultDataTranslator.translate(AbstractDefaultDataTranslator.java:136)
	at com.linkedin.data.avro.DefaultAvroToDataConvertCallback.translateField(DefaultAvroToDataConvertCallback.java:88)
	at com.linkedin.data.avro.AbstractDefaultDataTranslator.translate(AbstractDefaultDataTranslator.java:138)
	at com.linkedin.data.avro.DefaultAvroToDataConvertCallback.translateField(DefaultAvroToDataConvertCallback.java:88)
	at com.linkedin.data.avro.DefaultAvroToDataConvertCallback.callback(DefaultAvroToDataConvertCallback.java:38)
	at com.linkedin.data.schema.DataSchemaTraverse.traverseRecurse(DataSchemaTraverse.java:92)
	at com.linkedin.data.schema.DataSchemaTraverse.traverse(DataSchemaTraverse.java:75)
	at com.linkedin.data.schema.DataSchemaTraverse.traverse(DataSchemaTraverse.java:64)
	at com.linkedin.data.avro.SchemaTranslator.avroToDataSchema(SchemaTranslator.java:184)
	at com.linkedin.data.avro.SchemaTranslator.avroToDataSchema(SchemaTranslator.java:238)

```