### PR TITLE
Avoid using SmileFactoryBuilder to be more compatible with pre 2.10 jackson at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.11] - 2022-08-09
+- Avoid using SmileFactoryBuilder to be more compatible with pre 2.10 jackson at runtime
+
 ## [29.37.10] - 2022-08-08
 - Fix PrimitiveTemplateSpec not having className
 
@@ -5294,7 +5297,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.11...master
+[29.37.11]: https://github.com/linkedin/rest.li/compare/v29.37.10...v29.37.11
 [29.37.10]: https://github.com/linkedin/rest.li/compare/v29.37.9...v29.37.10
 [29.37.9]: https://github.com/linkedin/rest.li/compare/v29.37.8...v29.37.9
 [29.37.8]: https://github.com/linkedin/rest.li/compare/v29.37.7...v29.37.8

--- a/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonSmileStreamDataCodec.java
+++ b/data/src/main/java/com/linkedin/data/codec/entitystream/JacksonSmileStreamDataCodec.java
@@ -18,7 +18,6 @@
 package com.linkedin.data.codec.entitystream;
 
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
-import com.fasterxml.jackson.dataformat.smile.SmileFactoryBuilder;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import com.linkedin.data.ByteString;
 import com.linkedin.data.DataList;
@@ -47,13 +46,16 @@ public class JacksonSmileStreamDataCodec implements StreamDataCodec
     _smileFactory.enable(SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES);
   }
 
-  public JacksonSmileStreamDataCodec(SmileFactory base, int bufferSize)
+  @SuppressWarnings("deprecation")
+  public JacksonSmileStreamDataCodec(SmileFactory smileFactory, int bufferSize)
   {
-    SmileFactoryBuilder smileFactoryBuilder = new SmileFactoryBuilder(base);
-    // Always disable field name interning.
-    smileFactoryBuilder.configure(SmileFactory.Feature.INTERN_FIELD_NAMES, false);
-    _smileFactory = smileFactoryBuilder.build();
+    _smileFactory = smileFactory;
     _bufferSize = bufferSize;
+
+    // String interning is disabled by default since it causes GC issues. Note that we are using the deprecated disable
+    // method instead of JsonFactoryBuilder here preserves compatibility with some runtimes that pin jackson to a
+    // lower 2.x version. The method should still be available throughout jackson-core 2.x
+    _smileFactory.disable(SmileFactory.Feature.INTERN_FIELD_NAMES);
   }
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.10
+version=29.37.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Found another usage of a Jackson FactoryBuilder that causes some issues
for clients that pin jackson to an older version at runtime.

This PR is similar to #803 