### PR TITLE
Add Enum symbols order change as compatible message in checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.34.4] - 2022-06-07
+- Add Enum symbols order change as compatible message in checker. This will make equivalent compatibility check to fail and publish the new snapshot files.
+
 ## [29.34.3] - 2022-06-06
 - Translate Data.null to Avro null if schema field is optional
 
@@ -5252,7 +5255,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.4...master
+[29.34.4]: https://github.com/linkedin/rest.li/compare/v29.34.3...v29.34.4
 [29.34.3]: https://github.com/linkedin/rest.li/compare/v29.34.2...v29.34.3
 [29.34.2]: https://github.com/linkedin/rest.li/compare/v29.34.1...v29.34.2
 [29.34.1]: https://github.com/linkedin/rest.li/compare/v29.34.0...v29.34.1

--- a/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
@@ -41,13 +41,11 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.avro.util.Utf8;
 

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityChecker.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityChecker.java
@@ -546,23 +546,36 @@ public class CompatibilityChecker
 
     // using list to preserve symbol order
     List<String> newerOnlySymbols = new CheckerArrayList<>(newer.getSymbols());
-    newerOnlySymbols.removeAll(older.getSymbols());
-
     List<String> olderOnlySymbols = new CheckerArrayList<>(older.getSymbols());
+
+    newerOnlySymbols.removeAll(older.getSymbols());
     olderOnlySymbols.removeAll(newer.getSymbols());
 
-    if (newerOnlySymbols.isEmpty() == false)
+    if (!newerOnlySymbols.isEmpty())
     {
       appendMessage(CompatibilityMessage.Impact.BREAKS_OLD_READER,
                     "new enum added symbols %s",
                     newerOnlySymbols);
     }
 
-    if (olderOnlySymbols.isEmpty() == false)
+    if (!olderOnlySymbols.isEmpty())
     {
       appendMessage(CompatibilityMessage.Impact.BREAKS_NEW_READER,
                     "new enum removed symbols %s",
                     olderOnlySymbols);
+    }
+
+    if (newerOnlySymbols.isEmpty() && olderOnlySymbols.isEmpty())
+    {
+      for (int i = 0; i < newer.getSymbols().size(); i++)
+      {
+        if (!newer.getSymbols().get(i).equals(older.getSymbols().get(i)))
+        {
+          appendMessage(CompatibilityMessage.Impact.ENUM_SYMBOLS_ORDER_CHANGE, "enum symbols order changed at symbol %s",
+              newer.getSymbols().get(i));
+          break;
+        }
+      }
     }
 
     _path.removeLast();

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
@@ -69,7 +69,11 @@ public class CompatibilityMessage extends Message
     /**
      * Annotation compatible change, which can be used in custom annotation compatibility check
      */
-    ANNOTATION_COMPATIBLE_CHANGE(false);
+    ANNOTATION_COMPATIBLE_CHANGE(false),
+    /**
+     * Enum symbol order changed, which is a compatible change.
+     */
+    ENUM_SYMBOLS_ORDER_CHANGE(false);
 
     private final boolean _error;
 

--- a/data/src/test/java/com/linkedin/data/schema/compatibility/TestCompatibilityChecker.java
+++ b/data/src/test/java/com/linkedin/data/schema/compatibility/TestCompatibilityChecker.java
@@ -803,6 +803,13 @@ public class TestCompatibilityChecker
         _noCheckNamesOnly,
         false
       },
+      {
+        "{ \"type\" : \"enum\", \"name\" : \"a.b.Enum\", \"symbols\" : [ \"A\", \"B\" ] }",
+        "{ \"type\" : \"enum\", \"name\" : \"a.b.Enum\", \"symbols\" : [ \"B\", \"A\" ] }",
+        _dataAndSchema,
+        false,
+        "INFO :: ENUM_ORDER_CHANGE :: /a.b.Enum/symbols :: enum symbols order changed at symbol B"
+      },
     };
 
     testCompatibility(inputs);

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
@@ -59,7 +59,7 @@ public class GenerateDataTemplateTask extends DefaultTask
    */
   @InputDirectory
   @SkipWhenEmpty
-  @Classpath
+  @PathSensitive(PathSensitivity.RELATIVE)
   public File getInputDir()
   {
     return _inputDir;

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateDataTemplateTask.java
@@ -59,7 +59,7 @@ public class GenerateDataTemplateTask extends DefaultTask
    */
   @InputDirectory
   @SkipWhenEmpty
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @Classpath
   public File getInputDir()
   {
     return _inputDir;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.34.3
+version=29.34.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This is added to fail equivalent compatibility check and also avoid skipping publish snapshot/idl task which are only executed if snapshot/idl are not equivalent.