### PR TITLE
Serialize ZK data with non-null fields only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.4] - 2022-07-25
+- Serialize ZK data with non-null fields only 
+
 ## [29.37.3] - 2022-07-18
 - Add connection warm up support when a failout has been initiated
 
@@ -5273,7 +5276,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.4...master
+[29.37.4]: https://github.com/linkedin/rest.li/compare/v29.37.3...v29.37.4
 [29.37.3]: https://github.com/linkedin/rest.li/compare/v29.37.2...v29.37.3
 [29.37.2]: https://github.com/linkedin/rest.li/compare/v29.37.1...v29.37.2
 [29.37.1]: https://github.com/linkedin/rest.li/compare/v29.37.0...v29.37.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterStoreProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterStoreProperties.java
@@ -16,8 +16,8 @@
 
 package com.linkedin.d2.balancer.properties;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
-import com.linkedin.d2.balancer.properties.FailoutProperties;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,6 +36,7 @@ import java.util.Set;
  * how Jackson would serialize the object (for instance, using different key names), and
  * that will cause problems in serialization/deserialization.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL) // NOTE: fields with null values will NOT be serialized (won't be included in ZK data)
 public class ClusterStoreProperties extends ClusterProperties
 {
   protected final ClusterProperties _canaryConfigs;

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceStoreProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceStoreProperties.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.balancer.properties;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategy;
 import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
 import java.net.URI;
@@ -34,6 +35,7 @@ import java.util.Set;
  * certain objects are serialized differently than how Jackson would serialize the object (for instance, using different key names), and
  * that will cause problems in serialization/deserialization.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL) // NOTE: fields with null values will NOT be serialized (won't be included in ZK data)
 public class ServiceStoreProperties extends ServiceProperties
 {
   protected final ServiceProperties _canaryConfigs;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.3
+version=29.37.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
D2 clients with deprecated pegasus versions, `[29.22.12 to 29.30.0] inclusive`, will crash when reading ZK data pushed by `d2-config-service 3.x`, which includes canary configs fields but with null values when there is no canary configs. 

Many client apps are still on the deprecated versions, so we will modify the ZK serializers (both cluster and service) to only include non-null fields in ZK data. 

Please also see related d2-config-service RB which uses these new serializers and did integration tests to verify ZK data.