### PR TITLE
Upgrade Apache Commons Text to 1.10.0 as vulnerability fix (CVE-2022-42889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.8] - 2022-11-14
+Upgrade Apache Commons Text to 1.10.0 as vulnerability fix (CVE-2022-42889)
+
 ## [29.40.7] - 2022-11-07
 Remove @PathSensitive from property idlDestinationDir in GenerateRestModelTask
 
@@ -5393,7 +5396,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.8...master
+[29.40.8]: https://github.com/linkedin/rest.li/compare/v29.40.7...v29.40.8
 [29.40.7]: https://github.com/linkedin/rest.li/compare/v29.40.6...v29.40.7
 [29.40.6]: https://github.com/linkedin/rest.li/compare/v29.40.5...v29.40.6
 [29.40.5]: https://github.com/linkedin/rest.li/compare/v29.40.4...v29.40.5

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ project.ext.externalDependency = [
   'commonsHttpClient': 'commons-httpclient:commons-httpclient:3.1',
   'commonsIo': 'commons-io:commons-io:2.4',
   'commonsLang': 'commons-lang:commons-lang:2.6',
-  'commonsText': 'org.apache.commons:commons-text:1.8',
+  'commonsText': 'org.apache.commons:commons-text:1.10.0',
   'disruptor': 'com.lmax:disruptor:3.2.0',
   'easymock': 'org.easymock:easymock:4.0.2',
   'findbugs': 'com.google.code.findbugs:annotations:3.0.0',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.7
+version=29.40.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-42889