### PR TITLE
Ensure skip deprecation config is only applied to the direct input schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.8] - 2022-08-04
+- Switch to use name regex pattern to skip deprecated fields in spec generation
+
 ## [29.37.7] - 2022-08-03
 - Bugfix: mark a dark request as sent if it is sent to any dark clusters
 
@@ -5285,7 +5288,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.8...master
+[29.37.8]: https://github.com/linkedin/rest.li/compare/v29.37.7...v29.37.8
 [29.37.7]: https://github.com/linkedin/rest.li/compare/v29.37.6...v29.37.7
 [29.37.6]: https://github.com/linkedin/rest.li/compare/v29.37.5...v29.37.6
 [29.37.5]: https://github.com/linkedin/rest.li/compare/v29.37.4...v29.37.5

--- a/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
@@ -140,7 +140,6 @@ public class TemplateSpecGenerator
    * Generate {@link ClassTemplateSpec} from the specified {@link DataSchema} and its location.
    *
    * @param skipDeprecatedField flag to indicate whether to skip spec generation for deprecated fields, their types and referenced types.
-   *                            This behavior affect the spec generation recursively.
    */
   public ClassTemplateSpec generate(DataSchema schema, DataSchemaLocation location, boolean skipDeprecatedField)
   {
@@ -756,18 +755,18 @@ public class TemplateSpecGenerator
     final List<NamedDataSchema> includes = schema.getInclude();
     for (NamedDataSchema includedSchema : includes)
     {
-      processSchema(includedSchema, null, null, skipDeprecatedField);
+      processSchema(includedSchema, null, null, false);
     }
 
     final Map<CustomInfoSpec, Object> customInfoMap = new IdentityHashMap<>(schema.getFields().size() * 2);
 
     for (RecordDataSchema.Field field : schema.getFields())
     {
-      // If skipDeprecatedField is set, spec generator will recursively skip deprecated field, its type and types referenced within this type
+      // If skipDeprecatedField is set, spec generator will skip deprecated field, its type and types referenced within this type
       if (skipDeprecatedField && isDeprecated(field)) {
         continue;
       }
-      final ClassTemplateSpec fieldClass = processSchema(field.getType(), recordClass, field.getName(), skipDeprecatedField);
+      final ClassTemplateSpec fieldClass = processSchema(field.getType(), recordClass, field.getName(), false);
       final RecordTemplateSpec.Field newField = new RecordTemplateSpec.Field();
       newField.setSchemaField(field);
       newField.setType(fieldClass);

--- a/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/TemplateSpecGenerator.java
@@ -48,6 +48,7 @@ import com.linkedin.util.CustomTypeUtil;
 
 import java.io.File;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
@@ -56,6 +57,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,6 +102,11 @@ public class TemplateSpecGenerator
   private final String _customTypeLanguage;
   private final String _templatePackageName;
 
+  /**
+   * List of regex pattern of schema full names to identify which schema need to skip deprecated fields when generating its spec.
+   */
+  private final List<Pattern> _skipDeprecatedPatterns  = new ArrayList<>();
+
   public TemplateSpecGenerator(DataSchemaResolver schemaResolver)
   {
     this(schemaResolver, CustomTypeUtil.JAVA_PROPERTY, DataTemplate.class.getPackage().getName());
@@ -137,14 +145,14 @@ public class TemplateSpecGenerator
   }
 
   /**
-   * Generate {@link ClassTemplateSpec} from the specified {@link DataSchema} and its location.
-   *
-   * @param skipDeprecatedField flag to indicate whether to skip spec generation for deprecated fields, their types and referenced types.
+   * Do not use this deprecated method. If need to skip deprecated field when generating specs, please use setSkipDeprecatedPatterns
+   * and generate(DataSchema schema, DataSchemaLocation location) instead.
    */
+  @Deprecated
   public ClassTemplateSpec generate(DataSchema schema, DataSchemaLocation location, boolean skipDeprecatedField)
   {
     pushCurrentLocation(location);
-    final ClassTemplateSpec result = processSchema(schema, null, null, skipDeprecatedField);
+    final ClassTemplateSpec result = processSchema(schema, null, null);
     popCurrentLocation();
     return result;
   }
@@ -152,6 +160,16 @@ public class TemplateSpecGenerator
   public Collection<ClassTemplateSpec> getGeneratedSpecs()
   {
     return _classTemplateSpecs;
+  }
+
+  /**
+   * Set the regex name patterns for schemas which needs to skip deprecated fields when generating the specs
+   *
+   * @param skipDeprecatedPatterns list of regex name patterns to be set. They will be used to match full name of schemas.
+   */
+  public void setSkipDeprecatedPatterns(@Nonnull List<Pattern> skipDeprecatedPatterns) {
+    _skipDeprecatedPatterns.clear();
+    _skipDeprecatedPatterns.addAll(skipDeprecatedPatterns);
   }
 
   /**
@@ -324,7 +342,7 @@ public class TemplateSpecGenerator
     _classTemplateSpecs.add(classTemplateSpec);
   }
 
-  private ClassTemplateSpec processSchema(DataSchema schema, ClassTemplateSpec enclosingClass, String memberName, boolean skipDeprecatedField)
+  private ClassTemplateSpec processSchema(DataSchema schema, ClassTemplateSpec enclosingClass, String memberName)
   {
     final CustomInfoSpec customInfo = getImmediateCustomInfo(schema);
     ClassTemplateSpec result = null;
@@ -343,7 +361,7 @@ public class TemplateSpecGenerator
       schema = typerefSchema.getRef();
       if (schema.getType() == DataSchema.Type.UNION)
       {
-        result = (found != null) ? found : generateUnion((UnionDataSchema) schema, typerefSchema, skipDeprecatedField);
+        result = (found != null) ? found : generateUnion((UnionDataSchema) schema, typerefSchema);
         break;
       }
       else if (found == null)
@@ -363,11 +381,11 @@ public class TemplateSpecGenerator
         {
           if (schema instanceof NamedDataSchema)
           {
-            result = generateNamedSchema((NamedDataSchema) schema, skipDeprecatedField);
+            result = generateNamedSchema((NamedDataSchema) schema);
           }
           else
           {
-            result = generateUnnamedComplexSchema(schema, enclosingClass, memberName, skipDeprecatedField);
+            result = generateUnnamedComplexSchema(schema, enclosingClass, memberName);
           }
         }
         else
@@ -498,7 +516,7 @@ public class TemplateSpecGenerator
     throw unrecognizedSchemaType(enclosingClass, memberName, schema);
   }
 
-  private ClassTemplateSpec generateNamedSchema(NamedDataSchema schema, boolean skipDeprecatedField)
+  private ClassTemplateSpec generateNamedSchema(NamedDataSchema schema)
   {
     pushCurrentLocation(_schemaResolver.nameToDataSchemaLocations().get(schema.getFullName()));
 
@@ -510,7 +528,7 @@ public class TemplateSpecGenerator
     switch (schema.getType())
     {
       case RECORD:
-        templateClass = generateRecord((RecordDataSchema) schema, skipDeprecatedField);
+        templateClass = generateRecord((RecordDataSchema) schema);
         break;
       case ENUM:
         templateClass = generateEnum((EnumDataSchema) schema);
@@ -527,19 +545,19 @@ public class TemplateSpecGenerator
     return templateClass;
   }
 
-  private ClassTemplateSpec generateUnnamedComplexSchema(DataSchema schema, ClassTemplateSpec enclosingClass, String memberName, boolean skipDeprecatedField)
+  private ClassTemplateSpec generateUnnamedComplexSchema(DataSchema schema, ClassTemplateSpec enclosingClass, String memberName)
   {
     if (schema instanceof ArrayDataSchema)
     {
-      return generateArray((ArrayDataSchema) schema, enclosingClass, memberName, skipDeprecatedField);
+      return generateArray((ArrayDataSchema) schema, enclosingClass, memberName);
     }
     else if (schema instanceof MapDataSchema)
     {
-      return generateMap((MapDataSchema) schema, enclosingClass, memberName, skipDeprecatedField);
+      return generateMap((MapDataSchema) schema, enclosingClass, memberName);
     }
     else if (schema instanceof UnionDataSchema)
     {
-      return generateUnion((UnionDataSchema) schema, enclosingClass, memberName, skipDeprecatedField);
+      return generateUnion((UnionDataSchema) schema, enclosingClass, memberName);
     }
     else
     {
@@ -566,7 +584,7 @@ public class TemplateSpecGenerator
     return result;
   }
 
-  private ArrayTemplateSpec generateArray(ArrayDataSchema schema, ClassTemplateSpec enclosingClass, String memberName, boolean skipDeprecatedField)
+  private ArrayTemplateSpec generateArray(ArrayDataSchema schema, ClassTemplateSpec enclosingClass, String memberName)
   {
     final DataSchema itemSchema = schema.getItems();
 
@@ -579,7 +597,7 @@ public class TemplateSpecGenerator
        * schema processing is necessary in order to processSchema the data template classes for those type
        * refs.
        */
-      processSchema(itemSchema, enclosingClass, memberName, skipDeprecatedField);
+      processSchema(itemSchema, enclosingClass, memberName);
 
       return (ArrayTemplateSpec) classInfo.existingClass;
     }
@@ -587,7 +605,7 @@ public class TemplateSpecGenerator
     final ArrayTemplateSpec arrayClass = (ArrayTemplateSpec) classInfo.definedClass;
     registerClassTemplateSpec(schema, arrayClass);
 
-    arrayClass.setItemClass(processSchema(itemSchema, enclosingClass, memberName, skipDeprecatedField));
+    arrayClass.setItemClass(processSchema(itemSchema, enclosingClass, memberName));
     arrayClass.setItemDataClass(determineDataClass(itemSchema, enclosingClass, memberName));
 
     final CustomInfoSpec customInfo = getImmediateCustomInfo(itemSchema);
@@ -596,7 +614,7 @@ public class TemplateSpecGenerator
     return arrayClass;
   }
 
-  private MapTemplateSpec generateMap(MapDataSchema schema, ClassTemplateSpec enclosingClass, String memberName, boolean skipDeprecatedField)
+  private MapTemplateSpec generateMap(MapDataSchema schema, ClassTemplateSpec enclosingClass, String memberName)
   {
     final DataSchema valueSchema = schema.getValues();
 
@@ -609,7 +627,7 @@ public class TemplateSpecGenerator
        * schema processing is necessary in order to processSchema the data template classes for those type
        * refs.
        */
-      processSchema(valueSchema, enclosingClass, memberName, skipDeprecatedField);
+      processSchema(valueSchema, enclosingClass, memberName);
 
       return (MapTemplateSpec) classInfo.existingClass;
     }
@@ -617,7 +635,7 @@ public class TemplateSpecGenerator
     final MapTemplateSpec mapClass = (MapTemplateSpec) classInfo.definedClass;
     registerClassTemplateSpec(schema, mapClass);
 
-    mapClass.setValueClass(processSchema(valueSchema, enclosingClass, memberName, skipDeprecatedField));
+    mapClass.setValueClass(processSchema(valueSchema, enclosingClass, memberName));
     mapClass.setValueDataClass(determineDataClass(valueSchema, enclosingClass, memberName));
 
     final CustomInfoSpec customInfo = getImmediateCustomInfo(valueSchema);
@@ -626,7 +644,7 @@ public class TemplateSpecGenerator
     return mapClass;
   }
 
-  private UnionTemplateSpec generateUnion(UnionDataSchema schema, ClassTemplateSpec enclosingClass, String memberName, boolean skipDeprecatedField)
+  private UnionTemplateSpec generateUnion(UnionDataSchema schema, ClassTemplateSpec enclosingClass, String memberName)
   {
     if (enclosingClass == null || memberName == null)
     {
@@ -639,10 +657,10 @@ public class TemplateSpecGenerator
     }
     final UnionTemplateSpec unionClass = (UnionTemplateSpec) classInfo.definedClass;
     registerClassTemplateSpec(schema, unionClass);
-    return generateUnion(schema, unionClass, skipDeprecatedField);
+    return generateUnion(schema, unionClass);
   }
 
-  private ClassTemplateSpec generateUnion(UnionDataSchema schema, TyperefDataSchema typerefDataSchema, boolean skipDeprecatedField)
+  private ClassTemplateSpec generateUnion(UnionDataSchema schema, TyperefDataSchema typerefDataSchema)
   {
     assert typerefDataSchema.getRef() == schema;
 
@@ -660,14 +678,14 @@ public class TemplateSpecGenerator
     typerefInfoClass.setClassName("UnionTyperefInfo");
     typerefInfoClass.setModifiers(ModifierSpec.PRIVATE, ModifierSpec.STATIC, ModifierSpec.FINAL);
 
-    final UnionTemplateSpec result = generateUnion(schema, unionClass, skipDeprecatedField);
+    final UnionTemplateSpec result = generateUnion(schema, unionClass);
     result.setTyperefClass(typerefInfoClass);
 
     popCurrentLocation();
     return result;
   }
 
-  private UnionTemplateSpec generateUnion(UnionDataSchema schema, UnionTemplateSpec unionClass, boolean skipDeprecatedField)
+  private UnionTemplateSpec generateUnion(UnionDataSchema schema, UnionTemplateSpec unionClass)
   {
     final Map<CustomInfoSpec, Object> customInfoMap = new IdentityHashMap<>(schema.getMembers().size() * 2);
 
@@ -683,7 +701,7 @@ public class TemplateSpecGenerator
 
       if (memberType.getDereferencedType() != DataSchema.Type.NULL)
       {
-        newMember.setClassTemplateSpec(processSchema(memberType, unionClass, memberType.getUnionMemberKey(), skipDeprecatedField));
+        newMember.setClassTemplateSpec(processSchema(memberType, unionClass, memberType.getUnionMemberKey()));
         newMember.setDataClass(determineDataClass(memberType, unionClass, memberType.getUnionMemberKey()));
         final CustomInfoSpec customInfo = getImmediateCustomInfo(memberType);
         if (customInfo != null)
@@ -741,7 +759,7 @@ public class TemplateSpecGenerator
     return typerefClass;
   }
 
-  private RecordTemplateSpec generateRecord(RecordDataSchema schema, boolean skipDeprecatedField)
+  private RecordTemplateSpec generateRecord(RecordDataSchema schema)
   {
     final RecordTemplateSpec recordClass = new RecordTemplateSpec(schema);
     recordClass.setNamespace(schema.getNamespace());
@@ -755,18 +773,19 @@ public class TemplateSpecGenerator
     final List<NamedDataSchema> includes = schema.getInclude();
     for (NamedDataSchema includedSchema : includes)
     {
-      processSchema(includedSchema, null, null, false);
+      processSchema(includedSchema, null, null);
     }
 
     final Map<CustomInfoSpec, Object> customInfoMap = new IdentityHashMap<>(schema.getFields().size() * 2);
 
+    boolean skipDeprecatedField = shouldSkipDeprecatedFields(schema);
     for (RecordDataSchema.Field field : schema.getFields())
     {
       // If skipDeprecatedField is set, spec generator will skip deprecated field, its type and types referenced within this type
       if (skipDeprecatedField && isDeprecated(field)) {
         continue;
       }
-      final ClassTemplateSpec fieldClass = processSchema(field.getType(), recordClass, field.getName(), false);
+      final ClassTemplateSpec fieldClass = processSchema(field.getType(), recordClass, field.getName());
       final RecordTemplateSpec.Field newField = new RecordTemplateSpec.Field();
       newField.setSchemaField(field);
       newField.setType(fieldClass);
@@ -808,6 +827,10 @@ public class TemplateSpecGenerator
     } else {
       return false;
     }
+  }
+
+  public boolean shouldSkipDeprecatedFields(NamedDataSchema dataSchema) {
+    return _skipDeprecatedPatterns.stream().anyMatch(pattern -> pattern.matcher(dataSchema.getFullName()).matches());
   }
 
   /*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.7
+version=29.37.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Skip deprecation config will only remain in the direct input schema and not passed down recursively. This is to ensure there is no conflict behavior in common shared models between difference schema.