### PR TITLE
[Java 11] Export jvm stat in :d2:javadoc

### DIFF
--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -1,7 +1,12 @@
 // internal api inaccessible starting 1.9
-if(JavaVersion.current() > JavaVersion.VERSION_1_9){
+if (JavaVersion.current() > JavaVersion.VERSION_1_9) {
   project.tasks.withType(JavaCompile) {
     options.compilerArgs += [ "--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED" ]
+  }
+  javadoc {
+    options {
+      addStringOption('-add-exports', 'jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED')
+    }
   }
 }
 


### PR DESCRIPTION
Follow-up to #834, jvm stat needs to be exposed for the javadoc task as well for java 1.9+