### PR TITLE
Bugfix: mark a dark request as sent if it is sent to any dark clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.7] - 2022-08-03
+- Bugfix: mark a dark request as sent if it is sent to any dark clusters
+
 ## [29.37.6] - 2022-07-28
 - Bump ZooKeeper client version to [3.7.1](https://zookeeper.apache.org/releases.html#releasenotes) (latest stable version at the time).
 
@@ -5282,7 +5285,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.7...master
+[29.37.7]: https://github.com/linkedin/rest.li/compare/v29.37.6...v29.37.7
 [29.37.6]: https://github.com/linkedin/rest.li/compare/v29.37.5...v29.37.6
 [29.37.5]: https://github.com/linkedin/rest.li/compare/v29.37.4...v29.37.5
 [29.37.4]: https://github.com/linkedin/rest.li/compare/v29.37.3...v29.37.4

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterManagerImpl.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterManagerImpl.java
@@ -129,7 +129,7 @@ public class DarkClusterManagerImpl implements DarkClusterManager
             RestRequest newD2Request = rewriteRequest(reqCopy, darkClusterName);
             // now find the strategy appropriate for each dark cluster
             DarkClusterStrategy strategy = _darkClusterStrategyFactory.get(darkClusterName);
-            darkRequestSent = strategy.handleRequest(reqCopy, newD2Request, newRequestContext);
+            darkRequestSent |= strategy.handleRequest(reqCopy, newD2Request, newRequestContext);
           }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.6
+version=29.37.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The current code has a bug in the dark request logic: the boolean `darkRequestSent` will be overwritten in the for loop, so it only reflects whether the request is sent to the last dark cluster configured. However, this boolean should be true if the dark request is sent to **any** of the dark clusters.