### PR TITLE
update d2 partitioning logic to map unmapped keys to default partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.34.0] - 2022-05-11
+- update d2 partitioning logic to map unmapped URIs to default partition 0
+
 ## [29.33.7] - 2022-05-04
 - Silence Zookeeper errors in logs on race condition between watched events and async shutdown.
 
@@ -5233,7 +5236,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.33.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.0...master
+[29.34.0]: https://github.com/linkedin/rest.li/compare/v29.33.7...v29.34.0
 [29.33.7]: https://github.com/linkedin/rest.li/compare/v29.33.6...v29.33.7
 [29.33.6]: https://github.com/linkedin/rest.li/compare/v29.33.5...v29.33.6
 [29.33.5]: https://github.com/linkedin/rest.li/compare/v29.33.4...v29.33.5

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -52,6 +52,7 @@ import com.linkedin.d2.balancer.util.MapKeyResult;
 import com.linkedin.d2.balancer.util.hashing.HashFunction;
 import com.linkedin.d2.balancer.util.hashing.HashRingProvider;
 import com.linkedin.d2.balancer.util.hashing.Ring;
+import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessException;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessor;
 import com.linkedin.d2.balancer.util.partitions.PartitionInfoProvider;
@@ -901,8 +902,10 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
       }
       catch (PartitionAccessException e)
       {
-        die(serviceName, "PEGA_1013. Error in finding the partition for URI: " + requestUri + ", " +
-          "in cluster: " + clusterName + ", " + e.getMessage());
+        debug(_log,
+            "PEGA_1013. Mapped URI to default partition as there was error in finding the partition for URI: "
+                + requestUri + ", in cluster: " + clusterName + ", " + e.getMessage());
+        partitionId = DefaultPartitionAccessor.DEFAULT_PARTITION_ID;
       }
     }
     else

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -1475,16 +1475,12 @@ public class SimpleLoadBalancerTest
           assertEquals(unmappedKeys.size(), 1);
         }
 
-        try
-        {
-          loadBalancer.getClient(new URIRequest("d2://foo/id=100"), new RequestContext());
-          if (partitionMethod == 0)
-          {
-            // key out of range
-            fail("Should throw ServiceUnavailableException caused by PartitionAccessException");
-          }
+        loadBalancer.getClient(new URIRequest("d2://foo/id=100"), new RequestContext());
+        if (partitionMethod == 0) {
+          // key out of range
+          assertEquals(mapKeyResult.getUnmappedKeys().size(), 1);
+          //fail("Should throw ServiceUnavailableException caused by PartitionAccessException");
         }
-        catch(ServiceUnavailableException e) {}
       }
 
       final CountDownLatch latch = new CountDownLatch(1);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.33.7
+version=29.34.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Updated partition accessor exception branch to map unmapped keys to default partition. 
added debug log for dev to identify any partition misconfiguration during testing.

Note: this breaks the current contract to fail fast on unmappable URI, but this should ideally be fine if tested on staging env.