### PR TITLE
fix security issues due to transitive dependency icu4j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Update antlr dependency to fix security issues.
 
 ## [29.33.6] - 2022-05-03
 - Provide a mechanism to set a routing hint for the d2 request to get request symbol table.

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ apply from: environmentScript
 apply from: "${buildScriptDirPath}/configBuildScript.gradle"
 
 project.ext.externalDependency = [
-  'antlr': 'org.antlr:antlr4:4.9.3',
-  'antlrRuntime': 'org.antlr:antlr4-runtime:4.9.3',
+  'antlr': 'org.antlr:antlr4:4.6',
+  'antlrRuntime': 'org.antlr:antlr4-runtime:4.6',
   'avro': 'org.apache.avro:avro:1.9.2',
   'avro_1_6': 'org.apache.avro:avro:1.6.3',
    // avro compatibility layer

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ apply from: environmentScript
 apply from: "${buildScriptDirPath}/configBuildScript.gradle"
 
 project.ext.externalDependency = [
-  'antlr': 'org.antlr:antlr4:4.5',
-  'antlrRuntime': 'org.antlr:antlr4-runtime:4.5',
+  'antlr': 'org.antlr:antlr4:4.10.1',
+  'antlrRuntime': 'org.antlr:antlr4-runtime:4.10.1',
   'avro': 'org.apache.avro:avro:1.9.2',
   'avro_1_6': 'org.apache.avro:avro:1.6.3',
    // avro compatibility layer

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ apply from: environmentScript
 apply from: "${buildScriptDirPath}/configBuildScript.gradle"
 
 project.ext.externalDependency = [
-  'antlr': 'org.antlr:antlr4:4.10.1',
-  'antlrRuntime': 'org.antlr:antlr4-runtime:4.10.1',
+  'antlr': 'org.antlr:antlr4:4.9.3',
+  'antlrRuntime': 'org.antlr:antlr4-runtime:4.9.3',
   'avro': 'org.apache.avro:avro:1.9.2',
   'avro_1_6': 'org.apache.avro:avro:1.6.3',
    // avro compatibility layer

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/acl/AclAwareZookeeper.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/acl/AclAwareZookeeper.java
@@ -20,7 +20,6 @@ import com.linkedin.d2.discovery.stores.zk.AbstractZooKeeper;
 import com.linkedin.d2.discovery.stores.zk.ZKPersistentConnection;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeper;
 import java.util.List;
-import org.antlr.v4.runtime.misc.NotNull;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -30,6 +29,7 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.annotation.Nonnull;
 
 
 /**
@@ -44,7 +44,7 @@ public class AclAwareZookeeper extends AbstractZooKeeper
 
   private final ZKAclProvider _aclProvider;
 
-  public AclAwareZookeeper(@NotNull ZooKeeper zooKeeper, @NotNull ZKAclProvider aclProvider)
+  public AclAwareZookeeper(@Nonnull ZooKeeper zooKeeper, @Nonnull ZKAclProvider aclProvider)
   {
     super(zooKeeper);
     _aclProvider = aclProvider;


### PR DESCRIPTION
These dependencies are brought in when using latest release of `rest.li`
```
\--- org.antlr:antlr4:4.7.2
     +--- org.antlr:antlr4-runtime:4.7.2
     +--- org.antlr:antlr-runtime:3.5.2
     +--- org.antlr:ST4:4.1
     |    \--- org.antlr:antlr-runtime:3.5.2
     +--- org.abego.treelayout:org.abego.treelayout.core:1.0.3
     +--- org.glassfish:javax.json:1.0.4
     \--- com.ibm.icu:icu4j:61.1
```

OWASP scanner on a sample project shows these vulnerabilities

<img width="1381" alt="image" src="https://user-images.githubusercontent.com/4127841/166864606-3cbc3cf6-ac78-422b-b50e-996d54684279.png">

Upgrading to latest `4.10.1` we get these
```
\--- org.antlr:antlr4:4.10.1
     +--- org.antlr:antlr4-runtime:4.10.1
     +--- org.antlr:antlr-runtime:3.5.3
     +--- org.antlr:ST4:4.3.3
     |    \--- org.antlr:antlr-runtime:3.5.2 -> 3.5.3
     +--- org.abego.treelayout:org.abego.treelayout.core:1.0.3
     +--- org.glassfish:javax.json:1.0.4
     \--- com.ibm.icu:icu4j:69.1
```

After update 0 CVEs

<img width="1466" alt="image" src="https://user-images.githubusercontent.com/4127841/166866033-7421d418-b657-4068-9cd4-d38e373e5f14.png">


Ref
- https://plugins.gradle.org/plugin/org.owasp.dependencycheck
- https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/index.html