### PR TITLE
[rest.li] Update IndentedPdlBuilder to remove extra whitespace when writing a blank comment line

### DIFF
--- a/data/src/main/java/com/linkedin/data/schema/IndentedPdlBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/IndentedPdlBuilder.java
@@ -115,9 +115,9 @@ class IndentedPdlBuilder extends PdlBuilder
       writeLine("/**");
       for (String line : doc.split("\n"))
       {
-        String commentPrefix = line.isBlank()
-          ? " *"
-          : " * ";
+        String commentPrefix = StringUtils.isNotBlank(line)
+          ? " * "
+          : " *";
         indent().write(commentPrefix).write(line).newline();
       }
       writeLine(" */");

--- a/data/src/main/java/com/linkedin/data/schema/IndentedPdlBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/IndentedPdlBuilder.java
@@ -115,7 +115,10 @@ class IndentedPdlBuilder extends PdlBuilder
       writeLine("/**");
       for (String line : doc.split("\n"))
       {
-        indent().write(" * ").write(line).newline();
+        String commentPrefix = line.isBlank()
+          ? " *"
+          : " * ";
+        indent().write(commentPrefix).write(line).newline();
       }
       writeLine(" */");
       return true;


### PR DESCRIPTION
In some scenarios, we have a PDL where we need to write a comment that looks like 
`Flavors for an elementary particle and a fundamental constituent of matter\n\nThis is to test multi-line comment`
This is a 3 line comment with an empty 2nd line. However, since the 2nd line is empty, we do not want a trailing whitespace on the right (see image below). This PR helps address this.
<img width="536" alt="Screen Shot 2022-10-21 at 12 22 04 AM" src="https://user-images.githubusercontent.com/6971410/197140217-b9d37f30-f29d-4be5-9d3a-e276e7039beb.png">
