### PR TITLE
Add Enum symbols order change as compatible message in checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.36.0] - 2022-06-21
+- Add Enum symbols order change as compatible message in checker. This will make equivalent compatibility check to fail and publish the new snapshot files.
+
 ## [29.35.0] - 2022-06-15
 - Avoid using JsonFactoryBuilder to be more compatible with pre 2.10 jackson at runtime
 
@@ -5255,7 +5258,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.35.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.36.0...master
+[29.36.0]: https://github.com/linkedin/rest.li/compare/v29.35.0...v29.36.0
 [29.35.0]: https://github.com/linkedin/rest.li/compare/v29.34.3...v29.35.0
 [29.34.3]: https://github.com/linkedin/rest.li/compare/v29.34.2...v29.34.3
 [29.34.2]: https://github.com/linkedin/rest.li/compare/v29.34.1...v29.34.2

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityChecker.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityChecker.java
@@ -546,23 +546,36 @@ public class CompatibilityChecker
 
     // using list to preserve symbol order
     List<String> newerOnlySymbols = new CheckerArrayList<>(newer.getSymbols());
-    newerOnlySymbols.removeAll(older.getSymbols());
-
     List<String> olderOnlySymbols = new CheckerArrayList<>(older.getSymbols());
+
+    newerOnlySymbols.removeAll(older.getSymbols());
     olderOnlySymbols.removeAll(newer.getSymbols());
 
-    if (newerOnlySymbols.isEmpty() == false)
+    if (!newerOnlySymbols.isEmpty())
     {
       appendMessage(CompatibilityMessage.Impact.BREAKS_OLD_READER,
                     "new enum added symbols %s",
                     newerOnlySymbols);
     }
 
-    if (olderOnlySymbols.isEmpty() == false)
+    if (!olderOnlySymbols.isEmpty())
     {
       appendMessage(CompatibilityMessage.Impact.BREAKS_NEW_READER,
                     "new enum removed symbols %s",
                     olderOnlySymbols);
+    }
+
+    if (newerOnlySymbols.isEmpty() && olderOnlySymbols.isEmpty())
+    {
+      for (int i = 0; i < newer.getSymbols().size(); i++)
+      {
+        if (!newer.getSymbols().get(i).equals(older.getSymbols().get(i)))
+        {
+          appendMessage(CompatibilityMessage.Impact.ENUM_SYMBOLS_ORDER_CHANGE, "enum symbols order changed at symbol %s",
+              newer.getSymbols().get(i));
+          break;
+        }
+      }
     }
 
     _path.removeLast();

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
@@ -69,7 +69,11 @@ public class CompatibilityMessage extends Message
     /**
      * Annotation compatible change, which can be used in custom annotation compatibility check
      */
-    ANNOTATION_COMPATIBLE_CHANGE(false);
+    ANNOTATION_COMPATIBLE_CHANGE(false),
+    /**
+     * Enum symbol order changed, which is a compatible change.
+     */
+    ENUM_SYMBOLS_ORDER_CHANGE(false);
 
     private final boolean _error;
 

--- a/data/src/test/java/com/linkedin/data/schema/compatibility/TestCompatibilityChecker.java
+++ b/data/src/test/java/com/linkedin/data/schema/compatibility/TestCompatibilityChecker.java
@@ -803,6 +803,13 @@ public class TestCompatibilityChecker
         _noCheckNamesOnly,
         false
       },
+      {
+        "{ \"type\" : \"enum\", \"name\" : \"a.b.Enum\", \"symbols\" : [ \"A\", \"B\" ] }",
+        "{ \"type\" : \"enum\", \"name\" : \"a.b.Enum\", \"symbols\" : [ \"B\", \"A\" ] }",
+        _dataAndSchema,
+        false,
+        "INFO :: ENUM_SYMBOLS_ORDER_CHANGE :: /a.b.Enum/symbols :: enum symbols order changed at symbol B"
+      },
     };
 
     testCompatibility(inputs);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.35.0
+version=29.36.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This is added to fail equivalent compatibility check and also avoid skipping publish snapshot/idl task which are only executed if snapshot/idl are not equivalent.