### PR TITLE
Implement rest.li changes for adding D2 Canary metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.34.0] - 2022-04-19
+- Add JMX-based canary monitoring for cluster properties and service properties.
+
 ## [29.33.1] - 2022-04-12
 - Fix an Avro translation bug where optional fields in a partial default record are not treated properly.
 
@@ -5215,7 +5218,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.33.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.0...master
+[29.34.0]: https://github.com/linkedin/rest.li/compare/v29.33.1...v29.34.0
 [29.33.1]: https://github.com/linkedin/rest.li/compare/v29.33.0...v29.33.1
 [29.33.0]: https://github.com/linkedin/rest.li/compare/v29.32.5...v29.33.0
 [29.32.5]: https://github.com/linkedin/rest.li/compare/v29.32.4...v29.32.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.34.0] - 2022-04-19
+## [29.33.2] - 2022-04-21
 - Add JMX-based canary monitoring for cluster properties and service properties.
 
 ## [29.33.1] - 2022-04-12
@@ -5218,8 +5218,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.0...master
-[29.34.0]: https://github.com/linkedin/rest.li/compare/v29.33.1...v29.34.0
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.33.2...master
+[29.33.2]: https://github.com/linkedin/rest.li/compare/v29.33.1...v29.33.2
 [29.33.1]: https://github.com/linkedin/rest.li/compare/v29.33.0...v29.33.1
 [29.33.0]: https://github.com/linkedin/rest.li/compare/v29.32.5...v29.33.0
 [29.32.5]: https://github.com/linkedin/rest.li/compare/v29.32.4...v29.32.5

--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -55,10 +55,3 @@ configurations {
   // exclude slf4j-log4j12 which is pulled in from zookeeper
   all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
 }
-
-test {
-    testLogging {
-        exceptionFormat = 'full'
-        showStandardStreams = true
-    }
-}

--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -55,3 +55,10 @@ configurations {
   // exclude slf4j-log4j12 which is pulled in from zookeeper
   all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
 }
+
+test {
+    testLogging {
+        exceptionFormat = 'full'
+        showStandardStreams = true
+    }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerStateItem.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerStateItem.java
@@ -16,17 +16,30 @@
 
 package com.linkedin.d2.balancer;
 
+import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
+
 public class LoadBalancerStateItem<P>
 {
   private final P    _property;
   private final long _version;
   private final long _lastUpdate;
+  private final CanaryDistributionProvider.Distribution _distribution;
 
   public LoadBalancerStateItem(P property, long version, long lastUpdate)
+  {
+    this(property, version, lastUpdate, CanaryDistributionProvider.Distribution.STABLE);
+  }
+
+  public LoadBalancerStateItem(
+      P property,
+      long version,
+      long lastUpdate,
+      CanaryDistributionProvider.Distribution distribution)
   {
     _property = property;
     _version = version;
     _lastUpdate = lastUpdate;
+    _distribution = distribution;
   }
 
   public P getProperty()
@@ -42,6 +55,14 @@ public class LoadBalancerStateItem<P>
   public long getLastUpdate()
   {
     return _lastUpdate;
+  }
+
+  /**
+   * Get the canary state of the underlying property object.
+   */
+  public CanaryDistributionProvider.Distribution getDistribution()
+  {
+    return _distribution;
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerStateItem.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerStateItem.java
@@ -17,6 +17,8 @@
 package com.linkedin.d2.balancer;
 
 import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
+import javax.annotation.Nonnull;
+
 
 public class LoadBalancerStateItem<P>
 {
@@ -34,6 +36,7 @@ public class LoadBalancerStateItem<P>
       P property,
       long version,
       long lastUpdate,
+      @Nonnull
       CanaryDistributionProvider.Distribution distribution)
   {
     _property = property;

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterInfoItem.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterInfoItem.java
@@ -18,34 +18,46 @@ package com.linkedin.d2.balancer.simple;
 
 import com.linkedin.d2.balancer.LoadBalancerStateItem;
 import com.linkedin.d2.balancer.properties.ClusterProperties;
+import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
 
 /**
  * We put together the cluster properties and the partition accessor for a cluster so that we don't have to
  * maintain two separate maps (which have to be in sync all the time)
  */
-class ClusterInfoItem
+public class ClusterInfoItem
 {
   private final LoadBalancerStateItem<ClusterProperties> _clusterPropertiesItem;
   private final LoadBalancerStateItem<PartitionAccessor> _partitionAccessorItem;
 
   ClusterInfoItem(SimpleLoadBalancerState simpleLoadBalancerState, ClusterProperties clusterProperties, PartitionAccessor partitionAccessor)
   {
-    long version = simpleLoadBalancerState.getVersionAccess().incrementAndGet();
-    _clusterPropertiesItem = new LoadBalancerStateItem<>(clusterProperties,
-      version,
-      System.currentTimeMillis());
-    _partitionAccessorItem = new LoadBalancerStateItem<>(partitionAccessor,
-      version,
-      System.currentTimeMillis());
+    this(simpleLoadBalancerState, clusterProperties, partitionAccessor, CanaryDistributionProvider.Distribution.STABLE);
   }
 
-  LoadBalancerStateItem<ClusterProperties> getClusterPropertiesItem()
+  ClusterInfoItem(
+      SimpleLoadBalancerState simpleLoadBalancerState,
+      ClusterProperties clusterProperties,
+      PartitionAccessor partitionAccessor,
+      CanaryDistributionProvider.Distribution distribution)
+  {
+    long version = simpleLoadBalancerState.getVersionAccess().incrementAndGet();
+    _clusterPropertiesItem = new LoadBalancerStateItem<>(clusterProperties,
+        version,
+        System.currentTimeMillis(),
+        distribution);
+    _partitionAccessorItem = new LoadBalancerStateItem<>(partitionAccessor,
+        version,
+        System.currentTimeMillis());
+  }
+
+
+  public LoadBalancerStateItem<ClusterProperties> getClusterPropertiesItem()
   {
     return _clusterPropertiesItem;
   }
 
-  LoadBalancerStateItem<PartitionAccessor> getPartitionAccessorItem()
+  public LoadBalancerStateItem<PartitionAccessor> getPartitionAccessorItem()
   {
     return _partitionAccessorItem;
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterInfoItem.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterInfoItem.java
@@ -20,6 +20,8 @@ import com.linkedin.d2.balancer.LoadBalancerStateItem;
 import com.linkedin.d2.balancer.properties.ClusterProperties;
 import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
+import javax.annotation.Nonnull;
+
 
 /**
  * We put together the cluster properties and the partition accessor for a cluster so that we don't have to
@@ -30,15 +32,16 @@ public class ClusterInfoItem
   private final LoadBalancerStateItem<ClusterProperties> _clusterPropertiesItem;
   private final LoadBalancerStateItem<PartitionAccessor> _partitionAccessorItem;
 
-  ClusterInfoItem(SimpleLoadBalancerState simpleLoadBalancerState, ClusterProperties clusterProperties, PartitionAccessor partitionAccessor)
+  public ClusterInfoItem(SimpleLoadBalancerState simpleLoadBalancerState, ClusterProperties clusterProperties, PartitionAccessor partitionAccessor)
   {
     this(simpleLoadBalancerState, clusterProperties, partitionAccessor, CanaryDistributionProvider.Distribution.STABLE);
   }
 
-  ClusterInfoItem(
+  public ClusterInfoItem(
       SimpleLoadBalancerState simpleLoadBalancerState,
       ClusterProperties clusterProperties,
       PartitionAccessor partitionAccessor,
+      @Nonnull
       CanaryDistributionProvider.Distribution distribution)
   {
     long version = simpleLoadBalancerState.getVersionAccess().incrementAndGet();

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriber.java
@@ -48,12 +48,18 @@ class ClusterLoadBalancerSubscriber extends
   {
     if (discoveryProperties != null)
     {
-      ClusterProperties pickedProperties = pickActiveProperties(discoveryProperties);
+      PickActivePropertiesResult pickedPropertiesResult = pickActiveProperties(discoveryProperties);
 
-      _simpleLoadBalancerState.getClusterInfo().put(listenTo,
-        new ClusterInfoItem(_simpleLoadBalancerState, pickedProperties,
-          PartitionAccessorFactory.getPartitionAccessor(pickedProperties.getClusterName(),
-              _partitionAccessorRegistry, pickedProperties.getPartitionProperties())));
+      ClusterInfoItem newClusterInfoItem = new ClusterInfoItem(
+          _simpleLoadBalancerState,
+          pickedPropertiesResult.clusterProperties,
+          PartitionAccessorFactory.getPartitionAccessor(
+              pickedPropertiesResult.clusterProperties.getClusterName(),
+              _partitionAccessorRegistry,
+              pickedPropertiesResult.clusterProperties.getPartitionProperties()),
+          pickedPropertiesResult.distribution);
+      _simpleLoadBalancerState.getClusterInfo().put(listenTo, newClusterInfoItem);
+      _simpleLoadBalancerState.notifyListenersOnClusterInfoUpdates(newClusterInfoItem);
       // notify the cluster listeners only when discoveryProperties is not null, because we don't
       // want to count initialization (just because listenToCluster is called)
       _simpleLoadBalancerState.notifyClusterListenersOnAdd(listenTo);
@@ -69,16 +75,34 @@ class ClusterLoadBalancerSubscriber extends
   @Override
   protected void handleRemove(final String listenTo)
   {
-    _simpleLoadBalancerState.getClusterInfo().remove(listenTo);
+    ClusterInfoItem clusterInfoRemoved = _simpleLoadBalancerState.getClusterInfo().remove(listenTo);
+    _simpleLoadBalancerState.notifyListenersOnClusterInfoRemovals(clusterInfoRemoved);
     _simpleLoadBalancerState.notifyClusterListenersOnRemove(listenTo);
+  }
+
+  /**
+   * Data class for returning both the canary distribution policy
+   * and the final cluster properties from PickActiveProperties.
+   */
+  static private class PickActivePropertiesResult
+  {
+    final CanaryDistributionProvider.Distribution distribution;
+    final ClusterProperties clusterProperties;
+
+    PickActivePropertiesResult(CanaryDistributionProvider.Distribution distribution,
+        ClusterProperties clusterProperties)
+    {
+      this.distribution = distribution;
+      this.clusterProperties = clusterProperties;
+    }
   }
 
   /**
    * Pick the active properties (stable or canary configs) based on canary distribution strategy.
    * @param discoveryProperties a composite properties containing all data on the cluster store (stable configs, canary configs, etc.).
-   * @return the picked active properties
+   * @return the picked active properties and the canary distribution strategy.
    */
-  private ClusterProperties pickActiveProperties(final ClusterProperties discoveryProperties)
+  private PickActivePropertiesResult pickActiveProperties(final ClusterProperties discoveryProperties)
   {
     ClusterProperties pickedProperties = discoveryProperties;
     CanaryDistributionProvider.Distribution distribution = CanaryDistributionProvider.Distribution.STABLE;
@@ -94,7 +118,7 @@ class ClusterLoadBalancerSubscriber extends
       }
       pickedProperties = clusterStoreProperties.getDistributedClusterProperties(distribution);
     }
-    // TODO: set canary/stable config metric
-    return pickedProperties;
+
+    return new PickActivePropertiesResult(distribution, pickedProperties);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriber.java
@@ -48,7 +48,7 @@ class ClusterLoadBalancerSubscriber extends
   {
     if (discoveryProperties != null)
     {
-      PickActivePropertiesResult pickedPropertiesResult = pickActiveProperties(discoveryProperties);
+      ActivePropertiesResult pickedPropertiesResult = pickActiveProperties(discoveryProperties);
 
       ClusterInfoItem newClusterInfoItem = new ClusterInfoItem(
           _simpleLoadBalancerState,
@@ -82,14 +82,14 @@ class ClusterLoadBalancerSubscriber extends
 
   /**
    * Data class for returning both the canary distribution policy
-   * and the final cluster properties from PickActiveProperties.
+   * and the final cluster properties from PickActiveProperties method.
    */
-  static private class PickActivePropertiesResult
+  static private class ActivePropertiesResult
   {
     final CanaryDistributionProvider.Distribution distribution;
     final ClusterProperties clusterProperties;
 
-    PickActivePropertiesResult(CanaryDistributionProvider.Distribution distribution,
+    ActivePropertiesResult(CanaryDistributionProvider.Distribution distribution,
         ClusterProperties clusterProperties)
     {
       this.distribution = distribution;
@@ -102,7 +102,7 @@ class ClusterLoadBalancerSubscriber extends
    * @param discoveryProperties a composite properties containing all data on the cluster store (stable configs, canary configs, etc.).
    * @return the picked active properties and the canary distribution strategy.
    */
-  private PickActivePropertiesResult pickActiveProperties(final ClusterProperties discoveryProperties)
+  private ActivePropertiesResult pickActiveProperties(final ClusterProperties discoveryProperties)
   {
     ClusterProperties pickedProperties = discoveryProperties;
     CanaryDistributionProvider.Distribution distribution = CanaryDistributionProvider.Distribution.STABLE;
@@ -119,6 +119,6 @@ class ClusterLoadBalancerSubscriber extends
       pickedProperties = clusterStoreProperties.getDistributedClusterProperties(distribution);
     }
 
-    return new PickActivePropertiesResult(distribution, pickedProperties);
+    return new ActivePropertiesResult(distribution, pickedProperties);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/ServiceLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/ServiceLoadBalancerSubscriber.java
@@ -52,7 +52,7 @@ class ServiceLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<Servi
   {
     LoadBalancerStateItem<ServiceProperties> oldServicePropertiesItem =
       _simpleLoadBalancerState.getServiceProperties().get(listenTo);
-    PickActivePropertiesResult pickedPropertiesResult = pickActiveProperties(discoveryProperties);
+    ActivePropertiesResult pickedPropertiesResult = pickActiveProperties(discoveryProperties);
     ServiceProperties pickedProperties = pickedPropertiesResult.serviceProperties;
 
     LoadBalancerStateItem<ServiceProperties> newServiceProperties = new LoadBalancerStateItem<>(
@@ -154,14 +154,14 @@ class ServiceLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<Servi
 
   /**
    * Data class for returning both the canary distribution policy
-   * and the final service properties from PickActiveProperties.
+   * and the final service properties from PickActiveProperties method.
    */
-  static private class PickActivePropertiesResult
+  static private class ActivePropertiesResult
   {
     final CanaryDistributionProvider.Distribution distribution;
     final ServiceProperties serviceProperties;
 
-    PickActivePropertiesResult(CanaryDistributionProvider.Distribution distribution,
+    ActivePropertiesResult(CanaryDistributionProvider.Distribution distribution,
         ServiceProperties serviceProperties)
     {
       this.distribution = distribution;
@@ -174,7 +174,7 @@ class ServiceLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<Servi
    * @param discoveryProperties a composite properties containing all data on the service store (stable configs, canary configs, etc.).
    * @return the picked active properties and the canary decision
    */
-  private PickActivePropertiesResult pickActiveProperties(final ServiceProperties discoveryProperties)
+  private ActivePropertiesResult pickActiveProperties(final ServiceProperties discoveryProperties)
   {
     ServiceProperties pickedProperties = discoveryProperties;
     CanaryDistributionProvider.Distribution distribution = CanaryDistributionProvider.Distribution.STABLE;
@@ -190,6 +190,6 @@ class ServiceLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<Servi
       pickedProperties = serviceStoreProperties.getDistributedServiceProperties(distribution);
     }
 
-    return new PickActivePropertiesResult(distribution, pickedProperties);
+    return new ActivePropertiesResult(distribution, pickedProperties);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -463,18 +463,24 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
         // so it is needed to notify all the listeners
         for (SimpleLoadBalancerStateListener listener : _listeners)
         {
+          // Send removal notifications for service properties.
+          for (LoadBalancerStateItem<ServiceProperties> serviceProperties :
+              _serviceProperties.values()) {
+            listener.onServicePropertiesRemoval(serviceProperties);
+          }
+
+          // Send removal notification for cluster properties.
+          for (ClusterInfoItem clusterInfoItem: _clusterInfo.values())
+          {
+            listener.onClusterInfoRemoval(clusterInfoItem);
+          }
+
           // Notify the strategy removal
           for (Map.Entry<String, Map<String, LoadBalancerStrategy>> serviceStrategy : _serviceStrategies.entrySet())
           {
             for (Map.Entry<String, LoadBalancerStrategy> strategyEntry : serviceStrategy.getValue().entrySet())
             {
               listener.onStrategyRemoved(serviceStrategy.getKey(), strategyEntry.getKey(), strategyEntry.getValue());
-            }
-
-            // Send removal notifications for other service D2 information.
-            for (LoadBalancerStateItem<ServiceProperties> serviceProperties :
-                _serviceProperties.values()) {
-              listener.onServicePropertiesRemoval(serviceProperties);
             }
 
             // Also notify the client removal
@@ -486,15 +492,6 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
                 listener.onClientRemoved(serviceStrategy.getKey(), client);
               }
             }
-          }
-        }
-
-        // Send ClusterInfo removal notification to all listeners.
-        for (SimpleLoadBalancerStateListener listener : _listeners)
-        {
-          for (ClusterInfoItem clusterInfoItem: _clusterInfo.values())
-          {
-            listener.onClusterInfoRemoval(clusterInfoItem);
           }
         }
 

--- a/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmx.java
@@ -29,6 +29,12 @@ public class ClusterInfoJmx implements ClusterInfoJmxMBean
   }
 
   @Override
+  public ClusterInfoItem getClusterInfoItem()
+  {
+    return _clusterInfoItem;
+  }
+
+  @Override
   public int getCanaryDistributionPolicy()
   {
     switch (_clusterInfoItem.getClusterPropertiesItem().getDistribution())

--- a/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmx.java
@@ -29,7 +29,7 @@ public class ClusterInfoJmx implements ClusterInfoJmxMBean
   }
 
   @Override
-  public long getCanaryDistributionPolicy()
+  public int getCanaryDistributionPolicy()
   {
     switch (_clusterInfoItem.getClusterPropertiesItem().getDistribution())
     {

--- a/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmx.java
@@ -1,0 +1,41 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
+import com.linkedin.d2.balancer.simple.ClusterInfoItem;
+
+
+public class ClusterInfoJmx implements ClusterInfoJmxMBean
+{
+  private final ClusterInfoItem _clusterInfoItem;
+
+  public ClusterInfoJmx(ClusterInfoItem clusterInfoItem) {
+    _clusterInfoItem = clusterInfoItem;
+  }
+
+  @Override
+  public long getCanaryDistributionPolicy()
+  {
+    switch (_clusterInfoItem.getClusterPropertiesItem().getDistribution())
+    {
+      case STABLE: return 0;
+      case CANARY: return 1;
+      default: return -1;
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmxMBean.java
@@ -22,5 +22,5 @@ public interface ClusterInfoJmxMBean {
    * @return integer value of canary distribution policy when building the cluster properties:
    *         0 - STABLE, 1 - CANARY, -1 - UNSPECIFIED
    */
-  long getCanaryDistributionPolicy();
+  int getCanaryDistributionPolicy();
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmxMBean.java
@@ -16,6 +16,9 @@
 
 package com.linkedin.d2.jmx;
 
+import com.linkedin.d2.balancer.simple.ClusterInfoItem;
+
+
 public interface ClusterInfoJmxMBean {
   /**
    *
@@ -23,4 +26,10 @@ public interface ClusterInfoJmxMBean {
    *         0 - STABLE, 1 - CANARY, -1 - UNSPECIFIED
    */
   int getCanaryDistributionPolicy();
+
+  /**
+   *
+   * @return the raw ClusterInfoItem object that backs up this JMX MBean object.
+   */
+  ClusterInfoItem getClusterInfoItem();
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoJmxMBean.java
@@ -1,0 +1,26 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+public interface ClusterInfoJmxMBean {
+  /**
+   *
+   * @return integer value of canary distribution policy when building the cluster properties:
+   *         0 - STABLE, 1 - CANARY, -1 - UNSPECIFIED
+   */
+  long getCanaryDistributionPolicy();
+}

--- a/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
@@ -90,7 +90,7 @@ public class D2ClientJmxManager
       {
         _jmxManager.registerClusterInfoJmxBean(
             getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName()),
-            clusterInfoItem);
+            new ClusterInfoJmx(clusterInfoItem));
       }
 
       @Override
@@ -106,7 +106,7 @@ public class D2ClientJmxManager
       {
         _jmxManager.registerServicePropertiesJmxBean(
             getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName()),
-            serviceProperties);
+            new ServicePropertiesJmx(serviceProperties));
       }
 
 

--- a/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
@@ -88,9 +88,9 @@ public class D2ClientJmxManager
       @Override
       public void onClusterInfoUpdate(ClusterInfoItem clusterInfoItem)
       {
-        _jmxManager.registerClusterInfoJmxBean(
+        _jmxManager.registerClusterInfo(
             getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName()),
-            new ClusterInfoJmx(clusterInfoItem));
+            clusterInfoItem);
       }
 
       @Override
@@ -104,9 +104,9 @@ public class D2ClientJmxManager
       @Override
       public void onServicePropertiesUpdate(LoadBalancerStateItem<ServiceProperties> serviceProperties)
       {
-        _jmxManager.registerServicePropertiesJmxBean(
+        _jmxManager.registerServiceProperties(
             getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName()),
-            new ServicePropertiesJmx(serviceProperties));
+            serviceProperties);
       }
 
 

--- a/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
@@ -16,7 +16,10 @@
 
 package com.linkedin.d2.jmx;
 
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
 import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.simple.ClusterInfoItem;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancer;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState.SimpleLoadBalancerStateListener;
@@ -58,13 +61,13 @@ public class D2ClientJmxManager
       @Override
       public void onStrategyAdded(String serviceName, String scheme, LoadBalancerStrategy strategy)
       {
-        _jmxManager.registerLoadBalancerStrategy(getLoadBalancerJmxName(serviceName, scheme), strategy);
+        _jmxManager.registerLoadBalancerStrategy(getLoadBalancerStrategyJmxName(serviceName, scheme), strategy);
       }
 
       @Override
       public void onStrategyRemoved(String serviceName, String scheme, LoadBalancerStrategy strategy)
       {
-        _jmxManager.unregister(getLoadBalancerJmxName(serviceName, scheme));
+        _jmxManager.unregister(getLoadBalancerStrategyJmxName(serviceName, scheme));
       }
 
       @Override
@@ -82,7 +85,50 @@ public class D2ClientJmxManager
         //  _jmxManager.unregister(_prefix + "-" + clusterName + "-" + client.getUri().toString().replace("://", "-") + "-TrackerClient-Degrader");
       }
 
-      private String getLoadBalancerJmxName(String serviceName, String scheme)
+      @Override
+      public void onClusterInfoUpdate(ClusterInfoItem clusterInfoItem)
+      {
+        _jmxManager.registerClusterInfo(
+            getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName()),
+            clusterInfoItem);
+      }
+
+      @Override
+      public void onClusterInfoRemoval(ClusterInfoItem clusterInfoItem)
+      {
+        _jmxManager.unregister(
+            getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName())
+        );
+      }
+
+      @Override
+      public void onServicePropertiesUpdate(LoadBalancerStateItem<ServiceProperties> serviceProperties)
+      {
+        _jmxManager.registerServiceProperties(
+            getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName()),
+            serviceProperties);
+      }
+
+
+      @Override
+      public void onServicePropertiesRemoval(LoadBalancerStateItem<ServiceProperties> serviceProperties)
+      {
+        _jmxManager.unregister(
+            getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName())
+        );
+      }
+
+      private String getClusterInfoJmxName(String clusterName)
+      {
+        return String.format("%s-ClusterInfo", clusterName);
+      }
+
+      private String getServicePropertiesJmxName(String serviceName)
+      {
+        return String.format("%s-ServiceProperties", serviceName);
+      }
+
+      private String getLoadBalancerStrategyJmxName(String serviceName, String scheme)
       {
         return serviceName + "-" + scheme + "-LoadBalancerStrategy";
       }

--- a/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
@@ -88,7 +88,7 @@ public class D2ClientJmxManager
       @Override
       public void onClusterInfoUpdate(ClusterInfoItem clusterInfoItem)
       {
-        _jmxManager.registerClusterInfo(
+        _jmxManager.registerClusterInfoJmxBean(
             getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName()),
             clusterInfoItem);
       }
@@ -104,7 +104,7 @@ public class D2ClientJmxManager
       @Override
       public void onServicePropertiesUpdate(LoadBalancerStateItem<ServiceProperties> serviceProperties)
       {
-        _jmxManager.registerServiceProperties(
+        _jmxManager.registerServicePropertiesJmxBean(
             getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName()),
             serviceProperties);
       }

--- a/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
@@ -16,9 +16,12 @@
 
 package com.linkedin.d2.jmx;
 
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
 import com.linkedin.d2.balancer.servers.ZooKeeperAnnouncer;
 import com.linkedin.d2.balancer.servers.ZooKeeperConnectionManager;
 import com.linkedin.d2.balancer.servers.ZooKeeperServer;
+import com.linkedin.d2.balancer.simple.ClusterInfoItem;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancer;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
@@ -108,6 +111,21 @@ public class JmxManager
   public synchronized JmxManager registerServicePropertiesJmxBean(String name, ServicePropertiesJmx servicePropertiesJmx)
   {
     checkReg(servicePropertiesJmx, name);
+
+    return this;
+  }
+
+  public synchronized JmxManager registerClusterInfo(String name, ClusterInfoItem clusterInfo)
+  {
+    checkReg(new ClusterInfoJmx(clusterInfo), name);
+
+    return this;
+  }
+
+  public synchronized JmxManager registerServiceProperties(
+      String name, LoadBalancerStateItem<ServiceProperties> serviceProperties)
+  {
+    checkReg(new ServicePropertiesJmx(serviceProperties), name);
 
     return this;
   }

--- a/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
@@ -96,14 +96,14 @@ public class JmxManager
     return this;
   }
 
-  public synchronized JmxManager registerClusterInfo(String name, ClusterInfoItem clusterInfoItem)
+  public synchronized JmxManager registerClusterInfoJmxBean(String name, ClusterInfoItem clusterInfoItem)
   {
     checkReg(new ClusterInfoJmx(clusterInfoItem), name);
 
     return this;
   }
 
-  public synchronized JmxManager registerServiceProperties(
+  public synchronized JmxManager registerServicePropertiesJmxBean(
       String name, LoadBalancerStateItem<ServiceProperties> serviceProperties)
   {
     checkReg(new ServicePropertiesJmx(serviceProperties), name);

--- a/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
@@ -16,9 +16,12 @@
 
 package com.linkedin.d2.jmx;
 
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
 import com.linkedin.d2.balancer.servers.ZooKeeperAnnouncer;
 import com.linkedin.d2.balancer.servers.ZooKeeperConnectionManager;
 import com.linkedin.d2.balancer.servers.ZooKeeperServer;
+import com.linkedin.d2.balancer.simple.ClusterInfoItem;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancer;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
@@ -89,6 +92,21 @@ public class JmxManager
                                                            SimpleLoadBalancerState state)
   {
     checkReg(new SimpleLoadBalancerStateJmx(state), name);
+
+    return this;
+  }
+
+  public synchronized JmxManager registerClusterInfo(String name, ClusterInfoItem clusterInfoItem)
+  {
+    checkReg(new ClusterInfoJmx(clusterInfoItem), name);
+
+    return this;
+  }
+
+  public synchronized JmxManager registerServiceProperties(
+      String name, LoadBalancerStateItem<ServiceProperties> serviceProperties)
+  {
+    checkReg(new ServicePropertiesJmx(serviceProperties), name);
 
     return this;
   }

--- a/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
@@ -16,12 +16,9 @@
 
 package com.linkedin.d2.jmx;
 
-import com.linkedin.d2.balancer.LoadBalancerStateItem;
-import com.linkedin.d2.balancer.properties.ServiceProperties;
 import com.linkedin.d2.balancer.servers.ZooKeeperAnnouncer;
 import com.linkedin.d2.balancer.servers.ZooKeeperConnectionManager;
 import com.linkedin.d2.balancer.servers.ZooKeeperServer;
-import com.linkedin.d2.balancer.simple.ClusterInfoItem;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancer;
 import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
@@ -53,6 +50,11 @@ public class JmxManager
   public JmxManager()
   {
     _server = ManagementFactory.getPlatformMBeanServer();
+  }
+
+  MBeanServer getMBeanServer()
+  {
+    return _server;
   }
 
   public synchronized void shutdown()
@@ -96,17 +98,16 @@ public class JmxManager
     return this;
   }
 
-  public synchronized JmxManager registerClusterInfoJmxBean(String name, ClusterInfoItem clusterInfoItem)
+  public synchronized JmxManager registerClusterInfoJmxBean(String name, ClusterInfoJmx clusterInfoJmx)
   {
-    checkReg(new ClusterInfoJmx(clusterInfoItem), name);
+    checkReg(clusterInfoJmx, name);
 
     return this;
   }
 
-  public synchronized JmxManager registerServicePropertiesJmxBean(
-      String name, LoadBalancerStateItem<ServiceProperties> serviceProperties)
+  public synchronized JmxManager registerServicePropertiesJmxBean(String name, ServicePropertiesJmx servicePropertiesJmx)
   {
-    checkReg(new ServicePropertiesJmx(serviceProperties), name);
+    checkReg(servicePropertiesJmx, name);
 
     return this;
   }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmx.java
@@ -28,7 +28,7 @@ public class ServicePropertiesJmx implements ServicePropertiesJmxMBean
   }
 
   @Override
-  public long getCanaryDistributionPolicy()
+  public int getCanaryDistributionPolicy()
   {
     switch (_serviceProperties.getDistribution())
     {

--- a/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmx.java
@@ -1,0 +1,40 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+
+public class ServicePropertiesJmx implements ServicePropertiesJmxMBean
+{
+  private final LoadBalancerStateItem<ServiceProperties> _serviceProperties;
+
+  public ServicePropertiesJmx(LoadBalancerStateItem<ServiceProperties> serviceProperties) {
+    _serviceProperties = serviceProperties;
+  }
+
+  @Override
+  public long getCanaryDistributionPolicy()
+  {
+    switch (_serviceProperties.getDistribution())
+    {
+      case STABLE: return 0;
+      case CANARY: return 1;
+      default: return -1;
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmx.java
@@ -37,4 +37,9 @@ public class ServicePropertiesJmx implements ServicePropertiesJmxMBean
       default: return -1;
     }
   }
+
+  @Override
+  public LoadBalancerStateItem<ServiceProperties> getServicePropertiesLBStateItem() {
+    return _serviceProperties;
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmxMBean.java
@@ -16,6 +16,10 @@
 
 package com.linkedin.d2.jmx;
 
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+
+
 public interface ServicePropertiesJmxMBean {
   /**
    *
@@ -23,4 +27,10 @@ public interface ServicePropertiesJmxMBean {
    *         0 - STABLE, 1 - CANARY, -1 - UNSPECIFIED
    */
   int getCanaryDistributionPolicy();
+
+  /**
+   *
+   * @return the service properties load balancer state item that backs up the JMX Mbeans object;
+   */
+  LoadBalancerStateItem<ServiceProperties> getServicePropertiesLBStateItem();
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmxMBean.java
@@ -19,8 +19,8 @@ package com.linkedin.d2.jmx;
 public interface ServicePropertiesJmxMBean {
   /**
    *
-   * @return integer value of canary distribution policy when building the cluster properties:
+   * @return integer value of canary distribution policy when building the service properties:
    *         0 - STABLE, 1 - CANARY, -1 - UNSPECIFIED
    */
-  long getCanaryDistributionPolicy();
+  int getCanaryDistributionPolicy();
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ServicePropertiesJmxMBean.java
@@ -1,0 +1,26 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+public interface ServicePropertiesJmxMBean {
+  /**
+   *
+   * @return integer value of canary distribution policy when building the cluster properties:
+   *         0 - STABLE, 1 - CANARY, -1 - UNSPECIFIED
+   */
+  long getCanaryDistributionPolicy();
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriberTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriberTest.java
@@ -21,13 +21,17 @@ import com.linkedin.d2.balancer.properties.ClusterProperties;
 import com.linkedin.d2.balancer.properties.ClusterStoreProperties;
 import com.linkedin.d2.balancer.properties.FailoutProperties;
 import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
+import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
 import com.linkedin.d2.discovery.event.PropertyEventBus;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
@@ -35,8 +39,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -57,12 +60,19 @@ public class ClusterLoadBalancerSubscriberTest
     @Mock
     AtomicLong _version;
 
+    @Captor
+    ArgumentCaptor<ClusterInfoItem> _clusterInfoUpdatesCaptor;
+
     Map<String, ClusterInfoItem> _clusterInfo;
 
     ClusterLoadBalancerSubscriberFixture() {
       MockitoAnnotations.initMocks(this);
       _clusterInfo = new HashMap<>();
       _version = new AtomicLong(0);
+      when(_simpleLoadBalancerState.getVersionAccess()).thenReturn(_version);
+      when(_simpleLoadBalancerState.getClusterInfo()).thenReturn(_clusterInfo);
+      doNothing().when(_simpleLoadBalancerState).notifyListenersOnClusterInfoUpdates(
+          _clusterInfoUpdatesCaptor.capture());
     }
 
     ClusterLoadBalancerSubscriber getMockSubscriber(boolean hasCanaryProvider)
@@ -72,9 +82,6 @@ public class ClusterLoadBalancerSubscriberTest
       } else {
         when(_simpleLoadBalancerState.getCanaryDistributionProvider()).thenReturn(null);
       }
-
-      when(_simpleLoadBalancerState.getClusterInfo()).thenReturn(_clusterInfo);
-      when(_simpleLoadBalancerState.getVersionAccess()).thenReturn(_version);
       doNothing().when(_simpleLoadBalancerState).notifyClusterListenersOnAdd(any());
       return new ClusterLoadBalancerSubscriber(_simpleLoadBalancerState, _eventBus, null);
     }
@@ -119,5 +126,40 @@ public class ClusterLoadBalancerSubscriberTest
 
     Assert.assertEquals(fixture._clusterInfo.get(CLUSTER_NAME).getClusterPropertiesItem().getProperty(),
         distribution == CanaryDistributionProvider.Distribution.CANARY ? canaryConfigs : stableConfigs);
+    verify(fixture._simpleLoadBalancerState, times(1)).notifyClusterListenersOnAdd(CLUSTER_NAME);
+    Assert.assertEquals(fixture._clusterInfoUpdatesCaptor.getValue().getClusterPropertiesItem().getProperty(),
+        distribution == CanaryDistributionProvider.Distribution.CANARY ? canaryConfigs : stableConfigs);
+    Assert.assertEquals(fixture._clusterInfoUpdatesCaptor.getValue().getClusterPropertiesItem().getDistribution(),
+        distribution == null ? CanaryDistributionProvider.Distribution.STABLE : distribution);
+  }
+
+  @Test
+  public void testHandleRemove()
+  {
+    String clusterName = "mock-cluster-foo";
+    ClusterLoadBalancerSubscriberFixture fixture = new ClusterLoadBalancerSubscriberFixture();
+    ClusterInfoItem clusterInfoItemToRemove =
+        new ClusterInfoItem(fixture._simpleLoadBalancerState, new ClusterProperties(clusterName),
+            new PartitionAccessor() {
+              @Override
+              public int getMaxPartitionId() {
+                return 0;
+              }
+
+              @Override
+              public int getPartitionId(URI uri) {
+                return 0;
+              }
+            }, CanaryDistributionProvider.Distribution.CANARY);
+    fixture._simpleLoadBalancerState.getClusterInfo().put(clusterName, clusterInfoItemToRemove);
+    fixture.getMockSubscriber(false).handleRemove(clusterName);
+
+    Assert.assertFalse(fixture._simpleLoadBalancerState.getClusterInfo().containsKey(clusterName));
+    verify(fixture._simpleLoadBalancerState, times(1)).notifyListenersOnClusterInfoRemovals(
+        clusterInfoItemToRemove
+    );
+    verify(fixture._simpleLoadBalancerState, times(1)).notifyClusterListenersOnRemove(
+        clusterName
+    );
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerStateTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerStateTest.java
@@ -22,6 +22,7 @@ import com.linkedin.common.util.None;
 import com.linkedin.d2.balancer.LoadBalancerState;
 import com.linkedin.d2.balancer.LoadBalancerState.LoadBalancerStateListenerCallback;
 import com.linkedin.d2.balancer.LoadBalancerState.NullStateListenerCallback;
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
 import com.linkedin.d2.balancer.clients.DegraderTrackerClientImpl;
 import com.linkedin.d2.balancer.clients.TrackerClient;
 import com.linkedin.d2.balancer.event.NoopEventEmitter;
@@ -43,6 +44,8 @@ import com.linkedin.d2.balancer.strategies.random.RandomLoadBalancerStrategyFact
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.relative.RelativeLoadBalancerStrategyFactory;
 import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
+import com.linkedin.d2.balancer.util.partitions.PartitionAccessException;
+import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
 import com.linkedin.d2.discovery.event.PropertyEventBusImpl;
 import com.linkedin.d2.discovery.event.PropertyEventThread.PropertyEventShutdownCallback;
 import com.linkedin.d2.discovery.event.SynchronousExecutorService;
@@ -334,14 +337,17 @@ public class SimpleLoadBalancerStateTest
     assertNull(listener.serviceName);
 
     // set up state
+    ClusterProperties clusterProperties = new ClusterProperties("cluster-1", schemes);
+    ServiceProperties serviceProperties = new ServiceProperties("service-1",
+        "cluster-1",
+        "/test",
+        Arrays.asList("random"));
+
     _state.listenToCluster("cluster-1", new NullStateListenerCallback());
     _state.listenToService("service-1", new NullStateListenerCallback());
-    _clusterRegistry.put("cluster-1", new ClusterProperties("cluster-1", schemes));
+    _clusterRegistry.put("cluster-1", clusterProperties);
     _uriRegistry.put("cluster-1", new UriProperties("cluster-1", uriData));
-    _serviceRegistry.put("service-1", new ServiceProperties("service-1",
-                                                            "cluster-1",
-                                                            "/test",
-                                                            Arrays.asList("random")));
+    _serviceRegistry.put("service-1", serviceProperties);
 
     TrackerClient client = _state.getClient("cluster-1", uri);
 
@@ -359,6 +365,12 @@ public class SimpleLoadBalancerStateTest
       SimpleLoadBalancerTest.DoNothingClientFactory f = (SimpleLoadBalancerTest.DoNothingClientFactory)factory;
       assertEquals(f.getRunningClientCount(), 0, "Not all clients were shut down");
     }
+
+    // Verify that registered listeners get all removal events for cluster properties and service properties.
+    Assert.assertEquals(listener.servicePropertiesRemoved.size(), 1);
+    Assert.assertEquals(listener.servicePropertiesRemoved.get(0).getProperty(), serviceProperties);
+    Assert.assertEquals(listener.clusterInfoRemoved.size(), 1);
+    Assert.assertEquals(listener.clusterInfoRemoved.get(0).getClusterPropertiesItem().getProperty(), clusterProperties);
   }
 
   @Test(groups = { "small", "back-end" })
@@ -1858,6 +1870,56 @@ public class SimpleLoadBalancerStateTest
     assertNull(client);
   }
 
+  @Test
+  public void testNotifyListenersOnPropertiesChanges()
+  {
+    reset();
+
+    ClusterProperties clusterProperties = new ClusterProperties(
+        "cluster-1", Collections.singletonList("Random"));
+    ClusterInfoItem clusterInfoItem = new ClusterInfoItem(_state, clusterProperties, new PartitionAccessor() {
+      @Override
+      public int getMaxPartitionId() {
+        return 0;
+      }
+
+      @Override
+      public int getPartitionId(URI uri) throws PartitionAccessException {
+        return 0;
+      }
+    });
+    ServiceProperties serviceProperties = new ServiceProperties("service-1",
+        "cluster-1",
+        "/test",
+        Arrays.asList("random"));
+    LoadBalancerStateItem<ServiceProperties> servicePropertiesLBItem = new LoadBalancerStateItem<ServiceProperties>(
+        serviceProperties, 0, 0);
+
+
+    TestListener[] listeners = new TestListener[] {new TestListener(), new TestListener()};
+    Arrays.stream(listeners).forEach(listener -> _state.register(listener));
+
+    _state.notifyListenersOnServicePropertiesUpdates(servicePropertiesLBItem);
+    _state.notifyListenersOnClusterInfoUpdates(clusterInfoItem);
+    for (TestListener listener : listeners)
+    {
+      Assert.assertEquals(listener.clusterInfoUpdated.size(), 1);
+      Assert.assertEquals(listener.clusterInfoUpdated.get(0).getClusterPropertiesItem().getProperty(), clusterProperties);
+      Assert.assertEquals(listener.servicePropertiesUpdated.size(), 1);
+      Assert.assertEquals(listener.servicePropertiesUpdated.get(0).getProperty(), serviceProperties);
+    }
+
+    _state.notifyListenersOnServicePropertiesRemovals(servicePropertiesLBItem);
+    _state.notifyListenersOnClusterInfoRemovals(clusterInfoItem);
+    for (TestListener listener : listeners)
+    {
+      Assert.assertEquals(listener.clusterInfoRemoved.size(), 1);
+      Assert.assertEquals(listener.clusterInfoRemoved.get(0).getClusterPropertiesItem().getProperty(), clusterProperties);
+      Assert.assertEquals(listener.servicePropertiesRemoved.size(), 1);
+      Assert.assertEquals(listener.servicePropertiesRemoved.get(0).getProperty(), serviceProperties);
+    }
+  }
+
   private static class TestShutdownCallback implements PropertyEventShutdownCallback
   {
     private final CountDownLatch _latch = new CountDownLatch(1);
@@ -1878,6 +1940,19 @@ public class SimpleLoadBalancerStateTest
     public String               serviceName;
     public String               scheme;
     public LoadBalancerStrategy strategy;
+
+    public ArrayList<ClusterInfoItem> clusterInfoUpdated;
+    public ArrayList<LoadBalancerStateItem<ServiceProperties>> servicePropertiesUpdated;
+
+    public ArrayList<ClusterInfoItem> clusterInfoRemoved;
+    public ArrayList<LoadBalancerStateItem<ServiceProperties>> servicePropertiesRemoved;
+
+    public TestListener() {
+      clusterInfoRemoved = new ArrayList<>();
+      servicePropertiesRemoved = new ArrayList<>();
+      clusterInfoUpdated = new ArrayList<>();
+      servicePropertiesUpdated = new ArrayList<>();
+    }
 
     @Override
     public void onStrategyAdded(String serviceName,
@@ -1907,6 +1982,30 @@ public class SimpleLoadBalancerStateTest
     @Override
     public void onClientRemoved(String serviceName, TrackerClient client)
     {
+    }
+
+    @Override
+    public void onClusterInfoUpdate(ClusterInfoItem clusterInfoItem)
+    {
+      clusterInfoUpdated.add(clusterInfoItem);
+    }
+
+    @Override
+    public void onClusterInfoRemoval(ClusterInfoItem clusterInfoItem)
+    {
+      clusterInfoRemoved.add(clusterInfoItem);
+    }
+
+    @Override
+    public void onServicePropertiesUpdate(LoadBalancerStateItem<ServiceProperties> serviceProperties)
+    {
+      servicePropertiesUpdated.add(serviceProperties);
+    }
+
+    @Override
+    public void onServicePropertiesRemoval(LoadBalancerStateItem<ServiceProperties> serviceProperties)
+    {
+      servicePropertiesRemoved.add(serviceProperties);
     }
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/jmx/ClusterInfoJmxTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/ClusterInfoJmxTest.java
@@ -1,0 +1,74 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.balancer.properties.ClusterProperties;
+import com.linkedin.d2.balancer.simple.ClusterInfoItem;
+import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
+import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
+import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicLong;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class ClusterInfoJmxTest
+{
+  @Mock
+  SimpleLoadBalancerState _mockedSimpleBalancerState;
+
+  @BeforeTest
+  public void setUp()
+  {
+    MockitoAnnotations.initMocks(this);
+    AtomicLong _mockedSimpleBalancerVersion = new AtomicLong(0);
+    Mockito.when(_mockedSimpleBalancerState.getVersionAccess()).thenReturn(_mockedSimpleBalancerVersion);
+  }
+
+  @DataProvider(name = "getCanaryDistributionPoliciesTestData")
+  public Object[][] getCanaryDistributionPoliciesTestData() {
+    return new Object[][] {
+        {CanaryDistributionProvider.Distribution.STABLE, 0},
+        {CanaryDistributionProvider.Distribution.CANARY, 1},
+    };
+  }
+
+  @Test(dataProvider = "getCanaryDistributionPoliciesTestData")
+  public void testGetCanaryDistributionPolicy(CanaryDistributionProvider.Distribution distribution, int expectedValue)
+  {
+    ClusterInfoJmx clusterInfoJmx = new ClusterInfoJmx(
+        new ClusterInfoItem(_mockedSimpleBalancerState, new ClusterProperties("Foo"), new PartitionAccessor() {
+          @Override
+          public int getMaxPartitionId() {
+            return 0;
+          }
+
+          @Override
+          public int getPartitionId(URI uri) {
+            return 0;
+          }
+        }, distribution)
+    );
+    Assert.assertEquals(clusterInfoJmx.getCanaryDistributionPolicy(), expectedValue);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/jmx/D2ClientJmxManagerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/D2ClientJmxManagerTest.java
@@ -1,0 +1,155 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
+import com.linkedin.d2.balancer.properties.ClusterProperties;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.simple.ClusterInfoItem;
+import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
+import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
+import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
+import org.mockito.Captor;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+public class D2ClientJmxManagerTest {
+  @Mock
+  SimpleLoadBalancerState _simpleLoadBalancerState;
+  @Mock
+  JmxManager _jmxManager;
+  @Captor
+  ArgumentCaptor<String> _simpleLoadBalancerStateNameCaptor;
+  @Captor
+  ArgumentCaptor<SimpleLoadBalancerState> _simpleLoadBalancerStateCaptor;
+  @Captor
+  ArgumentCaptor<SimpleLoadBalancerState.SimpleLoadBalancerStateListener> _simpleLoadBalancerStateListenerCaptor;
+  @Captor
+  ArgumentCaptor<String> _unregisteredObjectNameCaptor;
+  @Captor
+  ArgumentCaptor<String> _registerObjectNameCaptor;
+  @Captor
+  ArgumentCaptor<ClusterInfoJmx> _clusterInfoJmxArgumentCaptor;
+  @Captor
+  ArgumentCaptor<ServicePropertiesJmx> _servicePropertiesJmxArgumentCaptor;
+
+  D2ClientJmxManager _d2ClientJmxManager;
+  private ClusterInfoItem _clusterInfoItem;
+  private LoadBalancerStateItem<ServiceProperties> _servicePropertiesLBState;
+
+  @BeforeMethod
+  public void setUp()
+  {
+    MockitoAnnotations.initMocks(this);
+    AtomicLong version = new AtomicLong(0);
+    when(_simpleLoadBalancerState.getVersionAccess()).thenReturn(version);
+    _clusterInfoItem =
+        new ClusterInfoItem(_simpleLoadBalancerState, new ClusterProperties("C_Foo"), new PartitionAccessor() {
+          @Override
+          public int getMaxPartitionId() {
+            return 0;
+          }
+
+          @Override
+          public int getPartitionId(URI uri) {
+            return 0;
+          }
+        }, CanaryDistributionProvider.Distribution.CANARY);
+    _servicePropertiesLBState = new LoadBalancerStateItem<>(
+        new ServiceProperties("S_Foo", "Bar", "/", Collections.singletonList("Random")),
+        0,
+        0,
+        CanaryDistributionProvider.Distribution.CANARY
+    );
+    _d2ClientJmxManager = new D2ClientJmxManager("Foo", _jmxManager);
+    Mockito.doReturn(_jmxManager).when(_jmxManager).unregister(_unregisteredObjectNameCaptor.capture());
+    Mockito.doReturn(_jmxManager).when(_jmxManager).registerLoadBalancerState(
+        _simpleLoadBalancerStateNameCaptor.capture(), _simpleLoadBalancerStateCaptor.capture());
+    Mockito.doReturn(_jmxManager).when(_jmxManager).registerClusterInfoJmxBean(
+        _registerObjectNameCaptor.capture(),
+        _clusterInfoJmxArgumentCaptor.capture());
+    Mockito.doReturn(_jmxManager).when(_jmxManager).registerServicePropertiesJmxBean(
+        _registerObjectNameCaptor.capture(),
+        _servicePropertiesJmxArgumentCaptor.capture());
+    Mockito.doNothing().when(_simpleLoadBalancerState).register(_simpleLoadBalancerStateListenerCaptor.capture());
+  }
+
+  @Test
+  public void testSetSimpleLBStateListenerUpdateServiceProperties()
+  {
+    _d2ClientJmxManager.setSimpleLoadBalancerState(_simpleLoadBalancerState);
+    _simpleLoadBalancerStateListenerCaptor.getValue().onServicePropertiesUpdate(_servicePropertiesLBState);
+    Assert.assertEquals(
+        _registerObjectNameCaptor.getValue(),
+        "S_Foo-ServiceProperties"
+    );
+    Assert.assertEquals(
+        _servicePropertiesJmxArgumentCaptor.getValue().getServicePropertiesLBStateItem(),
+        _servicePropertiesLBState
+    );
+  }
+
+  @Test
+  public void testSetSimpleLBStateListenerUpdateClusterInfo()
+  {
+    _d2ClientJmxManager.setSimpleLoadBalancerState(_simpleLoadBalancerState);
+    _simpleLoadBalancerStateListenerCaptor.getValue().onClusterInfoUpdate(_clusterInfoItem);
+    Assert.assertEquals(
+        _registerObjectNameCaptor.getValue(),
+        "C_Foo-ClusterInfo"
+    );
+    Assert.assertEquals(
+        _clusterInfoJmxArgumentCaptor.getValue().getClusterInfoItem(),
+        _clusterInfoItem
+    );
+  }
+
+  @Test
+  public void testSetSimpleLBStateListenerRemoveClusterInfo()
+  {
+    _d2ClientJmxManager.setSimpleLoadBalancerState(_simpleLoadBalancerState);
+    Assert.assertEquals(_simpleLoadBalancerStateNameCaptor.getValue(), "Foo-LoadBalancerState");
+    Assert.assertEquals(_simpleLoadBalancerStateCaptor.getValue(), _simpleLoadBalancerState);
+    _simpleLoadBalancerStateListenerCaptor.getValue().onClusterInfoRemoval(_clusterInfoItem);
+    Assert.assertEquals(
+        _unregisteredObjectNameCaptor.getValue(),
+        _clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName() + "-ClusterInfo");
+  }
+
+  @Test
+  public void testSetSimpleLBStateListenerRemoveServiceProperties()
+  {
+    _d2ClientJmxManager.setSimpleLoadBalancerState(_simpleLoadBalancerState);
+    Assert.assertEquals(_simpleLoadBalancerStateNameCaptor.getValue(), "Foo-LoadBalancerState");
+    Assert.assertEquals(_simpleLoadBalancerStateCaptor.getValue(), _simpleLoadBalancerState);
+    _simpleLoadBalancerStateListenerCaptor.getValue().onServicePropertiesRemoval(_servicePropertiesLBState);
+    Assert.assertEquals(
+        _unregisteredObjectNameCaptor.getValue(),
+        _servicePropertiesLBState.getProperty().getServiceName() + "-ServiceProperties");
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/jmx/D2ClientJmxManagerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/D2ClientJmxManagerTest.java
@@ -54,9 +54,9 @@ public class D2ClientJmxManagerTest {
   @Captor
   ArgumentCaptor<String> _registerObjectNameCaptor;
   @Captor
-  ArgumentCaptor<ClusterInfoJmx> _clusterInfoJmxArgumentCaptor;
+  ArgumentCaptor<ClusterInfoItem> _clusterInfoArgumentCaptor;
   @Captor
-  ArgumentCaptor<ServicePropertiesJmx> _servicePropertiesJmxArgumentCaptor;
+  ArgumentCaptor<LoadBalancerStateItem<ServiceProperties>> _servicePropertiesArgumentCaptor;
 
   D2ClientJmxManager _d2ClientJmxManager;
   private ClusterInfoItem _clusterInfoItem;
@@ -90,12 +90,12 @@ public class D2ClientJmxManagerTest {
     Mockito.doReturn(_jmxManager).when(_jmxManager).unregister(_unregisteredObjectNameCaptor.capture());
     Mockito.doReturn(_jmxManager).when(_jmxManager).registerLoadBalancerState(
         _simpleLoadBalancerStateNameCaptor.capture(), _simpleLoadBalancerStateCaptor.capture());
-    Mockito.doReturn(_jmxManager).when(_jmxManager).registerClusterInfoJmxBean(
+    Mockito.doReturn(_jmxManager).when(_jmxManager).registerClusterInfo(
         _registerObjectNameCaptor.capture(),
-        _clusterInfoJmxArgumentCaptor.capture());
-    Mockito.doReturn(_jmxManager).when(_jmxManager).registerServicePropertiesJmxBean(
+        _clusterInfoArgumentCaptor.capture());
+    Mockito.doReturn(_jmxManager).when(_jmxManager).registerServiceProperties(
         _registerObjectNameCaptor.capture(),
-        _servicePropertiesJmxArgumentCaptor.capture());
+        _servicePropertiesArgumentCaptor.capture());
     Mockito.doNothing().when(_simpleLoadBalancerState).register(_simpleLoadBalancerStateListenerCaptor.capture());
   }
 
@@ -109,7 +109,7 @@ public class D2ClientJmxManagerTest {
         "S_Foo-ServiceProperties"
     );
     Assert.assertEquals(
-        _servicePropertiesJmxArgumentCaptor.getValue().getServicePropertiesLBStateItem(),
+        _servicePropertiesArgumentCaptor.getValue(),
         _servicePropertiesLBState
     );
   }
@@ -124,7 +124,7 @@ public class D2ClientJmxManagerTest {
         "C_Foo-ClusterInfo"
     );
     Assert.assertEquals(
-        _clusterInfoJmxArgumentCaptor.getValue().getClusterInfoItem(),
+        _clusterInfoArgumentCaptor.getValue(),
         _clusterInfoItem
     );
   }

--- a/d2/src/test/java/com/linkedin/d2/jmx/JmxManagerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/JmxManagerTest.java
@@ -1,0 +1,147 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
+import com.linkedin.d2.balancer.properties.ClusterProperties;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.simple.ClusterInfoItem;
+import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
+import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
+import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import org.junit.Assert;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+public class JmxManagerTest {
+  @Mock
+  SimpleLoadBalancerState _mockedSimpleBalancerState;
+
+  private JmxManager _jmxManager;
+  private ClusterInfoItem _clusterInfoItem;
+  private ClusterInfoJmx _clusterInfoJmx;
+  private LoadBalancerStateItem<ServiceProperties> _servicePropertiesLBState;
+  private ServicePropertiesJmx _servicePropertiesJmx;
+
+  private void resetJmxObjects()
+  {
+    _clusterInfoItem =
+        new ClusterInfoItem(_mockedSimpleBalancerState, new ClusterProperties("Foo"), new PartitionAccessor() {
+          @Override
+          public int getMaxPartitionId() {
+            return 0;
+          }
+
+          @Override
+          public int getPartitionId(URI uri) {
+            return 0;
+          }
+        }, CanaryDistributionProvider.Distribution.CANARY);
+    _clusterInfoJmx = new ClusterInfoJmx(_clusterInfoItem);
+    _servicePropertiesLBState = new LoadBalancerStateItem<>(
+        new ServiceProperties("Foo", "Bar", "/", Collections.singletonList("Random")),
+        0,
+        0,
+        CanaryDistributionProvider.Distribution.CANARY
+    );
+    _servicePropertiesJmx = new ServicePropertiesJmx(_servicePropertiesLBState);
+  }
+
+  @BeforeMethod(firstTimeOnly = true)
+  public void setUp()
+  {
+    MockitoAnnotations.initMocks(this);
+    AtomicLong version = new AtomicLong(0);
+    when(_mockedSimpleBalancerState.getVersionAccess()).thenReturn(version);
+    _jmxManager = new JmxManager();
+    resetJmxObjects();
+  }
+
+  @DataProvider(name = "getJmxBeans")
+  public Object[][] getJmxBeans()
+  {
+    return new Object[][] {
+        {_servicePropertiesJmx},
+        {_clusterInfoJmx}
+    };
+  }
+
+  @Test(dataProvider = "getJmxBeans", invocationCount = 2)
+  public void testRegisterJmxBeans(Object jmxBean)
+  {
+    String name = "Foo";
+    ObjectName jmxObjName = null;
+    try {
+      jmxObjName = _jmxManager.getName(name);
+    } catch (MalformedObjectNameException e) {
+      Assert.fail("Unexpected bad JMX object name: " + e.getMessage());
+    }
+    if (jmxBean instanceof  ServicePropertiesJmx) {
+      _jmxManager.registerServicePropertiesJmxBean(name, (ServicePropertiesJmx)jmxBean);
+      try {
+        Assert.assertEquals(
+            _jmxManager.getMBeanServer().getAttribute(jmxObjName, "ServicePropertiesLBStateItem"),
+            _servicePropertiesLBState);
+      } catch (Exception e) {
+        Assert.fail("Failed to check MBean attribute: " + e.getMessage());
+      }
+    } else if (jmxBean instanceof ClusterInfoJmx) {
+      _jmxManager.registerClusterInfoJmxBean(name, (ClusterInfoJmx)jmxBean);
+      try {
+        Assert.assertEquals(
+            _jmxManager.getMBeanServer().getAttribute(jmxObjName, "ClusterInfoItem"),
+            _clusterInfoItem);
+      } catch (Exception e) {
+        Assert.fail("Failed to check MBean attribute: " + e.getMessage());
+      }
+    }
+  }
+
+  @Test(dataProvider = "getJmxBeans")
+  public void testUnRegisterJmxBeans(Object jmxBean)
+  {
+    String name = "Foo";
+    ObjectName jmxObjName = null;
+    try {
+      jmxObjName = _jmxManager.getName(name);
+    } catch (MalformedObjectNameException e) {
+      Assert.fail("Unexpected bad JMX object name: " + e.getMessage());
+    }
+    if (jmxBean instanceof  ServicePropertiesJmx) {
+      _jmxManager.registerServicePropertiesJmxBean(name, (ServicePropertiesJmx)jmxBean);
+      Assert.assertTrue(_jmxManager.getMBeanServer().isRegistered(jmxObjName));
+      _jmxManager.unregister(name);
+      Assert.assertFalse(_jmxManager.getMBeanServer().isRegistered(jmxObjName));
+    } else if (jmxBean instanceof ClusterInfoJmx) {
+      _jmxManager.registerClusterInfoJmxBean(name, (ClusterInfoJmx) jmxBean);
+      Assert.assertTrue(_jmxManager.getMBeanServer().isRegistered(jmxObjName));
+      _jmxManager.unregister(name);
+      Assert.assertFalse(_jmxManager.getMBeanServer().isRegistered(jmxObjName));
+    }
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/jmx/ServicePropertiesJmxTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/ServicePropertiesJmxTest.java
@@ -1,0 +1,68 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.jmx;
+
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.simple.SimpleLoadBalancerState;
+import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class ServicePropertiesJmxTest
+{
+  @Mock
+  SimpleLoadBalancerState _mockedSimpleBalancerState;
+
+  @BeforeTest
+  public void setUp()
+  {
+    MockitoAnnotations.initMocks(this);
+    AtomicLong _mockedSimpleBalancerVersion = new AtomicLong(0);
+    Mockito.when(_mockedSimpleBalancerState.getVersionAccess()).thenReturn(_mockedSimpleBalancerVersion);
+  }
+
+  @DataProvider(name = "getCanaryDistributionPoliciesTestData")
+  public Object[][] getCanaryDistributionPoliciesTestData() {
+    return new Object[][] {
+        {CanaryDistributionProvider.Distribution.STABLE, 0},
+        {CanaryDistributionProvider.Distribution.CANARY, 1},
+    };
+  }
+
+  @Test(dataProvider = "getCanaryDistributionPoliciesTestData")
+  public void testGetCanaryDistributionPolicy(CanaryDistributionProvider.Distribution distribution, int expectedValue)
+  {
+    ServicePropertiesJmx servicePropertiesJmx = new ServicePropertiesJmx(
+        new LoadBalancerStateItem<>(
+            new ServiceProperties("Foo", "Bar", "/", Collections.singletonList("Random")),
+            0,
+            0,
+            distribution
+        )
+    );
+    Assert.assertEquals(servicePropertiesJmx.getCanaryDistributionPolicy(), expectedValue);
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.33.1
+version=29.34.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.34.0
+version=29.33.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Implement rest.li changes for adding D2 Canary metrics. This commit adds the following items:

1. Add canary distribution policy into ClusterInfo and SimpleLoadBalancerState to facilitate
   constructing corresponding JMX beans
2. New callbacks in SimpleLoadBalancerState for notifying listeners about ServiceProperties updates, the callbacks can then be used to register / deregister corresponding JMX and Sensor in the follow-up diff.
3. Simple JMX and MBeans for ClusterInfo and ServiceProperties, for now we only expose canary distribution policy. In the future, we can add more metrics about Service or Cluster properties by resuing the same framework.