### PR TITLE
Support removing cluster watches after failout is over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.7] - 2022-08-02
+- Support removing cluster watches created due to cluster failout
+
 ## [29.37.6] - 2022-07-28
 - Bump ZooKeeper client version to [3.7.1](https://zookeeper.apache.org/releases.html#releasenotes) (latest stable version at the time).
 
@@ -5282,7 +5285,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.7...master
+[29.37.7]: https://github.com/linkedin/rest.li/compare/v29.37.6...v29.37.7
 [29.37.6]: https://github.com/linkedin/rest.li/compare/v29.37.5...v29.37.6
 [29.37.5]: https://github.com/linkedin/rest.li/compare/v29.37.4...v29.37.5
 [29.37.4]: https://github.com/linkedin/rest.li/compare/v29.37.3...v29.37.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
@@ -76,12 +76,9 @@ public interface LoadBalancerState
   /**
    * Stops listening to a cluster
    * @param clusterName the cluster to stop listening to.
-   * @return true if listeners successfully stopped.
+   * @param callback callback to be invoked after stopped listening to the cluster.
    */
-  default boolean stopListenToCluster(String clusterName)
-  {
-    return false;
-  }
+  default void stopListenToCluster(String clusterName, LoadBalancerStateListenerCallback callback) {}
 
   void start(Callback<None> callback);
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
@@ -73,6 +73,16 @@ public interface LoadBalancerState
 
   void listenToCluster(String clusterName, LoadBalancerStateListenerCallback callback);
 
+  /**
+   * Stops listening to a cluster
+   * @param clusterName the cluster to stop listening to.
+   * @return true if listeners successfully stopped.
+   */
+  default boolean stopListenToCluster(String clusterName)
+  {
+    return false;
+  }
+
   void start(Callback<None> callback);
 
   void shutdown(PropertyEventShutdownCallback shutdown);

--- a/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterConnectionWarmUpHandler.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterConnectionWarmUpHandler.java
@@ -29,6 +29,11 @@ public interface FailedoutClusterConnectionWarmUpHandler
   void warmUpConnections(@Nonnull String clusterName, @Nullable FailoutConfig config);
 
   /**
+   * Cancels any pending requests to the given cluster.
+   */
+  default void cancelPendingRequests(@Nonnull String clusterName) {}
+
+  /**
    * Shuts down this handler.
    */
   void shutdown();

--- a/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterManager.java
@@ -95,7 +95,8 @@ public class FailedoutClusterManager
 
   public void shutdown()
   {
-    if (_connectionWarmUpHandler != null) {
+    if (_connectionWarmUpHandler != null)
+    {
       _connectionWarmUpHandler.shutdown();
     }
   }
@@ -164,11 +165,13 @@ public class FailedoutClusterManager
     }
     for (final String cluster : clustersToWatch)
     {
-      _peerWatches.computeIfAbsent(cluster, clusterName -> {
+      _peerWatches.computeIfAbsent(cluster, clusterName ->
+      {
         boolean watchExistsBeforeFailout = _loadBalancerState.isListeningToCluster(clusterName);
         PeerWatchState peerWatchState = new PeerWatchState(watchExistsBeforeFailout);
 
-        LoadBalancerStateListenerCallback listenerCallback = (type, name) -> {
+        LoadBalancerStateListenerCallback listenerCallback = (type, name) ->
+        {
           if (_connectionWarmUpHandler != null)
           {
             _log.debug("Warming up connections to: " + cluster);
@@ -192,7 +195,8 @@ public class FailedoutClusterManager
     for (String cluster : clustersToRemove)
     {
       final PeerWatchState peerWatchState = _peerWatches.remove(cluster);
-      if (peerWatchState == null) {
+      if (peerWatchState == null)
+      {
         continue;
       }
       if (_connectionWarmUpHandler != null)

--- a/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterManager.java
@@ -22,6 +22,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -40,16 +42,22 @@ public class FailedoutClusterManager
   private static final Logger _log = LoggerFactory.getLogger(FailedoutClusterManager.class);
   private final String _clusterName;
   private final LoadBalancerState _loadBalancerState;
-  private final ConcurrentMap<String, LoadBalancerStateListenerCallback> _clusterListenerCallbacks = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, PeerWatchState> _peerWatches = new ConcurrentHashMap<>();
   private final FailedoutClusterConnectionWarmUpHandler _connectionWarmUpHandler;
+  private final long _peerWatchTeardownDelayMs;
+  private final ScheduledExecutorService _scheduledExecutorService;
   private FailoutConfig _failoutConfig;
 
   public FailedoutClusterManager(@Nonnull String clusterName, @Nonnull LoadBalancerState loadBalancerState,
-                                 @Nullable FailedoutClusterConnectionWarmUpHandler connectionWarmUpHandler)
+                                 @Nullable FailedoutClusterConnectionWarmUpHandler connectionWarmUpHandler,
+                                 long peerWatchTeardownDelayMs,
+                                 @Nullable ScheduledExecutorService scheduledExecutorService)
   {
     _clusterName = clusterName;
     _loadBalancerState = loadBalancerState;
     _connectionWarmUpHandler = connectionWarmUpHandler;
+    _peerWatchTeardownDelayMs = peerWatchTeardownDelayMs;
+    _scheduledExecutorService = scheduledExecutorService;
   }
 
   public String getClusterName()
@@ -68,10 +76,13 @@ public class FailedoutClusterManager
 
   /**
    * Updates to a new failout config version.
-   * @param failoutConfig The new failout config. Null when there is not active failout associated with the cluster.
+   * @param failoutConfig The new failout config. Null when there is no active failout associated with the cluster.
    */
   public void updateFailoutConfig(@Nullable FailoutConfig failoutConfig)
   {
+    // Updating config first so that clients will get the latest config while we are processing the updates.
+    _failoutConfig = failoutConfig;
+
     if (failoutConfig == null)
     {
       removePeerClusterWatches();
@@ -80,8 +91,6 @@ public class FailedoutClusterManager
     {
       processNewConfig(failoutConfig);
     }
-
-    _failoutConfig = failoutConfig;
   }
 
   public void shutdown()
@@ -114,7 +123,7 @@ public class FailedoutClusterManager
    */
   void addPeerClusterWatches(@Nonnull Set<String> newPeerClusters, @Nonnull FailoutConfig failoutConfig)
   {
-    final Set<String> existingPeerClusters = _clusterListenerCallbacks.keySet();
+    final Set<String> existingPeerClusters = _peerWatches.keySet();
 
     if (newPeerClusters.isEmpty())
     {
@@ -144,7 +153,7 @@ public class FailedoutClusterManager
    */
   void removePeerClusterWatches()
   {
-    removeClusterWatches(_clusterListenerCallbacks.keySet());
+    removeClusterWatches(_peerWatches.keySet());
   }
 
   private void addClusterWatches(@Nonnull Set<String> clustersToWatch, @Nonnull FailoutConfig failoutConfig)
@@ -155,16 +164,21 @@ public class FailedoutClusterManager
     }
     for (final String cluster : clustersToWatch)
     {
-      _clusterListenerCallbacks.computeIfAbsent(cluster, clusterName -> {
+      _peerWatches.computeIfAbsent(cluster, clusterName -> {
+        boolean watchExistsBeforeFailout = _loadBalancerState.isListeningToCluster(clusterName);
+        PeerWatchState peerWatchState = new PeerWatchState(watchExistsBeforeFailout);
+
         LoadBalancerStateListenerCallback listenerCallback = (type, name) -> {
           if (_connectionWarmUpHandler != null)
           {
             _log.debug("Warming up connections to: " + cluster);
             _connectionWarmUpHandler.warmUpConnections(cluster, failoutConfig);
           }
+          peerWatchState.setWatchEstablished(true);
         };
         _loadBalancerState.listenToCluster(cluster, listenerCallback);
-        return listenerCallback;
+
+        return peerWatchState;
       });
     }
   }
@@ -177,11 +191,50 @@ public class FailedoutClusterManager
     }
     for (String cluster : clustersToRemove)
     {
-      final LoadBalancerStateListenerCallback listener = _clusterListenerCallbacks.remove(cluster);
-      if (listener != null)
-      {
-        // TODO(RESILIEN-51): Unregister watches when failout is over
+      final PeerWatchState peerWatchState = _peerWatches.remove(cluster);
+      if (peerWatchState == null) {
+        continue;
       }
+      if (_connectionWarmUpHandler != null)
+      {
+        _log.debug("Cancel pending requests to: {}", cluster);
+        _connectionWarmUpHandler.cancelPendingRequests(cluster);
+      }
+      if (peerWatchState.shouldUnregisterWatches())
+      {
+        if (_scheduledExecutorService == null)
+        {
+          _log.debug("Stop listening to: {}", cluster);
+          _loadBalancerState.stopListenToCluster(cluster);
+        }
+        else
+        {
+          _log.debug("Scheduling listening to: {} to be removed in {} ms", _clusterName, _peerWatchTeardownDelayMs);
+          _scheduledExecutorService.schedule(() -> _loadBalancerState.stopListenToCluster(cluster),
+              _peerWatchTeardownDelayMs, TimeUnit.MILLISECONDS);
+        }
+      }
+    }
+  }
+
+  private static class PeerWatchState
+  {
+    private final boolean _watchExistsBeforeFailout;
+    private boolean _watchEstablished = false;
+
+    public PeerWatchState(boolean watchExistsBeforeFailout)
+    {
+      _watchExistsBeforeFailout = watchExistsBeforeFailout;
+    }
+
+    public void setWatchEstablished(boolean watchEstablished)
+    {
+      _watchEstablished = watchEstablished;
+    }
+
+    public boolean shouldUnregisterWatches()
+    {
+      return !_watchExistsBeforeFailout && _watchEstablished;
     }
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/AbstractLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/AbstractLoadBalancerSubscriber.java
@@ -94,32 +94,32 @@ public abstract class AbstractLoadBalancerSubscriber<T> implements
 
   /**
    * Tries to stop listening for property change.
-   * @return true if successfully stopped.
    */
-  public boolean ensureNotListening(String propertyName)
+  public void ensureNotListening(String propertyName, LoadBalancerState.LoadBalancerStateListenerCallback callback)
   {
     if (!isListeningToProperty(propertyName))
     {
-      return false;
+      callback.done(_type, propertyName);
+      return;
     }
     ClosableQueue<LoadBalancerState.LoadBalancerStateListenerCallback> waiterQueue =
         _waiters.get(propertyName);
     if (waiterQueue != null && !waiterQueue.isClosed())
     {
       // Watches is in the process of being established. Unregister now may cause unexpected race.
-      return false;
+      callback.done(_type, propertyName);
+      return;
     }
 
     // We need to remove waiters first. eventBus register/unregister is thread safe. Unregister only removes the first
-    // occurrence of the subscriber in its listener queue. It is ok if a subscriber is register again between waiter
+    // occurrence of the subscriber in its listener queue. It is ok if a subscriber is registered again between waiter
     // removal and subscriber unregister. It will only remove the subscriber registered when waiter was initially added.
     waiterQueue = _waiters.remove(propertyName);
     if (waiterQueue != null)
     {
       _eventBus.unregister(Collections.singleton(propertyName), this);
-      return true;
     }
-    return false;
+    callback.done(_type, propertyName);
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/AbstractLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/AbstractLoadBalancerSubscriber.java
@@ -95,7 +95,7 @@ public abstract class AbstractLoadBalancerSubscriber<T> implements
   /**
    * Tries to stop listening for property change.
    */
-  public void ensureNotListening(String propertyName, LoadBalancerState.LoadBalancerStateListenerCallback callback)
+  public void tryStopListening(String propertyName, LoadBalancerState.LoadBalancerStateListenerCallback callback)
   {
     if (!isListeningToProperty(propertyName))
     {

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/AbstractLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/AbstractLoadBalancerSubscriber.java
@@ -92,6 +92,36 @@ public abstract class AbstractLoadBalancerSubscriber<T> implements
     }
   }
 
+  /**
+   * Tries to stop listening for property change.
+   * @return true if successfully stopped.
+   */
+  public boolean ensureNotListening(String propertyName)
+  {
+    if (!isListeningToProperty(propertyName))
+    {
+      return false;
+    }
+    ClosableQueue<LoadBalancerState.LoadBalancerStateListenerCallback> waiterQueue =
+        _waiters.get(propertyName);
+    if (waiterQueue != null && !waiterQueue.isClosed())
+    {
+      // Watches is in the process of being established. Unregister now may cause unexpected race.
+      return false;
+    }
+
+    // We need to remove waiters first. eventBus register/unregister is thread safe. Unregister only removes the first
+    // occurrence of the subscriber in its listener queue. It is ok if a subscriber is register again between waiter
+    // removal and subscriber unregister. It will only remove the subscriber registered when waiter was initially added.
+    waiterQueue = _waiters.remove(propertyName);
+    if (waiterQueue != null)
+    {
+      _eventBus.unregister(Collections.singleton(propertyName), this);
+      return true;
+    }
+    return false;
+  }
+
   @Override
   public void onAdd(final String propertyName, final T propertyValue)
   {

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -544,6 +544,13 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
     _uriSubscriber.ensureListening(clusterName, wrappedCallback);
   }
 
+  public boolean stopListenToCluster(final String clusterName)
+  {
+    trace(_log, "stopListenToCluster: ", clusterName);
+
+    return _clusterSubscriber.ensureNotListening(clusterName) && _uriSubscriber.ensureNotListening(clusterName);
+  }
+
   @Override
   public LoadBalancerStateItem<UriProperties> getUriProperties(String clusterName)
   {

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -565,8 +565,8 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
           }
         };
 
-    _clusterSubscriber.ensureNotListening(clusterName, wrappedCallback);
-    _uriSubscriber.ensureNotListening(clusterName, wrappedCallback);
+    _clusterSubscriber.tryStopListening(clusterName, wrappedCallback);
+    _uriSubscriber.tryStopListening(clusterName, wrappedCallback);
   }
 
   @Override

--- a/d2/src/test/java/com/linkedin/d2/balancer/LoadBalancerTestState.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/LoadBalancerTestState.java
@@ -166,9 +166,9 @@ public class LoadBalancerTestState implements LoadBalancerState
   }
 
   @Override
-  public boolean stopListenToCluster(String clusterName)
+  public void stopListenToCluster(String clusterName, LoadBalancerStateListenerCallback callback)
   {
-    return !listenToCluster;
+    callback.done(LoadBalancerStateListenerCallback.CLUSTER, clusterName);
   }
 
   @Override

--- a/d2/src/test/java/com/linkedin/d2/balancer/LoadBalancerTestState.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/LoadBalancerTestState.java
@@ -166,6 +166,12 @@ public class LoadBalancerTestState implements LoadBalancerState
   }
 
   @Override
+  public boolean stopListenToCluster(String clusterName)
+  {
+    return !listenToCluster;
+  }
+
+  @Override
   public void listenToService(String serviceName,
                               LoadBalancerStateListenerCallback callback)
   {

--- a/d2/src/test/java/com/linkedin/d2/balancer/PartitionedLoadBalancerTestState.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/PartitionedLoadBalancerTestState.java
@@ -96,9 +96,9 @@ public class PartitionedLoadBalancerTestState implements LoadBalancerState
   }
 
   @Override
-  public boolean stopListenToCluster(String clusterName)
+  public void stopListenToCluster(String clusterName, LoadBalancerStateListenerCallback callback)
   {
-    return false;
+    callback.done(LoadBalancerStateListenerCallback.SERVICE, null);
   }
 
   @Override

--- a/d2/src/test/java/com/linkedin/d2/balancer/PartitionedLoadBalancerTestState.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/PartitionedLoadBalancerTestState.java
@@ -92,7 +92,14 @@ public class PartitionedLoadBalancerTestState implements LoadBalancerState
   public void listenToCluster(String clusterName, LoadBalancerStateListenerCallback callback)
   {
     // trigger callback
-    callback.done(LoadBalancerStateListenerCallback.SERVICE, null);  }
+    callback.done(LoadBalancerStateListenerCallback.SERVICE, null);
+  }
+
+  @Override
+  public boolean stopListenToCluster(String clusterName)
+  {
+    return false;
+  }
 
   @Override
   public void start(Callback<None> callback)

--- a/d2/src/test/java/com/linkedin/d2/balancer/StaticLoadBalancerState.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/StaticLoadBalancerState.java
@@ -145,6 +145,12 @@ public class StaticLoadBalancerState implements LoadBalancerState
   }
 
   @Override
+  public boolean stopListenToCluster(String clusterName)
+  {
+    return false;
+  }
+
+  @Override
   public void start(Callback<None> callback)
   {
     callback.onSuccess(None.none());

--- a/d2/src/test/java/com/linkedin/d2/balancer/StaticLoadBalancerState.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/StaticLoadBalancerState.java
@@ -145,9 +145,9 @@ public class StaticLoadBalancerState implements LoadBalancerState
   }
 
   @Override
-  public boolean stopListenToCluster(String clusterName)
+  public void stopListenToCluster(String clusterName, LoadBalancerStateListenerCallback callback)
   {
-    return false;
+    callback.done(LoadBalancerStateListenerCallback.CLUSTER, clusterName);
   }
 
   @Override

--- a/d2/src/test/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterManagerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterManagerTest.java
@@ -105,8 +105,8 @@ public class FailedoutClusterManagerTest
   }
 
   @Test
-  public void testAddPeerClusterWatchesWithPeerClusterRemoved()
-  {
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void testAddPeerClusterWatchesWithPeerClusterRemoved() throws Exception {
     _manager.addPeerClusterWatches(new HashSet<>(Arrays.asList(PEER_CLUSTER_NAME1, PEER_CLUSTER_NAME2)), mock(FailoutConfig.class));
     _manager.addPeerClusterWatches(new HashSet<>(Arrays.asList(PEER_CLUSTER_NAME1)), mock(FailoutConfig.class));
     verify(_loadBalancerState, times(1)).listenToCluster(eq(PEER_CLUSTER_NAME1), any());
@@ -206,7 +206,8 @@ public class FailedoutClusterManagerTest
   }
 
   @Test
-  public void testUpdateFailoutConfigUpdateToNull() {
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void testUpdateFailoutConfigUpdateToNull() throws Exception {
     FailoutConfig config = mock(FailoutConfig.class);
     when(config.isFailedOut()).thenReturn(true);
     when(config.getPeerClusters()).thenReturn(Collections.singleton(PEER_CLUSTER_NAME1));

--- a/d2/src/test/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterManagerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clusterfailout/FailedoutClusterManagerTest.java
@@ -20,6 +20,7 @@ import com.linkedin.d2.balancer.LoadBalancerState;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.mockito.ArgumentCaptor;
@@ -112,11 +113,11 @@ public class FailedoutClusterManagerTest
     verify(_loadBalancerState, times(1)).listenToCluster(eq(PEER_CLUSTER_NAME2), any());
     verify(_warmUpHandler, times(1)).cancelPendingRequests(eq(PEER_CLUSTER_NAME2));
 
-    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    ArgumentCaptor<Callable> captor = ArgumentCaptor.forClass(Callable.class);
     verify(_scheduledExecutorService, times(1)).schedule(captor.capture(),
         eq(PEER_WATCH_TEAR_DOWN_DELAY_MS), eq(TimeUnit.MILLISECONDS));
 
-    captor.getValue().run();
+    captor.getValue().call();
     verify(_loadBalancerState, times(1)).stopListenToCluster(eq(PEER_CLUSTER_NAME2));
   }
 
@@ -222,11 +223,11 @@ public class FailedoutClusterManagerTest
     verify(_warmUpHandler, never()).warmUpConnections(any(), any());
     verify(_warmUpHandler, times(1)).cancelPendingRequests(eq(PEER_CLUSTER_NAME1));
 
-    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    ArgumentCaptor<Callable> captor = ArgumentCaptor.forClass(Callable.class);
     verify(_scheduledExecutorService, times(1)).schedule(captor.capture(),
         eq(PEER_WATCH_TEAR_DOWN_DELAY_MS), eq(TimeUnit.MILLISECONDS));
 
-    captor.getValue().run();
+    captor.getValue().call();
     verify(_loadBalancerState, times(1)).stopListenToCluster(eq(PEER_CLUSTER_NAME1));
   }
 

--- a/d2/src/test/java/com/linkedin/d2/discovery/event/PropertyEventBusTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/event/PropertyEventBusTest.java
@@ -188,6 +188,54 @@ public abstract class PropertyEventBusTest
     assertEquals(listener2.properties.get("add-dtest2"), "exists");
   }
 
+  @Test(groups = { "small", "back-end" })
+  public void testUnregisterRemovesSingleListener() throws InterruptedException
+  {
+    PropertyEventBus<String> bus = getBus();
+    PropertyEventTestSubscriber listener1 = new PropertyEventTestSubscriber();
+
+    put(bus, "dtest", "exists");
+
+    Set<String> listenTos = new HashSet<>();
+
+    listenTos.add("dtest");
+    bus.register(listenTos, listener1);
+    bus.register(listenTos, listener1);
+
+    assertEquals(listener1.properties.get("init-dtest"), "exists");
+
+    // Unregister once. We should still have a listener listening to changes
+    bus.unregister(listenTos, listener1);
+    put(bus, "dtest", "new-value");
+
+    // wait for the listener to get the response, in case this registry is async
+    for (int i = 0; i < 10 && listener1.properties.get("init-dtest") == null; ++i)
+    {
+      Thread.sleep(500);
+    }
+
+    // Verify property change is observed
+    assertEquals(listener1.properties.get("add-dtest"), "new-value");
+
+    // Unregister the second listener. listener1 should no longer be getting updates
+    bus.unregister(listenTos, listener1);
+
+    // Register listener2 to make sure updates are being propagated.
+    PropertyEventTestSubscriber listener2 = new PropertyEventTestSubscriber();
+    bus.register(listenTos, listener2);
+
+    put(bus, "dtest", "latest-value");
+
+    // wait for the listener to get the response, in case this registry is async
+    for (int i = 0; i < 10 && listener2.properties.get("add-dtest") == null; ++i)
+    {
+      Thread.sleep(500);
+    }
+
+    assertEquals(listener1.properties.get("add-dtest"), "new-value");
+    assertEquals(listener2.properties.get("add-dtest"), "latest-value");
+  }
+
   @Test
   public void testMaintainRegistration()
   {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.6
+version=29.37.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
When a failout is over or when a peer cluster is no longer accepting request, we should remove clusters/uris watches for that peer cluster to reduce the load on ZK:
* Cancels any pending connection warm-up requests
* Support cluster watches removal to be scheduled to sometime in the future to allow in-flight requests to finish.
* If there was no existing watches on the peer cluster, it's likely that cluster failout is the only consumer of the peer cluster info. Only remove the watches on the peer cluster if this is the case.
* Added a `stopListenToCluster` method to `LoadBalancerState`
* `SimpleLoadBalancerState` will invoke `ensureNotListening` on `cluster` and `uri` subscribers