### PR TITLE
Fix the deprecated configuration name used in the PegasusPlugin

### DIFF
--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -1838,7 +1838,7 @@ public class PegasusPlugin implements Plugin<Project>
 
     // include additional dependencies into the appropriate configuration used to compile the input source set
     // must include the generated data template classes and their dependencies the configuration
-    String compileConfigName = isTestSourceSet(sourceSet) ? "testCompile" : "compile";
+    String compileConfigName = isTestSourceSet(sourceSet) ? "testImplementation" : project.getConfigurations().findByName("api") != null ? "api" : "implementation";
 
     Configuration compileConfig = project.getConfigurations().maybeCreate(compileConfigName);
     compileConfig.extendsFrom(


### PR DESCRIPTION
The pegasus used the `Implementation` and `testImplementation` configuration in the code, this PR is to fix that, and also added a integration test to verify data-template classes in api moudle can be consumed by other modules