### PR TITLE
Replace the API call getArchivePath() with getArchiveFile() on Gradle 7 in the Pegasus Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.40.16] - 2022-12-14
+Replace the API call getArchivePath() with getArchiveFile() on Gradle 7 in the Pegasus Plugin
+
 ## [29.40.15] - 2022-12-08
 Allow disabling the ivy publication preconfiguration in the Pegasus Gradle plugin
 
@@ -5417,7 +5420,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.15...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.16...master
+[29.40.16]: https://github.com/linkedin/rest.li/compare/v29.40.15...v29.40.16
 [29.40.15]: https://github.com/linkedin/rest.li/compare/v29.40.14...v29.40.15
 [29.40.14]: https://github.com/linkedin/rest.li/compare/v29.40.13...v29.40.14
 [29.40.13]: https://github.com/linkedin/rest.li/compare/v29.40.12...v29.40.13

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -1860,8 +1860,11 @@ public class PegasusPlugin implements Plugin<Project>
         getDataModelConfig(project, sourceSet),
         project.getConfigurations().getByName("dataTemplateCompile"));
 
-    // FIXME change to #getArchiveFile(); breaks backwards-compatibility before 5.1
-    project.getDependencies().add(compileConfigName, project.files(dataTemplateJarTask.getArchivePath()));
+    // The getArchivePath() API doesn’t carry any task dependency and has been deprecated.
+    // Replace it with getArchiveFile() on Gradle 7,
+    // but keep getArchivePath() to be backwards-compatibility with Gradle version older than 5.1
+    project.getDependencies().add(compileConfigName, project.files(
+        isAtLeastGradle7() ? dataTemplateJarTask.getArchiveFile() : dataTemplateJarTask.getArchivePath()));
 
     if (_configureIvyPublications) {
       // The below Action is only applied when the 'ivy-publish' is applied by the consumer.
@@ -2008,8 +2011,11 @@ public class PegasusPlugin implements Plugin<Project>
         System.out.println("sourceSet " + sourceSet.getName() + " has generated sourceSet " + dataTemplateSourceSetName);
       }
       dataTemplateJarTask = (Jar) project.getTasks().getByName(sourceSet.getName() + "DataTemplateJar");
-      // FIXME change to #getArchiveFile(); breaks backwards-compatibility before 5.1
-      dataModels = dataModelConfig.plus(project.files(dataTemplateJarTask.getArchivePath()));
+      // The getArchivePath() API doesn’t carry any task dependency and has been deprecated.
+      // Replace it with getArchiveFile() on Gradle 7,
+      // but keep getArchivePath() to be backwards-compatibility with Gradle version older than 5.1
+      dataModels = dataModelConfig.plus(project.files(
+          isAtLeastGradle7() ? dataTemplateJarTask.getArchiveFile() : dataTemplateJarTask.getArchivePath()));
     }
     else
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.15
+version=29.40.16
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
 The `getArchivePath()` API doesn’t carry any task dependency and has been deprecated. Replace it with `getArchiveFile()` on Gradle 7,  but keep `getArchivePath()` to be backwards-compatibility with Gradle version older than 5.1.

If we don't make the fix, when build one of our product, we may see the warning
```
> Task :jeeves-api:checkForDuplicates
Execution optimizations have been disabled for task ':jeeves-api:checkForDuplicates' to ensure correctness due to the following reasons:

Gradle detected a problem with the following location: '/Users/yli4/dev/jeeves/build/jeeves-api/libs/jeeves-api-data-template-2.1.93.jar'. Reason: Task ':jeeves-api:checkForDuplicates' uses this output of task ':jeeves-api:mainDataTemplateJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem. 
```

The root cause is the checkForDuplicates task use the `compileClass` configuration as the input, but the archive of `mainDataTemplateJar` task was added to the `compile` configuration with `getArchivePath()` API, which doesn't carry any task dependency. Change to use `getArchiveFile()` API will declare an implicit dependency to the `mainDataTemplateJar` task and fix the warning message. 