### PR TITLE
Fix d2-test-api dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.13] - 2022-08-15
+- Fix d2-test-api dependencies
+
 ## [29.37.12] - 2022-08-10
 - Support removing cluster watches created due to cluster failout
 
@@ -5300,7 +5303,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.13...master
+[29.37.13]: https://github.com/linkedin/rest.li/compare/v29.37.12...v29.37.13
 [29.37.12]: https://github.com/linkedin/rest.li/compare/v29.37.11...v29.37.12
 [29.37.11]: https://github.com/linkedin/rest.li/compare/v29.37.10...v29.37.11
 [29.37.10]: https://github.com/linkedin/rest.li/compare/v29.37.9...v29.37.10

--- a/d2-test-api/build.gradle
+++ b/d2-test-api/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
   compile project(':d2')
   compile externalDependency.testng
+  compile externalDependency.metricsCore
+  compile externalDependency.xerialSnappy
   compileOnly externalDependency.findbugs
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.12
+version=29.37.13
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
In https://github.com/linkedin/rest.li/pull/811, some new dependencies are introduced with the zookeeper upgrade. Tests depending on `d2-test-api` are failing to compile. Adding the missing dependencies to fix tests.