### PR TITLE
Avoid using JsonFactoryBuilder to be more compatible with pre 2.10 jackson at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.34.4] - 2022-06-15
+- Avoid using JsonFactoryBuilder to be more compatible with pre 2.10 jackson at runtime
+
 ## [29.34.3] - 2022-06-06
 - Translate Data.null to Avro null if schema field is optional
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.34.4] - 2022-06-15
+## [29.35.0] - 2022-06-15
 - Avoid using JsonFactoryBuilder to be more compatible with pre 2.10 jackson at runtime
 
 ## [29.34.3] - 2022-06-06
@@ -5255,7 +5255,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.34.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.35.0...master
+[29.35.0]: https://github.com/linkedin/rest.li/compare/v29.34.3...v29.35.0
 [29.34.3]: https://github.com/linkedin/rest.li/compare/v29.34.2...v29.34.3
 [29.34.2]: https://github.com/linkedin/rest.li/compare/v29.34.1...v29.34.2
 [29.34.1]: https://github.com/linkedin/rest.li/compare/v29.34.0...v29.34.1

--- a/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/AbstractJacksonDataCodec.java
@@ -57,14 +57,14 @@ public abstract class AbstractJacksonDataCodec implements DataCodec
    * performance reasons as recommended by Jackson authors.
    *
    * <a href="https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance">Jackson Performance</a>
+   *
+   * String interning is disabled by default since it causes GC issues. Note that we are using the deprecated disable
+   * method instead of JsonFactoryBuilder here preserves compatibility with some runtimes that pin jackson to a
+   * lower 2.x version. The method should still be available throughout jackson-core 2.x
+   * releases.
    */
-  public static final JsonFactoryBuilder JSON_FACTORY_BUILDER = new JsonFactoryBuilder();
-  public static final JsonFactory JSON_FACTORY;
-  static {
-    // Disable string interning by default since it causes GC issues.
-    JSON_FACTORY_BUILDER.configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false);
-    JSON_FACTORY = JSON_FACTORY_BUILDER.build();
-  }
+  @SuppressWarnings("deprecation")
+  public static final JsonFactory JSON_FACTORY = new JsonFactory().disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
 
   protected static final int DEFAULT_BUFFER_SIZE = 4096;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.34.3
+version=29.34.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.34.4
+version=29.35.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Some users have runtimes that pin jackson-core to older pre 2.10
versions. This introduces compatibility issues with the newer
JsonFactoryBuilder APIs. For the remaining jackson-core 2.x releases we
can continue to use the deprecated JsonFactory.enable/disable methods.