### PR TITLE
Add RestLiTraceInfo to the request context for both client and server…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.39.5] - 2022-10-05
+Add `RestLiTraceInfo` to the `RequestContext` for both incoming and outgoing requests.
+Added `Request.getResourceMethodIdentifier()`,
+ `ResourceDefinition.getBaseUriTemplate()`, and `ResourceMethodDescriptor.getResourceMethodIdentifier()`.
+
 ## [29.39.4] - 2022-09-30
 Add JMX metrics for DNS resolution and clarify DNS timeout errors.
 
@@ -5359,7 +5364,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.5...master
+[29.39.5]: https://github.com/linkedin/rest.li/compare/v29.39.4...v29.39.5
 [29.39.4]: https://github.com/linkedin/rest.li/compare/v29.39.3...v29.39.4
 [29.39.3]: https://github.com/linkedin/rest.li/compare/v29.39.2...v29.39.3
 [29.39.2]: https://github.com/linkedin/rest.li/compare/v29.39.1...v29.39.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.39.6] - 2022-10-06
 - Add equals and hashCode methods to `CollectionResult`, `GetResult`, `UpdateResponse` and `UpdateEntityResponse`.
 
 Add `RestLiTraceInfo` to the `RequestContext` for both incoming and outgoing requests.
@@ -5367,7 +5369,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.39.6...master
+[29.39.6]: https://github.com/linkedin/rest.li/compare/v29.39.5...v29.39.6
 [29.39.5]: https://github.com/linkedin/rest.li/compare/v29.39.4...v29.39.5
 [29.39.4]: https://github.com/linkedin/rest.li/compare/v29.39.3...v29.39.4
 [29.39.3]: https://github.com/linkedin/rest.li/compare/v29.39.2...v29.39.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,12 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 - Add equals and hashCode methods to `CollectionResult`, `GetResult`, `UpdateResponse` and `UpdateEntityResponse`.
 
-## [29.39.5] - 2022-10-04
-- Emit service discovery status related events
-
-## [29.39.5] - 2022-10-05
 Add `RestLiTraceInfo` to the `RequestContext` for both incoming and outgoing requests.
 Added `Request.getResourceMethodIdentifier()`,
  `ResourceDefinition.getBaseUriTemplate()`, and `ResourceMethodDescriptor.getResourceMethodIdentifier()`.
+
+## [29.39.5] - 2022-10-04
+- Emit service discovery status related events
 
 ## [29.39.4] - 2022-09-30
 Add JMX metrics for DNS resolution and clarify DNS timeout errors.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.39.5
+version=29.39.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.39.4
+version=29.39.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/filter/R2Constants.java
+++ b/r2-core/src/main/java/com/linkedin/r2/filter/R2Constants.java
@@ -72,6 +72,7 @@ public class R2Constants
   public static final String PREEMPTIVE_TIMEOUT_RATE = "PREEMPTIVE_TIMEOUT_RATE";
   public static final String PROJECTION_INFO = "PROJECTION_INFO";
   public static final String RESTLI_INFO = "RESTLI_INFO";
+  public static final String RESTLI_TRACE_INFO = "RESTLI_TRACE_INFO";
 
   /**
    * Client uses this key to designate a request as belonging to a group of requests that will be monitored in a

--- a/restli-client/src/main/java/com/linkedin/restli/client/Request.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/Request.java
@@ -26,6 +26,7 @@ import com.linkedin.data.transform.filter.request.MaskTree;
 import com.linkedin.jersey.api.uri.UriTemplate;
 import com.linkedin.restli.common.HttpMethod;
 import com.linkedin.restli.common.ResourceMethod;
+import com.linkedin.restli.common.ResourceMethodIdentifierGenerator;
 import com.linkedin.restli.common.ResourceProperties;
 import com.linkedin.restli.common.ResourceSpec;
 import com.linkedin.restli.common.RestConstants;
@@ -71,6 +72,7 @@ public class Request<T>
   private final Map<String, Class<?>>       _queryParamClasses; // Used for coercing query params. In case of collection or iterable, contains the type parameter class.
   private final String                      _methodName; // needed to identify finders and actions. null for everything else
   private final String                      _baseUriTemplate;
+  private final String                      _resourceMethodIdentifier;
   private final Map<String, Object>         _pathKeys;
   private final List<Object>                _streamingAttachments; //Usually null since streaming is rare. Creating an empty List is wasteful.
   private RestliRequestOptions              _requestOptions;
@@ -113,6 +115,7 @@ public class Request<T>
     _queryParamClasses = queryParamClasses;
     _methodName = methodName;
     _baseUriTemplate = baseUriTemplate;
+    _resourceMethodIdentifier = ResourceMethodIdentifierGenerator.generate(baseUriTemplate, method, methodName);
     _pathKeys = pathKeys;
 
     if (_baseUriTemplate != null && _pathKeys != null)
@@ -215,6 +218,10 @@ public class Request<T>
   public String getBaseUriTemplate()
   {
     return _baseUriTemplate;
+  }
+
+  public String getResourceMethodIdentifier() {
+    return _resourceMethodIdentifier;
   }
 
   public Map<String, Object> getPathKeys()

--- a/restli-client/src/main/java/com/linkedin/restli/client/RestClient.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/RestClient.java
@@ -26,7 +26,6 @@ import com.linkedin.d2.balancer.KeyMapper;
 import com.linkedin.d2.balancer.ServiceUnavailableException;
 import com.linkedin.d2.balancer.util.URIKeyPair;
 import com.linkedin.d2.balancer.util.URIMappingResult;
-import com.linkedin.data.ByteString;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.multipart.MultiPartMIMEUtils;
@@ -59,6 +58,7 @@ import com.linkedin.restli.common.OperationNameGenerator;
 import com.linkedin.restli.common.ProtocolVersion;
 import com.linkedin.restli.common.ResourceMethod;
 import com.linkedin.restli.common.RestConstants;
+import com.linkedin.restli.common.RestLiTraceInfo;
 import com.linkedin.restli.common.attachments.RestLiAttachmentDataSourceWriter;
 import com.linkedin.restli.common.attachments.RestLiDataSourceIterator;
 import com.linkedin.restli.disruptor.DisruptRestController;
@@ -346,6 +346,7 @@ public class RestClient implements Client {
         final ResourceMethod method = request.getMethod();
         final String methodName = request.getMethodName();
         addDisruptContext(request.getBaseUriTemplate(), method, methodName, requestContext);
+        addTraceInfo(request, requestContext);
         sendStreamRequestImpl(requestContext,
           requestUri,
           method,
@@ -407,6 +408,7 @@ public class RestClient implements Client {
         final ResourceMethod method = request.getMethod();
         final String methodName = request.getMethodName();
         addDisruptContext(request.getBaseUriTemplate(), method, methodName, requestContext);
+        addTraceInfo(request, requestContext);
         sendRestRequestImpl(requestContext,
           requestUri,
           method,
@@ -1041,6 +1043,14 @@ public class RestClient implements Client {
         return controller.getDisruptContext(resource, method, name);
       }
     });
+  }
+
+  private <T> void addTraceInfo(Request<T> request, RequestContext requestContext) {
+    RestLiTraceInfo.inject(requestContext,
+                           request.getServiceName(),
+                           OperationNameGenerator.generate(request.getMethod(), request.getMethodName()),
+                           request.getBaseUriTemplate(),
+                           request.getResourceMethodIdentifier());
   }
 
   // Return the scatter gather strategy for the given request, and per-request strategy takes precedence

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestClientBuilders.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestClientBuilders.java
@@ -409,6 +409,7 @@ public class TestClientBuilders
     BatchGetRequest<TestRecord> request =
         builder.ids(1L, 2L, 3L).fields(TestRecord.fields().id(), TestRecord.fields().message()).build();
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.getObjectIds(), new HashSet<>(Arrays.asList(1L, 2L, 3L)));
     Assert.assertEquals(request.getFields(), new HashSet<>(Arrays.asList(
         TestRecord.fields().id(), TestRecord.fields().message())));
@@ -541,6 +542,7 @@ public class TestClientBuilders
         builder.ids(key1,key2).fields(TestRecord.fields().id(), TestRecord.fields().message()).buildKV();
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
 
     // Compare key sets. Note that have to convert keys to Strings as the request internally converts them to string
     HashSet<CompoundKey> expectedIds = new HashSet<>(Arrays.asList(key1, key2));
@@ -602,6 +604,7 @@ public class TestClientBuilders
     GetRequest<TestRecord> request = builder.id(key).build();
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.isSafe(), true);
     Assert.assertEquals(request.isIdempotent(), true);
     checkBasicRequest(request,
@@ -645,6 +648,7 @@ public class TestClientBuilders
     Assert.assertEquals(request.isIdempotent(), false);
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     checkBasicRequest(request, expectedURIDetails, ResourceMethod.CREATE, record, Collections.<String, String>emptyMap(), null);
   }
 
@@ -660,6 +664,7 @@ public class TestClientBuilders
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), true);
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     checkBasicRequest(request,
                       expectedURIDetails,
                       ResourceMethod.UPDATE,
@@ -686,6 +691,7 @@ public class TestClientBuilders
     Assert.assertEquals(request.isIdempotent(), false);
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     checkBasicRequest(request, expectedURIDetails, ResourceMethod.PARTIAL_UPDATE, patch, Collections.<String, String>emptyMap(), null);
   }
 
@@ -745,6 +751,7 @@ public class TestClientBuilders
     BatchUpdateRequest<CompoundKey, TestRecord> request = builder.inputs(inputs).build();
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), true);
 
@@ -789,6 +796,7 @@ public class TestClientBuilders
     BatchPartialUpdateRequest<CompoundKey, TestRecord> request = builder.inputs(inputs).build();
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), false);
     Assert.assertNotNull(request.getPartialUpdateInputMap());
@@ -830,6 +838,7 @@ public class TestClientBuilders
     List<Long> ids = Arrays.asList(1L, 2L, 3L);
     BatchGetRequest<TestRecord> request = builder.ids(ids).fields(TestRecord.fields().id(), TestRecord.fields().message()).build();
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.getObjectIds(), new HashSet<>(Arrays.asList(1L, 2L, 3L)));
     Assert.assertEquals(request.getFields(), new HashSet<>(Arrays.asList(
         TestRecord.fields().id(), TestRecord.fields().message())));
@@ -878,6 +887,7 @@ public class TestClientBuilders
         .appendSingleAttachment(_dataSourceWriterB)
         .build();
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.getObjectIds(), new HashSet<>(Arrays.asList(1L, 2L, 3L)));
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), true);
@@ -926,6 +936,7 @@ public class TestClientBuilders
         .appendSingleAttachment(_dataSourceWriterB)
         .build();
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.getObjectIds(), new HashSet<>(Arrays.asList(1L, 2L, 3L)));
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), false);
@@ -970,6 +981,7 @@ public class TestClientBuilders
         new BatchDeleteRequestBuilder<>(TEST_URI, TestRecord.class, _COLL_SPEC, RestliRequestOptions.DEFAULT_OPTIONS);
     BatchDeleteRequest<Long, TestRecord> request = builder.ids(1L, 2L, 3L).build();
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.getObjectIds(), new HashSet<>(Arrays.asList(1L, 2L, 3L)));
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), true);
@@ -990,6 +1002,7 @@ public class TestClientBuilders
         .build();
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), false);
 
@@ -1451,6 +1464,7 @@ public class TestClientBuilders
     GetRequestBuilder<Long, TestRecord> builder = new GetRequestBuilder<>(TEST_URI, TestRecord.class, _COLL_SPEC, RestliRequestOptions.DEFAULT_OPTIONS);
     GetRequest<TestRecord> request = builder.id(1L).fields(TestRecord.fields().id(), TestRecord.fields().message()).build();
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.getObjectId(), Long.valueOf(1L));
     Assert.assertEquals(request.getFields(), new HashSet<>(Arrays.asList(
         TestRecord.fields().id(), TestRecord.fields().message())));
@@ -1533,6 +1547,7 @@ public class TestClientBuilders
         RestliRequestOptions.DEFAULT_OPTIONS);
     GetRequest<TestRecord> request = builder.fields(TestRecord.fields().id(), TestRecord.fields().message()).build();
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.getObjectId(), null);
     Assert.assertEquals(request.getFields(), new HashSet<>(Arrays.asList(
         TestRecord.fields().id(), TestRecord.fields().message())));
@@ -1857,6 +1872,7 @@ public class TestClientBuilders
     expectedRequest.getEntities().put(toEntityKey(id2, expectedURIDetails.getProtocolVersion()), t2);
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertTrue(request.isIdempotent());
     Assert.assertFalse(request.isSafe());
 
@@ -2074,6 +2090,7 @@ public class TestClientBuilders
     UpdateRequest<TestRecord> request = builder.id(key).input(new TestRecord()).build();
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), true);
     checkBasicRequest(request,
@@ -2095,6 +2112,7 @@ public class TestClientBuilders
     CreateRequest<TestRecord> request = builder.input(new TestRecord()).build();
 
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), false);
     checkBasicRequest(request,
@@ -2169,6 +2187,7 @@ public class TestClientBuilders
     Assert.assertEquals(request.isSafe(), false);
     Assert.assertEquals(request.isIdempotent(), false);
     testBaseUriGeneration(request, expectedURIDetails.getProtocolVersion());
+    testResourceMethodIdentifier(request);
 
     // using .toStringFull (which is deprecated) because this is only used for checking v1
     @SuppressWarnings({"unchecked","rawtypes"})
@@ -3270,6 +3289,21 @@ public class TestClientBuilders
   {
     Assert.assertEquals(request.getBaseUriTemplate(), expectedBaseUriTemplate);
     Assert.assertEquals(request.getPathKeys(), expectedPathKeys);
+  }
+
+  private void testResourceMethodIdentifier(Request<?> request)
+  {
+    final String resourceMethodIdentifier = request.getResourceMethodIdentifier();
+    final String method = request.getMethod().toString();
+    final String methodName = request.getMethodName();
+
+    Assert.assertTrue(resourceMethodIdentifier.startsWith(TEST_URI),"identifier doesn't start with baseUriTemplate");
+    if (methodName == null) {
+      Assert.assertTrue(resourceMethodIdentifier.endsWith(method), "identifier doesn't end with method");
+    } else {
+      Assert.assertTrue(resourceMethodIdentifier.contains(method), "identifier doesn't contain with method");
+      Assert.assertTrue(resourceMethodIdentifier.endsWith(methodName), "identifier doesn't end with methodName");
+    }
   }
 
   private void testBaseUriGeneration(Request<?> request, ProtocolVersion version)

--- a/restli-client/src/test/java/com/linkedin/restli/client/TestRestClientRequestBuilder.java
+++ b/restli-client/src/test/java/com/linkedin/restli/client/TestRestClientRequestBuilder.java
@@ -84,6 +84,7 @@ public class TestRestClientRequestBuilder
   private static final String ACCEPT_TYPE_HEADER = "Accept";
   private static final String HOST = "host";
   private static final String SERVICE_NAME = "foo";
+  private static final String RMI_TEMPLATE = "foo:test";
   private static final String BASE_URI_TEMPLATE = "/foo";
   private static final UriTemplate URI_TEMPALTE = new UriTemplate(BASE_URI_TEMPLATE);
   private static final Map<String, String> PATH_KEYS = ImmutableMap.of("test", "test");
@@ -1144,8 +1145,9 @@ public class TestRestClientRequestBuilder
     EasyMock.expect(mockRequest.getPathKeys()).andReturn(Collections.<String, String>emptyMap()).once();
     EasyMock.expect(mockRequest.getQueryParamsObjects()).andReturn(Collections.emptyMap()).once();
     EasyMock.expect(mockRequest.getQueryParamClasses()).andReturn(Collections.<String, Class<?>>emptyMap()).once();
+    EasyMock.expect(mockRequest.getResourceMethodIdentifier()).andReturn(RMI_TEMPLATE).times(2);
     EasyMock.expect(mockRequest.getBaseUriTemplate()).andReturn(BASE_URI_TEMPLATE).times(3);
-    EasyMock.expect(mockRequest.getServiceName()).andReturn(SERVICE_NAME).once();
+    EasyMock.expect(mockRequest.getServiceName()).andReturn(SERVICE_NAME).times(2);
     EasyMock.expect(mockRequest.getResponseDecoder()).andReturn(mockResponseDecoder).once();
     EasyMock.expect(mockRequest.getHeaders()).andReturn(Collections.<String, String>emptyMap()).once();
     EasyMock.expect(mockRequest.getCookies()).andReturn(Collections.<String>emptyList()).once();
@@ -1163,8 +1165,9 @@ public class TestRestClientRequestBuilder
     EasyMock.expect(mockRequest.getUriTemplate()).andReturn(URI_TEMPALTE);
     EasyMock.expect(mockRequest.getQueryParamsObjects()).andReturn(Collections.emptyMap()).once();
     EasyMock.expect(mockRequest.getQueryParamClasses()).andReturn(Collections.<String, Class<?>>emptyMap()).once();
+    EasyMock.expect(mockRequest.getResourceMethodIdentifier()).andReturn(RMI_TEMPLATE).times(2);
     EasyMock.expect(mockRequest.getBaseUriTemplate()).andReturn(BASE_URI_TEMPLATE).times(2);
-    EasyMock.expect(mockRequest.getServiceName()).andReturn(SERVICE_NAME).once();
+    EasyMock.expect(mockRequest.getServiceName()).andReturn(SERVICE_NAME).times(2);
     EasyMock.expect(mockRequest.getResponseDecoder()).andReturn(mockResponseDecoder).once();
     EasyMock.expect(mockRequest.getHeaders()).andReturn(Collections.<String, String>emptyMap()).once();
     EasyMock.expect(mockRequest.getCookies()).andReturn(Collections.<String>emptyList()).once();
@@ -1419,26 +1422,26 @@ public class TestRestClientRequestBuilder
                                      null,
                                      null,
                                      Collections.<String, CompoundKey.TypeInfo> emptyMap())).once();
-      EasyMock.expect(mockRequest.getMethodName()).andReturn(null);
+      EasyMock.expect(mockRequest.getMethodName()).andReturn(null).times(2);
     }
     else if (method == ResourceMethod.BATCH_GET)
     {
-      EasyMock.expect(mockRequest.getMethodName()).andReturn(null);
+      EasyMock.expect(mockRequest.getMethodName()).andReturn(null).times(2);
     }
     else if (method == ResourceMethod.ACTION)
     {
       EasyMock.expect(((ActionRequest)mockRequest).getId()).andReturn(null);
-      EasyMock.expect(mockRequest.getMethodName()).andReturn("testAction");
+      EasyMock.expect(mockRequest.getMethodName()).andReturn("testAction").times(2);
     }
     else if (method == ResourceMethod.FINDER)
     {
       EasyMock.expect(((FindRequest)mockRequest).getAssocKey()).andReturn(new CompoundKey());
-      EasyMock.expect(mockRequest.getMethodName()).andReturn("testFinder");
+      EasyMock.expect(mockRequest.getMethodName()).andReturn("testFinder").times(2);
     }
     else if (method == ResourceMethod.GET_ALL)
     {
       EasyMock.expect(((GetAllRequest)mockRequest).getAssocKey()).andReturn(new CompoundKey());
-      EasyMock.expect(mockRequest.getMethodName()).andReturn(null);
+      EasyMock.expect(mockRequest.getMethodName()).andReturn(null).times(2);
     }
     else if (method == ResourceMethod.UPDATE)
     {
@@ -1449,7 +1452,7 @@ public class TestRestClientRequestBuilder
                                      null,
                                      Collections.<String, CompoundKey.TypeInfo> emptyMap())).once();
       EasyMock.expect(((UpdateRequest)mockRequest).getId()).andReturn(null);
-      EasyMock.expect(mockRequest.getMethodName()).andReturn(null);
+      EasyMock.expect(mockRequest.getMethodName()).andReturn(null).times(2);
     }
     else if (method == ResourceMethod.PARTIAL_UPDATE)
     {
@@ -1460,7 +1463,7 @@ public class TestRestClientRequestBuilder
                                      null,
                                      Collections.<String, CompoundKey.TypeInfo> emptyMap())).once();
       EasyMock.expect(((PartialUpdateRequest)mockRequest).getId()).andReturn(null);
-      EasyMock.expect(mockRequest.getMethodName()).andReturn(null);
+      EasyMock.expect(mockRequest.getMethodName()).andReturn(null).times(2);
     }
     else if (method == ResourceMethod.DELETE)
     {
@@ -1471,11 +1474,11 @@ public class TestRestClientRequestBuilder
                                      null,
                                      Collections.<String, CompoundKey.TypeInfo> emptyMap())).once();
       EasyMock.expect(((DeleteRequest)mockRequest).getId()).andReturn(null);
-      EasyMock.expect(mockRequest.getMethodName()).andReturn(null);
+      EasyMock.expect(mockRequest.getMethodName()).andReturn(null).times(2);
     }
     else
     {
-      EasyMock.expect(mockRequest.getMethodName()).andReturn(null);
+      EasyMock.expect(mockRequest.getMethodName()).andReturn(null).times(2);
     }
 
     EasyMock.expect(mockRecordTemplate.data()).andReturn(entityBody).once();

--- a/restli-common/src/main/java/com/linkedin/restli/common/ResourceMethodIdentifierGenerator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/ResourceMethodIdentifierGenerator.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2013 LinkedIn Corp.
+   Copyright (c) 2022 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,11 @@
 package com.linkedin.restli.common;
 
 /**
+ * This class generates a unique identifier for each resource method. The identifier is based on the resource
+ * baseUriTemplate (with properties removed), the resource method, and any action or finder if appropriate.
+ *
+ * The resourceMethodIdentifier is available from the Request, and ResourceMethodDescriptor APIs.
+ *
  * @author dmessink
  */
 public class ResourceMethodIdentifierGenerator

--- a/restli-common/src/main/java/com/linkedin/restli/common/ResourceMethodIdentifierGenerator.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/ResourceMethodIdentifierGenerator.java
@@ -1,0 +1,70 @@
+/*
+   Copyright (c) 2013 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.restli.common;
+
+/**
+ * @author dmessink
+ */
+public class ResourceMethodIdentifierGenerator
+{
+  private static final char RESOURCE_METHOD_SEPARATOR = ':';
+  private static final char KEY_START_CHAR = '{';
+  private static final char KEY_END_CHAR = '}';
+  private static final char PATH_SEPARATOR_KEY = '/';
+
+  private ResourceMethodIdentifierGenerator() {
+  }
+
+  /**
+   * Builds the operation string for a method
+   */
+  public static String generate(String baseUriTemplate, ResourceMethod method, String methodName) {
+    final StringBuilder builder = new StringBuilder();
+
+    if (baseUriTemplate != null) {
+      builder.append(baseUriTemplate);
+
+      // Remove any pathKeys (example: album/{id}/photo -> album/photo)
+      int index = baseUriTemplate.indexOf(KEY_START_CHAR);
+
+      if (index >= 0) {
+        while (index < builder.length()) {
+          if (builder.charAt(index) == KEY_START_CHAR) {
+            final int startingIndex = index;
+
+            while (++index < builder.length()) {
+              if (builder.charAt(index) == KEY_END_CHAR) {
+                if (startingIndex > 0 && builder.charAt(startingIndex - 1) == PATH_SEPARATOR_KEY) {
+                  builder.replace(startingIndex - 1, index + 1, "");
+                } else {
+                  builder.replace(startingIndex, index + 1, "");
+                }
+
+                index -= index - startingIndex + 1;
+                break;
+              }
+            }
+          } else {
+            index++;
+          }
+        }
+      }
+    }
+
+    return builder.append(RESOURCE_METHOD_SEPARATOR).append(OperationNameGenerator.generate(method, methodName)).toString();
+  }
+}

--- a/restli-common/src/main/java/com/linkedin/restli/common/RestLiTraceInfo.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/RestLiTraceInfo.java
@@ -1,0 +1,48 @@
+package com.linkedin.restli.common;
+
+import com.linkedin.r2.filter.R2Constants;
+import com.linkedin.r2.message.RequestContext;
+
+
+/**
+ * This class exposes RestLi trace data within the requestContext to aid in request tracing.
+ */
+public class RestLiTraceInfo {
+  private final String _requestTarget;
+  private final String _requestOperation;
+  private final String _baseUriTemplate;
+  private final String _resourceMethodIdentifier;
+
+  public static void inject(RequestContext requestContext, String requestTarget, String requestOperation,
+      String baseUriTemplate, String resourceMethodIdentifier) {
+    requestContext.putLocalAttr(R2Constants.RESTLI_TRACE_INFO,
+        new RestLiTraceInfo(requestTarget, baseUriTemplate, resourceMethodIdentifier, requestOperation));
+  }
+
+  public static RestLiTraceInfo from(RequestContext requestContext) {
+    return (RestLiTraceInfo) requestContext.getLocalAttr(R2Constants.RESTLI_TRACE_INFO);
+  }
+
+  private RestLiTraceInfo(String requestTarget, String baseUriTemplate, String resourceMethodIdentifier, String requestOperation) {
+    _requestTarget = requestTarget;
+    _requestOperation = requestOperation;
+    _baseUriTemplate = baseUriTemplate;
+    _resourceMethodIdentifier = resourceMethodIdentifier;
+  }
+
+  public String getRequestTarget() {
+    return _requestTarget;
+  }
+
+  public String getRequestOperation() {
+    return _requestOperation;
+  }
+
+  public String getBaseUriTemplate() {
+    return _baseUriTemplate;
+  }
+
+  public String getResourceMethodIdentifier() {
+    return _resourceMethodIdentifier;
+  }
+}

--- a/restli-common/src/main/java/com/linkedin/restli/common/RestLiTraceInfo.java
+++ b/restli-common/src/main/java/com/linkedin/restli/common/RestLiTraceInfo.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.restli.common;
 
 import com.linkedin.r2.filter.R2Constants;

--- a/restli-common/src/test/java/com/linkedin/restli/common/TestResourceMethodIdentifierGenerator.java
+++ b/restli-common/src/test/java/com/linkedin/restli/common/TestResourceMethodIdentifierGenerator.java
@@ -25,8 +25,20 @@ public class TestResourceMethodIdentifierGenerator {
   @Test(dataProvider = "testData")
   public void testResourceMethodIdentifierGenerator(String baseUriTemplate, ResourceMethod method, String methodName,
       String expected) {
-    Assert.assertEquals(ResourceMethodIdentifierGenerator.generate(baseUriTemplate, method, methodName),
-        expected, "ResourceMethodIdentifier is incorrect");
+    final String resourceMethodIdentifier = ResourceMethodIdentifierGenerator.generate(baseUriTemplate, method, methodName);
+    final String keylessRMI = ResourceMethodIdentifierGenerator.stripPathKeys(resourceMethodIdentifier);
+    final String keylessBaseUriTemplate = ResourceMethodIdentifierGenerator.stripPathKeys(baseUriTemplate);
+
+    Assert.assertEquals(resourceMethodIdentifier, expected, "ResourceMethodIdentifier is incorrect");
+    Assert.assertFalse(keylessRMI.contains("{}"), "keylessRMI should not contain key pattern: " + keylessRMI);
+    Assert.assertEquals(keylessRMI, resourceMethodIdentifier.replaceAll("/?\\{}", ""),
+        "keylessRMI is incorrect for " + resourceMethodIdentifier);
+    if (baseUriTemplate != null) {
+      Assert.assertEquals(keylessBaseUriTemplate, baseUriTemplate.replaceAll("/?\\{[^}]*}", ""),
+          "Keyless baseUriTemplate is incorrect for " + baseUriTemplate);
+    } else {
+      Assert.assertNull(keylessBaseUriTemplate);
+    }
   }
 
   @DataProvider
@@ -39,11 +51,11 @@ public class TestResourceMethodIdentifierGenerator {
         new Object[]{"photos", ResourceMethod.BATCH_FINDER, "testFinder", "photos:batch_finder:testFinder"},
         new Object[]{"album/photos", ResourceMethod.GET, null, "album/photos:get"},
         new Object[]{"album/photos/date", ResourceMethod.GET, null, "album/photos/date:get"},
-        new Object[]{"album/{albumId}", ResourceMethod.GET, null, "album:get"},
-        new Object[]{"album/{albumId}/photos/{photoId}", ResourceMethod.GET, null, "album/photos:get"},
-        new Object[]{"album/{x, y}/photos/{x}", ResourceMethod.GET_ALL, null, "album/photos:get_all"},
-        new Object[]{"a/{x}{y}{z}/b/{x}/c", ResourceMethod.UPDATE, null, "a/b/c:update"},
-        new Object[]{"album{id}/photo{id}", ResourceMethod.DELETE, "garbage", "album/photo:delete"},
+        new Object[]{"album/{albumId}", ResourceMethod.GET, null, "album/{}:get"},
+        new Object[]{"album/{albumId}/photos/{photoId}", ResourceMethod.GET, null, "album/{}/photos/{}:get"},
+        new Object[]{"album/{x, y}/photos/{x}", ResourceMethod.GET_ALL, null, "album/{}/photos/{}:get_all"},
+        new Object[]{"a/{x}{y}{z}/b/{x}/c", ResourceMethod.UPDATE, null, "a/{}{}{}/b/{}/c:update"},
+        new Object[]{"album{id}/photo{id}", ResourceMethod.DELETE, "garbage", "album{}/photo{}:delete"},
         new Object[]{"/garbage/in/garbage/out/", ResourceMethod.GET, null, "/garbage/in/garbage/out/:get"},
         new Object[]{"garbage/{in/garbage/{out", ResourceMethod.PARTIAL_UPDATE, null, "garbage/{in/garbage/{out:partial_update"},
         new Object[]{"garbage/in}/garbage/out}", ResourceMethod.PARTIAL_UPDATE, null, "garbage/in}/garbage/out}:partial_update"},

--- a/restli-common/src/test/java/com/linkedin/restli/common/TestResourceMethodIdentifierGenerator.java
+++ b/restli-common/src/test/java/com/linkedin/restli/common/TestResourceMethodIdentifierGenerator.java
@@ -1,0 +1,41 @@
+package com.linkedin.restli.common;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TestResourceMethodIdentifierGenerator {
+  @Test(dataProvider = "testData")
+  public void testResourceMethodIdentifierGenerator(String baseUriTemplate, ResourceMethod method, String methodName,
+      String expected) {
+    Assert.assertEquals(ResourceMethodIdentifierGenerator.generate(baseUriTemplate, method, methodName),
+        expected, "ResourceMethodIdentifier is incorrect");
+  }
+
+  @DataProvider
+  public Object[][] testData()
+  {
+    return new Object[][] {
+        new Object[]{"photos", ResourceMethod.GET, null, "photos:get"},
+        new Object[]{"photos", ResourceMethod.ACTION, "testAction", "photos:action:testAction"},
+        new Object[]{"photos", ResourceMethod.FINDER, "testFinder", "photos:finder:testFinder"},
+        new Object[]{"photos", ResourceMethod.BATCH_FINDER, "testFinder", "photos:batch_finder:testFinder"},
+        new Object[]{"album/photos", ResourceMethod.GET, null, "album/photos:get"},
+        new Object[]{"album/photos/date", ResourceMethod.GET, null, "album/photos/date:get"},
+        new Object[]{"album/{albumId}", ResourceMethod.GET, null, "album:get"},
+        new Object[]{"album/{albumId}/photos/{photoId}", ResourceMethod.GET, null, "album/photos:get"},
+        new Object[]{"album/{x, y}/photos/{x}", ResourceMethod.GET_ALL, null, "album/photos:get_all"},
+        new Object[]{"a/{x}{y}{z}/b/{x}/c", ResourceMethod.UPDATE, null, "a/b/c:update"},
+        new Object[]{"album{id}/photo{id}", ResourceMethod.DELETE, "garbage", "album/photo:delete"},
+        new Object[]{"/garbage/in/garbage/out/", ResourceMethod.GET, null, "/garbage/in/garbage/out/:get"},
+        new Object[]{"garbage/{in/garbage/{out", ResourceMethod.PARTIAL_UPDATE, null, "garbage/{in/garbage/{out:partial_update"},
+        new Object[]{"garbage/in}/garbage/out}", ResourceMethod.PARTIAL_UPDATE, null, "garbage/in}/garbage/out}:partial_update"},
+        new Object[]{"", ResourceMethod.GET, null, ":get"},
+        new Object[]{null, ResourceMethod.GET_ALL, null, ":get_all"},
+        new Object[]{null, ResourceMethod.ACTION, "fubar", ":action:fubar"},
+        new Object[]{"error", ResourceMethod.ACTION, null, "error:action:null"}
+    };
+  }
+
+}

--- a/restli-common/src/test/java/com/linkedin/restli/common/TestResourceMethodIdentifierGenerator.java
+++ b/restli-common/src/test/java/com/linkedin/restli/common/TestResourceMethodIdentifierGenerator.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.restli.common;
 
 import org.testng.Assert;

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceMethodDescriptor.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceMethodDescriptor.java
@@ -25,6 +25,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.TemplateRuntimeException;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.common.ResourceMethod;
+import com.linkedin.restli.common.ResourceMethodIdentifierGenerator;
 import com.linkedin.restli.restspec.MaxBatchSizeSchema;
 import com.linkedin.restli.server.ResourceLevel;
 import com.linkedin.restli.server.annotations.ServiceErrors;
@@ -38,8 +39,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +78,7 @@ public class ResourceMethodDescriptor
   private final InterfaceType                           _interfaceType;
   private final DataMap                                 _customAnnotations;
   private final String                                  _linkedBatchFinderName;
+  private String                                        _resourceMethodIdentifier;
   // Method-level service error definitions
   private List<ServiceError>                            _serviceErrors;
   private List<HttpStatus>                              _successStatuses;
@@ -432,6 +432,24 @@ public class ResourceMethodDescriptor
     }
 
     return _type.toString();
+  }
+
+  /**
+   * Returns the resource method identifier if it can be determined, or null otherwise.
+   * This is identical to Request.getResourceMethodIdentifier().
+   * @return the resource method identifier if it can be determined, or null otherwise.
+   */
+  public String getResourceMethodIdentifier() {
+    if (_resourceMethodIdentifier == null) {
+      if (_resourceModel != null) {
+        _resourceMethodIdentifier =
+            ResourceMethodIdentifierGenerator.generate(_resourceModel.getBaseUriTemplate(),
+                                                       getMethodType(),
+                                                       getMethodName());
+      }
+    }
+
+    return _resourceMethodIdentifier;
   }
 
   /**

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceMethodDescriptor.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceMethodDescriptor.java
@@ -393,6 +393,7 @@ public class ResourceMethodDescriptor
   public void setResourceModel(final ResourceModel resourceModel)
   {
     _resourceModel = resourceModel;
+    generateResourceMethodIdentifier();
   }
 
   /**
@@ -434,21 +435,23 @@ public class ResourceMethodDescriptor
     return _type.toString();
   }
 
+  /* package-protected */ void generateResourceMethodIdentifier() {
+      if (_resourceModel != null) {
+        _resourceMethodIdentifier =
+            ResourceMethodIdentifierGenerator.generate(_resourceModel.getBaseUriTemplate(),
+                getMethodType(),
+                getMethodName());
+      } else {
+        _resourceMethodIdentifier = null;
+      }
+  }
+
   /**
    * Returns the resource method identifier if it can be determined, or null otherwise.
    * This is identical to Request.getResourceMethodIdentifier().
    * @return the resource method identifier if it can be determined, or null otherwise.
    */
   public String getResourceMethodIdentifier() {
-    if (_resourceMethodIdentifier == null) {
-      if (_resourceModel != null) {
-        _resourceMethodIdentifier =
-            ResourceMethodIdentifierGenerator.generate(_resourceModel.getBaseUriTemplate(),
-                                                       getMethodType(),
-                                                       getMethodName());
-      }
-    }
-
     return _resourceMethodIdentifier;
   }
 

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java
@@ -365,6 +365,9 @@ public class ResourceModel implements ResourceDefinition
 
     // Ensure any sub-resources have the correct template
     _pathSubResourceMap.values().forEach(ResourceModel::generateBaseUriTemplate);
+
+    // Ensure any defined ResourceMethodDescriptors are updated
+    _resourceMethodDescriptors.forEach(ResourceMethodDescriptor::generateResourceMethodIdentifier);
   }
 
   @Override

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/ResourceModel.java
@@ -65,7 +65,7 @@ public class ResourceModel implements ResourceDefinition
   private final boolean                         _root;
   private final Class<?>                        _parentResourceClass;
   private ResourceModel                         _parentResourceModel;
-
+  private String                                _baseUriTemplate;
   private final Set<Key>                        _keys;
   private final Key                             _primaryKey;
   // These are the classes of the complex resource key RecordTemplate-derived
@@ -167,6 +167,8 @@ public class ResourceModel implements ResourceDefinition
     _primaryKey = primaryKey;
     _resourceType = resourceType;
     _pathSubResourceMap = new HashMap<>();
+
+    generateBaseUriTemplate();
   }
 
   /**
@@ -189,7 +191,7 @@ public class ResourceModel implements ResourceDefinition
     this(null,
          null,
          null,
-         Collections.<Key>emptySet(),
+         Collections.emptySet(),
          valueClass,
          resourceClass,
          parentResourceClass,
@@ -220,7 +222,7 @@ public class ResourceModel implements ResourceDefinition
     this(null,
         null,
         null,
-        Collections.<Key>emptySet(),
+        Collections.emptySet(),
         valueClass,
         resourceClass,
         parentResourceClass,
@@ -348,6 +350,26 @@ public class ResourceModel implements ResourceDefinition
   public void setParentResourceModel(final ResourceModel parentResourceModel)
   {
     _parentResourceModel = parentResourceModel;
+
+    // This will modify the baseUriTemplate, so we need to regenerate it
+    generateBaseUriTemplate();
+  }
+
+  /**
+   * This method generates the resource template identical to com.linkedin.restli.client.Request.getBaseUriTemplate()
+   */
+  private void generateBaseUriTemplate() {
+    final String baseUriTemplate = ResourceModelEncoder.buildPath(this);
+
+    _baseUriTemplate = baseUriTemplate.charAt(0) == '/' ? baseUriTemplate.substring(1) : baseUriTemplate;
+
+    // Ensure any sub-resources have the correct template
+    _pathSubResourceMap.values().forEach(ResourceModel::generateBaseUriTemplate);
+  }
+
+  @Override
+  public String getBaseUriTemplate() {
+    return _baseUriTemplate;
   }
 
   public void setCustomAnnotation(DataMap customAnnotationData)

--- a/restli-server/src/main/java/com/linkedin/restli/server/BaseRestLiServer.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/BaseRestLiServer.java
@@ -10,8 +10,10 @@ import com.linkedin.r2.message.timing.TimingContextUtil;
 import com.linkedin.restli.common.ContentType;
 import com.linkedin.restli.common.ErrorResponse;
 import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.common.OperationNameGenerator;
 import com.linkedin.restli.common.ProtocolVersion;
 import com.linkedin.restli.common.RestConstants;
+import com.linkedin.restli.common.RestLiTraceInfo;
 import com.linkedin.restli.internal.common.AllProtocolVersions;
 import com.linkedin.restli.internal.common.HeaderUtil;
 import com.linkedin.restli.internal.common.ProtocolVersionUtil;
@@ -226,6 +228,12 @@ abstract class BaseRestLiServer
   {
     ServerResourceContext context = routingResult.getContext();
     ResourceMethodDescriptor method = routingResult.getResourceMethod();
+
+    RestLiTraceInfo.inject(context.getRawRequestContext(),
+        method.getResourceName(),
+        OperationNameGenerator.generate(method.getMethodType(), method.getMethodName()),
+        method.getResourceModel().getBaseUriTemplate(),
+        method.getResourceMethodIdentifier());
 
     FilterRequestContext filterContext;
     RestLiArgumentBuilder argumentBuilder;

--- a/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
@@ -53,6 +53,12 @@ public interface ResourceDefinition
   String getD2ServiceName();
 
   /**
+   * Gets the base uri template.
+   * @return the base uri template.
+   */
+  String getBaseUriTemplate();
+
+  /**
    * Gets the rest.li resource java class.
    *
    * @return java class for this rest.li resource.

--- a/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
@@ -56,7 +56,9 @@ public interface ResourceDefinition
    * Gets the base uri template.
    * @return the base uri template.
    */
-  String getBaseUriTemplate();
+  default String getBaseUriTemplate() {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Gets the rest.li resource java class.

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestRestLiServer.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestRestLiServer.java
@@ -47,10 +47,10 @@ import com.linkedin.r2.message.stream.entitystream.EntityStreams;
 import com.linkedin.r2.message.stream.entitystream.FullEntityReader;
 import com.linkedin.r2.message.stream.entitystream.Observer;
 import com.linkedin.restli.common.ErrorResponse;
-import com.linkedin.restli.common.HttpMethod;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.common.ProtocolVersion;
 import com.linkedin.restli.common.RestConstants;
+import com.linkedin.restli.common.RestLiTraceInfo;
 import com.linkedin.restli.common.attachments.RestLiAttachmentReader;
 import com.linkedin.restli.docgen.DefaultDocumentationRequestHandler;
 import com.linkedin.restli.internal.common.AllProtocolVersions;
@@ -537,9 +537,11 @@ public class TestRestLiServer
       }
     };
 
+    final RequestContext requestContext = new RequestContext();
+
     if (restOrStream == RestOrStream.REST)
     {
-      restLiServer.handleRequest(request, new RequestContext(), restResponseCallback);
+      restLiServer.handleRequest(request, requestContext, restResponseCallback);
     }
     else
     {
@@ -571,12 +573,14 @@ public class TestRestLiServer
         }
       };
 
-      restLiServer.handleRequest(streamRequest, new RequestContext(), streamResponseCallback);
+      restLiServer.handleRequest(streamRequest, requestContext, streamResponseCallback);
     }
     if (filters)
     {
       EasyMock.verify(_mockFilter, _mockFilter);
     }
+
+    Assert.assertNotNull(RestLiTraceInfo.from(requestContext), "RestLiTraceInfo not found in request context");
   }
 
   @Test(dataProvider = "invalidClientProtocolVersionData")


### PR DESCRIPTION
The intent is to provide additional Rest.Li trace information to R2 by packaging this info into a RestLiTraceInfo bean and adding it to the request context for both incoming and outgoing requests. The main id is the resourceMethodIdentifier in the form: stripped(baseUriTemplate) + ':' + <operation name>. Example: album/photo:get or album:action:purgeAll. Note that keys are stripped from the baseUriTemplate when generating the identifier.

For outgoing requests, the identifier is available via Request.getResourceMethodIdentifier(). For incoming requests, the identifier is available via ResourceMethodDescriptor.getResourceMethodIdentifier(). (The baseUriTemplate is also available from the ResourceMethodDescriptor.)

