### PR TITLE
Support supplying D2 subsetting peer cluster name at run-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.18] - 2022-08-29
+- Support supplying D2 subsetting peer cluster name at run-time
+- 
 ## [29.37.17] - 2022-08-29
 - Add "notify" to reversed word set when generating data template
 
@@ -5316,7 +5319,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.17...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.18...master
+[29.37.18]: https://github.com/linkedin/rest.li/compare/v29.37.17...v29.37.18
 [29.37.17]: https://github.com/linkedin/rest.li/compare/v29.37.16...v29.37.17
 [29.37.16]: https://github.com/linkedin/rest.li/compare/v29.37.15...v29.37.16
 [29.37.15]: https://github.com/linkedin/rest.li/compare/v29.37.14...v29.37.15

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 public class ZKDeterministicSubsettingMetadataProvider implements DeterministicSubsettingMetadataProvider
 {
   private static final Logger _log = LoggerFactory.getLogger(ZKDeterministicSubsettingMetadataProvider.class);
-  private final String _clusterName;
   private final String _hostName;
   private final long _timeout;
   private final TimeUnit _unit;
@@ -49,6 +48,12 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
   private long _peerClusterVersion = -1;
   @GuardedBy("_lock")
   private DeterministicSubsettingMetadata _subsettingMetadata;
+  private String _clusterName;
+
+  public ZKDeterministicSubsettingMetadataProvider(String hostName, long timeout, TimeUnit unit)
+  {
+    this(null, hostName, timeout, unit);
+  }
 
   public ZKDeterministicSubsettingMetadataProvider(String clusterName,
                                       String hostName,
@@ -61,9 +66,19 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
     _unit = unit;
   }
 
+  public void setClusterName(String clusterName) {
+    _clusterName = clusterName;
+  }
+
   @Override
   public DeterministicSubsettingMetadata getSubsettingMetadata(LoadBalancerState state)
   {
+    if (_clusterName == null)
+    {
+      _log.debug("Peer cluster name not provided.");
+      return null;
+    }
+
     FutureCallback<DeterministicSubsettingMetadata> metadataFutureCallback = new FutureCallback<>();
 
     state.listenToCluster(_clusterName, (type, name) ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.17
+version=29.37.18
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This change will support supplying D2 subsetting peer cluster name at run-time, so that the service can automatically fill in the peer cluster name from the ZooKeeper announcers during server start-up.