### PR TITLE
Add support for r2 Netty client DNS metrics, and clarify timeout errors for DNS timeouts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.39.4] - 2022-09-30
+Add JMX metrics for DNS resolution and clarify DNS timeout errors.
+
 ## [29.39.3] - 2022-09-26
 Catch exceptions when zk connection state change event is received after zk connection shutdown.
 
@@ -5356,7 +5359,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.4...master
+[29.39.4]: https://github.com/linkedin/rest.li/compare/v29.39.3...v29.39.4
 [29.39.3]: https://github.com/linkedin/rest.li/compare/v29.39.2...v29.39.3
 [29.39.2]: https://github.com/linkedin/rest.li/compare/v29.39.1...v29.39.2
 [29.39.1]: https://github.com/linkedin/rest.li/compare/v29.39.0...v29.39.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.39.3
+version=29.39.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/HttpNettyClient.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/HttpNettyClient.java
@@ -18,6 +18,9 @@ package com.linkedin.r2.netty.client;
 
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.callback.MultiCallback;
+import com.linkedin.common.stats.LongStats;
+import com.linkedin.common.stats.LongTracker;
+import com.linkedin.common.stats.LongTracking;
 import com.linkedin.common.util.None;
 import com.linkedin.r2.filter.R2Constants;
 import com.linkedin.r2.message.Messages;
@@ -32,10 +35,10 @@ import com.linkedin.r2.message.timing.TimingContextUtil;
 import com.linkedin.r2.message.timing.TimingImportance;
 import com.linkedin.r2.message.timing.TimingKey;
 import com.linkedin.r2.netty.callback.StreamExecutionCallback;
-import com.linkedin.r2.netty.common.StreamingTimeout;
 import com.linkedin.r2.netty.common.NettyChannelAttributes;
 import com.linkedin.r2.netty.common.NettyClientState;
 import com.linkedin.r2.netty.common.ShutdownTimeoutException;
+import com.linkedin.r2.netty.common.StreamingTimeout;
 import com.linkedin.r2.netty.common.UnknownSchemeException;
 import com.linkedin.r2.netty.handler.common.SslHandshakeTimingHandler;
 import com.linkedin.r2.transport.common.MessageType;
@@ -75,6 +78,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -108,6 +112,10 @@ public class HttpNettyClient implements TransportClient
   private final String _udsAddress;
 
   private final AtomicReference<NettyClientState> _state;
+
+  private final AtomicLong _dnsResolutionErrors = new AtomicLong(0);
+  private final AtomicLong _dnsResolutions = new AtomicLong(0);
+  private final LongTracker _dnsResolutionLatency = new LongTracking();
 
   @Deprecated
   public HttpNettyClient(
@@ -318,7 +326,8 @@ public class HttpNettyClient implements TransportClient
     // responsibility of invoking the callback is handed over to the pipeline.
     final Timeout<None> timeout = new Timeout<>(_scheduler, resolvedRequestTimeout, TimeUnit.MILLISECONDS, None.none());
     timeout.addTimeoutTask(() -> decoratedCallback.onResponse(TransportResponseImpl.error(
-        new TimeoutException("Exceeded request timeout of " + resolvedRequestTimeout + "ms"))));
+        new TimeoutException("Exceeded request timeout of " + resolvedRequestTimeout + "ms" +
+            (requestContext.getLocalAttr(R2Constants.REMOTE_SERVER_ADDR) == null ? " (timeout during DNS resolution)" : "")))));
 
     // resolve address
     final SocketAddress address;
@@ -326,9 +335,13 @@ public class HttpNettyClient implements TransportClient
     if (StringUtils.isEmpty(_udsAddress)) {
       try {
         TimingContextUtil.markTiming(requestContext, TIMING_KEY);
+        _dnsResolutions.incrementAndGet();
+        long startTime = _clock.currentTimeMillis();
         address = resolveAddress(request, requestContext);
+        _dnsResolutionLatency.addValue(_clock.currentTimeMillis() - startTime);
         TimingContextUtil.markTiming(requestContext, TIMING_KEY);
       } catch (Exception e) {
+        _dnsResolutionErrors.incrementAndGet();
         decoratedCallback.onResponse(TransportResponseImpl.error(e));
         return;
       }
@@ -586,12 +599,22 @@ public class HttpNettyClient implements TransportClient
       port = HTTP_SCHEME.equalsIgnoreCase(scheme) ? HTTP_DEFAULT_PORT : HTTPS_DEFAULT_PORT;
     }
 
-    // TODO investigate DNS resolution and timing
     final InetAddress inetAddress = InetAddress.getByName(host);
+
     final SocketAddress address = new InetSocketAddress(inetAddress, port);
     requestContext.putLocalAttr(R2Constants.REMOTE_SERVER_ADDR, inetAddress.getHostAddress());
     requestContext.putLocalAttr(R2Constants.REMOTE_SERVER_PORT, port);
 
     return address;
+  }
+
+  public long getDnsResolutions() { return _dnsResolutions.get(); }
+
+  public long getDnsResolutionErrors() {
+    return _dnsResolutionErrors.get();
+  }
+
+  public LongStats getDnsResolutionLatency() {
+    return _dnsResolutionLatency.getStats();
   }
 }

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/HttpNettyClientJmx.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/HttpNettyClientJmx.java
@@ -1,0 +1,44 @@
+/*
+   Copyright (c) 2019 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.r2.netty.client;
+
+import com.linkedin.common.stats.LongStats;
+
+
+public class HttpNettyClientJmx implements HttpNettyClientJmxMBean {
+  private HttpNettyClient _client;
+
+  public HttpNettyClientJmx(HttpNettyClient client)
+  {
+    _client = client;
+  }
+
+  @Override
+  public long getDnsResolutions() {
+    return _client.getDnsResolutions();
+  }
+
+  @Override
+  public long getDnsResolutionErrors() {
+    return _client.getDnsResolutionErrors();
+  }
+
+  @Override
+  public LongStats getDnsResolutionLatency() {
+    return _client.getDnsResolutionLatency();
+  }
+}

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/HttpNettyClientJmxMBean.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/HttpNettyClientJmxMBean.java
@@ -1,0 +1,28 @@
+/*
+   Copyright (c) 2019 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.r2.netty.client;
+
+import com.linkedin.common.stats.LongStats;
+
+
+public interface HttpNettyClientJmxMBean {
+  long getDnsResolutions();
+
+  long getDnsResolutionErrors();
+
+  LongStats getDnsResolutionLatency();
+}


### PR DESCRIPTION
There can be a misleading situation where DNS resolution is timing out due to host system DNS issues, which present as request timeouts in the error messages. In these situations the request is actually never made, since the DNS resolution is done within the same timeout boundaries as the request. This will clarify the error messages and also makes it possible to use JMX metrics to track DNS latency.