### PR TITLE
Add channel writability to streaming timeout exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.12] - 2022-11-30
+Add channel writability to streaming timeout exception
+
 ## [29.40.11] - 2022-11-17
 Add util class to convert generic List/Map to DataList/DataMap or vice versa
 
@@ -5405,7 +5408,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.12...master
+[29.40.12]: https://github.com/linkedin/rest.li/compare/v29.40.11...v29.40.12
 [29.40.11]: https://github.com/linkedin/rest.li/compare/v29.40.10...v29.40.11
 [29.40.10]: https://github.com/linkedin/rest.li/compare/v29.40.9...v29.40.10
 [29.40.9]: https://github.com/linkedin/rest.li/compare/v29.40.8...v29.40.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.11
+version=29.40.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamingTimeout.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamingTimeout.java
@@ -137,7 +137,7 @@ public class TestStreamingTimeout extends AbstractServiceTest
     final Throwable rootCause = ExceptionUtils.getRootCause(throwable.get());
     Assert.assertTrue(rootCause instanceof TimeoutException);
     final TimeoutException timeoutException = (TimeoutException) rootCause;
-    Assert.assertEquals(timeoutException.getMessage(), String.format(StreamingTimeout.STREAMING_TIMEOUT_MESSAGE, HTTP_STREAMING_TIMEOUT));
+    assertTimeoutMessage(timeoutException.getMessage());
   }
 
   @Test
@@ -204,7 +204,12 @@ public class TestStreamingTimeout extends AbstractServiceTest
     final Throwable rootCause = ExceptionUtils.getRootCause(throwable.get());
     Assert.assertTrue(rootCause instanceof TimeoutException);
     final TimeoutException timeoutException = (TimeoutException) rootCause;
-    Assert.assertEquals(timeoutException.getMessage(), String.format(StreamingTimeout.STREAMING_TIMEOUT_MESSAGE, HTTP_STREAMING_TIMEOUT));
+    assertTimeoutMessage(timeoutException.getMessage());
+  }
+
+  private static void assertTimeoutMessage(String message) {
+    String normalizedMessage = message.replaceFirst("writable=(false|true)", "writable=false");
+    Assert.assertEquals(normalizedMessage, String.format(StreamingTimeout.STREAMING_TIMEOUT_MESSAGE, HTTP_STREAMING_TIMEOUT, false));
   }
 
   private static Callback<StreamResponse> expectSuccessCallback(final CountDownLatch latch, final AtomicInteger status)

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/common/StreamingTimeout.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/common/StreamingTimeout.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class StreamingTimeout
 {
-  public static final String STREAMING_TIMEOUT_MESSAGE = "Exceeded stream idle timeout of %sms";
+  public static final String STREAMING_TIMEOUT_MESSAGE = "Exceeded stream idle timeout of %sms (writable=%b)";
 
   private final ScheduledExecutorService _scheduler;
   private final long _streamingTimeout;
@@ -90,7 +90,7 @@ public class StreamingTimeout
     }
     else
     {
-      _channel.pipeline().fireExceptionCaught(new TimeoutException(String.format(STREAMING_TIMEOUT_MESSAGE, _streamingTimeout)));
+      _channel.pipeline().fireExceptionCaught(new TimeoutException(String.format(STREAMING_TIMEOUT_MESSAGE, _streamingTimeout, _channel.isWritable())));
     }
   }
 


### PR DESCRIPTION
This should help with determining the cause of the timeout. If the channel is not writable, then it is likely that the remote endpoint has stopped consuming date. Otherwise, the local endpoint is the likely culprit.