### PR TITLE
Remove @PathSensitive from property idlDestinationDir in GenerateRestModelTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.7] - 2022-11-07
+Remove @PathSensitive from property idlDestinationDir in GenerateRestModelTask
+
 ## [29.40.6] - 2022-11-06
 Add getter of IncludesDeclaredInline in RecordDataSchema
 
@@ -5390,7 +5393,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.7...master
+[29.40.7]: https://github.com/linkedin/rest.li/compare/v29.40.6...v29.40.7
 [29.40.6]: https://github.com/linkedin/rest.li/compare/v29.40.5...v29.40.6
 [29.40.5]: https://github.com/linkedin/rest.li/compare/v29.40.4...v29.40.5
 [29.40.4]: https://github.com/linkedin/rest.li/compare/v29.40.3...v29.40.4

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateRestModelTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/GenerateRestModelTask.java
@@ -163,7 +163,6 @@ public class GenerateRestModelTask extends DefaultTask
   }
 
   @OutputDirectory
-  @PathSensitive(PathSensitivity.NAME_ONLY)
   public File getIdlDestinationDir()
   {
     return _idlDestinationDir;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.6
+version=29.40.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
When build one product with Gradle 7, we see the error below:

```
A problem was found with the configuration of task ':<module>:generateRestModel' (type 'GenerateRestModelTask').
  - Type 'com.linkedin.pegasus.gradle.tasks.GenerateRestModelTask' property 'idlDestinationDir' is annotated with @PathSensitive but that is not allowed for 'OutputDirectory' properties. 
    Reason: This modifier is used in conjunction with a property of type 'OutputDirectory' but this doesn't have semantics. 
    Possible solution: Remove the '@PathSensitive' annotation.
    Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#incompatible_annotations for more details about this problem.
```

`@PathSensitive` doesn't make sense to `OutputDirectory` properties, this PR remove @PathSensitive from this affected property