### PR TITLE
Java 11 - export jvm stat for java version >= 1_9

### DIFF
--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -1,5 +1,5 @@
-// required starting 1.11
-if(JavaVersion.current() >= JavaVersion.VERSION_11){
+// internal api inaccessible starting 1.9
+if(JavaVersion.current() > JavaVersion.VERSION_1_9){
   project.tasks.withType(JavaCompile) {
     options.compilerArgs += [ "--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED" ]
   }

--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -1,3 +1,10 @@
+// required starting 1.11
+if(JavaVersion.current() >= JavaVersion.VERSION_11){
+  project.tasks.withType(JavaCompile) {
+    options.compilerArgs += [ "--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED" ]
+  }
+}
+
 dependencies {
   compile project(':degrader')
   compile project(':r2-core')

--- a/data/src/test/java/com/linkedin/data/TestData.java
+++ b/data/src/test/java/com/linkedin/data/TestData.java
@@ -96,8 +96,8 @@ public class TestData
     illegalObjects.add(new AtomicLong(-13));
     illegalObjects.add(new BigDecimal(13));
     illegalObjects.add(new BigInteger("13"));
-    illegalObjects.add(new Byte("13"));
-    illegalObjects.add(new Short("13"));
+    illegalObjects.add(Byte.valueOf("13"));
+    illegalObjects.add(Short.valueOf("13"));
 
     illegalObjects.add(new ArrayList<>());
     illegalObjects.add(new HashMap<>());


### PR DESCRIPTION
- Internal apis encapsulated starting 1.9, exporting jvmstat

- Updated constructor calls, deprecated in newer versions of Java