### PR TITLE
Avoid casting classloader to URLLoader in ResourceModelEncoder to be compatible with Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.14] - 2022-08-19
+- Avoid casting classloader to URLLoader in ResourceModelEncoder and use ClassGraph to search for restspec file
+
+
 ## [29.37.13] - 2022-08-15
 - Fix d2-test-api dependencies
 
@@ -5303,7 +5307,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.13...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.14...master
+[29.37.14]: https://github.com/linkedin/rest.li/compare/v29.37.13...v29.37.14
 [29.37.13]: https://github.com/linkedin/rest.li/compare/v29.37.12...v29.37.13
 [29.37.12]: https://github.com/linkedin/rest.li/compare/v29.37.11...v29.37.12
 [29.37.11]: https://github.com/linkedin/rest.li/compare/v29.37.10...v29.37.11

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ project.ext.externalDependency = [
 
   'jsr305': 'com.google.code.findbugs:jsr305:3.0.0',
   "avroSpotBugsPlugin": "com.linkedin.avroutil1:spotbugs-plugin:0.2.56",
+  "classgraph": "io.github.classgraph:classgraph:4.8.149",
 ];
 
 if (!project.ext.isDefaultEnvironment)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.13
+version=29.37.14
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/build.gradle
+++ b/restli-server/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   compile externalDependency.parseq
   compile externalDependency.servletApi
   compile externalDependency.antlrRuntime
+  compile externalDependency.classgraph
 
   antlr externalDependency.antlr
 

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModelEncoder.java
@@ -119,7 +119,7 @@ public class ResourceModelEncoder
 
   private final DataCodec codec = new JacksonDataCodec();
 
-  // Used to cache the mapping between restspec file and
+  // Used to cache the mapping between restspec file name and
   // the Resource object
   private Map<String, Resource> _restSpecPathToResourceMap = null;
 
@@ -335,7 +335,7 @@ public class ResourceModelEncoder
         return new ResourceSchema(resourceSchemaDataMap);
       }
     }
-    catch (Exception e)
+    catch (IOException e)
     {
       throw new RuntimeException("Failed to read " + resourceFilePath.toString() + " from classpath.", e);
     }


### PR DESCRIPTION
Prior to Java 9, AppClassLoader is a subclass of URLClassLoader, but this is not the case after Java 9.

Therefore casting AppClassLoader to URLClassLoader will fail in Java 11.

This change removed related logic contains casting and instead use ClassGraph to search for restspec file instead.