### PR TITLE
Exclude transitive Netty dependency for ZooKeeper client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.15] - 2022-08-23
+- Exclude transitive Netty dependency for ZooKeeper client.
+
 ## [29.37.14] - 2022-08-19
 - Avoid casting classloader to URLLoader in ResourceModelEncoder and use ClassGraph to search for restspec file
-
 
 ## [29.37.13] - 2022-08-15
 - Fix d2-test-api dependencies
@@ -5307,7 +5309,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.14...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.15...master
+[29.37.15]: https://github.com/linkedin/rest.li/compare/v29.37.14...v29.37.15
 [29.37.14]: https://github.com/linkedin/rest.li/compare/v29.37.13...v29.37.14
 [29.37.13]: https://github.com/linkedin/rest.li/compare/v29.37.12...v29.37.13
 [29.37.12]: https://github.com/linkedin/rest.li/compare/v29.37.11...v29.37.12

--- a/d2-int-test/build.gradle
+++ b/d2-int-test/build.gradle
@@ -10,7 +10,9 @@ dependencies {
   compile externalDependency.commonsCodec
   compile externalDependency.commonsIo
   compile externalDependency.commonsHttpClient
-  compile externalDependency.zookeeper
+  compile(externalDependency.zookeeper) {
+    exclude group: 'io.netty'
+  }
   compile externalDependency.jdkTools
   compile externalDependency.netty
   testCompile externalDependency.testng

--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -13,7 +13,9 @@ dependencies {
   compile externalDependency.httpclient
   compile externalDependency.httpcore
   compile externalDependency.hdrhistogram
-  compile externalDependency.zookeeper
+  compile(externalDependency.zookeeper) {
+    exclude group: 'io.netty'
+  }
   compile externalDependency.jacksonCore
   compile externalDependency.jacksonDataBind
   compile externalDependency.jdkTools

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.14
+version=29.37.15
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-example-server/build.gradle
+++ b/restli-example-server/build.gradle
@@ -13,7 +13,9 @@ dependencies {
   compile project(':pegasus-common')
   compile externalDependency.javaxInject
   compile externalDependency.parseq
-  compile externalDependency.zookeeper
+  compile(externalDependency.zookeeper) {
+    exclude group: 'io.netty'
+  }
   testCompile project(':restli-client')
   testCompile externalDependency.testng
   testCompile externalDependency.easymock


### PR DESCRIPTION
The updated ZooKeeper client depends on Netty, but uses a newer version.
Prior to that version Netty switched its netty-all Maven coordinates from
being a super jar to being a pom that transitively depends on the other
Netty dependencies. This makes it possible for it to bring in a conflicting
version of Netty, resulting in two versions in the classpath. ZooKeeper
appears fine with our current Netty version, so excluding the transitive
dependencies seems the safest way to ensure no issues are caused by
upgrading Netty to match the ZooKeeper version.