### PR TITLE
Change logging level of D2 cluster subsetting updates to DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.3] - 2022-10-25
+Change logging level of D2 cluster subsetting updates to DEBUG
+
 ## [29.40.2] - 2022-10-25
 Refactor the Netty JMX handling for injection of the metrics handling into the client rather than the other way around.
 
@@ -5378,7 +5381,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.3...master
+[29.40.3]: https://github.com/linkedin/rest.li/compare/v29.40.2...v29.40.3
 [29.40.2]: https://github.com/linkedin/rest.li/compare/v29.40.1...v29.40.2
 [29.40.1]: https://github.com/linkedin/rest.li/compare/v29.40.0...v29.40.1
 [29.40.0]: https://github.com/linkedin/rest.li/compare/v29.39.6...v29.40.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/ClientSelector.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/ClientSelector.java
@@ -140,7 +140,7 @@ public class ClientSelector
           .findAny().orElse(null);
       if (trackerClient != null)
       {
-        LOG.warn("Did not find a valid client from the ring, picked {} instead", trackerClient.getUri());
+        LOG.debug("Did not find a valid client from the ring, picked {} instead", trackerClient.getUri());
       }
     }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/SubsettingState.java
@@ -93,7 +93,7 @@ public class SubsettingState
       }
       else
       {
-        LOG.info("Force updating subset cache for service " + serviceName);
+        LOG.debug("Force updating subset cache for service " + serviceName);
         Set<URI> doNotSlowStartUris = new HashSet<>();
 
         if (subsetCache != null)
@@ -114,6 +114,7 @@ public class SubsettingState
         }
         else
         {
+          LOG.info("Cluster subsetting enabled for service: " + serviceName);
           Map<Integer, Set<URI>> servicePossibleUris = new HashMap<>();
           Map<Integer, Map<URI, Double>> serviceWeightedSubset = new HashMap<>();
           servicePossibleUris.put(partitionId, possibleUris.keySet());

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.2
+version=29.40.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
- Change logging level of D2 cluster subsetting updates to DEBUG
- Only emit an INFO level log when subsetting is enabled for a new service