### PR TITLE
Emit service discovery status related events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.39.5] - 2022-10-04
+- Emit service discovery status related events
+
 ## [29.39.4] - 2022-09-30
 Add JMX metrics for DNS resolution and clarify DNS timeout errors.
 
@@ -5359,7 +5362,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.5...master
+[29.39.5]: https://github.com/linkedin/rest.li/compare/v29.39.4...v29.39.5
 [29.39.4]: https://github.com/linkedin/rest.li/compare/v29.39.3...v29.39.4
 [29.39.3]: https://github.com/linkedin/rest.li/compare/v29.39.2...v29.39.3
 [29.39.2]: https://github.com/linkedin/rest.li/compare/v29.39.1...v29.39.2

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/D2ServiceDiscoveryEventHelper.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/D2ServiceDiscoveryEventHelper.java
@@ -1,0 +1,55 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.discovery.event;
+
+/**
+ * D2-specific helper for emitting Service Discovery Status related events by calling the general
+ * {@link ServiceDiscoveryEventEmitter}.
+ */
+public interface D2ServiceDiscoveryEventHelper {
+  //---- d2 server-side events ----//
+
+  /**
+   * To emit ServiceDiscoveryStatusActiveUpdateIntentEvent and ServiceDiscoveryStatusWriteEvent.
+   * @param cluster cluster name.
+   * @param isMarkUp true for markUp, o.w for markDown.
+   * @param succeeded true if the write succeeded, o.w failed.
+   * @param startAt when the update intent is initiated (start time of the markUp/markDown).
+   */
+  void emitSDStatusActiveUpdateIntentAndWriteEvents(String cluster, boolean isMarkUp, boolean succeeded, long startAt);
+
+  //---- d2 client-side events ----//
+
+  /**
+   * To emit ServiceDiscoveryStatusUpdateReceiptEvent.
+   * @param cluster cluster name.
+   * @param isMarkUp true for markUp, o.w for markDown.
+   * @param nodePath path of the uri ephemeral znode.
+   * @param nodeData data in the uri ephemeral znode.
+   * @param timestamp when the update is received.
+   */
+  void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, boolean isMarkUp, String zkConnectString, String nodePath, String nodeData, long timestamp);
+
+  /**
+   * To emit ServiceDiscoveryStatusInitialRequestEvent, when a new service discovery request is sent for a cache miss,
+   * (the first time of getting uris for a cluster).
+   * @param cluster cluster name.
+   * @param duration duration the request took.
+   * @param succeeded true if the request succeeded, o.w failed.
+   */
+  void emitSDStatusInitialRequestEvent(String cluster, long duration, boolean succeeded);
+}

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/LogOnlyServiceDiscoveryEventEmitter.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/LogOnlyServiceDiscoveryEventEmitter.java
@@ -1,0 +1,106 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.discovery.event;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Implementation of {@link ServiceDiscoveryEventEmitter} which only logs about the events for debugging purpose. NO event is emitted.
+ */
+public class LogOnlyServiceDiscoveryEventEmitter implements ServiceDiscoveryEventEmitter
+{
+  private static final Logger _log = LoggerFactory.getLogger(LogOnlyServiceDiscoveryEventEmitter.class);
+
+  @Override
+  public void emitSDStatusActiveUpdateIntentEvent(List<String> clustersClaimed, StatusUpdateActionType actionType,
+      boolean isNextGen, String tracingId, long timestamp)
+  {
+    _log.debug(String.format("[LOG ONLY] emit ServiceDiscoveryStatusActiveUpdateIntentEvent: "
+            + "{"
+            + "clustersClaimed: %s,"
+            + " actionType: %s,"
+            + " isNextGen: %s,"
+            + " tracingId: %s,"
+            + " timestamp: %d"
+            + "}",
+        clustersClaimed, actionType, isNextGen, tracingId, timestamp));
+  }
+
+  @Override
+  public void emitSDStatusWriteEvent(String cluster, String host, int port, StatusUpdateActionType actionType,
+      String serviceRegistry, String serviceRegistryKey, String serviceRegistryValue, Integer serviceRegistryVersion,
+      String tracingId, boolean succeeded, long timestamp)
+  {
+    _log.debug(String.format("[LOG ONLY] emit ServiceDiscoveryStatusWriteEvent for update: "
+            + "{"
+            + "%s,"
+            + " succeeded: %s"
+            + "}",
+        formatStatusUpdate(cluster, host, port, actionType, serviceRegistry, serviceRegistryKey,
+            serviceRegistryValue, serviceRegistryVersion, tracingId, timestamp),
+        succeeded));
+  }
+
+  @Override
+  public void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, StatusUpdateActionType actionType,
+      boolean isNextGen, String serviceRegistry, String serviceRegistryKey, String serviceRegistryValue,
+      Integer serviceRegistryVersion, String tracingId, long timestamp)
+  {
+    _log.debug(String.format("[LOG ONLY] emit ServiceDiscoveryStatusUpdateReceiptEvent for update: "
+        + "{"
+        + "%s,"
+        + " isNextGen: %s"
+        + "}",
+        formatStatusUpdate(cluster, host, port, actionType, serviceRegistry, serviceRegistryKey,
+            serviceRegistryValue, serviceRegistryVersion, tracingId, timestamp),
+        isNextGen));
+  }
+
+  @Override
+  public void emitSDStatusInitialRequestEvent(String cluster, boolean isNextGen, long duration, boolean succeeded)
+  {
+    _log.debug(String.format("[LOG ONLY] emit ServiceDiscoveryStatusInitialRequestEvent: "
+        + "{"
+        + "cluster: %s,"
+        + " duration: %d,"
+        + " isNextGen: %s,"
+        + " succeeded: %s"
+        + "}",
+        cluster, duration, isNextGen, succeeded));
+  }
+
+  private String formatStatusUpdate(String cluster, String host, int port, StatusUpdateActionType actionType,
+      String serviceRegistry, String serviceRegistryKey, String serviceRegistryValue, Integer serviceRegistryVersion,
+      String tracingId, long timestamp)
+  {
+    return String.format("cluster: %s,"
+        + " host: %s,"
+        + " port: %d,"
+        + " actionType: %s,"
+        + " serviceRegistry: %s,"
+        + " serviceRegistryKey: %s,"
+        + " serviceRegistryValue: %s,"
+        + " serviceRegistryVersion: %s,"
+        + " tracingId: %s,"
+        + " timestamp: %d",
+        cluster, host, port, actionType, serviceRegistry, serviceRegistryKey, serviceRegistryValue, serviceRegistryVersion,
+        tracingId, timestamp);
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopServiceDiscoveryEventEmitter.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopServiceDiscoveryEventEmitter.java
@@ -1,0 +1,46 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.discovery.event;
+
+import java.util.List;
+
+
+/**
+ * Placeholder implementation of {@link ServiceDiscoveryEventEmitter} which has no operation.
+ */
+public class NoopServiceDiscoveryEventEmitter implements ServiceDiscoveryEventEmitter {
+  @Override
+  public void emitSDStatusActiveUpdateIntentEvent(List<String> clustersClaimed, StatusUpdateActionType actionType,
+      boolean isNextGen, String tracingId, long timestamp) {
+  }
+
+  @Override
+  public void emitSDStatusWriteEvent(String cluster, String host, int port, StatusUpdateActionType actionType, String serviceRegistry,
+      String serviceRegistryKey, String serviceRegistryValue, Integer serviceRegistryVersion, String tracingId,
+      boolean succeeded, long timestamp) {
+  }
+
+  @Override
+  public void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, StatusUpdateActionType actionType, boolean isNextGen,
+      String serviceRegistry, String serviceRegistryKey, String serviceRegistryValue, Integer serviceRegistryVersion,
+      String tracingId, long timestamp) {
+  }
+
+  @Override
+  public void emitSDStatusInitialRequestEvent(String cluster, boolean isNextGen, long duration, boolean succeeded) {
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/ServiceDiscoveryEventEmitter.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/ServiceDiscoveryEventEmitter.java
@@ -1,0 +1,107 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.discovery.event;
+
+import java.util.List;
+
+
+/**
+ * Emitter for Service Discovery Status related events, to be called for both D2 and next-gen systems.
+ * (Event schemas at: avro-schemas/avro-schemas/avro-schemas-tracking/schemas/monitoring/events/serviceDiscovery).
+ */
+public interface ServiceDiscoveryEventEmitter {
+
+  /**
+   * To emit ServiceDiscoveryStatusActiveUpdateIntentEvent, when the server instance actively intends to update its status.
+   * @param clustersClaimed a list of clusters that the instance claimed to apply the update to.
+   * @param actionType action type of updating the status.
+   * @param isNextGen true for next-gen system, o.w for D2.
+   * @param tracingId A unique tracing id to be used in joining other related events for tracing end-to-end status update related behaviors.
+   *                  In current D2 system, it is the path of the Zookeeper ephemeral znode, e.g: /d2/uris/ClusterA/hostA-1234, in case of failure,
+   *                  it will use a FAILURE path suffix: /d2/uris/ClusterA/hostA-FAILURE. In next-gen, it’s a UUID.
+   * @param timestamp when the update intent is initiated. In D2, it's the start time of markUp/markDown. In next-gen, it's when an active status report is sent.
+   */
+  void emitSDStatusActiveUpdateIntentEvent(List<String> clustersClaimed, StatusUpdateActionType actionType, boolean isNextGen, String tracingId, long timestamp);
+
+  /**
+   * NOTE: ONLY for D2. In next-gen, writes will never happen on the server app, instead it will be on Service Registry Writer, so write event will never be
+   * emitted from the server app.
+   * To emit ServiceDiscoveryStatusWriteEvent, to trace a write request to Service Registry.
+   * @param cluster cluster name of the status update.
+   * @param host host name of the URI in the update.
+   * @param port port number of the URI in the update.
+   * @param actionType action type of updating the status.
+   * @param serviceRegistry ID/URI that identifies the Service Registry (for ZK, it's the connect string).
+   * @param serviceRegistryKey key of the service discovery status data stored in Service Registry (for mark-down, it's the key that was deleted).
+   *                           Note: In current D2 system, this is the path of the created/deleted ephemeral znode.
+   * @param serviceRegistryValue value of the service discovery status data stored in Service Registry (for mark-down, it's the data that was deleted).
+   *                             Note: In current D2 system, this is UriProperties.
+   * @param serviceRegistryVersion version of the status data in Service Registry. For writes, it will be the new data version after the write (for mark-down,
+   *                               it's the data version that was deleted). Null if the write failed.
+   *                               Note: In current D2 system, this is the version of the ephemeral znode, which is 0 for a new node, and increments for every data update.
+   *                               But current D2 system does data update by removing the old node and recreating a new node, so the version is always 0.
+   * @param tracingId same as the tracing id that was generated when the intent of this status update was made in ServiceDiscoveryStatusActiveUpdateIntentEvent.
+   * @param succeeded true if the request succeeded, o.w failed.
+   * @param timestamp when the write request is complete.
+   */
+  void emitSDStatusWriteEvent(String cluster, String host, int port, StatusUpdateActionType actionType, String serviceRegistry, String serviceRegistryKey,
+      String serviceRegistryValue, Integer serviceRegistryVersion, String tracingId, boolean succeeded, long timestamp);
+
+  /**
+   * To emit ServiceDiscoveryStatusUpdateReceiptEvent, to trace when a status update is received by a subscriber.
+   * NOTE: In current D2 system, this event is emitted from a client service instance. In next-gen, it could be from a client service instance,
+   *       sidecar proxy, or Service Registry Observer.
+   * @param cluster cluster name of the status update.
+   * @param host host name of the URI in the update.
+   * @param port port number of the URI in the update.
+   * @param actionType action type of updating the status.
+   * @param isNextGen true for next-gen system, o.w for D2.
+   * @param serviceRegistry same as in method emitSDStatusWriteEvent.
+   * @param serviceRegistryKey same as in method emitSDStatusWriteEvent.
+   * @param serviceRegistryValue same as in method emitSDStatusWriteEvent.
+   * @param serviceRegistryVersion same as in method emitSDStatusWriteEvent.
+   * @param tracingId same as the tracing id that was generated when the intent of this status update was made in ServiceDiscoveryStatusActiveUpdateIntentEvent
+   *                  or future next-gen HealthCheckStatusUpdateIntentEvent.
+   * @param timestamp when the update is received.
+   */
+  void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, StatusUpdateActionType actionType, boolean isNextGen, String serviceRegistry,
+      String serviceRegistryKey, String serviceRegistryValue, Integer serviceRegistryVersion, String tracingId, long timestamp);
+
+  /**
+   * To emit ServiceDiscoveryStatusInitialRequestEvent, when a new service discovery request is sent for a cache miss,
+   * (the first time of getting uris for a cluster).
+   * @param cluster cluster name.
+   * @param isNextGen true for next-gen system, o.w for D2.
+   * @param duration duration the request took.
+   * @param succeeded true if the request succeeded, o.w failed.
+   */
+  void emitSDStatusInitialRequestEvent(String cluster, boolean isNextGen, long duration, boolean succeeded);
+
+  // Action type of updating an app status.
+  enum StatusUpdateActionType {
+    // mark the app instance as ready to serve traffic (all infra and app-custom components which relate to service discovery are ready).
+    MARK_READY,
+    // Mark the app instance as running (still reachable/discoverable) but doesn't intend to take traffic (clients could still try with them for corner cases,
+    // like when no ready ones are there). Note: Current D2 system doesn't save apps of this state to ZK, so this action won't be used in D2.
+    MARK_RUNNING,
+    // Mark the app instance as shut/shutting down or unreachable/unresponsive, could because of undeployment or outage incidences.
+    MARK_DOWN,
+    // Update the app status data, such as instance properties for custom routing, latencies, etc. Note: Current D2 system does data
+    // update by removing the existing node and creating a new one, so this action won't be used in D2.
+    UPDATE_DATA
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperServerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperServerJmx.java
@@ -30,6 +30,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+
+/**
+ * NOTE: NOT IN USE
+ */
 public class ZooKeeperServerJmx implements ZooKeeperServerJmxMXBean
 {
   private final ZooKeeperServer _server;

--- a/d2/src/test/java/com/linkedin/d2/balancer/properties/UriPropertiesTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/properties/UriPropertiesTest.java
@@ -25,31 +25,18 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.linkedin.d2.util.TestDataHelper.*;
+
+
 public class UriPropertiesTest
 {
   @Test
   public void testUriProperties()
   {
-    URI uri1 = URI.create("http://google.com");
-    URI uri2 = URI.create("http://linkedin.com");
-    URI uri3 = URI.create("https://linkedin.com");
-
-    Map<Integer, PartitionData> map1 = new HashMap<>();
-    map1.put(0, new PartitionData(1));
-    map1.put(1, new PartitionData(2));
-
-    Map<Integer, PartitionData> map2 = new HashMap<>();
-    map2.put(1, new PartitionData(0.5));
-
-    Map<Integer, PartitionData> map3 = new HashMap<>();
-    map3.put(1, new PartitionData(2));
-    map3.put(3, new PartitionData(3.5));
-    map3.put(4, new PartitionData(1));
-
     Map<URI, Map<Integer, PartitionData>> uriData = new HashMap<>();
-    uriData.put(uri1, map1);
-    uriData.put(uri2, map2);
-    uriData.put(uri3, map3);
+    uriData.put(URI_1, MAP_1);
+    uriData.put(URI_2, MAP_2);
+    uriData.put(URI_3, MAP_3);
 
     String clusterName = "TestCluster";
     UriProperties properties = new UriProperties(clusterName, uriData);
@@ -58,32 +45,32 @@ public class UriPropertiesTest
     Assert.assertEquals(clusterName, properties.getClusterName());
     Assert.assertEquals(properties.getPartitionDesc(), uriData);
     Assert.assertEquals(properties.Uris(), uriData.keySet());
-    Assert.assertEquals(properties.getPartitionDataMap(uri1), map1);
-    Assert.assertEquals(properties.getPartitionDataMap(uri2), map2);
-    Assert.assertEquals(properties.getPartitionDataMap(uri3), map3);
+    Assert.assertEquals(properties.getPartitionDataMap(URI_1), MAP_1);
+    Assert.assertEquals(properties.getPartitionDataMap(URI_2), MAP_2);
+    Assert.assertEquals(properties.getPartitionDataMap(URI_3), MAP_3);
 
     // test getUriBySchemeAndPartition
     Set<URI> set = new HashSet<>(1);
-    set.add(uri1);
+    set.add(URI_1);
     Assert.assertEquals(properties.getUriBySchemeAndPartition("http", 0), set);
-    set.add(uri2);
+    set.add(URI_2);
     Assert.assertEquals(properties.getUriBySchemeAndPartition("http", 1), set);
     set.clear();
-    set.add(uri3);
+    set.add(URI_3);
     Assert.assertEquals(properties.getUriBySchemeAndPartition("https", 1), set);
     Assert.assertNull(properties.getUriBySchemeAndPartition("rtp", 0));
     Assert.assertNull(properties.getUriBySchemeAndPartition("http", 2));
 
     // test unmodifiability
     Map<URI, Map<Integer, PartitionData>> partitionDesc = properties.getPartitionDesc();
-    Map<Integer, PartitionData> partitionDataMap = properties.getPartitionDataMap(uri1);
+    Map<Integer, PartitionData> partitionDataMap = properties.getPartitionDataMap(URI_1);
     URI testUri = URI.create("test");
     try
     {
       partitionDesc.put(testUri, null);
       Assert.fail("Should not be modifiable");
     }
-    catch (UnsupportedOperationException e)
+    catch (UnsupportedOperationException ignored)
     {
 
     }
@@ -92,7 +79,7 @@ public class UriPropertiesTest
       partitionDataMap.put(1, new PartitionData(1));
       Assert.fail("Should not be modifiable");
     }
-    catch (UnsupportedOperationException e)
+    catch (UnsupportedOperationException ignored)
     {
 
     }

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenWatcherTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenWatcherTest.java
@@ -16,19 +16,20 @@
 
 package com.linkedin.d2.discovery.stores.zk;
 
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
+import com.linkedin.d2.balancer.properties.UriProperties;
+import com.linkedin.d2.balancer.properties.UriPropertiesJsonSerializer;
+import com.linkedin.d2.balancer.properties.UriPropertiesMerger;
 import com.linkedin.d2.discovery.event.PropertyEventBusImpl;
 import com.linkedin.d2.discovery.event.PropertyEventSubscriber;
-import com.linkedin.d2.discovery.stores.PropertySetStringMerger;
-import com.linkedin.d2.discovery.stores.PropertySetStringSerializer;
+import com.linkedin.d2.util.TestDataHelper;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -45,10 +46,12 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
+import static com.linkedin.d2.util.TestDataHelper.*;
+
+
 /**
- * Tests for the Publisher part of the EphemeralStore, which keeps track of children of a node
- *
- * @author Francesco Capponi (fcapponi@linkedin.com)
+ * Tests for the Child Watcher of {@link ZooKeeperEphemeralStore}, which keeps track of the uri nodes under a cluster.
+ * Also tests the publisher part that publishes to property event bus.
  */
 public class ZooKeeperEphemeralStoreChildrenWatcherTest
 {
@@ -56,9 +59,17 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
   private ZKServer _zkServer;
   private int _port;
   private ExecutorService _executor = Executors.newSingleThreadExecutor();
-  private PropertyEventBusImpl<Set<String>> _eventBus;
-  private volatile Set<String> _outputData;
-  private Map<String, String> _testData;
+  private PropertyEventBusImpl<UriProperties> _eventBus;
+  private volatile UriProperties _outputData;
+  private Map<String, UriProperties> _testData;
+
+  private static final String CHILD_PATH_1 = "/" + CLUSTER_NAME + "/child-1";
+  private static final String CHILD_PATH_2 = "/" + CLUSTER_NAME + "/child-2";
+  private static final String CHILD_PATH_3 = "/" + CLUSTER_NAME + "/child-3";
+  private static final String CHILD_PATH_4 = "/" + CLUSTER_NAME + "/child-4";
+
+  private static final UriPropertiesJsonSerializer SERIALIZER = new UriPropertiesJsonSerializer();
+  private static final UriPropertiesMerger MERGER = new UriPropertiesMerger();
 
   @BeforeSuite
   public void setup() throws InterruptedException, ExecutionException, IOException
@@ -88,10 +99,10 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
 
   private void generateTestData()
   {
-    _testData = new HashMap<>();
-    _testData.put("/bucket/child-1", "1");
-    _testData.put("/bucket/child-2", "2");
-    _testData.put("/bucket/child-3", "3");
+    _testData = new TreeMap<>();
+    _testData.put(CHILD_PATH_1, PROPERTIES_1);
+    _testData.put(CHILD_PATH_2, PROPERTIES_2);
+    _testData.put(CHILD_PATH_3, PROPERTIES_3);
   }
 
   @BeforeMethod
@@ -101,25 +112,25 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     generateTestData();
     FutureCallback<None> callback = new FutureCallback<>();
 
-    _zkClient.ensurePersistentNodeExists("/bucket", callback);
+    _zkClient.ensurePersistentNodeExists("/" + CLUSTER_NAME, callback);
     callback.get(5, TimeUnit.SECONDS);
 
-    for (Map.Entry<String, String> entry : _testData.entrySet())
+    for (Map.Entry<String, UriProperties> entry : _testData.entrySet())
     {
       addNode(entry.getKey(), entry.getValue());
     }
   }
 
-  private void addNode(String key, String value) throws InterruptedException, ExecutionException, TimeoutException, KeeperException
+  private void addNode(String key, UriProperties value) throws InterruptedException, ExecutionException, TimeoutException, KeeperException
   {
-    _zkClient.getZooKeeper().create(key, value.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    _zkClient.getZooKeeper().create(key, SERIALIZER.toBytes(value), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
   }
 
   @AfterMethod
   public void tearDownMethod() throws ExecutionException, InterruptedException
   {
     FutureCallback<None> callback = new FutureCallback<>();
-    _zkClient.removeNodeUnsafeRecursive("/bucket", callback);
+    _zkClient.removeNodeUnsafeRecursive("/" + CLUSTER_NAME, callback);
     callback.get();
   }
 
@@ -129,24 +140,24 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     ZKConnection client = new ZKConnection("localhost:" + _port, 5000);
     client.start();
 
-    final ZooKeeperEphemeralStore<Set<String>> publisher =
-      new ZooKeeperEphemeralStore<>(client, new PropertySetStringSerializer(),
-        new PropertySetStringMerger(), "/");
+    final ZooKeeperEphemeralStore<UriProperties> publisher = getStore(client);
+    TestDataHelper.MockD2ServiceDiscoveryEventHelper mockEventHelper = getMockD2ServiceDiscoveryEventHelper();
+    publisher.setServiceDiscoveryEventHelper(mockEventHelper);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
     final CountDownLatch startLatch = new CountDownLatch(1);
-    final PropertyEventSubscriber<Set<String>> subscriber = new PropertyEventSubscriber<Set<String>>()
+    final PropertyEventSubscriber<UriProperties> subscriber = new PropertyEventSubscriber<UriProperties>()
     {
       @Override
-      public void onInitialize(String propertyName, Set<String> propertyValue)
+      public void onInitialize(String propertyName, UriProperties propertyValue)
       {
         _outputData = propertyValue;
         initLatch.countDown();
       }
 
       @Override
-      public void onAdd(String propertyName, Set<String> propertyValue)
+      public void onAdd(String propertyName, UriProperties propertyValue)
       {
         addLatch.countDown();
       }
@@ -168,7 +179,7 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
       public void onSuccess(None result)
       {
         _eventBus = new PropertyEventBusImpl<>(_executor, publisher);
-        _eventBus.register(Collections.singleton("bucket"), subscriber);
+        _eventBus.register(Collections.singleton(CLUSTER_NAME), subscriber);
         startLatch.countDown();
       }
     });
@@ -182,17 +193,37 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
       Assert.fail("unable to publish initial property value");
     }
 
+    // 1 initial request succeeded
+    mockEventHelper.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
+    // 3 markups
+    mockEventHelper.verifySDStatusUpdateReceiptEvents(
+        ImmutableSet.of(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME),
+        ImmutableSet.of(HOST_1, HOST_2, HOST_3),
+        ImmutableSet.of(PORT_1, PORT_2, PORT_3),
+        ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3),
+        ImmutableSet.of(PROPERTIES_1.toString(), PROPERTIES_2.toString(), PROPERTIES_3.toString()),
+        true
+    );
+
     FutureCallback<None> callback = new FutureCallback<>();
-    _zkClient.setDataUnsafe("/bucket/child-1", "4".getBytes(), callback);
+    _zkClient.setDataUnsafe(CHILD_PATH_1, SERIALIZER.toBytes(PROPERTIES_4), callback);
     callback.get();
 
     if (addLatch.await(2, TimeUnit.SECONDS))
     {
       Assert.fail("The EphemeralStore shouldn't watch for data change");
     }
-    Assert.assertEquals(_outputData, new HashSet<>(_testData.values()));
-    _eventBus.unregister(Collections.singleton("bucket"), subscriber);
+    // no more markups
+    Assert.assertEquals(mockEventHelper._receiptMarkUpHosts.size(), 3);
+    // 0 markdown
+    Assert.assertEquals(mockEventHelper._receiptMarkDownHosts.size(), 0);
+    Assert.assertEquals(_outputData, MERGER.merge(CLUSTER_NAME, _testData.values()));
+    _eventBus.unregister(Collections.singleton(CLUSTER_NAME), subscriber);
     client.shutdown();
+  }
+
+  private ZooKeeperEphemeralStore<UriProperties> getStore(ZKConnection client) {
+    return new ZooKeeperEphemeralStore<>(client, SERIALIZER, MERGER, "/", false, true);
   }
 
   @Test
@@ -201,24 +232,24 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     ZKConnection client = new ZKConnection("localhost:" + _port, 5000);
     client.start();
 
-    final ZooKeeperEphemeralStore<Set<String>> publisher =
-      new ZooKeeperEphemeralStore<>(client, new PropertySetStringSerializer(),
-        new PropertySetStringMerger(), "/");
+    final ZooKeeperEphemeralStore<UriProperties> publisher = getStore(client);
+    TestDataHelper.MockD2ServiceDiscoveryEventHelper mockEventHelper = getMockD2ServiceDiscoveryEventHelper();
+    publisher.setServiceDiscoveryEventHelper(mockEventHelper);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
     final CountDownLatch startLatch = new CountDownLatch(1);
-    final PropertyEventSubscriber<Set<String>> subscriber = new PropertyEventSubscriber<Set<String>>()
+    final PropertyEventSubscriber<UriProperties> subscriber = new PropertyEventSubscriber<UriProperties>()
     {
       @Override
-      public void onInitialize(String propertyName, Set<String> propertyValue)
+      public void onInitialize(String propertyName, UriProperties propertyValue)
       {
         _outputData = propertyValue;
         initLatch.countDown();
       }
 
       @Override
-      public void onAdd(String propertyName, Set<String> propertyValue)
+      public void onAdd(String propertyName, UriProperties propertyValue)
       {
         _outputData = propertyValue;
         addLatch.countDown();
@@ -241,7 +272,7 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
       public void onSuccess(None result)
       {
         _eventBus = new PropertyEventBusImpl<>(_executor, publisher);
-        _eventBus.register(Collections.singleton("bucket"), subscriber);
+        _eventBus.register(Collections.singleton(CLUSTER_NAME), subscriber);
         startLatch.countDown();
       }
     });
@@ -254,15 +285,27 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     {
       Assert.fail("unable to publish initial property value");
     }
-    addNode("/bucket/child-4", "4");
+    addNode(CHILD_PATH_4, PROPERTIES_4);
 
     if (!addLatch.await(5, TimeUnit.SECONDS))
     {
       Assert.fail("didn't get notified for the new node");
     }
-    _testData.put("/bucket/child-4", "4");
-    Assert.assertEquals(_outputData, new HashSet<>(_testData.values()));
-    _eventBus.unregister(Collections.singleton("bucket"), subscriber);
+
+    // 1 initial request succeeded
+    mockEventHelper.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
+    // 4 mark ups
+    mockEventHelper.verifySDStatusUpdateReceiptEvents(
+        ImmutableSet.of(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME),
+        ImmutableSet.of(HOST_1, HOST_2, HOST_3, HOST_4),
+        ImmutableSet.of(PORT_1, PORT_2, PORT_3, PORT_4),
+        ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3, CHILD_PATH_4),
+        ImmutableSet.of(PROPERTIES_1.toString(), PROPERTIES_2.toString(), PROPERTIES_3.toString(), PROPERTIES_4.toString()),
+        true
+    );
+    _testData.put(CHILD_PATH_4, PROPERTIES_4);
+    Assert.assertEquals(_outputData, MERGER.merge(CLUSTER_NAME, _testData.values()));
+    _eventBus.unregister(Collections.singleton(CLUSTER_NAME), subscriber);
     client.shutdown();
   }
 
@@ -272,24 +315,24 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     ZKConnection client = new ZKConnection("localhost:" + _port, 5000);
     client.start();
 
-    final ZooKeeperEphemeralStore<Set<String>> publisher =
-      new ZooKeeperEphemeralStore<>(client, new PropertySetStringSerializer(),
-        new PropertySetStringMerger(), "/");
+    final ZooKeeperEphemeralStore<UriProperties> publisher = getStore(client);
+    TestDataHelper.MockD2ServiceDiscoveryEventHelper mockEventHelper = getMockD2ServiceDiscoveryEventHelper();
+    publisher.setServiceDiscoveryEventHelper(mockEventHelper);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
     final CountDownLatch startLatch = new CountDownLatch(1);
-    final PropertyEventSubscriber<Set<String>> subscriber = new PropertyEventSubscriber<Set<String>>()
+    final PropertyEventSubscriber<UriProperties> subscriber = new PropertyEventSubscriber<UriProperties>()
     {
       @Override
-      public void onInitialize(String propertyName, Set<String> propertyValue)
+      public void onInitialize(String propertyName, UriProperties propertyValue)
       {
         _outputData = propertyValue;
         initLatch.countDown();
       }
 
       @Override
-      public void onAdd(String propertyName, Set<String> propertyValue)
+      public void onAdd(String propertyName, UriProperties propertyValue)
       {
         _outputData = propertyValue;
         addLatch.countDown();
@@ -312,7 +355,7 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
       public void onSuccess(None result)
       {
         _eventBus = new PropertyEventBusImpl<>(_executor, publisher);
-        _eventBus.register(Collections.singleton("bucket"), subscriber);
+        _eventBus.register(Collections.singleton(CLUSTER_NAME), subscriber);
         startLatch.countDown();
       }
     });
@@ -326,17 +369,32 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
       Assert.fail("unable to publish initial property value");
     }
 
+    // 1 initial request succeeded
+    mockEventHelper.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
+    // 3 markups
+    mockEventHelper.verifySDStatusUpdateReceiptEvents(
+        ImmutableSet.of(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME),
+        ImmutableSet.of(HOST_1, HOST_2, HOST_3),
+        ImmutableSet.of(PORT_1, PORT_2, PORT_3),
+        ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3),
+        ImmutableSet.of(PROPERTIES_1.toString(), PROPERTIES_2.toString(), PROPERTIES_3.toString()),
+        true
+    );
     FutureCallback<None> callback = new FutureCallback<>();
-    _zkClient.removeNodeUnsafe("/bucket/child-1", callback);
+    _zkClient.removeNodeUnsafe(CHILD_PATH_1, callback);
     callback.get();
 
     if (!addLatch.await(5, TimeUnit.SECONDS))
     {
       Assert.fail("didn't get notified for the removed node");
     }
-    _testData.remove("/bucket/child-1");
-    Assert.assertEquals(_outputData, new HashSet<>(_testData.values()));
-    _eventBus.unregister(Collections.singleton("bucket"), subscriber);
+
+    // 1 markdown
+    mockEventHelper.verifySDStatusUpdateReceiptEvents(ImmutableSet.of(CLUSTER_NAME), ImmutableSet.of(HOST_1), ImmutableSet.of(1),
+        ImmutableSet.of(CHILD_PATH_1), ImmutableSet.of(PROPERTIES_1.toString()), false);
+    _testData.remove(CHILD_PATH_1);
+    Assert.assertEquals(_outputData, MERGER.merge(CLUSTER_NAME, _testData.values()));
+    _eventBus.unregister(Collections.singleton(CLUSTER_NAME), subscriber);
     client.shutdown();
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStoreTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperPermanentStoreTest.java
@@ -19,6 +19,7 @@ package com.linkedin.d2.discovery.stores.zk;
 import com.linkedin.d2.discovery.stores.PropertyStoreException;
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -31,15 +32,20 @@ import java.io.IOException;
 
 public class ZooKeeperPermanentStoreTest extends PropertyStoreTest
 {
-  protected static final int PORT = 5000;
+  protected int _port;
 
   protected ZKServer _zkServer;
 
   @BeforeMethod
   public void setupServer() throws IOException, InterruptedException
   {
-    _zkServer = new ZKServer(PORT);
-    _zkServer.startup();
+    try {
+      _zkServer = new ZKServer();
+      _zkServer.startup();
+      _port = _zkServer.getPort();
+    } catch (IOException e) {
+      Assert.fail("unable to instantiate real zk server on port " + _port);
+    }
   }
 
   @AfterMethod
@@ -53,7 +59,7 @@ public class ZooKeeperPermanentStoreTest extends PropertyStoreTest
   {
     try
     {
-      ZKConnection client = new ZKConnection("localhost:" + PORT, 30000);
+      ZKConnection client = new ZKConnection("localhost:" + _port, 30000);
       client.start();
 
       ZooKeeperPermanentStore<String> store = new ZooKeeperPermanentStore<>(

--- a/d2/src/test/java/com/linkedin/d2/util/TestDataHelper.java
+++ b/d2/src/test/java/com/linkedin/d2/util/TestDataHelper.java
@@ -1,0 +1,213 @@
+package com.linkedin.d2.util;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.UriProperties;
+import com.linkedin.d2.discovery.event.D2ServiceDiscoveryEventHelper;
+import com.linkedin.d2.discovery.event.ServiceDiscoveryEventEmitter;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class TestDataHelper {
+  public static final String CLUSTER_NAME = "TestCluster";
+  public static final String HOST_1 = "google.com";
+  public static final String HOST_2 = "linkedin.com";
+  public static final String HOST_3 = "youtube.com";
+  public static final String HOST_4 = "facebook.com";
+  public static final int PORT_1 = 1;
+  public static final int PORT_2 = 2;
+  public static final int PORT_3 = 3;
+  public static final int PORT_4 = 4;
+  public static final URI URI_1 = URI.create("http://" + HOST_1 + ":" + PORT_1);
+  public static final URI URI_2 = URI.create("http://" + HOST_2 + ":" + PORT_2);
+  public static final URI URI_3 = URI.create("https://" + HOST_3 + ":" + PORT_3);
+  public static final URI URI_4 = URI.create("https://" + HOST_4 + ":" + PORT_4);
+
+  public static final UriProperties PROPERTIES_1;
+  public static final UriProperties PROPERTIES_2;
+  public static final UriProperties PROPERTIES_3;
+  public static final UriProperties PROPERTIES_4;
+
+  public static final Map<Integer, PartitionData> MAP_1 = ImmutableMap.of(
+    0, new PartitionData(1),
+    1, new PartitionData(2));
+
+  public static final Map<Integer, PartitionData> MAP_2 = Collections.singletonMap(1, new PartitionData(0.5));
+
+  public static final Map<Integer, PartitionData> MAP_3 = ImmutableMap.of(
+    1, new PartitionData(2),
+    3, new PartitionData(3.5),
+    4, new PartitionData(1));
+
+  public static final Map<Integer, PartitionData> MAP_4 = ImmutableMap.of(
+    0, new PartitionData(1),
+    1, new PartitionData(3));
+
+  static {
+    PROPERTIES_1 = new UriProperties(CLUSTER_NAME, Collections.singletonMap(URI_1, MAP_1));
+    PROPERTIES_2 = new UriProperties(CLUSTER_NAME, Collections.singletonMap(URI_2, MAP_2));
+    PROPERTIES_3 = new UriProperties(CLUSTER_NAME, Collections.singletonMap(URI_3, MAP_3));
+    PROPERTIES_4 = new UriProperties(CLUSTER_NAME, Collections.singletonMap(URI_4, MAP_4));
+  }
+
+
+  public static MockD2ServiceDiscoveryEventHelper getMockD2ServiceDiscoveryEventHelper() {
+    return new MockD2ServiceDiscoveryEventHelper();
+  }
+
+  public static MockServiceDiscoveryEventEmitter getMockServiceDiscoveryEventEmitter() {
+    return new MockServiceDiscoveryEventEmitter();
+  }
+
+  public static class MockD2ServiceDiscoveryEventHelper implements D2ServiceDiscoveryEventHelper {
+    public final List<String> _activeUpdateIntentAndWriteClusters = new ArrayList<>();
+    public final List<Boolean> _activeUpdateIntentAndWriteIsMarkUpFlags = new ArrayList<>();
+    public final List<Boolean> _activeUpdateIntentAndWriteSucceededFlags = new ArrayList<>();
+
+    public final Set<String> _receiptMarkUpClusters = new HashSet<>();
+    public final Set<String> _receiptMarkUpHosts = new HashSet<>();
+    public final Set<Integer> _receiptMarkUpPorts = new HashSet<>();
+    public final Set<String> _receiptMarkUpPaths = new HashSet<>();
+    public final Set<String> _receiptMarkUpProperties = new HashSet<>();
+
+    public final Set<String> _receiptMarkDownClusters = new HashSet<>();
+    public final Set<String> _receiptMarkDownHosts = new HashSet<>();
+    public final Set<Integer> _receiptMarkDownPorts = new HashSet<>();
+    public final Set<String> _receiptMarkDownPaths = new HashSet<>();
+    public final Set<String> _receiptMarkDownProperties = new HashSet<>();
+
+    public final List<String> _initialRequestClusters = new ArrayList<>();
+    public final List<Long> _initialRequestDurations = new ArrayList<>();
+    public final List<Boolean> _initialRequestSucceededFlags = new ArrayList<>();
+
+    @Override
+    public void emitSDStatusActiveUpdateIntentAndWriteEvents(String cluster, boolean isMarkUp, boolean succeeded,
+        long startAt) {
+      _activeUpdateIntentAndWriteClusters.add(cluster);
+      _activeUpdateIntentAndWriteIsMarkUpFlags.add(isMarkUp);
+      _activeUpdateIntentAndWriteSucceededFlags.add(succeeded);
+    }
+
+    @Override
+    public void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, boolean isMarkUp,
+        String zkConnectString, String nodePath, String properties, long timestamp) {
+      if (isMarkUp) {
+        _receiptMarkUpClusters.add(cluster);
+        _receiptMarkUpHosts.add(host);
+        _receiptMarkUpPorts.add(port);
+        _receiptMarkUpPaths.add(nodePath);
+        _receiptMarkUpProperties.add(properties);
+      } else {
+        _receiptMarkDownClusters.add(cluster);
+        _receiptMarkDownHosts.add(host);
+        _receiptMarkDownPorts.add(port);
+        _receiptMarkDownPaths.add(nodePath);
+        _receiptMarkDownProperties.add(properties);
+      }
+    }
+
+    @Override
+    public void emitSDStatusInitialRequestEvent(String cluster, long duration, boolean succeeded) {
+      _initialRequestClusters.add(cluster);
+      _initialRequestDurations.add(duration);
+      _initialRequestSucceededFlags.add(succeeded);
+    }
+
+    public void verifySDStatusActiveUpdateIntentAndWriteEvents(List<String> clusters, List<Boolean> isMarkUpFlags, List<Boolean> succeededFlags) {
+      assertEquals(clusters, _activeUpdateIntentAndWriteClusters, "incorrect clusters");
+      assertEquals(isMarkUpFlags, _activeUpdateIntentAndWriteIsMarkUpFlags, "incorrect isMarkUp flags");
+      assertEquals(succeededFlags, _activeUpdateIntentAndWriteSucceededFlags, "incorrect succeeded flags");
+    }
+
+    public void verifySDStatusUpdateReceiptEvents(Set<String> clusters, Set<String> hosts, Set<Integer> ports,
+        Set<String> nodePaths, Set<String> properties, boolean isForMarkUp) {
+      assertEquals(clusters, isForMarkUp ? _receiptMarkUpClusters : _receiptMarkDownClusters, "incorrect clusters");
+      assertEquals(hosts, isForMarkUp ? _receiptMarkUpHosts : _receiptMarkDownHosts, "incorrect hosts");
+      assertEquals(ports, isForMarkUp ? _receiptMarkUpPorts : _receiptMarkDownPorts, "incorrect ports");
+      assertEquals(nodePaths, isForMarkUp ? _receiptMarkUpPaths : _receiptMarkDownPaths, "incorrect node paths");
+      assertEquals(properties, isForMarkUp ? _receiptMarkUpProperties : _receiptMarkDownProperties, "incorrect node properties");
+    }
+
+    public void verifySDStatusInitialRequestEvents(List<String> clusters, List<Boolean> succeededFlags) {
+      assertEquals(clusters, _initialRequestClusters, "incorrect clusters");
+      // the duration could be 0 when requests took < 1ms,
+      _initialRequestDurations.forEach(duration -> assertTrue(duration >= 0, "incorrect durations"));
+      assertEquals(succeededFlags, _initialRequestSucceededFlags, "incorrect succeeded flags");
+    }
+  }
+
+  public static class MockServiceDiscoveryEventEmitter implements ServiceDiscoveryEventEmitter {
+    public final List<List<String>> _clustersClaimedList = new ArrayList<>();
+    public final List<StatusUpdateActionType> _activeUpdateIntentActionTypes = new ArrayList<>();
+    public final List<String> _activeUpdateIntentTracingIds = new ArrayList<>();
+
+    public final List<String> _writeClusters = new ArrayList<>();
+    public final List<String> _writeHosts = new ArrayList<>();
+    public final List<StatusUpdateActionType> _writeActionTypes = new ArrayList<>();
+    public final List<String> _writeServiceRegistryKeys = new ArrayList<>();
+    public final List<String> _writeServiceRegistryValues = new ArrayList<>();
+    public final List<Integer> _writeServiceRegistryVersions = new ArrayList<>();
+    public final List<String> _writeTracingIds = new ArrayList<>();
+    public final List<Boolean> _writeSucceededFlags = new ArrayList<>();
+
+    @Override
+    public void emitSDStatusActiveUpdateIntentEvent(List<String> clustersClaimed, StatusUpdateActionType actionType,
+        boolean isNextGen, String tracingId, long timestamp) {
+      _clustersClaimedList.add(clustersClaimed);
+      _activeUpdateIntentActionTypes.add(actionType);
+      _activeUpdateIntentTracingIds.add(tracingId);
+    }
+
+    @Override
+    public void emitSDStatusWriteEvent(String cluster, String host, int port, StatusUpdateActionType actionType,
+        String serviceRegistry, String serviceRegistryKey, String serviceRegistryValue, Integer serviceRegistryVersion,
+        String tracingId, boolean succeeded, long timestamp) {
+      _writeClusters.add(cluster);
+      _writeHosts.add(host);
+      _writeActionTypes.add(actionType);
+      _writeServiceRegistryKeys.add(serviceRegistryKey);
+      _writeServiceRegistryValues.add(serviceRegistryValue);
+      _writeServiceRegistryVersions.add(serviceRegistryVersion);
+      _writeTracingIds.add(tracingId);
+      _writeSucceededFlags.add(succeeded);
+    }
+
+    @Override
+    public void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, StatusUpdateActionType actionType,
+        boolean isNextGen, String serviceRegistry, String serviceRegistryKey, String serviceRegistryValue,
+        Integer serviceRegistryVersion, String tracingId, long timestamp) {
+    }
+
+    @Override
+    public void emitSDStatusInitialRequestEvent(String cluster, boolean isNextGen, long duration, boolean succeeded) {
+    }
+
+    public void verifySDStatusActiveUpdateIntentEvents(List<List<String>> clustersClaimedList, List<StatusUpdateActionType> actionTypes,
+        List<String> tracingIds) {
+      assertEquals(clustersClaimedList, _clustersClaimedList, "incorrect clustersClaimedList");
+      assertEquals(actionTypes, _activeUpdateIntentActionTypes, "incorrect action types");
+      assertEquals(tracingIds, _activeUpdateIntentTracingIds, "incorrect tracing ids");
+    }
+
+    public void verifySDStatusWriteEvents(List<String> clusters, List<String> hosts, List<StatusUpdateActionType> actionTypes, List<String> serviceRegistryKeys,
+        List<String> serviceRegistryValues, List<Integer> serviceRegistryVersions, List<String> tracingIds, List<Boolean> succeededFlags) {
+      assertEquals(clusters, _writeClusters, "incorrect clusters");
+      assertEquals(hosts, _writeHosts, "incorrect hosts");
+      assertEquals(actionTypes, _writeActionTypes, "incorrect actionTypes");
+      assertEquals(serviceRegistryKeys, _writeServiceRegistryKeys, "incorrect serviceRegistryKeys");
+      assertEquals(serviceRegistryValues, _writeServiceRegistryValues, "incorrect serviceRegistryValues");
+      assertEquals(serviceRegistryVersions, _writeServiceRegistryVersions, "incorrect serviceRegistryVersions");
+      assertEquals(tracingIds, _writeTracingIds, "incorrect tracingIds");
+      assertEquals(succeededFlags, _writeSucceededFlags, "incorrect succeededFlags");
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.39.4
+version=29.39.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Reference schemas in previous avro-schema RB, design doc at "[WIP][INDIS] End-to-End Monitoring Design".
Emit service discovery status related events at:
1) (de)announcements
2) when received updated host list (emit for each URI). 
3) first time requesting the host list for a cluster on cache miss. 

Note: will add tests once implementation is approved. Will add corresponding container part code soon.