### PR TITLE
add "notify" to reserved word set when generating date template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.37.17] - 2022-08-29
+- Add "notify" to reversed word set when generating data template
+
 ## [29.37.16] - 2022-08-24
 - Make `DefaultDocumentationRequestHandler` blocking again to avoid the `503` errors users were frequently seeing for `OPTIONS` calls.
   - Introduce the existing non-blocking ("fail fast") variant as optional subclass `NonBlockingDocumentationRequestHandler`.
@@ -5313,7 +5316,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.16...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.37.17...master
+[29.37.17]: https://github.com/linkedin/rest.li/compare/v29.37.16...v29.37.17
 [29.37.16]: https://github.com/linkedin/rest.li/compare/v29.37.15...v29.37.16
 [29.37.15]: https://github.com/linkedin/rest.li/compare/v29.37.14...v29.37.15
 [29.37.14]: https://github.com/linkedin/rest.li/compare/v29.37.13...v29.37.14

--- a/generator/src/main/java/com/linkedin/pegasus/generator/JavaCodeGeneratorBase.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/JavaCodeGeneratorBase.java
@@ -68,7 +68,7 @@ public class JavaCodeGeneratorBase
       "finally", "float", "for", "goto", "if", "implements", "import", "instanceof", "int",
       "interface", "long", "native", "new", "null", "package", "private", "protected", "public",
       "return", "short", "static", "strictfp", "super", "switch", "synchronized",
-      "this", "throw", "throws", "transient", "try", "void", "volatile", "while"
+      "this", "throw", "throws", "transient", "try", "void", "volatile", "while", "notify"
   )));
 
   /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.37.16
+version=29.37.17
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
"notify" is an internal method in Object.java class, therefore if we don't sanitize it, there will be conflict when generating data template