### PR TITLE
Provide a way to link a finder with a functionally equivalent batch finder declaratively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.34.2] - 2022-06-03
+- Provide a way to link a finder with a functionally equivalent batch finder declaratively
+
 ## [29.34.1] - 2022-05-28
 - fix passing in canary distribution provider from ZKFS load balancer factory.
 
@@ -5246,7 +5249,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.2...master
+[29.34.2]: https://github.com/linkedin/rest.li/compare/v29.34.1...v29.34.2
 [29.34.1]: https://github.com/linkedin/rest.li/compare/v29.34.0...v29.34.1
 [29.34.0]: https://github.com/linkedin/rest.li/compare/v29.33.7...v29.34.0
 [29.33.9]: https://github.com/linkedin/rest.li/compare/v29.33.8...v29.33.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.34.1
+version=29.34.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/src/main/pegasus/com/linkedin/restli/restspec/FinderSchema.pdl
+++ b/restli-common/src/main/pegasus/com/linkedin/restli/restspec/FinderSchema.pdl
@@ -39,4 +39,14 @@ record FinderSchema includes CustomAnnotationSchema, ServiceErrorsSchema, Succes
    * Indicates if this finder method has paging support using the start and count parameters
    */
   pagingSupported: optional boolean
+
+  /**
+   * The linked batch finder method name on the same resource if any. The finder and the linked batch finder
+   * need to conform to some structural constraints for this linkage to be valid. See the documentation of
+   * the com.linkedin.restli.server.annotations.Finder annotation for more details.
+   *
+   * This linkage is useful for clients to optimize parallel finder calls by merging them into a single
+   * batch finder.
+   */
+  linkedBatchFinderName: optional string
 }

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceMethodDescriptor.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceMethodDescriptor.java
@@ -74,6 +74,7 @@ public class ResourceMethodDescriptor
   private final RecordDataSchema                        _requestDataSchema;
   private final InterfaceType                           _interfaceType;
   private final DataMap                                 _customAnnotations;
+  private final String                                  _linkedBatchFinderName;
   // Method-level service error definitions
   private List<ServiceError>                            _serviceErrors;
   private List<HttpStatus>                              _successStatuses;
@@ -110,7 +111,46 @@ public class ResourceMethodDescriptor
                                         null,
                                         metadataType,
                                         interfaceType,
-                                        customAnnotations);
+                                        customAnnotations,
+                                        null);
+  }
+
+  /**
+   * Finder resource method descriptor factory.
+   *
+   * @param method resource {@link Method}
+   * @param parameters rest.li method {@link Parameter}s
+   * @param finderName finder name
+   * @param metadataType finder metadata type
+   * @param interfaceType method {@link InterfaceType}
+   * @param customAnnotations All the custom annotations associated with this method encoded as a {@link DataMap}
+   * @param linkedBatchFinderName The optional batch finder linked to this finder
+   * @return finder {@link ResourceMethodDescriptor}
+   */
+  public static ResourceMethodDescriptor createForFinder(final Method method,
+      final List<Parameter<?>> parameters,
+      final String finderName,
+      final Class<? extends RecordTemplate> metadataType,
+      final InterfaceType interfaceType,
+      final DataMap customAnnotations,
+      final String linkedBatchFinderName)
+  {
+    return new ResourceMethodDescriptor(ResourceMethod.FINDER,
+                                        method,
+                                        parameters,
+                                        finderName,
+                                        null,
+                                        BATCH_FINDER_NULL_CRITERIA_INDEX,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        false,
+                                        null,
+                                        metadataType,
+                                        interfaceType,
+                                        customAnnotations,
+                                        linkedBatchFinderName);
   }
 
   /**
@@ -146,7 +186,8 @@ public class ResourceMethodDescriptor
                                         null,
                                         metadataType,
                                         interfaceType,
-                                        customAnnotations);
+                                        customAnnotations,
+                     null);
   }
 
   /**
@@ -187,7 +228,8 @@ public class ResourceMethodDescriptor
                                         recordDataSchema,
                                         null,
                                         interfaceType,
-                                        customAnnotations);
+                                        customAnnotations,
+                                        null);
   }
 
   /**
@@ -230,7 +272,8 @@ public class ResourceMethodDescriptor
                                         recordDataSchema,
                                         null,
                                         interfaceType,
-                                        customAnnotations);
+                                        customAnnotations,
+                                        null);
   }
 
   /**
@@ -285,7 +328,8 @@ public class ResourceMethodDescriptor
                                         null,
                                         collectionCustomMetadataType,
                                         interfaceType,
-                                        customAnnotations);
+                                        customAnnotations,
+                                        null);
   }
 
   /**
@@ -305,7 +349,8 @@ public class ResourceMethodDescriptor
                                    final RecordDataSchema requestDataSchema,
                                    final Class<? extends RecordTemplate> collectionCustomMetadataType,
                                    final InterfaceType interfaceType,
-                                   final DataMap customAnnotations)
+                                   final DataMap customAnnotations,
+                                   final String linkedBatchFinderName)
   {
     super();
     _type = type;
@@ -323,6 +368,7 @@ public class ResourceMethodDescriptor
     _interfaceType = interfaceType;
     _customAnnotations = customAnnotations;
     _batchFinderCriteriaIndex = batchFinderCriteriaIndex;
+    _linkedBatchFinderName = linkedBatchFinderName;
   }
 
   /**
@@ -449,6 +495,13 @@ public class ResourceMethodDescriptor
   public String getBatchFinderName()
   {
     return _batchFinderName;
+  }
+
+  /**
+   * @return the name of the batch finder method linked with a finder method
+   */
+  public String getLinkedBatchFinderName() {
+    return _linkedBatchFinderName;
   }
 
   /**

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
@@ -982,6 +982,11 @@ public class ResourceModelEncoder
       finder.setPagingSupported(true);
     }
 
+    if (resourceMethodDescriptor.getLinkedBatchFinderName() != null)
+    {
+      finder.setLinkedBatchFinderName(resourceMethodDescriptor.getLinkedBatchFinderName());
+    }
+
     appendServiceErrors(finder, resourceMethodDescriptor.getServiceErrors());
     appendSuccessStatuses(finder, resourceMethodDescriptor.getSuccessStatuses());
 

--- a/restli-server/src/main/java/com/linkedin/restli/server/annotations/Finder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/annotations/Finder.java
@@ -21,6 +21,7 @@
 package com.linkedin.restli.server.annotations;
 
 
+import com.linkedin.restli.common.RestConstants;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -36,6 +37,24 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface Finder
 {
-  /** Name of this Finder */
+  /**
+   * Name of this Finder
+   */
   String value();
+
+  /**
+   * The linked batch finder method name on the same resource if any. For this to be valid:
+   *
+   * <ul>
+   *   <li>A batch finder method with the linked batch finder name must exist on the same resource.</li>
+   *   <li>If the finder has a metadata type then the linked batch finder must also have the same metadata type.</li>
+   *   <li>All the query and assoc key parameters in the finder must have fields with the same name, type and
+   *   optionality in the criteria object. The criteria object cannot contain any other fields.</li>
+   *   <li>If the finder supports paging, then the linked batch finder must also support paging.</li>
+   * </ul>
+   *
+   * <p>This linkage is useful for clients to optimize parallel finder calls by merging them into a single
+   * batch finder.</p>
+   */
+  String linkedBatchFinderName() default RestAnnotations.DEFAULT;
 }

--- a/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiResourceModels.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/test/TestRestLiResourceModels.java
@@ -225,6 +225,14 @@ public class TestRestLiResourceModels
     expectConfigException(InvalidResources.FinderTwoNamedInOneClass.class, "duplicate @Finder");
     expectConfigException(InvalidResources.FinderNonExistingAssocKey.class, "Non-existing assocKey");
     expectConfigException(InvalidResources.GetAllNonExistingAssocKey.class, "Non-existing assocKey");
+    expectConfigException(InvalidResources.MissingLinkedBatchFinder.class, "Did not find any Linked @BatchFinder method named");
+    expectConfigException(InvalidResources.LinkedBatchFinderMissingFieldInCriteria.class, "There is no field in the criteria object");
+    expectConfigException(InvalidResources.LinkedBatchFinderAssocKeyFieldInCriteria.class, "There is no field in the criteria object");
+    expectConfigException(InvalidResources.LinkedBatchFinderMismatchedFieldTypeInCriteria.class, "The type doesn't match in the criteria object");
+    expectConfigException(InvalidResources.LinkedBatchFinderMismatchedFieldOptionalityInCriteria.class, "The optionality doesn't match in the criteria object");
+    expectConfigException(InvalidResources.LinkedBatchFinderExtraFieldsInCriteria.class, "has an invalid criteria type with extra fields");
+    expectConfigException(InvalidResources.LinkedBatchFinderMetadataMismatch.class, "does not have the same metadata type");
+    expectConfigException(InvalidResources.LinkedBatchFinderUnsupportedPaging.class, "does not support paging while the finder does");
   }
 
   @Test

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/ResourceCompatibilityChecker.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/ResourceCompatibilityChecker.java
@@ -789,6 +789,10 @@ public class ResourceCompatibilityChecker
                           prevRec.getName(GetMode.DEFAULT),
                           currRec.getName(GetMode.DEFAULT));
 
+    checkEqualSingleValue(prevRec.schema().getField("linkedBatchFinderName"),
+                          prevRec.getLinkedBatchFinderName(),
+                          currRec.getLinkedBatchFinderName());
+
     checkDoc(prevRec.schema().getField("doc"), prevRec.getDoc(GetMode.DEFAULT), currRec.getDoc(GetMode.DEFAULT));
 
     checkAnnotationsMap(prevRec.schema().getField("annotations"),

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/compatibility/TestResourceCompatibilityChecker.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/compatibility/TestResourceCompatibilityChecker.java
@@ -379,6 +379,9 @@ public class TestResourceCompatibilityChecker
     resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "collection", "finders", "search", "assocKeys"),
                                                  CompatibilityInfo.Type.VALUE_NOT_EQUAL,
                                                  new StringArray("q", "s"), new StringArray("q", "changed_key")));
+    resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "collection", "finders", "search", "linkedBatchFinderName"),
+                                                 CompatibilityInfo.Type.VALUE_NOT_EQUAL,
+                                                 "someBatchFinder", "someOtherBatchFinder"));
     resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "collection", "finders", "find_assocKey_downgrade", "assocKeys"),
                                                  CompatibilityInfo.Type.FINDER_ASSOCKEYS_DOWNGRADE));
     resourceTestErrors.add(new CompatibilityInfo(Arrays.asList("", "collection", "actions", "oneAction", "parameters", "bitfield", "items"),

--- a/restli-tools/src/test/resources/idls/curr-greetings-coll-fail.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greetings-coll-fail.restspec.json
@@ -53,6 +53,7 @@
     } ],
     "finders" : [ {
       "name" : "search",
+      "linkedBatchFinderName" : "someOtherBatchFinder",
       "default" : true,
       "parameters" : [ {
         "name" : "tone",

--- a/restli-tools/src/test/resources/idls/curr-greetings-coll-pass.restspec.json
+++ b/restli-tools/src/test/resources/idls/curr-greetings-coll-pass.restspec.json
@@ -55,6 +55,7 @@
     } ],
     "finders" : [ {
       "name" : "search",
+      "linkedBatchFinderName" : "someBatchFinder",
       "parameters" : [ {
         "name" : "tone",
         "type" : "array",

--- a/restli-tools/src/test/resources/idls/prev-greetings-coll.restspec.json
+++ b/restli-tools/src/test/resources/idls/prev-greetings-coll.restspec.json
@@ -51,6 +51,7 @@
     } ],
     "finders" : [ {
       "name" : "search",
+      "linkedBatchFinderName" : "someBatchFinder",
       "parameters" : [ {
         "name" : "tone",
         "type" : "array",


### PR DESCRIPTION
This provides a way for client applications to batch multiple finder requests together into a single batch finder request to optimize downstream fanout.