### PR TITLE
Translate restli-common PDL files to PDSC files to support legacy web use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.37.0] - 2022-06-23
-- Translate `:restli-common` PDL files to PDSC files to support legacy web use cases.
+- Package translated legacy PDSC models into `:restli-common` JAR
 
 ## [29.36.1] - 2022-06-22
 - Fix FailoutClient delegated client's restRequest invocation 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.0] - 2022-06-23
+- Translate `:restli-common` PDL files to PDSC files to support legacy web use cases.
+
 ## [29.36.1] - 2022-06-22
 - Fix FailoutClient delegated client's restRequest invocation 
 
@@ -5261,7 +5264,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.36.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.0...master
+[29.37.0]: https://github.com/linkedin/rest.li/compare/v29.36.1...v29.37.0
 [29.36.1]: https://github.com/linkedin/rest.li/compare/v29.36.0...v29.36.1
 [29.36.0]: https://github.com/linkedin/rest.li/compare/v29.35.0...v29.36.0
 [29.35.0]: https://github.com/linkedin/rest.li/compare/v29.34.3...v29.35.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.36.1
+version=29.37.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-common/build.gradle
+++ b/restli-common/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   compile project(':data')
   compile project(':data-transform')
+  compile project(':generator')
   compile project(':li-jersey-uri')
   compile project(':pegasus-common')
   compile project(':r2-core')

--- a/restli-common/build.gradle
+++ b/restli-common/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
   compile project(':data')
   compile project(':data-transform')
-  compile project(':generator')
   compile project(':li-jersey-uri')
   compile project(':pegasus-common')
   compile project(':r2-core')
@@ -9,6 +8,7 @@ dependencies {
   compile externalDependency.jacksonCore
   compile externalDependency.javaxAnnotation
   testCompile project(path: ':data', configuration: 'testArtifacts')
+  testCompile project(':generator')
   testCompile project(path: ':generator-test', configuration: 'testArtifacts')
   testCompile project(path: ':restli-internal-testutils', configuration: 'testArtifacts')
   testCompile project(path: ':multipart-mime', configuration: 'testArtifacts')

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/CollectionMetadata.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/CollectionMetadata.pdsc
@@ -1,0 +1,26 @@
+{
+  "type" : "record",
+  "name" : "CollectionMetadata",
+  "namespace" : "com.linkedin.restli.common",
+  "doc" : "Metadata and pagination links for this collection",
+  "fields" : [ {
+    "name" : "start",
+    "type" : "int",
+    "doc" : "The start index of this collection"
+  }, {
+    "name" : "count",
+    "type" : "int",
+    "doc" : "The number of elements in this collection segment"
+  }, {
+    "name" : "total",
+    "type" : "int",
+    "doc" : "The total number of elements in the entire collection (not just this segment)",
+    "default" : 0
+  }, {
+    "name" : "links",
+    "type" : {
+      "type" : "array",
+      "items" : "Link"
+    }
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/CreateStatus.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/CreateStatus.pdsc
@@ -1,0 +1,24 @@
+{
+  "type" : "record",
+  "name" : "CreateStatus",
+  "namespace" : "com.linkedin.restli.common",
+  "doc" : "A rest.li create status.",
+  "fields" : [ {
+    "name" : "status",
+    "type" : "int"
+  }, {
+    "name" : "id",
+    "type" : "string",
+    "optional" : true,
+    "deprecated" : "The serialized form of the returned key. You can get a strongly-typed form of the key by casting CreateStatus to CreateIdStatus and calling .getKey()"
+  }, {
+    "name" : "location",
+    "type" : "string",
+    "doc" : "The location url to retrieve the newly created entity",
+    "optional" : true
+  }, {
+    "name" : "error",
+    "type" : "ErrorResponse",
+    "optional" : true
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/EmptyRecord.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/EmptyRecord.pdsc
@@ -1,0 +1,10 @@
+{
+  "type" : "record",
+  "name" : "EmptyRecord",
+  "namespace" : "com.linkedin.restli.common",
+  "doc" : "An literally empty record.  Intended as a marker to indicate the absence of content where a record type is required.  If used the underlying DataMap *must* be empty, EmptyRecordValidator is provided to help enforce this.  For example,  CreateRequest extends Request<EmptyRecord> to indicate it has no response body.   Also, a ComplexKeyResource implementation that has no ParamKey should have a signature like XyzResource implements ComplexKeyResource<XyzKey, EmptyRecord, Xyz>.",
+  "fields" : [ ],
+  "validate" : {
+    "com.linkedin.restli.common.EmptyRecordValidator" : { }
+  }
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/ErrorResponse.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/ErrorResponse.pdsc
@@ -1,0 +1,62 @@
+{
+  "type" : "record",
+  "name" : "ErrorResponse",
+  "namespace" : "com.linkedin.restli.common",
+  "doc" : "A generic ErrorResponse",
+  "fields" : [ {
+    "name" : "status",
+    "type" : "int",
+    "doc" : "The HTTP status code.",
+    "optional" : true
+  }, {
+    "name" : "serviceErrorCode",
+    "type" : "int",
+    "doc" : "A service-specific error code.",
+    "optional" : true,
+    "deprecated" : "Deprecated - use the code field instead."
+  }, {
+    "name" : "code",
+    "type" : "string",
+    "doc" : "The canonical error code, e.g. for '400 Bad Request' it can be 'INPUT_VALIDATION_FAILED'. Only predefined codes should be used.",
+    "optional" : true
+  }, {
+    "name" : "message",
+    "type" : "string",
+    "doc" : "A human-readable explanation of the error.",
+    "optional" : true
+  }, {
+    "name" : "docUrl",
+    "type" : "string",
+    "doc" : "URL to a page that describes this particular error in more detail.",
+    "optional" : true
+  }, {
+    "name" : "requestId",
+    "type" : "string",
+    "doc" : "The unique identifier that would identify this error. For example, it can be used to identify requests in the service's logs.",
+    "optional" : true
+  }, {
+    "name" : "exceptionClass",
+    "type" : "string",
+    "doc" : "The FQCN of the exception thrown by the server.",
+    "optional" : true
+  }, {
+    "name" : "stackTrace",
+    "type" : "string",
+    "doc" : "The full stack trace of the exception thrown by the server.",
+    "optional" : true
+  }, {
+    "name" : "errorDetailType",
+    "type" : "string",
+    "doc" : "The type of the error detail model, e.g. com.example.api.BadRequest. Clients can use this field to identify the actual error detail schema.",
+    "optional" : true
+  }, {
+    "name" : "errorDetails",
+    "type" : {
+      "type" : "record",
+      "name" : "ErrorDetails",
+      "fields" : [ ]
+    },
+    "doc" : "This field should be used for communicating extra error details to clients.",
+    "optional" : true
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/ExtensionSchemaAnnotation.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/ExtensionSchemaAnnotation.pdsc
@@ -1,0 +1,25 @@
+{
+  "type" : "record",
+  "name" : "ExtensionSchemaAnnotation",
+  "namespace" : "com.linkedin.restli.common",
+  "doc" : "Specifies the extension schema annotation configuration for defining the entity relationship among entities.",
+  "fields" : [ {
+    "name" : "using",
+    "type" : "string",
+    "doc" : "Specifies only for one to many relationship. It can use either GET_ALL(\"get_all\") or a FINDER(\"finder:<method name>\").",
+    "optional" : true
+  }, {
+    "name" : "params",
+    "type" : {
+      "type" : "map",
+      "values" : "string"
+    },
+    "doc" : "Specifies parameters if any of them are specified. It is also used for FINDER.",
+    "optional" : true
+  }, {
+    "name" : "versionSuffix",
+    "type" : "string",
+    "doc" : "Specifies versionSuffix in multi-version scenario. If is is not provided, will pick first version by default.",
+    "optional" : true
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/Link.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/Link.pdsc
@@ -1,0 +1,19 @@
+{
+  "type" : "record",
+  "name" : "Link",
+  "namespace" : "com.linkedin.restli.common",
+  "doc" : "A atom:link-inspired link",
+  "fields" : [ {
+    "name" : "rel",
+    "type" : "string",
+    "doc" : "The link relation e.g. 'self' or 'next'"
+  }, {
+    "name" : "href",
+    "type" : "string",
+    "doc" : "The link URI"
+  }, {
+    "name" : "type",
+    "type" : "string",
+    "doc" : "The type (media type) of the resource"
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/PegasusSchema.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/PegasusSchema.pdsc
@@ -1,0 +1,7 @@
+{
+  "type" : "record",
+  "name" : "PegasusSchema",
+  "namespace" : "com.linkedin.restli.common",
+  "doc" : "A \"marker\" data schema for data that is itself a data schema (a \"PDSC for PDSCs\"). Because PDSC is not expressive enough to describe it's own format, this is only a marker, and has no fields. Despite having no fields, it is required that data marked with this schema be non-empty. Specifically, is required that data marked as using this schema fully conform to the PDSC format (https://github.com/linkedin/rest.li/wiki/DATA-Data-Schema-and-Templates#schema-definition).",
+  "fields" : [ ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/UpdateStatus.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/UpdateStatus.pdsc
@@ -1,0 +1,14 @@
+{
+  "type" : "record",
+  "name" : "UpdateStatus",
+  "namespace" : "com.linkedin.restli.common",
+  "doc" : "A rest.li update status.",
+  "fields" : [ {
+    "name" : "status",
+    "type" : "int"
+  }, {
+    "name" : "error",
+    "type" : "ErrorResponse",
+    "optional" : true
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/IndividualBody.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/IndividualBody.pdsc
@@ -1,0 +1,7 @@
+{
+  "type" : "record",
+  "name" : "IndividualBody",
+  "namespace" : "com.linkedin.restli.common.multiplexer",
+  "doc" : "Represents content that may be in the body of an individual request / response",
+  "fields" : [ ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/IndividualRequest.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/IndividualRequest.pdsc
@@ -1,0 +1,36 @@
+{
+  "type" : "record",
+  "name" : "IndividualRequest",
+  "namespace" : "com.linkedin.restli.common.multiplexer",
+  "doc" : "Individual HTTP request within a multiplexed request. For security reasons, cookies are not allowed to be specified in the IndividualRequest. Instead, it MUST be specified in the top level envelope request.",
+  "fields" : [ {
+    "name" : "method",
+    "type" : "string",
+    "doc" : "HTTP method name"
+  }, {
+    "name" : "headers",
+    "type" : {
+      "type" : "map",
+      "values" : "string"
+    },
+    "doc" : "HTTP headers specific to the individual request. All common headers should be specified in the top level envelope request. If IndividualRequest headers contain a header that is also specified in the top level envelope request, the header in the IndividualRequest will be used. In additions, for security reasons, headers in IndividualRequest are whitelisted. Only headers within the whitelist can be specified here.",
+    "default" : { }
+  }, {
+    "name" : "relativeUrl",
+    "type" : "string",
+    "doc" : "Relative URL of the request"
+  }, {
+    "name" : "body",
+    "type" : "IndividualBody",
+    "doc" : "Request body",
+    "optional" : true
+  }, {
+    "name" : "dependentRequests",
+    "type" : {
+      "type" : "map",
+      "values" : "IndividualRequest"
+    },
+    "doc" : "Requests that should be executed after the current request is processed (sequential ordering). Dependent requests are executed in parallel. Keys of the dependent requests are used to correlate responses with requests. They should be unique within the multiplexed request",
+    "default" : { }
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/IndividualResponse.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/IndividualResponse.pdsc
@@ -1,0 +1,24 @@
+{
+  "type" : "record",
+  "name" : "IndividualResponse",
+  "namespace" : "com.linkedin.restli.common.multiplexer",
+  "doc" : "Individual HTTP response within a multiplexed response",
+  "fields" : [ {
+    "name" : "status",
+    "type" : "int",
+    "doc" : "HTTP status code"
+  }, {
+    "name" : "headers",
+    "type" : {
+      "type" : "map",
+      "values" : "string"
+    },
+    "doc" : "HTTP headers",
+    "default" : { }
+  }, {
+    "name" : "body",
+    "type" : "IndividualBody",
+    "doc" : "Response body",
+    "optional" : true
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/MultiplexedRequestContent.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/MultiplexedRequestContent.pdsc
@@ -1,0 +1,14 @@
+{
+  "type" : "record",
+  "name" : "MultiplexedRequestContent",
+  "namespace" : "com.linkedin.restli.common.multiplexer",
+  "doc" : "Represents multiple HTTP requests to send as a single multiplexed HTTP request",
+  "fields" : [ {
+    "name" : "requests",
+    "type" : {
+      "type" : "map",
+      "values" : "IndividualRequest"
+    },
+    "doc" : "Individual HTTP requests executed in parallel.  Keys of the requests are used to correlate responses with requests. They should be unique within the multiplexed request"
+  } ]
+}

--- a/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/MultiplexedResponseContent.pdsc
+++ b/restli-common/src/main/resources/legacyPegasusSchemas/com/linkedin/restli/common/multiplexer/MultiplexedResponseContent.pdsc
@@ -1,0 +1,14 @@
+{
+  "type" : "record",
+  "name" : "MultiplexedResponseContent",
+  "namespace" : "com.linkedin.restli.common.multiplexer",
+  "doc" : "Represents multiple HTTP responses to send as a single multiplexed HTTP response",
+  "fields" : [ {
+    "name" : "responses",
+    "type" : {
+      "type" : "map",
+      "values" : "IndividualResponse"
+    },
+    "doc" : "Individual HTTP responses, where the key is Id of the corresponding individual request."
+  } ]
+}

--- a/restli-common/src/test/java/com/linkedin/restli/common/TestLegacyPdscEquivalence.java
+++ b/restli-common/src/test/java/com/linkedin/restli/common/TestLegacyPdscEquivalence.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2015 LinkedIn Corp.
+   Copyright (c) 2022 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -36,7 +36,9 @@ import org.testng.reporters.Files;
 
 
 /**
- * TODO: Remove this and PDSC field in resources permanently once translated PDSCs are no longer needed.
+ * We manually added translated PDSCs to be consistent with legacy PDSC JAR publishing behavior.
+ * This test is needed to ensure that PDLs and PDSCs models don't diverge.
+ * TODO: Remove this test and PDSC files in resources permanently once translated PDSCs are no longer needed.
  */
 public class TestLegacyPdscEquivalence
 {
@@ -51,7 +53,7 @@ public class TestLegacyPdscEquivalence
         (file) -> FilenameUtils.getExtension(file.getName()).equals(SchemaParser.FILETYPE))
         .stream()
         .collect(Collectors.toMap((file) -> FilenameUtils.removeExtension(file.getName()), file -> file));
-
+    Assert.assertFalse(pdscFiles.isEmpty(), "List of legacy PDSC files shouldn't be empty");
     DataSchemaParser dataSchemaParser = new DataSchemaParser.Builder(pdlSrcDir).build();
     Map<DataSchema, DataSchemaLocation> schemaLocationMap =
         dataSchemaParser.parseSources(new String[]{pdlSrcDir + "/com/linkedin/restli/common"}).getSchemaAndLocations();
@@ -67,7 +69,7 @@ public class TestLegacyPdscEquivalence
         pdscEncoder.encode(schemaEntry.getKey());
         String translatedPdsc = builder.result();
         Assert.assertEquals(translatedPdsc, Files.readFile(
-            pdscFiles.get(FilenameUtils.removeExtension(schemaEntry.getValue().getSourceFile().getName()))));
+            pdscFiles.get(FilenameUtils.removeExtension(schemaEntry.getValue().getSourceFile().getName()))).trim());
       }
     }
   }

--- a/restli-common/src/test/java/com/linkedin/restli/common/TestLegacyPdscEquivalence.java
+++ b/restli-common/src/test/java/com/linkedin/restli/common/TestLegacyPdscEquivalence.java
@@ -1,0 +1,74 @@
+/*
+   Copyright (c) 2015 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.restli.common;
+
+import com.linkedin.data.schema.AbstractSchemaEncoder;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.DataSchemaLocation;
+import com.linkedin.data.schema.JsonBuilder;
+import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.SchemaParser;
+import com.linkedin.data.schema.SchemaToJsonEncoder;
+import com.linkedin.pegasus.generator.DataSchemaParser;
+import com.linkedin.util.FileUtil;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FilenameUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.reporters.Files;
+
+
+/**
+ * TODO: Remove this and PDSC field in resources permanently once translated PDSCs are no longer needed.
+ */
+public class TestLegacyPdscEquivalence
+{
+  private final String pdlSrcDir = System.getProperty("srcDir", "src/main") + "/pegasus";
+  private final File legacyPdscDir =
+      new File(System.getProperty("resourcesDir", "src/main/resources") + "/legacyPegasusSchemas");
+
+  @Test
+  public void testPdscEquivalence() throws IOException
+  {
+    final Map<String, File> pdscFiles = FileUtil.listFiles(legacyPdscDir,
+        (file) -> FilenameUtils.getExtension(file.getName()).equals(SchemaParser.FILETYPE))
+        .stream()
+        .collect(Collectors.toMap((file) -> FilenameUtils.removeExtension(file.getName()), file -> file));
+
+    DataSchemaParser dataSchemaParser = new DataSchemaParser.Builder(pdlSrcDir).build();
+    Map<DataSchema, DataSchemaLocation> schemaLocationMap =
+        dataSchemaParser.parseSources(new String[]{pdlSrcDir + "/com/linkedin/restli/common"}).getSchemaAndLocations();
+    for (Map.Entry<DataSchema, DataSchemaLocation> schemaEntry : schemaLocationMap.entrySet())
+    {
+      String pdlFileName = FilenameUtils.removeExtension(schemaEntry.getValue().getSourceFile().getName());
+      if (schemaEntry.getKey() instanceof NamedDataSchema && pdlFileName.equals(
+          ((NamedDataSchema) schemaEntry.getKey()).getName()))
+      {
+        JsonBuilder builder = new JsonBuilder(JsonBuilder.Pretty.INDENTED);
+        SchemaToJsonEncoder pdscEncoder =
+            new SchemaToJsonEncoder(builder, AbstractSchemaEncoder.TypeReferenceFormat.PRESERVE);
+        pdscEncoder.encode(schemaEntry.getKey());
+        String translatedPdsc = builder.result();
+        Assert.assertEquals(translatedPdsc, Files.readFile(
+            pdscFiles.get(FilenameUtils.removeExtension(schemaEntry.getValue().getSourceFile().getName()))));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is required since PDSCs are still used in web products and Restli common models jar only packed PDL files. 
This PR manually adds translated PDSC files to the restli-common module as the auto-translation task can't be added due to the circular dependency of restli-tools on restli-common.