### PR TITLE
Fix passing in canary distribution provider from ZKFS load balancer factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.34.1] - 2022-05-28
+- fix passing in canary distribution provider from ZKFS load balancer factory.
+
 ## [29.34.0] - 2022-05-11
 - update d2 partitioning logic to map unmapped URIs to default partition 0
 
@@ -5243,7 +5246,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.1...master
+[29.34.1]: https://github.com/linkedin/rest.li/compare/v29.34.0...v29.34.1
 [29.34.0]: https://github.com/linkedin/rest.li/compare/v29.33.7...v29.34.0
 [29.33.9]: https://github.com/linkedin/rest.li/compare/v29.33.8...v29.33.9
 [29.33.8]: https://github.com/linkedin/rest.li/compare/v29.33.7...v29.33.8

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -94,7 +94,8 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    d2ClientJmxManager,
                                                    config.zookeeperReadWindowMs,
                                                    config.deterministicSubsettingMetadataProvider,
-                                                   config.failoutConfigProviderFactory
+                                                   config.failoutConfigProviderFactory,
+                                                   config.canaryDistributionProvider
     );
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
@@ -241,7 +241,6 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
             d2ClientJmxManager,
             zookeeperReadWindowMs,
             deterministicSubsettingMetadataProvider,
-            null,
             null);
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.34.0
+version=29.34.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Previously, canary distribution provider was passed in only from last-seen load balancer factory, which causes the canary distribution provider being null for ZKFS toggling load balancer. This PR is to fix that by passing in the provider from ZKFS load balancer factory as well. 