### PR TITLE
Add service discovery status event emitter to d2 client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.1] - 2022-10-13
+Add service discovery event emitter to d2 client
+
 ## [29.40.0] - 2022-10-13
 - Empty commit to bump pegasus minor version 
 
@@ -5372,7 +5375,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.1...master
+[29.40.1]: https://github.com/linkedin/rest.li/compare/v29.40.0...v29.40.1
 [29.40.0]: https://github.com/linkedin/rest.li/compare/v29.39.6...v29.40.0
 [29.39.6]: https://github.com/linkedin/rest.li/compare/v29.39.5...v29.39.6
 [29.39.5]: https://github.com/linkedin/rest.li/compare/v29.39.4...v29.39.5

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -44,6 +44,7 @@ import com.linkedin.d2.balancer.util.healthcheck.HealthCheckOperations;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessorRegistry;
 import com.linkedin.d2.balancer.zkfs.ZKFSTogglingLoadBalancerFactoryImpl;
 import com.linkedin.d2.balancer.zkfs.ZKFSUtil;
+import com.linkedin.d2.discovery.event.ServiceDiscoveryEventEmitter;
 import com.linkedin.d2.discovery.stores.zk.ZKPersistentConnection;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeper;
 import com.linkedin.d2.jmx.JmxManager;
@@ -184,7 +185,9 @@ public class D2ClientBuilder
                   _config.canaryDistributionProvider,
                   _config.enableClusterFailout,
                   _config.failoutConfigProviderFactory,
-                  _config.failoutRedirectStrategy);
+                  _config.failoutRedirectStrategy,
+                  _config.serviceDiscoveryEventEmitter
+    );
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() :
@@ -581,6 +584,11 @@ public class D2ClientBuilder
   public D2ClientBuilder setFailoutRedirectStrategy(FailoutRedirectStrategy failoutRedirectStrategy)
   {
     _config.failoutRedirectStrategy = failoutRedirectStrategy;
+    return this;
+  }
+
+  public D2ClientBuilder setServiceDiscoveryEventEmitter(ServiceDiscoveryEventEmitter emitter) {
+    _config.serviceDiscoveryEventEmitter = emitter;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -31,6 +31,8 @@ import com.linkedin.d2.balancer.util.healthcheck.HealthCheckOperations;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessorRegistry;
 import com.linkedin.d2.balancer.zkfs.ZKFSTogglingLoadBalancerFactoryImpl;
 import com.linkedin.d2.balancer.zkfs.ZKFSTogglingLoadBalancerFactoryImpl.ComponentFactory;
+import com.linkedin.d2.discovery.event.LogOnlyServiceDiscoveryEventEmitter;
+import com.linkedin.d2.discovery.event.ServiceDiscoveryEventEmitter;
 import com.linkedin.d2.discovery.stores.zk.ZKPersistentConnection;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeper;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperStore;
@@ -113,6 +115,7 @@ public class D2ClientConfig
   boolean enableClusterFailout = false;
   FailoutConfigProviderFactory failoutConfigProviderFactory;
   FailoutRedirectStrategy failoutRedirectStrategy;
+  ServiceDiscoveryEventEmitter serviceDiscoveryEventEmitter = new LogOnlyServiceDiscoveryEventEmitter(); // default to use log-only emitter
 
   public D2ClientConfig()
   {
@@ -172,7 +175,8 @@ public class D2ClientConfig
                  CanaryDistributionProvider canaryDistributionProvider,
                  boolean enableClusterFailout,
                  FailoutConfigProviderFactory failoutConfigProviderFactory,
-                 FailoutRedirectStrategy failoutRedirectStrategy)
+                 FailoutRedirectStrategy failoutRedirectStrategy,
+                 ServiceDiscoveryEventEmitter serviceDiscoveryEventEmitter)
   {
     this.zkHosts = zkHosts;
     this.zkSessionTimeoutInMs = zkSessionTimeoutInMs;
@@ -229,5 +233,6 @@ public class D2ClientConfig
     this.enableClusterFailout = enableClusterFailout;
     this.failoutConfigProviderFactory = failoutConfigProviderFactory;
     this.failoutRedirectStrategy = failoutRedirectStrategy;
+    this.serviceDiscoveryEventEmitter = serviceDiscoveryEventEmitter;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -131,6 +131,7 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
       .setUseNewWatcher(config.useNewEphemeralStoreWatcher)
       .setExecutorService(executorService)
       .setZookeeperReadWindowMs(zookeeperReadWindowMs)
+      .setServiceDiscoveryEventEmitter(config.serviceDiscoveryEventEmitter)
       // register jmx every time the object is created
       .addOnBuildListener(d2ClientJmxManager::setZkUriRegistry);
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -95,7 +95,8 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    config.zookeeperReadWindowMs,
                                                    config.deterministicSubsettingMetadataProvider,
                                                    config.failoutConfigProviderFactory,
-                                                   config.canaryDistributionProvider
+                                                   config.canaryDistributionProvider,
+                                                   config.serviceDiscoveryEventEmitter
     );
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/D2ServiceDiscoveryEventHelper.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/D2ServiceDiscoveryEventHelper.java
@@ -32,6 +32,8 @@ public interface D2ServiceDiscoveryEventHelper {
    */
   void emitSDStatusActiveUpdateIntentAndWriteEvents(String cluster, boolean isMarkUp, boolean succeeded, long startAt);
 
+
+  // NOTE: Deprecated, client side events should be directly emitted with {@link ServiceDiscoveryEventEmitter}
   //---- d2 client-side events ----//
 
   /**
@@ -42,7 +44,9 @@ public interface D2ServiceDiscoveryEventHelper {
    * @param nodeData data in the uri ephemeral znode.
    * @param timestamp when the update is received.
    */
-  void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, boolean isMarkUp, String zkConnectString, String nodePath, String nodeData, long timestamp);
+  @Deprecated
+  default void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, boolean isMarkUp, String zkConnectString, String nodePath, String nodeData, long timestamp) {
+  };
 
   /**
    * To emit ServiceDiscoveryStatusInitialRequestEvent, when a new service discovery request is sent for a cache miss,
@@ -51,5 +55,7 @@ public interface D2ServiceDiscoveryEventHelper {
    * @param duration duration the request took.
    * @param succeeded true if the request succeeded, o.w failed.
    */
-  void emitSDStatusInitialRequestEvent(String cluster, long duration, boolean succeeded);
+  @Deprecated
+  default void emitSDStatusInitialRequestEvent(String cluster, long duration, boolean succeeded) {
+  };
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperEphemeralStoreBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/builder/ZooKeeperEphemeralStoreBuilder.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.discovery.stores.zk.builder;
 
 import com.linkedin.d2.discovery.PropertySerializer;
+import com.linkedin.d2.discovery.event.ServiceDiscoveryEventEmitter;
 import com.linkedin.d2.discovery.stores.zk.ZKConnection;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperEphemeralStore;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperPropertyMerger;
@@ -51,6 +52,7 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
   private int _zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   private ZookeeperChildFilter _zookeeperChildFilter = null;
   private ZookeeperEphemeralPrefixGenerator _zookeeperEphemeralPrefixGenerator = null;
+  private ServiceDiscoveryEventEmitter _eventEmitter = null;
   private List<Consumer<ZooKeeperEphemeralStore<T>>> _onBuildListeners = new ArrayList<>();
 
   @Override
@@ -122,6 +124,11 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
     return this;
   }
 
+  public ZooKeeperEphemeralStoreBuilder<T> setServiceDiscoveryEventEmitter(ServiceDiscoveryEventEmitter emitter) {
+    this._eventEmitter = emitter;
+    return this;
+  }
+
   @Override
   public ZooKeeperEphemeralStoreBuilder<T> addOnBuildListener(Consumer<ZooKeeperEphemeralStore<T>> onBuildListener)
   {
@@ -140,6 +147,7 @@ public class ZooKeeperEphemeralStoreBuilder<T> implements ZooKeeperStoreBuilder<
     ZooKeeperEphemeralStore<T> zooKeeperEphemeralStore =
       new ZooKeeperEphemeralStore<>(_client, _serializer, _merger, _path, _watchChildNodes, _useNewWatcher,
                                     backupStoreFilePath, _executorService, _zookeeperReadWindowMs, _zookeeperChildFilter, _zookeeperEphemeralPrefixGenerator);
+    zooKeeperEphemeralStore.setServiceDiscoveryEventEmitter(_eventEmitter);
 
     for (Consumer<ZooKeeperEphemeralStore<T>> onBuildListener : _onBuildListeners)
     {

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenWatcherTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenWatcherTest.java
@@ -141,8 +141,8 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     client.start();
 
     final ZooKeeperEphemeralStore<UriProperties> publisher = getStore(client);
-    TestDataHelper.MockD2ServiceDiscoveryEventHelper mockEventHelper = getMockD2ServiceDiscoveryEventHelper();
-    publisher.setServiceDiscoveryEventHelper(mockEventHelper);
+    TestDataHelper.MockServiceDiscoveryEventEmitter mockEventEmitter = getMockServiceDiscoveryEventEmitter();
+    publisher.setServiceDiscoveryEventEmitter(mockEventEmitter);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
@@ -194,14 +194,15 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     }
 
     // 1 initial request succeeded
-    mockEventHelper.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
+    mockEventEmitter.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
     // 3 markups
-    mockEventHelper.verifySDStatusUpdateReceiptEvents(
+    mockEventEmitter.verifySDStatusUpdateReceiptEvents(
         ImmutableSet.of(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME),
         ImmutableSet.of(HOST_1, HOST_2, HOST_3),
         ImmutableSet.of(PORT_1, PORT_2, PORT_3),
         ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3),
         ImmutableSet.of(PROPERTIES_1.toString(), PROPERTIES_2.toString(), PROPERTIES_3.toString()),
+        ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3),
         true
     );
 
@@ -214,16 +215,16 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
       Assert.fail("The EphemeralStore shouldn't watch for data change");
     }
     // no more markups
-    Assert.assertEquals(mockEventHelper._receiptMarkUpHosts.size(), 3);
+    Assert.assertEquals(mockEventEmitter._receiptMarkUpHosts.size(), 3);
     // 0 markdown
-    Assert.assertEquals(mockEventHelper._receiptMarkDownHosts.size(), 0);
+    Assert.assertEquals(mockEventEmitter._receiptMarkDownHosts.size(), 0);
     Assert.assertEquals(_outputData, MERGER.merge(CLUSTER_NAME, _testData.values()));
     _eventBus.unregister(Collections.singleton(CLUSTER_NAME), subscriber);
     client.shutdown();
   }
 
   private ZooKeeperEphemeralStore<UriProperties> getStore(ZKConnection client) {
-    return new ZooKeeperEphemeralStore<>(client, SERIALIZER, MERGER, "/", false, true);
+    return new ZooKeeperEphemeralStore<>(client, SERIALIZER, MERGER, "/", false, true); // use new child watcher
   }
 
   @Test
@@ -233,8 +234,8 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     client.start();
 
     final ZooKeeperEphemeralStore<UriProperties> publisher = getStore(client);
-    TestDataHelper.MockD2ServiceDiscoveryEventHelper mockEventHelper = getMockD2ServiceDiscoveryEventHelper();
-    publisher.setServiceDiscoveryEventHelper(mockEventHelper);
+    TestDataHelper.MockServiceDiscoveryEventEmitter mockEventEmitter = getMockServiceDiscoveryEventEmitter();
+    publisher.setServiceDiscoveryEventEmitter(mockEventEmitter);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
@@ -293,14 +294,15 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     }
 
     // 1 initial request succeeded
-    mockEventHelper.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
+    mockEventEmitter.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
     // 4 mark ups
-    mockEventHelper.verifySDStatusUpdateReceiptEvents(
+    mockEventEmitter.verifySDStatusUpdateReceiptEvents(
         ImmutableSet.of(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME),
         ImmutableSet.of(HOST_1, HOST_2, HOST_3, HOST_4),
         ImmutableSet.of(PORT_1, PORT_2, PORT_3, PORT_4),
         ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3, CHILD_PATH_4),
         ImmutableSet.of(PROPERTIES_1.toString(), PROPERTIES_2.toString(), PROPERTIES_3.toString(), PROPERTIES_4.toString()),
+        ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3, CHILD_PATH_4),
         true
     );
     _testData.put(CHILD_PATH_4, PROPERTIES_4);
@@ -316,8 +318,8 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     client.start();
 
     final ZooKeeperEphemeralStore<UriProperties> publisher = getStore(client);
-    TestDataHelper.MockD2ServiceDiscoveryEventHelper mockEventHelper = getMockD2ServiceDiscoveryEventHelper();
-    publisher.setServiceDiscoveryEventHelper(mockEventHelper);
+    TestDataHelper.MockServiceDiscoveryEventEmitter mockEventEmitter = getMockServiceDiscoveryEventEmitter();
+    publisher.setServiceDiscoveryEventEmitter(mockEventEmitter);
 
     final CountDownLatch initLatch = new CountDownLatch(1);
     final CountDownLatch addLatch = new CountDownLatch(1);
@@ -370,14 +372,15 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     }
 
     // 1 initial request succeeded
-    mockEventHelper.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
+    mockEventEmitter.verifySDStatusInitialRequestEvents(Collections.singletonList(CLUSTER_NAME), Collections.singletonList(true));
     // 3 markups
-    mockEventHelper.verifySDStatusUpdateReceiptEvents(
+    mockEventEmitter.verifySDStatusUpdateReceiptEvents(
         ImmutableSet.of(CLUSTER_NAME, CLUSTER_NAME, CLUSTER_NAME),
         ImmutableSet.of(HOST_1, HOST_2, HOST_3),
         ImmutableSet.of(PORT_1, PORT_2, PORT_3),
         ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3),
         ImmutableSet.of(PROPERTIES_1.toString(), PROPERTIES_2.toString(), PROPERTIES_3.toString()),
+        ImmutableSet.of(CHILD_PATH_1, CHILD_PATH_2, CHILD_PATH_3),
         true
     );
     FutureCallback<None> callback = new FutureCallback<>();
@@ -390,8 +393,14 @@ public class ZooKeeperEphemeralStoreChildrenWatcherTest
     }
 
     // 1 markdown
-    mockEventHelper.verifySDStatusUpdateReceiptEvents(ImmutableSet.of(CLUSTER_NAME), ImmutableSet.of(HOST_1), ImmutableSet.of(1),
-        ImmutableSet.of(CHILD_PATH_1), ImmutableSet.of(PROPERTIES_1.toString()), false);
+    mockEventEmitter.verifySDStatusUpdateReceiptEvents(
+        ImmutableSet.of(CLUSTER_NAME),
+        ImmutableSet.of(HOST_1),
+        ImmutableSet.of(1),
+        ImmutableSet.of(CHILD_PATH_1),
+        ImmutableSet.of(PROPERTIES_1.toString()),
+        ImmutableSet.of(CHILD_PATH_1),
+        false);
     _testData.remove(CHILD_PATH_1);
     Assert.assertEquals(_outputData, MERGER.merge(CLUSTER_NAME, _testData.values()));
     _eventBus.unregister(Collections.singleton(CLUSTER_NAME), subscriber);

--- a/d2/src/test/java/com/linkedin/d2/util/TestDataHelper.java
+++ b/d2/src/test/java/com/linkedin/d2/util/TestDataHelper.java
@@ -12,9 +12,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.testng.Assert;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 
 public class TestDataHelper {
@@ -73,22 +73,6 @@ public class TestDataHelper {
     public final List<Boolean> _activeUpdateIntentAndWriteIsMarkUpFlags = new ArrayList<>();
     public final List<Boolean> _activeUpdateIntentAndWriteSucceededFlags = new ArrayList<>();
 
-    public final Set<String> _receiptMarkUpClusters = new HashSet<>();
-    public final Set<String> _receiptMarkUpHosts = new HashSet<>();
-    public final Set<Integer> _receiptMarkUpPorts = new HashSet<>();
-    public final Set<String> _receiptMarkUpPaths = new HashSet<>();
-    public final Set<String> _receiptMarkUpProperties = new HashSet<>();
-
-    public final Set<String> _receiptMarkDownClusters = new HashSet<>();
-    public final Set<String> _receiptMarkDownHosts = new HashSet<>();
-    public final Set<Integer> _receiptMarkDownPorts = new HashSet<>();
-    public final Set<String> _receiptMarkDownPaths = new HashSet<>();
-    public final Set<String> _receiptMarkDownProperties = new HashSet<>();
-
-    public final List<String> _initialRequestClusters = new ArrayList<>();
-    public final List<Long> _initialRequestDurations = new ArrayList<>();
-    public final List<Boolean> _initialRequestSucceededFlags = new ArrayList<>();
-
     @Override
     public void emitSDStatusActiveUpdateIntentAndWriteEvents(String cluster, boolean isMarkUp, boolean succeeded,
         long startAt) {
@@ -97,51 +81,10 @@ public class TestDataHelper {
       _activeUpdateIntentAndWriteSucceededFlags.add(succeeded);
     }
 
-    @Override
-    public void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, boolean isMarkUp,
-        String zkConnectString, String nodePath, String properties, long timestamp) {
-      if (isMarkUp) {
-        _receiptMarkUpClusters.add(cluster);
-        _receiptMarkUpHosts.add(host);
-        _receiptMarkUpPorts.add(port);
-        _receiptMarkUpPaths.add(nodePath);
-        _receiptMarkUpProperties.add(properties);
-      } else {
-        _receiptMarkDownClusters.add(cluster);
-        _receiptMarkDownHosts.add(host);
-        _receiptMarkDownPorts.add(port);
-        _receiptMarkDownPaths.add(nodePath);
-        _receiptMarkDownProperties.add(properties);
-      }
-    }
-
-    @Override
-    public void emitSDStatusInitialRequestEvent(String cluster, long duration, boolean succeeded) {
-      _initialRequestClusters.add(cluster);
-      _initialRequestDurations.add(duration);
-      _initialRequestSucceededFlags.add(succeeded);
-    }
-
     public void verifySDStatusActiveUpdateIntentAndWriteEvents(List<String> clusters, List<Boolean> isMarkUpFlags, List<Boolean> succeededFlags) {
       assertEquals(clusters, _activeUpdateIntentAndWriteClusters, "incorrect clusters");
       assertEquals(isMarkUpFlags, _activeUpdateIntentAndWriteIsMarkUpFlags, "incorrect isMarkUp flags");
       assertEquals(succeededFlags, _activeUpdateIntentAndWriteSucceededFlags, "incorrect succeeded flags");
-    }
-
-    public void verifySDStatusUpdateReceiptEvents(Set<String> clusters, Set<String> hosts, Set<Integer> ports,
-        Set<String> nodePaths, Set<String> properties, boolean isForMarkUp) {
-      assertEquals(clusters, isForMarkUp ? _receiptMarkUpClusters : _receiptMarkDownClusters, "incorrect clusters");
-      assertEquals(hosts, isForMarkUp ? _receiptMarkUpHosts : _receiptMarkDownHosts, "incorrect hosts");
-      assertEquals(ports, isForMarkUp ? _receiptMarkUpPorts : _receiptMarkDownPorts, "incorrect ports");
-      assertEquals(nodePaths, isForMarkUp ? _receiptMarkUpPaths : _receiptMarkDownPaths, "incorrect node paths");
-      assertEquals(properties, isForMarkUp ? _receiptMarkUpProperties : _receiptMarkDownProperties, "incorrect node properties");
-    }
-
-    public void verifySDStatusInitialRequestEvents(List<String> clusters, List<Boolean> succeededFlags) {
-      assertEquals(clusters, _initialRequestClusters, "incorrect clusters");
-      // the duration could be 0 when requests took < 1ms,
-      _initialRequestDurations.forEach(duration -> assertTrue(duration >= 0, "incorrect durations"));
-      assertEquals(succeededFlags, _initialRequestSucceededFlags, "incorrect succeeded flags");
     }
   }
 
@@ -158,6 +101,24 @@ public class TestDataHelper {
     public final List<Integer> _writeServiceRegistryVersions = new ArrayList<>();
     public final List<String> _writeTracingIds = new ArrayList<>();
     public final List<Boolean> _writeSucceededFlags = new ArrayList<>();
+
+    public final Set<String> _receiptMarkUpClusters = new HashSet<>();
+    public final Set<String> _receiptMarkUpHosts = new HashSet<>();
+    public final Set<Integer> _receiptMarkUpPorts = new HashSet<>();
+    public final Set<String> _receiptMarkUpPaths = new HashSet<>();
+    public final Set<String> _receiptMarkUpProperties = new HashSet<>();
+    public final Set<String> _receiptMarkUpTracingIds = new HashSet<>();
+
+    public final Set<String> _receiptMarkDownClusters = new HashSet<>();
+    public final Set<String> _receiptMarkDownHosts = new HashSet<>();
+    public final Set<Integer> _receiptMarkDownPorts = new HashSet<>();
+    public final Set<String> _receiptMarkDownPaths = new HashSet<>();
+    public final Set<String> _receiptMarkDownProperties = new HashSet<>();
+    public final Set<String> _receiptMarkDownTracingIds = new HashSet<>();
+
+    public final List<String> _initialRequestClusters = new ArrayList<>();
+    public final List<Long> _initialRequestDurations = new ArrayList<>();
+    public final List<Boolean> _initialRequestSucceededFlags = new ArrayList<>();
 
     @Override
     public void emitSDStatusActiveUpdateIntentEvent(List<String> clustersClaimed, StatusUpdateActionType actionType,
@@ -185,10 +146,33 @@ public class TestDataHelper {
     public void emitSDStatusUpdateReceiptEvent(String cluster, String host, int port, StatusUpdateActionType actionType,
         boolean isNextGen, String serviceRegistry, String serviceRegistryKey, String serviceRegistryValue,
         Integer serviceRegistryVersion, String tracingId, long timestamp) {
+      if (actionType == StatusUpdateActionType.MARK_READY) {
+        _receiptMarkUpClusters.add(cluster);
+        _receiptMarkUpHosts.add(host);
+        _receiptMarkUpPorts.add(port);
+        _receiptMarkUpPaths.add(serviceRegistryKey);
+        _receiptMarkUpProperties.add(serviceRegistryValue);
+        _receiptMarkUpTracingIds.add(tracingId);
+      } else if (actionType == StatusUpdateActionType.MARK_DOWN){
+        _receiptMarkDownClusters.add(cluster);
+        _receiptMarkDownHosts.add(host);
+        _receiptMarkDownPorts.add(port);
+        _receiptMarkDownPaths.add(serviceRegistryKey);
+        _receiptMarkDownProperties.add(serviceRegistryValue);
+        _receiptMarkDownTracingIds.add(tracingId);
+      } else {
+        Assert.fail("Invalid action type in status update receipt. In D2, status update received should be either MARK_READY or MARK_DOWN.");
+      }
+      assertFalse(isNextGen);
+      assertEquals(serviceRegistryVersion.intValue(), 0);
     }
 
     @Override
     public void emitSDStatusInitialRequestEvent(String cluster, boolean isNextGen, long duration, boolean succeeded) {
+      _initialRequestClusters.add(cluster);
+      _initialRequestDurations.add(duration);
+      _initialRequestSucceededFlags.add(succeeded);
+      assertFalse(isNextGen);
     }
 
     public void verifySDStatusActiveUpdateIntentEvents(List<List<String>> clustersClaimedList, List<StatusUpdateActionType> actionTypes,
@@ -208,6 +192,23 @@ public class TestDataHelper {
       assertEquals(serviceRegistryVersions, _writeServiceRegistryVersions, "incorrect serviceRegistryVersions");
       assertEquals(tracingIds, _writeTracingIds, "incorrect tracingIds");
       assertEquals(succeededFlags, _writeSucceededFlags, "incorrect succeededFlags");
+    }
+
+    public void verifySDStatusUpdateReceiptEvents(Set<String> clusters, Set<String> hosts, Set<Integer> ports,
+        Set<String> nodePaths, Set<String> properties, Set<String> tracingIds, boolean isForMarkUp) {
+      assertEquals(clusters, isForMarkUp ? _receiptMarkUpClusters : _receiptMarkDownClusters, "incorrect clusters");
+      assertEquals(hosts, isForMarkUp ? _receiptMarkUpHosts : _receiptMarkDownHosts, "incorrect hosts");
+      assertEquals(ports, isForMarkUp ? _receiptMarkUpPorts : _receiptMarkDownPorts, "incorrect ports");
+      assertEquals(nodePaths, isForMarkUp ? _receiptMarkUpPaths : _receiptMarkDownPaths, "incorrect node paths");
+      assertEquals(properties, isForMarkUp ? _receiptMarkUpProperties : _receiptMarkDownProperties, "incorrect node properties");
+      assertEquals(tracingIds, isForMarkUp ? _receiptMarkUpTracingIds : _receiptMarkDownTracingIds, "incorrect tracing ids");
+    }
+
+    public void verifySDStatusInitialRequestEvents(List<String> clusters, List<Boolean> succeededFlags) {
+      assertEquals(clusters, _initialRequestClusters, "incorrect clusters");
+      // the duration could be 0 when requests took < 1ms,
+      _initialRequestDurations.forEach(duration -> assertTrue(duration >= 0, "incorrect durations"));
+      assertEquals(succeededFlags, _initialRequestSucceededFlags, "incorrect succeeded flags");
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.0
+version=29.40.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyStreamClient.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestHttpNettyStreamClient.java
@@ -398,7 +398,7 @@ public class TestHttpNettyStreamClient
     };
   }
 
-  @Test(dataProvider = "responseSizeClients")
+  @Test(dataProvider = "responseSizeClients", retryAnalyzer = ThreeRetries.class)
   public void testMaxResponseSizeOK(AbstractNettyStreamClient client) throws Exception
   {
     testResponseSize(client, TEST_MAX_RESPONSE_SIZE - 1, RESPONSE_OK);


### PR DESCRIPTION
In a previous PR: https://github.com/linkedin/rest.li/pull/835, there was a mistake that uses ZookeeperAnnouncer as a helper to emit service discovery status events for both server-side and client-side events (reference context about service discovery status events in the previous PR), but the announcer will only work for server-side events. This PR is to fix the client-side events for d2 client by adding the event emitter directly to ZookeeperEphemeralStore thru D2ClientConfig.