### PR TITLE
Add additional logging to help tracing the receiving of initial D2 Cluster and D2 URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.12] - 2022-11-30
+Add D2 loggings for tracking the initial received D2 Clusters and D2 Uris
+
 ## [29.40.11] - 2022-11-17
 Add util class to convert generic List/Map to DataList/DataMap or vice versa
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5411,7 +5411,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.13...master
+[29.40.13]: https://github.com/linkedin/rest.li/compare/v29.40.12...v29.40.13
 [29.40.12]: https://github.com/linkedin/rest.li/compare/v29.40.11...v29.40.12
 [29.40.11]: https://github.com/linkedin/rest.li/compare/v29.40.10...v29.40.11
 [29.40.10]: https://github.com/linkedin/rest.li/compare/v29.40.9...v29.40.10

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriber.java
@@ -25,6 +25,11 @@ import com.linkedin.d2.balancer.util.canary.CanaryDistributionProvider;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessorFactory;
 import com.linkedin.d2.balancer.util.partitions.PartitionAccessorRegistry;
 import com.linkedin.d2.discovery.event.PropertyEventBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.d2.discovery.util.LogUtil.*;
+
 
 /**
  * Subscriber to the cluster data to update the SimpleLoadBalancerState
@@ -32,6 +37,7 @@ import com.linkedin.d2.discovery.event.PropertyEventBus;
 class ClusterLoadBalancerSubscriber extends
   AbstractLoadBalancerSubscriber<ClusterProperties>
 {
+  private static final Logger _log = LoggerFactory.getLogger(ClusterLoadBalancerSubscriber.class);
 
   final private SimpleLoadBalancerState _simpleLoadBalancerState;
   final private PartitionAccessorRegistry _partitionAccessorRegistry;
@@ -59,7 +65,11 @@ class ClusterLoadBalancerSubscriber extends
               _partitionAccessorRegistry,
               pickedPropertiesResult.clusterProperties.getPartitionProperties()),
           pickedPropertiesResult.distribution, getFailoutProperties(discoveryProperties));
-      _simpleLoadBalancerState.getClusterInfo().put(listenTo, newClusterInfoItem);
+
+      if (_simpleLoadBalancerState.getClusterInfo().put(listenTo, newClusterInfoItem) == null) {
+        info(_log, "getting new ClusterInfoItem for cluster ", listenTo, ": ", newClusterInfoItem);
+      }
+
       _simpleLoadBalancerState.notifyListenersOnClusterInfoUpdates(newClusterInfoItem);
       // notify the cluster listeners only when discoveryProperties is not null, because we don't
       // want to count initialization (just because listenToCluster is called)

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/UriLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/UriLoadBalancerSubscriber.java
@@ -31,8 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.d2.discovery.util.LogUtil.debug;
-import static com.linkedin.d2.discovery.util.LogUtil.warn;
+import static com.linkedin.d2.discovery.util.LogUtil.*;
+
 
 /**
  * Subscriber to the uri data to update the SimpleLoadBalancerState
@@ -109,10 +109,13 @@ class UriLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<UriProper
     }
 
     // replace the URI properties
-    _simpleLoadBalancerState.getUriProperties().put(cluster,
+    LoadBalancerStateItem<UriProperties> existingLBItem = _simpleLoadBalancerState.getUriProperties().put(cluster,
       new LoadBalancerStateItem<>(uriProperties,
         _simpleLoadBalancerState.getVersionAccess().incrementAndGet(),
         System.currentTimeMillis()));
+    if (existingLBItem == null) {
+      info(_log, "getting new UriProperties for cluster ", cluster);
+    }
 
     // now remove URIs that we're tracking, but have been removed from the new uri properties
     if (uriProperties != null)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.12
+version=29.40.13
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Recently, we have seen issues of D2 layer not able to notify Client layer when it receives data. So, we're working on adding some logs to help identify issues. This RB adds the missing info logs for receiving D2 Cluster and D2 URIs for the very first time. Same logging is already there for D2 Service.