### PR TITLE
Add null-checks for cluster and service properties in D2ClientJmxManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.9] - 2022-08-07
+- Add null-checks for cluster and service properties in D2ClientJmxManager
+
 ## [29.37.8] - 2022-08-04
 - Switch to use name regex pattern to skip deprecated fields in spec generation
 
@@ -5288,7 +5291,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.9...master
+[29.37.9]: https://github.com/linkedin/rest.li/compare/v29.37.8...v29.37.9
 [29.37.8]: https://github.com/linkedin/rest.li/compare/v29.37.7...v29.37.8
 [29.37.7]: https://github.com/linkedin/rest.li/compare/v29.37.6...v29.37.7
 [29.37.6]: https://github.com/linkedin/rest.li/compare/v29.37.5...v29.37.6

--- a/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/D2ClientJmxManager.java
@@ -88,34 +88,42 @@ public class D2ClientJmxManager
       @Override
       public void onClusterInfoUpdate(ClusterInfoItem clusterInfoItem)
       {
-        _jmxManager.registerClusterInfo(
-            getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName()),
-            clusterInfoItem);
+        if (clusterInfoItem != null && clusterInfoItem.getClusterPropertiesItem() != null
+            && clusterInfoItem.getClusterPropertiesItem().getProperty() != null) {
+          _jmxManager.registerClusterInfo(
+              getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName()),
+              clusterInfoItem);
+        }
       }
 
       @Override
       public void onClusterInfoRemoval(ClusterInfoItem clusterInfoItem)
       {
-        _jmxManager.unregister(
-            getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName())
-        );
+        if (clusterInfoItem != null && clusterInfoItem.getClusterPropertiesItem() != null
+            && clusterInfoItem.getClusterPropertiesItem().getProperty() != null) {
+          _jmxManager.unregister(
+              getClusterInfoJmxName(clusterInfoItem.getClusterPropertiesItem().getProperty().getClusterName())
+          );
+        }
       }
 
       @Override
       public void onServicePropertiesUpdate(LoadBalancerStateItem<ServiceProperties> serviceProperties)
       {
-        _jmxManager.registerServiceProperties(
-            getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName()),
-            serviceProperties);
+        if (serviceProperties != null && serviceProperties.getProperty() != null) {
+          _jmxManager.registerServiceProperties(
+              getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName()),
+              serviceProperties);
+        }
       }
 
 
       @Override
       public void onServicePropertiesRemoval(LoadBalancerStateItem<ServiceProperties> serviceProperties)
       {
-        _jmxManager.unregister(
-            getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName())
-        );
+        if (serviceProperties != null && serviceProperties.getProperty() != null) {
+          _jmxManager.unregister(getServicePropertiesJmxName(serviceProperties.getProperty().getServiceName()));
+        }
       }
 
       private String getClusterInfoJmxName(String clusterName)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.8
+version=29.37.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This is a follow-up PR for a [previous change](https://github.com/linkedin/rest.li/pull/782/files#diff-9993e287812781a541ea17425748df60fe6966b7a77ea69eba72fcf8a5890102) to add null checks for cluster and service properties in D2ClientJmxManager which caused NPE in some rare edge cases (when the cluster or service properties received from PropertyEventBus is null, as seen in EXC-320587 and SI-27628).