### PR TITLE
Fix the Gradle 7 validation errors in GenerateRestClientTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.5] - 2022-11-03
+Fix the Gradle 7 validation errors in GenerateRestClientTask
+
 ## [29.40.4] - 2022-10-31
 Update SchemaToPdlEncoder to fix nested schema encoding layout
 
@@ -5384,7 +5387,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.5...master
+[29.40.5]: https://github.com/linkedin/rest.li/compare/v29.40.4...v29.40.5
 [29.40.4]: https://github.com/linkedin/rest.li/compare/v29.40.3...v29.40.4
 [29.40.3]: https://github.com/linkedin/rest.li/compare/v29.40.2...v29.40.3
 [29.40.2]: https://github.com/linkedin/rest.li/compare/v29.40.1...v29.40.2

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateRestClientTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateRestClientTask.java
@@ -290,9 +290,20 @@ public class GenerateRestClientTask extends DefaultTask
     _enableArgFile = enable;
   }
 
+  /**
+   * @deprecated by {@link #isGenerateLowercasePath()} ()} because Gradle 7
+   *     requires input and output properties to be annotated on getters, which
+   *     have a prefix of "is" or "get".
+   */
+  @Deprecated
+  public Boolean generateLowercasePath()
+  {
+    return isGenerateLowercasePath();
+  }
+
   @Optional
   @Input
-  public Boolean generateLowercasePath()
+  public Boolean isGenerateLowercasePath()
   {
     return _generateLowercasePath;
   }
@@ -322,6 +333,7 @@ public class GenerateRestClientTask extends DefaultTask
    * @deprecated use {@link #isRestli2FormatSuppressed()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsRestli2FormatSuppressed()
   {
     return isRestli2FormatSuppressed();
@@ -336,6 +348,7 @@ public class GenerateRestClientTask extends DefaultTask
    * @deprecated use {@link #isRestli2FormatSuppressed()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsRestli2FormatSuppressed()
   {
     return isRestli2FormatSuppressed();
@@ -397,6 +410,7 @@ public class GenerateRestClientTask extends DefaultTask
    * @deprecated use {@link #isRestli1BuildersDeprecated()} instead
    */
   @Deprecated
+  @Internal
   public boolean get_isRestli1BuildersDeprecated()
   {
     return isRestli1BuildersDeprecated();
@@ -411,6 +425,7 @@ public class GenerateRestClientTask extends DefaultTask
    * @deprecated use {@link #isRestli1BuildersDeprecated()} instead
    */
   @Deprecated
+  @Internal
   public boolean is_isRestli1BuildersDeprecated()
   {
     return isRestli1BuildersDeprecated();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.4
+version=29.40.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This PR is to fix the Gradle 7 validation errors in GenerateRestClientTask when build a rest.li service

```
  - Type 'com.linkedin.pegasus.gradle.tasks.GenerateRestClientTask' method 'generateLowercasePath()' should not be annotated with: @Optional, @Input.
    
    Reason: Input/Output annotations are ignored if they are placed on something else than a getter.
    
  - Type 'com.linkedin.pegasus.gradle.tasks.GenerateRestClientTask' property '_isRestli1BuildersDeprecated' has redundant getters: 'get_isRestli1BuildersDeprecated()' and 'is_isRestli1BuildersDeprecated()'.
    
    Reason: Boolean property '_isRestli1BuildersDeprecated' has both an `is` and a `get` getter.
    
  - Type 'com.linkedin.pegasus.gradle.tasks.GenerateRestClientTask' property '_isRestli1BuildersDeprecated' is missing an input or output annotation.
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    - Type 'com.linkedin.pegasus.gradle.tasks.GenerateRestClientTask' property 'isRestli2FormatSuppressed' has redundant getters: 'getIsRestli2FormatSuppressed()' and 'isIsRestli2FormatSuppressed()'.
    Reason: Boolean property 'isRestli2FormatSuppressed' has both an `is` and a `get` getter.
    
  - Type 'com.linkedin.pegasus.gradle.tasks.GenerateRestClientTask' property 'isRestli2FormatSuppressed' is missing an input or output annotation.
    Reason: A property without annotation isn't considered during up-to-date checking.
```
As the fix, this PR:
1. deprecated `generateLowercasePath()` and create i`sGenerateLowercasePath()` with annotation
2. add @Internal to `getIsRestli2FormatSuppressed()` and `isIsRestli2FormatSuppressed()`
3. add @Internal to `get_isRestli1BuildersDeprecated()` and `is_isRestli1BuildersDeprecated()`