### PR TITLE
Reenable LastSeenZKStoreTest test

### DIFF
--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/LastSeenZKStoreTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/LastSeenZKStoreTest.java
@@ -51,7 +51,7 @@ public class LastSeenZKStoreTest
    * 3) Restart ZKServer and see if this LastSeenZKStore which could never access to disk will retrieve latest
    *    information from there
    */
-  @Test(timeOut = 10000, enabled = false)
+  @Test
   public void testLastSeenLifeCycle()
       throws InterruptedException, ExecutionException, TimeoutException, IOException, PropertyStoreException
   {


### PR DESCRIPTION
Reenable LastSeenZKStoreTest to make sure it is included in the CI/CD pipeline. Not creating a new version for this, so it will be bundled with the next release.