### PR TITLE
Catch exceptions when connection state change event is received after ZK connection shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.39.3] - 2022-09-26
+Catch exceptions when zk connection state change event is received after zk connection shutdown.
+
 ## [29.39.2] - 2022-09-23
 Remove unnessary extra IDL annotations due to recent restriction of adding new method into bridged service and emit resourceC
 lass for javaparser to use to update rest.li resource.
@@ -5353,7 +5356,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.3...master
+[29.39.3]: https://github.com/linkedin/rest.li/compare/v29.39.2...v29.39.3
 [29.39.2]: https://github.com/linkedin/rest.li/compare/v29.39.1...v29.39.2
 [29.39.1]: https://github.com/linkedin/rest.li/compare/v29.39.0...v29.39.1
 [29.39.0]: https://github.com/linkedin/rest.li/compare/v29.38.6...v29.39.0

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZKConnection.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZKConnection.java
@@ -834,13 +834,9 @@ public class ZKConnection
       }
       catch (IllegalStateException e)
       {
-        if (_shutdownAsynchronously) {
-          // On asynchronous shutdown, this can be a legitimate race.
-          LOG.debug("Watched event received after connection shutdown (type {}, state {}.", watchedEvent.getType(),
-              watchedEvent.getState());
-          return;
-        }
-        throw e;
+        // if connection state change event is received after zk object is gone, it is a legitimate race.
+        LOG.debug("Watched event received after connection shutdown (type {}, state {}.", watchedEvent.getType(), watchedEvent.getState());
+        return;
       }
       long sessionID = zk.getSessionId();
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.39.2
+version=29.39.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
As titled, we used to catch the exception and log a debug message for async-shutdown only. But it was reported for regular shutdown as well. It's safe to catch the exception instead of throwing for all shutdown.