### PR TITLE
Fix PrimitiveTemplateSpec not having className

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.10] - 2022-08-08
+- Fix PrimitiveTemplateSpec not having className
+
 ## [29.37.9] - 2022-08-07
 - Add null-checks for cluster and service properties in D2ClientJmxManager
 
@@ -5291,7 +5294,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.10...master
+[29.37.10]: https://github.com/linkedin/rest.li/compare/v29.37.9...v29.37.10
 [29.37.9]: https://github.com/linkedin/rest.li/compare/v29.37.8...v29.37.9
 [29.37.8]: https://github.com/linkedin/rest.li/compare/v29.37.7...v29.37.8
 [29.37.7]: https://github.com/linkedin/rest.li/compare/v29.37.6...v29.37.7

--- a/generator/src/main/java/com/linkedin/pegasus/generator/spec/PrimitiveTemplateSpec.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/spec/PrimitiveTemplateSpec.java
@@ -19,6 +19,7 @@ package com.linkedin.pegasus.generator.spec;
 
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaUtil;
+import com.linkedin.data.schema.NullDataSchema;
 import com.linkedin.data.schema.PrimitiveDataSchema;
 
 import java.util.HashMap;
@@ -47,6 +48,9 @@ public class PrimitiveTemplateSpec extends ClassTemplateSpec
   private PrimitiveTemplateSpec(PrimitiveDataSchema schema)
   {
     setSchema(schema);
+    if (!(schema instanceof NullDataSchema)) {
+      setClassName(DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchemaClass(schema.getType()).getName());
+    }
   }
 
   public static PrimitiveTemplateSpec getInstance(DataSchema.Type schemaType)

--- a/generator/src/main/java/com/linkedin/pegasus/generator/spec/PrimitiveTemplateSpec.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/spec/PrimitiveTemplateSpec.java
@@ -48,7 +48,8 @@ public class PrimitiveTemplateSpec extends ClassTemplateSpec
   private PrimitiveTemplateSpec(PrimitiveDataSchema schema)
   {
     setSchema(schema);
-    if (!(schema instanceof NullDataSchema)) {
+    if (!(schema instanceof NullDataSchema)) 
+    {
       setClassName(DataSchemaUtil.dataSchemaTypeToPrimitiveDataSchemaClass(schema.getType()).getName());
     }
   }

--- a/generator/src/test/java/com/linkedin/pegasus/generator/TestTemplateSpecGenerator.java
+++ b/generator/src/test/java/com/linkedin/pegasus/generator/TestTemplateSpecGenerator.java
@@ -22,11 +22,13 @@ import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaLocation;
 import com.linkedin.data.schema.DataSchemaResolver;
 import com.linkedin.data.schema.DataSchemaUtil;
+import com.linkedin.data.schema.IntegerDataSchema;
 import com.linkedin.data.schema.Name;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.StringDataSchemaLocation;
 import com.linkedin.data.schema.TyperefDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
+import com.linkedin.pegasus.generator.spec.PrimitiveTemplateSpec;
 import com.linkedin.pegasus.generator.spec.RecordTemplateSpec;
 import com.linkedin.pegasus.generator.spec.UnionTemplateSpec;
 import com.linkedin.util.CustomTypeUtil;
@@ -130,6 +132,15 @@ public class TestTemplateSpecGenerator
       Assert.assertEquals(spec.getMembers().get(i).getCustomInfo().getCustomClass().getClassName(),
                           CustomTypeUtil.getJavaCustomTypeClassNameFromSchema((TyperefDataSchema) customTypedSchemas.get(i)));
     }
+  }
+
+  @Test
+  public void testPrimitiveDataSchema()
+  {
+    final IntegerDataSchema intSchema = new IntegerDataSchema();
+    final TemplateSpecGenerator generator = new TemplateSpecGenerator(_resolver);
+    final PrimitiveTemplateSpec spec = (PrimitiveTemplateSpec) generator.generate(intSchema, _location);
+    Assert.assertEquals(spec.getBindingName(), Integer.class.getName());
   }
 
   @DataProvider

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.9
+version=29.37.10
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Prior to the change, `<PrimitiveTemplateSpec>.getBindingName()` returns null, this is because the PrimitiveTemplateSpec does not have its class name properly set.