### PR TITLE
Expose an easy way to override validation options for ActionArgumentBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.39.1] - 2022-09-20
+Expose an easy way to override validation options for ActionArgumentBuilder
+
 ## [29.39.0] - 2022-09-19
 Releasing support for UDS in HTTP/2 stack
 
@@ -5346,7 +5349,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.1...master
+[29.39.1]: https://github.com/linkedin/rest.li/compare/v29.39.0...v29.39.1
 [29.39.0]: https://github.com/linkedin/rest.li/compare/v29.38.6...v29.39.0
 [29.38.6]: https://github.com/linkedin/rest.li/compare/v29.38.5...v29.38.6
 [29.38.5]: https://github.com/linkedin/rest.li/compare/v29.38.4...v29.38.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.39.0
+version=29.39.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/methods/arguments/ActionArgumentBuilder.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/methods/arguments/ActionArgumentBuilder.java
@@ -62,13 +62,17 @@ public class ActionArgumentBuilder implements RestLiArgumentBuilder
     }
     DynamicRecordTemplate template = new DynamicRecordTemplate(data, resourceMethodDescriptor.getRequestDataSchema());
     ValidationResult result =
-        ValidateDataAgainstSchema.validate(data, template.schema(), new ValidationOptions(RequiredMode.IGNORE,
-                                                                                          CoercionMode.NORMAL));
+        ValidateDataAgainstSchema.validate(data, template.schema(), getValidationOptions());
     if (!result.isValid())
     {
       throw new RoutingException("Parameters of method '" + resourceMethodDescriptor.getActionName()
           + "' failed validation with error '" + result.getMessages() + "'", HttpStatus.S_400_BAD_REQUEST.getCode());
     }
     return new RestLiRequestDataImpl.Builder().entity(template).build();
+  }
+
+  protected ValidationOptions getValidationOptions()
+  {
+    return new ValidationOptions(RequiredMode.IGNORE, CoercionMode.NORMAL);
   }
 }


### PR DESCRIPTION
This is useful for cases that want to customize validation of action arguments.