### PR TITLE
Update the error message to better guide users when zkRef is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.38.5] - 2022-09-15
+Update the error message to better guide users when zkRef is null.
+
 ## [29.38.4] - 2022-09-08
 - Use ZooKeeper 3.6.3
 
@@ -5337,7 +5340,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.38.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.38.5...master
+[29.38.5]: https://github.com/linkedin/rest.li/compare/v29.38.4...v29.38.5
 [29.38.4]: https://github.com/linkedin/rest.li/compare/v29.38.3...v29.38.4
 [29.38.3]: https://github.com/linkedin/rest.li/compare/v29.38.2...v29.38.3
 [29.38.2]: https://github.com/linkedin/rest.li/compare/v29.38.1-rc.1...v29.38.2

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZKConnection.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZKConnection.java
@@ -323,7 +323,8 @@ public class ZKConnection
       zk = _zkRef.get();
       if (zk == null)
       {
-        throw new IllegalStateException("Null zkRef after countdownlatch.");
+        throw new IllegalStateException("Null zkRef after countdownlatch. If this happened at shutdown, please check if your app has custom de-announcements. "
+            + "Mis-coordinating custom de-announcement with the default de-announcement could cause double de-announcing and lead to this exception.");
       }
     }
     catch (InterruptedException e)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.38.4
+version=29.38.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
When apps have custom de-announcement, they may end up double de-announcing, and zk connection will be closed after the first de-announcement and throw errors at the 2nd de-announcement (not causing any issue in the app though). Here we update the error message for the exception to better guide the users.  