### PR TITLE
Expose RestLiConfig from RestLiServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.33.5] - 2022-05-02
+- Expose RestLiConfig from RestLiServer.
+
 ## [29.33.4] - 2022-04-26
 - Support failout redirection in D2 client.
 
@@ -5224,7 +5227,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.33.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.33.5...master
+[29.33.5]: https://github.com/linkedin/rest.li/compare/v29.33.4...v29.33.5
 [29.33.4]: https://github.com/linkedin/rest.li/compare/v29.33.3...v29.33.4
 [29.33.3]: https://github.com/linkedin/rest.li/compare/v29.33.2...v29.33.3
 [29.33.2]: https://github.com/linkedin/rest.li/compare/v29.33.1...v29.33.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.33.4
+version=29.33.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/main/java/com/linkedin/restli/server/RestLiServer.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/RestLiServer.java
@@ -63,6 +63,7 @@ public class RestLiServer implements RestRequestHandler, RestToRestLiRequestHand
 
   private final RestRestLiServer _restRestLiServer;
   private final StreamRestLiServer _streamRestLiServer;
+  private final RestLiConfig _restliConfig;
 
   public RestLiServer(RestLiConfig config)
   {
@@ -76,6 +77,7 @@ public class RestLiServer implements RestRequestHandler, RestToRestLiRequestHand
 
   public RestLiServer(RestLiConfig config, ResourceFactory resourceFactory, Engine engine)
   {
+    _restliConfig = config;
     Map<String, ResourceModel> rootResources = new RestLiApiBuilder(config).build();
 
     // Notify listeners of the resource models.
@@ -150,6 +152,10 @@ public class RestLiServer implements RestRequestHandler, RestToRestLiRequestHand
   public void handleRequestWithRestLiResponse(StreamRequest request, RequestContext requestContext, Callback<RestLiResponse> callback)
   {
     _streamRestLiServer.handleRequestWithRestLiResponse(request, requestContext, callback);
+  }
+
+  public RestLiConfig getRestliConfig() {
+    return _restliConfig;
   }
 
   private boolean isMultipart(final Request request, final RequestContext requestContext, final Callback<?> callback)


### PR DESCRIPTION
In some optimization cases, we need to skip some rest.li filters for in-process invocation, where we need to have access to final rest.li filters used to initialize rest.li server. This RB provides a way to expose RestLiConfig used to initialize RestLiServer.