### PR TITLE
Enable task validation check in the build of the gradle plugin and fix some validation errors with Gradle 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.8] - 2022-11-14
+Enable validation check in the build of the gradle plugin and fix some validation errors with Gradle 7
+
 ## [29.40.7] - 2022-11-07
 Remove @PathSensitive from property idlDestinationDir in GenerateRestModelTask
 
@@ -5393,7 +5396,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.8...master
+[29.40.8]: https://github.com/linkedin/rest.li/compare/v29.40.7...v29.40.8
 [29.40.7]: https://github.com/linkedin/rest.li/compare/v29.40.6...v29.40.7
 [29.40.6]: https://github.com/linkedin/rest.li/compare/v29.40.5...v29.40.6
 [29.40.5]: https://github.com/linkedin/rest.li/compare/v29.40.4...v29.40.5

--- a/gradle-plugins/build.gradle
+++ b/gradle-plugins/build.gradle
@@ -48,3 +48,6 @@ integTest {
   systemProperty 'integTest.pegasusPluginDependencies', "'${configurations.pegasusPluginForTesting.join("', '")}'"
 }
 
+validateTaskProperties {
+  failOnWarning = true
+}

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckIdlTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckIdlTask.java
@@ -175,6 +175,7 @@ public class CheckIdlTask extends DefaultTask
    * @deprecated use {@link #isModelCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsModelCompatible()
   {
     return isModelCompatible();
@@ -189,6 +190,7 @@ public class CheckIdlTask extends DefaultTask
    * @deprecated use {@link #isModelCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsModelCompatible()
   {
     return isModelCompatible();
@@ -209,6 +211,7 @@ public class CheckIdlTask extends DefaultTask
    * @deprecated use {@link #isRestSpecCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsRestSpecCompatible()
   {
     return isRestSpecCompatible();
@@ -223,6 +226,7 @@ public class CheckIdlTask extends DefaultTask
    * @deprecated use {@link #isRestSpecCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsRestSpecCompatible()
   {
     return isRestSpecCompatible();
@@ -243,6 +247,7 @@ public class CheckIdlTask extends DefaultTask
    * @deprecated use {@link #isEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsEquivalent()
   {
     return _equivalent;
@@ -257,6 +262,7 @@ public class CheckIdlTask extends DefaultTask
    * @deprecated use {@link #isEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsEquivalent()
   {
     return _equivalent;

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckRestModelTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckRestModelTask.java
@@ -210,6 +210,7 @@ public class CheckRestModelTask extends DefaultTask
    * @deprecated use {@link #isModelCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsModelCompatible()
   {
     return isModelCompatible();
@@ -224,6 +225,7 @@ public class CheckRestModelTask extends DefaultTask
    * @deprecated use {@link #isModelCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsModelCompatible()
   {
     return isModelCompatible();
@@ -244,6 +246,7 @@ public class CheckRestModelTask extends DefaultTask
    * @deprecated use {@link #isRestSpecCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsRestSpecCompatible()
   {
     return isRestSpecCompatible();
@@ -258,6 +261,7 @@ public class CheckRestModelTask extends DefaultTask
    * @deprecated use {@link #isRestSpecCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsRestSpecCompatible()
   {
     return isRestSpecCompatible();
@@ -278,6 +282,7 @@ public class CheckRestModelTask extends DefaultTask
    * @deprecated use {@link #isEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsEquivalent()
   {
     return isEquivalent();
@@ -292,6 +297,7 @@ public class CheckRestModelTask extends DefaultTask
    * @deprecated use {@link #isEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsEquivalent()
   {
     return isEquivalent();
@@ -312,6 +318,7 @@ public class CheckRestModelTask extends DefaultTask
    * @deprecated use {@link #isRestSpecEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsRestSpecEquivalent()
   {
     return isRestSpecEquivalent();
@@ -326,6 +333,7 @@ public class CheckRestModelTask extends DefaultTask
    * @deprecated use {@link #isRestSpecEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsRestSpecEquivalent()
   {
     return isRestSpecEquivalent();

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckSnapshotTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/CheckSnapshotTask.java
@@ -105,6 +105,7 @@ public class CheckSnapshotTask extends DefaultTask
   }
 
   @InputDirectory
+  @PathSensitive(PathSensitivity.RELATIVE)
   public File getPreviousSnapshotDirectory()
   {
     return _previousSnapshotDirectory;
@@ -157,6 +158,7 @@ public class CheckSnapshotTask extends DefaultTask
    * @deprecated use {@link #isModelCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsModelCompatible()
   {
     return isModelCompatible();
@@ -171,6 +173,7 @@ public class CheckSnapshotTask extends DefaultTask
    * @deprecated use {@link #isModelCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsModelCompatible()
   {
     return isModelCompatible();
@@ -191,6 +194,7 @@ public class CheckSnapshotTask extends DefaultTask
    * @deprecated use {@link #isRestSpecCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsRestSpecCompatible()
   {
     return isRestSpecCompatible();
@@ -205,6 +209,7 @@ public class CheckSnapshotTask extends DefaultTask
    * @deprecated use {@link #isRestSpecCompatible()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsRestSpecCompatible()
   {
     return isRestSpecCompatible();
@@ -225,6 +230,7 @@ public class CheckSnapshotTask extends DefaultTask
    * @deprecated use {@link #isEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsEquivalent()
   {
     return isEquivalent();
@@ -239,6 +245,7 @@ public class CheckSnapshotTask extends DefaultTask
    * @deprecated use {@link #isEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsEquivalent()
   {
     return isEquivalent();
@@ -259,6 +266,7 @@ public class CheckSnapshotTask extends DefaultTask
    * @deprecated use {@link #isRestSpecEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean getIsRestSpecEquivalent()
   {
     return isRestSpecEquivalent();
@@ -273,6 +281,7 @@ public class CheckSnapshotTask extends DefaultTask
    * @deprecated use {@link #isRestSpecEquivalent()} instead
    */
   @Deprecated
+  @Internal
   public boolean isIsRestSpecEquivalent()
   {
     return isRestSpecEquivalent();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.7
+version=29.40.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This PR enable task validation check in the build of the gradle plugin so no validation warning of Gradle tasks can pass the build now. 

I also fixed the existing validation errors, which are listed below:

```
> Task property validation failed. See https://docs.gradle.org/5.2.1/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckIdlTask': property 'isEquivalent' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckIdlTask': property 'isModelCompatible' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckIdlTask': property 'isRestSpecCompatible' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckRestModelTask': property 'isEquivalent' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckRestModelTask': property 'isModelCompatible' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckRestModelTask': property 'isRestSpecCompatible' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckRestModelTask': property 'isRestSpecEquivalent' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckSnapshotTask': property 'isEquivalent' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckSnapshotTask': property 'isModelCompatible' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckSnapshotTask': property 'isRestSpecCompatible' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckSnapshotTask': property 'isRestSpecEquivalent' is not annotated with an input or output annotation.
   > Warning: Task type 'com.linkedin.pegasus.gradle.tasks.CheckSnapshotTask': property 'previousSnapshotDirectory' is missing a @PathSensitive annotation, defaulting to PathSensitivity.ABSOLUTE.
```

The problem is some task properties are marked as deprecated and  new replacement methods are added, but only the new methods are marked as `@internal`, the deprecated methods are NOT marked, which caused the warnings. The fix is to add `@internal` to the deprecated methods as well 