### PR TITLE
Add connection warmup handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.2] - 2022-07-01
+- Add connection warm up support when a failout has been initiated
+
 ## [29.37.1] - 2022-06-29
 - Handle method order when validating methods to ensure consistent linked batch finder validation
 
@@ -5267,7 +5270,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.2...master
+[29.37.2]: https://github.com/linkedin/rest.li/compare/v29.37.1...v29.37.2
 [29.37.1]: https://github.com/linkedin/rest.li/compare/v29.37.0...v29.37.1
 [29.37.0]: https://github.com/linkedin/rest.li/compare/v29.36.1...v29.37.0
 [29.36.1]: https://github.com/linkedin/rest.li/compare/v29.36.0...v29.36.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterConnectionWarmUpHandler.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterConnectionWarmUpHandler.java
@@ -1,0 +1,20 @@
+package com.linkedin.d2.balancer.clusterfailout;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A handler for handling connection warm up to peer clusters.
+ */
+public interface FailedoutClusterConnectionWarmUpHandler
+{
+  /**
+   * Warms up connections to the given cluster with provided failout config.
+   */
+  void warmUpConnections(@Nonnull String clusterName, @Nullable FailoutConfig config);
+
+  /**
+   * Shuts down this handler.
+   */
+  void shutdown();
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterConnectionWarmUpHandler.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterConnectionWarmUpHandler.java
@@ -1,3 +1,18 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package com.linkedin.d2.balancer.clusterfailout;
 
 import javax.annotation.Nonnull;

--- a/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailoutConfigProviderFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailoutConfigProviderFactory.java
@@ -1,3 +1,18 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package com.linkedin.d2.balancer.clusterfailout;
 
 import com.linkedin.d2.balancer.LoadBalancerState;

--- a/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/ZKFailoutConfigProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/ZKFailoutConfigProvider.java
@@ -102,6 +102,16 @@ public abstract class ZKFailoutConfigProvider implements FailoutConfigProvider, 
     }
   }
 
+  /**
+   * Creates a {@link FailedoutClusterConnectionWarmUpHandler} to warm-up the connection to peer clusters before
+   * sending the actual request. Establishing connections can be costly and possibly overload the peer clusters
+   * when a large number of clients trying to connect to the peer clusters at the same time when fail out starts.
+   * Sub-classes can override this method to return a non-null handler to warm up the connections. Method will be
+   * invoked for each cluster failed out.
+   * @return null if no connection warm-up is required.
+   *         An instance of {@link FailedoutClusterConnectionWarmUpHandler} to handle warm-up.
+   *         Handler will be invoked once when we first start watching a peer cluster.
+   */
   @Nullable
   public FailedoutClusterConnectionWarmUpHandler createConnectionWarmUpHandler()
   {

--- a/d2/src/test/java/com/linkedin/d2/balancer/clusterfailout/ZKFailoutConfigProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clusterfailout/ZKFailoutConfigProviderTest.java
@@ -53,6 +53,9 @@ import javax.net.ssl.SSLParameters;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -107,7 +110,7 @@ public class ZKFailoutConfigProviderTest
                                          new PropertyEventBusImpl<>(executorService, _serviceRegistry), clientFactories,
                                          loadBalancerStrategyFactories, sslContext, sslParameters, true, null, SSL_SESSION_VALIDATOR_FACTORY);
 
-    _clusterFailoutConfigProvider = new TestingZKFailoutConfigProvider(_state);
+    _clusterFailoutConfigProvider = spy(new TestingZKFailoutConfigProvider(_state));
     _clusterFailoutConfigProvider.start();
   }
 
@@ -117,6 +120,7 @@ public class ZKFailoutConfigProviderTest
     _state.listenToCluster(CLUSTER_NAME, new LoadBalancerState.NullStateListenerCallback());
     _clusterRegistry.put(CLUSTER_NAME, createClusterStoreProperties(false, false, Collections.emptySet()));
     assertNull(_clusterFailoutConfigProvider.getFailoutConfig(CLUSTER_NAME));
+    verify(_clusterFailoutConfigProvider, times(1)).createConnectionWarmUpHandler();
   }
 
   @Test
@@ -147,6 +151,8 @@ public class ZKFailoutConfigProviderTest
     assertNotNull(config);
     assertFalse(config.isFailedOut());
     assertTrue(config.getPeerClusters().isEmpty());
+
+    verify(_clusterFailoutConfigProvider, times(1)).createConnectionWarmUpHandler();
   }
 
   @Test
@@ -156,6 +162,8 @@ public class ZKFailoutConfigProviderTest
 
     _clusterRegistry.put(CLUSTER_NAME, createClusterStoreProperties(false, false, Collections.emptySet()));
     assertNull(_clusterFailoutConfigProvider.getFailoutConfig(CLUSTER_NAME));
+
+    verify(_clusterFailoutConfigProvider, times(1)).createConnectionWarmUpHandler();
   }
 
   private static class TestingZKFailoutConfigProvider extends ZKFailoutConfigProvider

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.1
+version=29.37.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Add a handler for handling warm up connections to peer clusters after watchers are established.

Since establishing connections can be expensive and all the clients need to connect to hosts in the downstream's peer clusters, by pre-establishing the connections, we can avoid the thundering herd effect of all clients trying to connect at the same time.