### PR TITLE
Translate Data.null to Avro null if schema field is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.34.3] - 2022-06-06
+- Translate Data.null to Avro null if schema field is optional
+
 ## [29.34.2] - 2022-06-03
 - Provide a way to link a finder with a functionally equivalent batch finder declaratively
 
@@ -5249,7 +5252,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.3...master
+[29.34.3]: https://github.com/linkedin/rest.li/compare/v29.34.2...v29.34.3
 [29.34.2]: https://github.com/linkedin/rest.li/compare/v29.34.1...v29.34.2
 [29.34.1]: https://github.com/linkedin/rest.li/compare/v29.34.0...v29.34.1
 [29.34.0]: https://github.com/linkedin/rest.li/compare/v29.33.7...v29.34.0

--- a/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
@@ -41,13 +41,11 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.avro.util.Utf8;
 

--- a/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
@@ -886,7 +886,7 @@ public class DataTranslator implements DataTranslatorContext
             boolean isOptional = field.getOptional();
             if (isOptional)
             {
-              if (fieldValue == null)
+              if (fieldValue == null || fieldValue == Data.NULL)
               {
                 fieldValue = Data.NULL;
                 fieldDataSchema = DataSchemaConstants.NULL_DATA_SCHEMA;

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -25,8 +25,8 @@ import com.linkedin.data.avro.testevents.EnumData;
 import com.linkedin.data.avro.testevents.MapArrayUnion;
 import com.linkedin.data.avro.testevents.MapOfArrayOfMapArrayUnion;
 import com.linkedin.data.avro.testevents.MapOfMapOfArrayOfMapArrayUnion;
-import com.linkedin.data.avro.testevents.RecordMap;
 import com.linkedin.data.avro.testevents.RecordArray;
+import com.linkedin.data.avro.testevents.RecordMap;
 import com.linkedin.data.avro.testevents.StringRecord;
 import com.linkedin.data.avro.testevents.TestEventRecordOfRecord;
 import com.linkedin.data.avro.testevents.TestEventWithUnionAndEnum;
@@ -58,9 +58,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class TestDataTranslator
 {
@@ -711,7 +709,8 @@ public class TestDataTranslator
         },
         {
           "{ \"intOptional\" : null }",
-          "Error processing /intOptional"
+          ONE_WAY,
+          "{\"intOptional\":null}"
         },
         {
           "{ \"intOptional\" : \"s1\" }",
@@ -751,7 +750,8 @@ public class TestDataTranslator
         },
         {
           "{ \"unionOptional\" : null }",
-          "Error processing /unionOptional"
+          ONE_WAY,
+          "{\"unionOptional\":null}"
         },
         {
           "{ \"unionOptional\" : \"s1\" }",
@@ -829,7 +829,8 @@ public class TestDataTranslator
         },
         {
           "{ \"uwaOptionalNoNull\" : null }",
-          "Error processing /uwaOptionalNoNull"
+          ONE_WAY,
+          "{\"uwaOptionalNoNull\":null}"
         },
         {
           "{ \"uwaOptionalNoNull\" : {} }",
@@ -877,7 +878,7 @@ public class TestDataTranslator
         },
         {
           "{ \"uwaOptionalWithNull\" : null }",
-          "{\"uwaOptionalWithNull\":{\"##NS(foo.)FooUwaOptionalWithNull\":{\"success\":null,\"failure\":null,\"fieldDiscriminator\":\"null\"}}}"
+          "{\"uwaOptionalWithNull\":null}"
         },
         {
           "{ \"uwaOptionalWithNull\" : {} }",
@@ -1133,7 +1134,7 @@ public class TestDataTranslator
       {
         // translate from Avro back to Pegasus
         DataMap dataMapResult = DataTranslator.genericRecordToDataMap(avroRecord, recordDataSchema, avroSchema);
-        ValidationResult vr = ValidateDataAgainstSchema.validate(dataMap,
+        ValidationResult vr = ValidateDataAgainstSchema.validate(dataMapResult,
                                                                  recordDataSchema,
                                                                  new ValidationOptions(RequiredMode.MUST_BE_PRESENT,
                                                                                        CoercionMode.NORMAL));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.34.2
+version=29.34.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This PR updates data schema to avro translation to handle Data.Null value in pegasus DataMap and translate it to Avro null