### PR TITLE
Remove method defaults from ResourceDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Remove method defaults from `ResourceDefinition`.
 
 ## [29.39.6] - 2022-10-06
 - Add equals and hashCode methods to `CollectionResult`, `GetResult`, `UpdateResponse` and `UpdateEntityResponse`.

--- a/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/ResourceDefinition.java
@@ -54,20 +54,17 @@ public interface ResourceDefinition
 
   /**
    * Gets the base uri template.
+   *
    * @return the base uri template.
    */
-  default String getBaseUriTemplate() {
-    throw new UnsupportedOperationException();
-  }
+  String getBaseUriTemplate();
 
   /**
    * Gets the rest.li resource java class.
    *
    * @return java class for this rest.li resource.
    */
-  default Class<?> getResourceClass() {
-    throw new UnsupportedOperationException();
-  }
+  Class<?> getResourceClass();
 
   /**
    * Returns whether the resource is a root resource or not.


### PR DESCRIPTION
Cleaning up workaround we did in #846 to avoid a major version bump.