### PR TITLE
Add equals and hashCode methods to classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+Add equals and hashCode methods to CollectionResult, GetResult, UpdateResponse and UpdateEntityResponse.
 
 ## [29.39.5] - 2022-10-04
 - Emit service discovery status related events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-Add equals and hashCode methods to CollectionResult, GetResult, UpdateResponse and UpdateEntityResponse.
+- Add equals and hashCode methods to `CollectionResult`, `GetResult`, `UpdateResponse` and `UpdateEntityResponse`.
 
 ## [29.39.5] - 2022-10-04
 - Emit service discovery status related events

--- a/restli-server/src/main/java/com/linkedin/restli/server/CollectionResult.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/CollectionResult.java
@@ -155,11 +155,14 @@ public class CollectionResult<T extends RecordTemplate, MD extends RecordTemplat
   }
 
   @Override
-  public boolean equals(Object object) {
-    if (this == object) {
+  public boolean equals(Object object)
+  {
+    if (this == object)
+    {
       return true;
     }
-    if (object == null || getClass() != object.getClass()) {
+    if (object == null || getClass() != object.getClass())
+    {
       return false;
     }
     CollectionResult<?, ?> that = (CollectionResult<?, ?>) object;
@@ -170,7 +173,8 @@ public class CollectionResult<T extends RecordTemplate, MD extends RecordTemplat
   }
 
   @Override
-  public int hashCode() {
+  public int hashCode()
+  {
     return Objects.hash(_elements, _metadata, _total, _pageIncrement);
   }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/CollectionResult.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/CollectionResult.java
@@ -19,6 +19,8 @@ package com.linkedin.restli.server;
 import java.util.List;
 
 import com.linkedin.data.template.RecordTemplate;
+import java.util.Objects;
+
 
 public class CollectionResult<T extends RecordTemplate, MD extends RecordTemplate>
 {
@@ -150,5 +152,25 @@ public class CollectionResult<T extends RecordTemplate, MD extends RecordTemplat
   public MD getMetadata()
   {
     return _metadata;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    CollectionResult<?, ?> that = (CollectionResult<?, ?>) object;
+    return Objects.equals(_elements, that._elements)
+        && Objects.equals(_metadata, that._metadata)
+        && Objects.equals(_total, that._total)
+        && _pageIncrement == that._pageIncrement;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_elements, _metadata, _total, _pageIncrement);
   }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/GetResult.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/GetResult.java
@@ -19,6 +19,7 @@ package com.linkedin.restli.server;
 
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.restli.common.HttpStatus;
+import java.util.Objects;
 
 
 /**
@@ -49,5 +50,22 @@ public class GetResult<V extends RecordTemplate>
   public HttpStatus getStatus()
   {
     return _status;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    GetResult<?> getResult = (GetResult<?>) object;
+    return Objects.equals(_value, getResult._value) && _status == getResult._status;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_value, _status);
   }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/GetResult.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/GetResult.java
@@ -53,11 +53,14 @@ public class GetResult<V extends RecordTemplate>
   }
 
   @Override
-  public boolean equals(Object object) {
-    if (this == object) {
+  public boolean equals(Object object)
+  {
+    if (this == object)
+    {
       return true;
     }
-    if (object == null || getClass() != object.getClass()) {
+    if (object == null || getClass() != object.getClass())
+    {
       return false;
     }
     GetResult<?> getResult = (GetResult<?>) object;
@@ -65,7 +68,8 @@ public class GetResult<V extends RecordTemplate>
   }
 
   @Override
-  public int hashCode() {
+  public int hashCode()
+  {
     return Objects.hash(_value, _status);
   }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/UpdateEntityResponse.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/UpdateEntityResponse.java
@@ -50,14 +50,18 @@ public class UpdateEntityResponse<V extends RecordTemplate> extends UpdateRespon
   }
 
   @Override
-  public boolean equals(Object object) {
-    if (this == object) {
+  public boolean equals(Object object)
+  {
+    if (this == object)
+    {
       return true;
     }
-    if (object == null || getClass() != object.getClass()) {
+    if (object == null || getClass() != object.getClass())
+    {
       return false;
     }
-    if (!super.equals(object)) {
+    if (!super.equals(object))
+    {
       return false;
     }
     UpdateEntityResponse<?> that = (UpdateEntityResponse<?>) object;
@@ -65,7 +69,8 @@ public class UpdateEntityResponse<V extends RecordTemplate> extends UpdateRespon
   }
 
   @Override
-  public int hashCode() {
+  public int hashCode()
+  {
     return Objects.hash(super.hashCode(), _entity);
   }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/UpdateEntityResponse.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/UpdateEntityResponse.java
@@ -18,6 +18,7 @@ package com.linkedin.restli.server;
 
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.restli.common.HttpStatus;
+import java.util.Objects;
 
 
 /**
@@ -46,5 +47,25 @@ public class UpdateEntityResponse<V extends RecordTemplate> extends UpdateRespon
   public V getEntity()
   {
     return _entity;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    if (!super.equals(object)) {
+      return false;
+    }
+    UpdateEntityResponse<?> that = (UpdateEntityResponse<?>) object;
+    return Objects.equals(_entity, that._entity);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), _entity);
   }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/UpdateResponse.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/UpdateResponse.java
@@ -17,6 +17,8 @@
 package com.linkedin.restli.server;
 
 import com.linkedin.restli.common.HttpStatus;
+import java.util.Objects;
+
 
 /**
  * @author dellamag
@@ -33,5 +35,22 @@ public class UpdateResponse
   public HttpStatus getStatus()
   {
     return _status;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    UpdateResponse that = (UpdateResponse) object;
+    return _status == that._status;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_status);
   }
 }

--- a/restli-server/src/main/java/com/linkedin/restli/server/UpdateResponse.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/UpdateResponse.java
@@ -38,11 +38,14 @@ public class UpdateResponse
   }
 
   @Override
-  public boolean equals(Object object) {
-    if (this == object) {
+  public boolean equals(Object object)
+  {
+    if (this == object)
+    {
       return true;
     }
-    if (object == null || getClass() != object.getClass()) {
+    if (object == null || getClass() != object.getClass())
+    {
       return false;
     }
     UpdateResponse that = (UpdateResponse) object;
@@ -50,7 +53,8 @@ public class UpdateResponse
   }
 
   @Override
-  public int hashCode() {
+  public int hashCode()
+  {
     return Objects.hash(_status);
   }
 }

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestCollectionResult.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestCollectionResult.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2016 LinkedIn Corp.
+   Copyright (c) 2022 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestCollectionResult.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestCollectionResult.java
@@ -1,0 +1,110 @@
+package com.linkedin.restli.server;
+
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.linkedin.restli.server.TestConstants.FOO_1;
+import static com.linkedin.restli.server.TestConstants.FOO_2;
+import static com.linkedin.restli.server.TestConstants.MD_1;
+import static com.linkedin.restli.server.TestConstants.MD_2;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+
+public class TestCollectionResult {
+
+  private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_1 =
+      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);
+  private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_2 =
+      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);
+  private static final String NON_COLLECTION_RESULT = "test";
+  private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_3 =
+      new CollectionResult<>(ImmutableList.of(FOO_2), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);
+  private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_4 =
+      new CollectionResult<>(ImmutableList.of(FOO_1), 2, MD_1, CollectionResult.PageIncrement.RELATIVE);
+  private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_5 =
+      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_2, CollectionResult.PageIncrement.RELATIVE);
+  private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_6 =
+      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.FIXED);
+  private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_7 =
+      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);
+
+  @DataProvider(name = "testEqualsDataProvider")
+  public Object[][] testEqualsDataProvider()
+  {
+    return new Object[][]
+        {
+            // 0. Basic test case when 2 CollectionResults are equal
+            { true, COLLECTION_RESULT_1, COLLECTION_RESULT_2 },
+            // 1. Test case to make sure equals is reflective
+            { true, COLLECTION_RESULT_1, COLLECTION_RESULT_1 },
+            // 2. Test case to make sure equals is symmetric
+            { true, COLLECTION_RESULT_2, COLLECTION_RESULT_1 },
+            // 3. Test case to make sure equals is transitive, done together with test case 0 and 4
+            { true, COLLECTION_RESULT_2, COLLECTION_RESULT_7 },
+            // 4. Test case to make sure equals is transitive, done together with test case 0 and 3
+            { true, COLLECTION_RESULT_1, COLLECTION_RESULT_7 },
+            // 5. Test case when target object is null
+            { false, COLLECTION_RESULT_1, null },
+            // 6. Test case when target object is not CollectionResult class
+            { false, COLLECTION_RESULT_1, NON_COLLECTION_RESULT },
+            // 7. Test case when the elements list is different
+            { false, COLLECTION_RESULT_1, COLLECTION_RESULT_3 },
+            // 8. Test case when the total is different
+            { false, COLLECTION_RESULT_1, COLLECTION_RESULT_4 },
+            // 9. Test case when the metadata is different
+            { false, COLLECTION_RESULT_1, COLLECTION_RESULT_5 },
+            // 10. Test case when the pageIncrement is different
+            { false, COLLECTION_RESULT_1, COLLECTION_RESULT_6 }
+        };
+  }
+
+  @Test(dataProvider = "testEqualsDataProvider")
+  public void testEquals
+      (
+          boolean shouldEquals,
+          @Nonnull CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> collectionResult,
+          @Nullable Object compareObject
+      )
+  {
+    assertEquals(collectionResult.equals(compareObject), shouldEquals);
+  }
+
+  @DataProvider(name = "testHashCodeDataProvider")
+  public Object[][] testHashCodeDataProvider()
+  {
+    return new Object[][]{
+        // 0. Basic test case when 2 CollectionResults have same hashcode
+        { true, COLLECTION_RESULT_1, COLLECTION_RESULT_2 },
+        // 1. Test case when the elements list is different
+        { false, COLLECTION_RESULT_1, COLLECTION_RESULT_3 },
+        // 2. Test case when the total is different
+        { false, COLLECTION_RESULT_1, COLLECTION_RESULT_4 },
+        // 3. Test case when the metadata is different
+        { false, COLLECTION_RESULT_1, COLLECTION_RESULT_5 },
+        // 4. Test case when the pageIncrement is different
+        { false, COLLECTION_RESULT_1, COLLECTION_RESULT_6 }
+    };
+  }
+
+  @Test(dataProvider = "testHashCodeDataProvider")
+  public void testHashCode
+      (
+          boolean hasSameHashCode,
+          @Nonnull CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> collectionResult1,
+          @Nonnull CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> collectionResult2
+      )
+  {
+    if (hasSameHashCode)
+    {
+      assertEquals(collectionResult1.hashCode(), collectionResult2.hashCode());
+    }
+    else
+    {
+      assertNotEquals(collectionResult1.hashCode(), collectionResult2.hashCode());
+    }
+  }
+}

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestCollectionResult.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestCollectionResult.java
@@ -14,7 +14,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 
-public class TestCollectionResult {
+public class TestCollectionResult
+{
 
   private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_1 =
       new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestCollectionResult.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestCollectionResult.java
@@ -1,6 +1,23 @@
+/*
+   Copyright (c) 2016 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.restli.server;
 
-import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Collections;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.testng.annotations.DataProvider;
@@ -18,20 +35,41 @@ public class TestCollectionResult
 {
 
   private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_1 =
-      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);
+      new CollectionResult<>
+          (
+              Collections.unmodifiableList(Arrays.asList(FOO_1)), 1, MD_1, CollectionResult.PageIncrement.RELATIVE
+          );
   private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_2 =
-      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);
+      new CollectionResult<>
+          (
+              Collections.unmodifiableList(Arrays.asList(FOO_1)), 1, MD_1, CollectionResult.PageIncrement.RELATIVE
+          );
   private static final String NON_COLLECTION_RESULT = "test";
   private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_3 =
-      new CollectionResult<>(ImmutableList.of(FOO_2), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);
+      new CollectionResult<>
+          (
+              Collections.unmodifiableList(Arrays.asList(FOO_2)), 1, MD_1, CollectionResult.PageIncrement.RELATIVE
+          );
   private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_4 =
-      new CollectionResult<>(ImmutableList.of(FOO_1), 2, MD_1, CollectionResult.PageIncrement.RELATIVE);
+      new CollectionResult<>
+          (
+              Collections.unmodifiableList(Arrays.asList(FOO_1)), 2, MD_1, CollectionResult.PageIncrement.RELATIVE
+          );
   private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_5 =
-      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_2, CollectionResult.PageIncrement.RELATIVE);
+      new CollectionResult<>
+          (
+              Collections.unmodifiableList(Arrays.asList(FOO_1)), 1, MD_2, CollectionResult.PageIncrement.RELATIVE
+          );
   private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_6 =
-      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.FIXED);
+      new CollectionResult<>
+          (
+              Collections.unmodifiableList(Arrays.asList(FOO_1)), 1, MD_1, CollectionResult.PageIncrement.FIXED
+          );
   private static final CollectionResult<TestRecordTemplateClass.Foo, TestRecordTemplateClass.Bar> COLLECTION_RESULT_7 =
-      new CollectionResult<>(ImmutableList.of(FOO_1), 1, MD_1, CollectionResult.PageIncrement.RELATIVE);
+      new CollectionResult<>
+          (
+              Collections.unmodifiableList(Arrays.asList(FOO_1)), 1, MD_1, CollectionResult.PageIncrement.RELATIVE
+          );
 
   @DataProvider(name = "testEqualsDataProvider")
   public Object[][] testEqualsDataProvider()

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestConstants.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestConstants.java
@@ -32,4 +32,9 @@ public interface TestConstants
   String TESTNG_GROUP_NOT_IMPLEMENTED = "not_implemented";
 
   String TESTNG_GROUP_REST_FRAMEWORK_EXAMPLE = "rest-framework-example";
+
+  TestRecordTemplateClass.Foo FOO_1 = TestRecordTemplateClass.Foo.createFoo("foo1_key", "foo1_value");
+  TestRecordTemplateClass.Foo FOO_2 = TestRecordTemplateClass.Foo.createFoo("foo2_key", "foo2_value");
+  TestRecordTemplateClass.Bar MD_1 = TestRecordTemplateClass.Bar.createBar("md1_key", "md1_value");
+  TestRecordTemplateClass.Bar MD_2 = TestRecordTemplateClass.Bar.createBar("md2_key", "md2_value");
 }

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestGetResult.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestGetResult.java
@@ -12,7 +12,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 
-public class TestGetResult {
+public class TestGetResult
+{
 
   private static final GetResult<TestRecordTemplateClass.Foo> REQUEST_1 = new GetResult<>(FOO_1, HttpStatus.S_200_OK);
   private static final GetResult<TestRecordTemplateClass.Foo> REQUEST_2 = new GetResult<>(FOO_1, HttpStatus.S_200_OK);

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestGetResult.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestGetResult.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2016 LinkedIn Corp.
+   Copyright (c) 2022 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestGetResult.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestGetResult.java
@@ -1,0 +1,94 @@
+package com.linkedin.restli.server;
+
+import com.linkedin.restli.common.HttpStatus;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.linkedin.restli.server.TestConstants.FOO_1;
+import static com.linkedin.restli.server.TestConstants.FOO_2;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+
+public class TestGetResult {
+
+  private static final GetResult<TestRecordTemplateClass.Foo> REQUEST_1 = new GetResult<>(FOO_1, HttpStatus.S_200_OK);
+  private static final GetResult<TestRecordTemplateClass.Foo> REQUEST_2 = new GetResult<>(FOO_1, HttpStatus.S_200_OK);
+  private static final GetResult<TestRecordTemplateClass.Foo> REQUEST_3 = new GetResult<>(FOO_2, HttpStatus.S_200_OK);
+  private static final GetResult<TestRecordTemplateClass.Foo> REQUEST_4 =
+      new GetResult<>(FOO_1, HttpStatus.S_500_INTERNAL_SERVER_ERROR);
+  private static final GetResult<TestRecordTemplateClass.Foo> REQUEST_5 = new GetResult<>(FOO_1, HttpStatus.S_200_OK);
+  private static final String NON_GET_RESULT = "test";
+
+  @DataProvider(name = "testEqualsDataProvider")
+  public Object[][] testEqualsDataProvider()
+  {
+    return new Object[][]
+        {
+            // 0. Basic test case when 2 GetResults are equal
+            { true, REQUEST_1, REQUEST_2 },
+            // 1. Test case to make sure equals is reflective
+            { true, REQUEST_1, REQUEST_1 },
+            // 2. Test case to make sure equals is symmetric
+            { true, REQUEST_2, REQUEST_1 },
+            // 3. Test case to make sure equals is transitive, done together with test case 0 and 4
+            { true, REQUEST_2, REQUEST_5 },
+            // 4. Test case to make sure equals is transitive, done together with test case 0 and 3
+            { true, REQUEST_1, REQUEST_5 },
+            // 5. Test case when target object is null
+            { false, REQUEST_1, null },
+            // 6. Test case when target object is not GetResult class
+            { false, REQUEST_1, NON_GET_RESULT },
+            // 7. Test case when the value is different
+            { false, REQUEST_1, REQUEST_3 },
+            // 8. Test case when the status is different
+            { false, REQUEST_1, REQUEST_4 }
+        };
+  }
+
+  @Test(dataProvider = "testEqualsDataProvider")
+  public void testEquals
+      (
+          boolean shouldEquals,
+          @Nonnull GetResult<TestRecordTemplateClass.Foo> request,
+          @Nullable Object compareObject
+      )
+  {
+    assertEquals(request.equals(compareObject), shouldEquals);
+  }
+
+  @DataProvider(name = "testHashCodeDataProvider")
+  public Object[][] testHashCodeDataProvider()
+  {
+    return new Object[][]{
+        // 0. Basic test case when 2 GetResult have same hashcode
+        { true, REQUEST_1, REQUEST_2 },
+        // 1. Test case to make sure hashcode is reflective
+        { true, REQUEST_1, REQUEST_1 },
+        // 2. Test case when the data list is different
+        { false, REQUEST_1, REQUEST_3 },
+        // 3. Test case when the data list is different
+        { false, REQUEST_1, REQUEST_4 }
+    };
+  }
+
+  @Test(dataProvider = "testHashCodeDataProvider")
+  public void testHashCode
+      (
+          boolean hasSameHashCode,
+          @Nonnull GetResult<TestRecordTemplateClass.Foo> request1,
+          @Nonnull GetResult<TestRecordTemplateClass.Foo> request2
+      )
+  {
+    if (hasSameHashCode)
+    {
+      assertEquals(request1.hashCode(), request2.hashCode());
+    }
+    else
+    {
+      assertNotEquals(request1.hashCode(), request2.hashCode());
+    }
+  }
+}

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestGetResult.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestGetResult.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2016 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.restli.server;
 
 import com.linkedin.restli.common.HttpStatus;

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestRecordTemplateClass.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestRecordTemplateClass.java
@@ -4,7 +4,8 @@ import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 
 
-public class TestRecordTemplateClass {
+public class TestRecordTemplateClass
+{
 
   static class Foo extends RecordTemplate
   {

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestRecordTemplateClass.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestRecordTemplateClass.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.restli.server;
 
 import com.linkedin.data.DataMap;

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestRecordTemplateClass.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestRecordTemplateClass.java
@@ -1,0 +1,38 @@
+package com.linkedin.restli.server;
+
+import com.linkedin.data.DataMap;
+import com.linkedin.data.template.RecordTemplate;
+
+
+public class TestRecordTemplateClass {
+
+  static class Foo extends RecordTemplate
+  {
+    private Foo(DataMap map)
+    {
+      super(map, null);
+    }
+
+    static Foo createFoo(String key, String value)
+    {
+      DataMap dataMap = new DataMap();
+      dataMap.put(key, value);
+      return new Foo(dataMap);
+    }
+  }
+
+  static class Bar extends RecordTemplate
+  {
+    private Bar(DataMap map)
+    {
+      super(map, null);
+    }
+
+    static Bar createBar(String key, String value)
+    {
+      DataMap dataMap = new DataMap();
+      dataMap.put(key, value);
+      return new Bar(dataMap);
+    }
+  }
+}

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateEntityResponse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateEntityResponse.java
@@ -1,0 +1,96 @@
+package com.linkedin.restli.server;
+
+import com.linkedin.restli.common.HttpStatus;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.linkedin.restli.server.TestConstants.FOO_1;
+import static com.linkedin.restli.server.TestConstants.FOO_2;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+
+public class TestUpdateEntityResponse {
+
+  private static final UpdateEntityResponse<TestRecordTemplateClass.Foo> UPDATE_ENTITY_RESPONSE_1 =
+      new UpdateEntityResponse<>(HttpStatus.S_200_OK, FOO_1);
+  private static final UpdateEntityResponse<TestRecordTemplateClass.Foo> UPDATE_ENTITY_RESPONSE_2 =
+      new UpdateEntityResponse<>(HttpStatus.S_200_OK, FOO_1);
+  private static final String NON_UPDATE_ENTITY_RESPONSE = "test";
+  private static final UpdateEntityResponse<TestRecordTemplateClass.Foo> UPDATE_ENTITY_RESPONSE_3 =
+      new UpdateEntityResponse<>(HttpStatus.S_201_CREATED, FOO_1);
+  private static final UpdateEntityResponse<TestRecordTemplateClass.Foo> UPDATE_ENTITY_RESPONSE_4 =
+      new UpdateEntityResponse<>(HttpStatus.S_200_OK, FOO_2);
+  private static final UpdateEntityResponse<TestRecordTemplateClass.Foo> UPDATE_ENTITY_RESPONSE_5 =
+      new UpdateEntityResponse<>(HttpStatus.S_200_OK, FOO_1);
+
+  @DataProvider(name = "testEqualsDataProvider")
+  public Object[][] testEqualsDataProvider()
+  {
+    return new Object[][]
+        {
+            // 0. Basic test case when 2 UpdateEntityResponses are equal
+            { true, UPDATE_ENTITY_RESPONSE_1, UPDATE_ENTITY_RESPONSE_2 },
+            // 1. Test case to make sure equals is reflective
+            { true, UPDATE_ENTITY_RESPONSE_1, UPDATE_ENTITY_RESPONSE_1 },
+            // 2. Test case to make sure equals is symmetric
+            { true, UPDATE_ENTITY_RESPONSE_2, UPDATE_ENTITY_RESPONSE_1 },
+            // 3. Test case to make sure equals is transitive, done together with test case 0 and 4
+            { true, UPDATE_ENTITY_RESPONSE_2, UPDATE_ENTITY_RESPONSE_5 },
+            // 4. Test case to make sure equals is transitive, done together with test case 0 and 3
+            { true, UPDATE_ENTITY_RESPONSE_1, UPDATE_ENTITY_RESPONSE_5 },
+            // 5. Test case when target object is null
+            { false, UPDATE_ENTITY_RESPONSE_1, null },
+            // 6. Test case when target object is not UpdateEntityResponse class
+            { false, UPDATE_ENTITY_RESPONSE_1, NON_UPDATE_ENTITY_RESPONSE },
+            // 7. Test case when the httpStatus is different
+            { false, UPDATE_ENTITY_RESPONSE_1, UPDATE_ENTITY_RESPONSE_3 },
+            // 8. Test case when the entity is different
+            { false, UPDATE_ENTITY_RESPONSE_1, UPDATE_ENTITY_RESPONSE_4 }
+        };
+  }
+
+  @Test(dataProvider = "testEqualsDataProvider")
+  public void testEquals
+      (
+          boolean shouldEquals,
+          @Nonnull UpdateEntityResponse<TestRecordTemplateClass.Foo> updateEntityResponse,
+          @Nullable Object compareObject
+      )
+  {
+    assertEquals(updateEntityResponse.equals(compareObject), shouldEquals);
+  }
+
+  @DataProvider(name = "testHashCodeDataProvider")
+  public Object[][] testHashCodeDataProvider()
+  {
+    return new Object[][]{
+        // 0. Basic test case when 2 UpdateEntityResponses have same hashcode
+        { true, UPDATE_ENTITY_RESPONSE_1, UPDATE_ENTITY_RESPONSE_2 },
+        // 1. Test case when the httpStatus is different
+        { false, UPDATE_ENTITY_RESPONSE_1, UPDATE_ENTITY_RESPONSE_3 },
+        // 2. Test case when the entity is different
+        { false, UPDATE_ENTITY_RESPONSE_1, UPDATE_ENTITY_RESPONSE_4 }
+    };
+  }
+
+  @Test(dataProvider = "testHashCodeDataProvider")
+  public void testHashCode
+      (
+          boolean hasSameHashCode,
+          @Nonnull UpdateEntityResponse<TestRecordTemplateClass.Foo> updateEntityResponse1,
+          @Nonnull UpdateEntityResponse<TestRecordTemplateClass.Foo> updateEntityResponse2
+      )
+  {
+    if (hasSameHashCode)
+    {
+      assertEquals(updateEntityResponse1.hashCode(), updateEntityResponse2.hashCode());
+    }
+    else
+    {
+      assertNotEquals(updateEntityResponse1.hashCode(), updateEntityResponse2.hashCode());
+    }
+  }
+}

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateEntityResponse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateEntityResponse.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2016 LinkedIn Corp.
+   Copyright (c) 2022 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateEntityResponse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateEntityResponse.java
@@ -12,7 +12,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 
-public class TestUpdateEntityResponse {
+public class TestUpdateEntityResponse
+{
 
   private static final UpdateEntityResponse<TestRecordTemplateClass.Foo> UPDATE_ENTITY_RESPONSE_1 =
       new UpdateEntityResponse<>(HttpStatus.S_200_OK, FOO_1);

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateEntityResponse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateEntityResponse.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2016 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.restli.server;
 
 import com.linkedin.restli.common.HttpStatus;

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateResponse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateResponse.java
@@ -1,0 +1,84 @@
+package com.linkedin.restli.server;
+
+import com.linkedin.restli.common.HttpStatus;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+
+public class TestUpdateResponse {
+
+  private static final UpdateResponse UPDATE_RESPONSE_1 = new UpdateResponse(HttpStatus.S_200_OK);
+  private static final UpdateResponse UPDATE_RESPONSE_2 = new UpdateResponse(HttpStatus.S_200_OK);
+  private static final String NON_UPDATE_RESPONSE = "test";
+  private static final UpdateResponse UPDATE_RESPONSE_3 = new UpdateResponse(HttpStatus.S_201_CREATED);
+  private static final UpdateResponse UPDATE_RESPONSE_4 = new UpdateResponse(HttpStatus.S_200_OK);
+
+  @DataProvider(name = "testEqualsDataProvider")
+  public Object[][] testEqualsDataProvider()
+  {
+    return new Object[][]
+        {
+            // 0. Basic test case when 2 UpdateResponses are equal
+            { true, UPDATE_RESPONSE_1, UPDATE_RESPONSE_2 },
+            // 1. Test case to make sure equals is reflective
+            { true, UPDATE_RESPONSE_1, UPDATE_RESPONSE_1 },
+            // 2. Test case to make sure equals is symmetric
+            { true, UPDATE_RESPONSE_2, UPDATE_RESPONSE_1 },
+            // 3. Test case to make sure equals is transitive, done together with test case 0 and 4
+            { true, UPDATE_RESPONSE_2, UPDATE_RESPONSE_4 },
+            // 4. Test case to make sure equals is transitive, done together with test case 0 and 3
+            { true, UPDATE_RESPONSE_1, UPDATE_RESPONSE_4 },
+            // 5. Test case when target object is null
+            { false, UPDATE_RESPONSE_1, null },
+            // 6. Test case when target object is not UpdateResponse class
+            { false, UPDATE_RESPONSE_1, NON_UPDATE_RESPONSE },
+            // 7. Test case when the httpStatus is different
+            { false, UPDATE_RESPONSE_1, UPDATE_RESPONSE_3 }
+        };
+  }
+
+  @Test(dataProvider = "testEqualsDataProvider")
+  public void testEquals
+      (
+          boolean shouldEquals,
+          @Nonnull UpdateResponse updateResponse,
+          @Nullable Object compareObject
+      )
+  {
+    assertEquals(updateResponse.equals(compareObject), shouldEquals);
+  }
+
+  @DataProvider(name = "testHashCodeDataProvider")
+  public Object[][] testHashCodeDataProvider()
+  {
+    return new Object[][]{
+        // 0. Basic test case when 2 UpdateResponses have same hashcode
+        { true, UPDATE_RESPONSE_1, UPDATE_RESPONSE_2 },
+        // 1. Test case when the httpStatus is different
+        { false, UPDATE_RESPONSE_1, UPDATE_RESPONSE_3 }
+    };
+  }
+
+  @Test(dataProvider = "testHashCodeDataProvider")
+  public void testHashCode
+      (
+          boolean hasSameHashCode,
+          @Nonnull UpdateResponse updateResponse1,
+          @Nonnull UpdateResponse updateResponse2
+      )
+  {
+    if (hasSameHashCode)
+    {
+      assertEquals(updateResponse1.hashCode(), updateResponse2.hashCode());
+    }
+    else
+    {
+      assertNotEquals(updateResponse1.hashCode(), updateResponse2.hashCode());
+    }
+  }
+}

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateResponse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateResponse.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2016 LinkedIn Corp.
+   Copyright (c) 2022 LinkedIn Corp.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateResponse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateResponse.java
@@ -10,7 +10,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 
-public class TestUpdateResponse {
+public class TestUpdateResponse
+{
 
   private static final UpdateResponse UPDATE_RESPONSE_1 = new UpdateResponse(HttpStatus.S_200_OK);
   private static final UpdateResponse UPDATE_RESPONSE_2 = new UpdateResponse(HttpStatus.S_200_OK);

--- a/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateResponse.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/TestUpdateResponse.java
@@ -1,3 +1,19 @@
+/*
+   Copyright (c) 2016 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.linkedin.restli.server;
 
 import com.linkedin.restli.common.HttpStatus;


### PR DESCRIPTION
Add equals and hashCode methods to CollectionResult, GetResult, UpdateResponse and UpdateEntityResponse. This is helpful to client's unit tests as it compares value instead of reference.