### PR TITLE
Reduce memory allocations during rich schema traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.41.0] - 2022-12-15
+Reduce memory allocations during rich schema traversal
+
 ## [29.40.15] - 2022-12-08
 Allow disabling the ivy publication preconfiguration in the Pegasus Gradle plugin
 
@@ -5417,7 +5420,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.40.15...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.0...master
+[29.41.0]: https://github.com/linkedin/rest.li/compare/v29.40.15...v29.41.0
 [29.40.15]: https://github.com/linkedin/rest.li/compare/v29.40.14...v29.40.15
 [29.40.14]: https://github.com/linkedin/rest.li/compare/v29.40.13...v29.40.14
 [29.40.13]: https://github.com/linkedin/rest.li/compare/v29.40.12...v29.40.13

--- a/data/src/main/java/com/linkedin/data/schema/DataSchemaConstants.java
+++ b/data/src/main/java/com/linkedin/data/schema/DataSchemaConstants.java
@@ -47,6 +47,7 @@ public class DataSchemaConstants
   public static final String TYPE_KEY = "type";
   public static final String VALUES_KEY = "values";
   public static final String MAP_KEY_REF= "$key";
+  public static final String TYPEREF_REF = "$typeref";
 
   public static final String NULL_TYPE = "null";
   public static final String BOOLEAN_TYPE = "boolean";

--- a/data/src/main/java/com/linkedin/data/schema/annotation/AnnotationEntry.java
+++ b/data/src/main/java/com/linkedin/data/schema/annotation/AnnotationEntry.java
@@ -6,8 +6,10 @@ import com.linkedin.data.schema.PathSpec;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.TyperefDataSchema;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 
 /**
@@ -69,7 +71,7 @@ public class AnnotationEntry
   // the actual property value that this AnnotationEntry stored
   private Object _annotationValue;
   // The traverser path of the annotatedTarget(field, or DataSchema) that this AnnotationEntry is constructed from, relative to the schema root
-  private final ArrayDeque<String> _pathToAnnotatedTarget;
+  private final List<String> _pathToAnnotatedTarget;
   // The annotatedTarget(field, dataSchema, etc) that this entry was annotated at.
   private final Object _annotatedTarget;
 
@@ -145,7 +147,7 @@ public class AnnotationEntry
   AnnotationEntry(String pathSpecStr,
                   Object annotationValue,
                   AnnotationType annotationType,
-                  ArrayDeque<String> pathToAnnotatedTarget,
+                  List<String> pathToAnnotatedTarget,
                   Object annotatedTarget)
   {
     _remainingPaths = new ArrayDeque<>(Arrays.asList(pathSpecStr.split(Character.toString(PathSpec.SEPARATOR))));
@@ -153,7 +155,7 @@ public class AnnotationEntry
     _annotationValue = annotationValue;
     _overridePathSpecStr = pathSpecStr;
     _annotationType = annotationType;
-    _pathToAnnotatedTarget = new ArrayDeque<>(pathToAnnotatedTarget);
+    _pathToAnnotatedTarget = new ArrayList<>(pathToAnnotatedTarget);
     _annotatedTarget = annotatedTarget;
   }
 
@@ -215,7 +217,7 @@ public class AnnotationEntry
   }
 
 
-  ArrayDeque<String> getPathToAnnotatedTarget()
+  List<String> getPathToAnnotatedTarget()
   {
     return _pathToAnnotatedTarget;
   }

--- a/data/src/main/java/com/linkedin/data/schema/annotation/SchemaAnnotationValidationVisitor.java
+++ b/data/src/main/java/com/linkedin/data/schema/annotation/SchemaAnnotationValidationVisitor.java
@@ -18,6 +18,7 @@ package com.linkedin.data.schema.annotation;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaTraverse;
 import com.linkedin.data.schema.annotation.SchemaAnnotationHandler.AnnotationValidationResult;
+import java.util.ArrayDeque;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,7 @@ public class SchemaAnnotationValidationVisitor implements SchemaVisitor
     DataSchema schema = context.getCurrentSchema();
     SchemaAnnotationHandler.ValidationMetaData metaData = new SchemaAnnotationHandler.ValidationMetaData();
     metaData.setDataSchema(context.getCurrentSchema());
-    metaData.setPathToSchema(context.getTraversePath());
+    metaData.setPathToSchema(new ArrayDeque<>(context.getTraversePath()));
     AnnotationValidationResult annotationValidationResult = _schemaAnnotationHandler.validate(schema.getResolvedProperties(),
                                                                                               metaData);
     if (!annotationValidationResult.isValid())

--- a/data/src/main/java/com/linkedin/data/schema/annotation/SchemaVisitor.java
+++ b/data/src/main/java/com/linkedin/data/schema/annotation/SchemaVisitor.java
@@ -52,6 +52,13 @@ public interface SchemaVisitor
   SchemaVisitorTraversalResult getSchemaVisitorTraversalResult();
 
   /**
+   * @return True if we should record typeref nodes in the path spec when traversing the schema, false otherwise.
+   */
+  default boolean shouldIncludeTyperefsInPathSpec() {
+    return false;
+  }
+
+  /**
    * A context that is defined and handled by {@link SchemaVisitor}
    *
    * The {@link DataSchemaRichContextTraverser} will get the initial context and then

--- a/data/src/main/java/com/linkedin/data/schema/annotation/SchemaVisitorTraversalResult.java
+++ b/data/src/main/java/com/linkedin/data/schema/annotation/SchemaVisitorTraversalResult.java
@@ -125,7 +125,7 @@ public class SchemaVisitorTraversalResult
    *
    * @see Message
    */
-  public void addMessage(ArrayDeque<String> path, String format, Object... args)
+  public void addMessage(List<String> path, String format, Object... args)
   {
     Message msg = new Message(path.toArray(), format, args);
     addMessage(msg);
@@ -140,10 +140,10 @@ public class SchemaVisitorTraversalResult
    *
    * @see Message
    */
-  public void addMessages(ArrayDeque<String> path, Collection<? extends Message> messages)
+  public void addMessages(List<String> path, Collection<? extends Message> messages)
   {
     List<Message> msgs = messages.stream()
-                                 .map(msg -> new Message(path.toArray(), ((Message) msg).toString()))
+                                 .map(msg -> new Message(path.toArray(), msg.toString()))
                                  .collect(Collectors.toList());
     _messages.addAll(msgs);
     MessageUtil.appendMessages(getMessageBuilder(), msgs);

--- a/data/src/main/java/com/linkedin/data/schema/annotation/TraverserContext.java
+++ b/data/src/main/java/com/linkedin/data/schema/annotation/TraverserContext.java
@@ -20,7 +20,7 @@ import com.linkedin.data.schema.DataSchemaTraverse;
 import com.linkedin.data.schema.PathSpec;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
-import java.util.ArrayDeque;
+import java.util.List;
 
 
 /**
@@ -100,13 +100,25 @@ public interface TraverserContext
    * The traversePath to the f2 field would be as detailed as "/Test/f1/Nested/f2/TypeRef_Name/int"
    * Meanwhile its schema pathSpec is as simple as "/f1/f2"
    *
+   * <p>The returned list is unmodifiable, but the underlying list may be mutated once the
+   * {@link SchemaVisitor#callbackOnContext(TraverserContext, DataSchemaTraverse.Order)} method finishes. Implementers
+   * who want to modify this list locally, or are sensitive to this mutation should make a copy of this list during the
+   * callback.</p>
    */
-  ArrayDeque<String> getTraversePath();
+  List<String> getTraversePath();
 
   /**
-   * This is the path components corresponds to {@link PathSpec}, it would not have TypeRef component inside its component list, also it would only contain field's name
+   * This is the path components corresponds to {@link PathSpec}, containing field names in the path. Note that
+   * any typerefs in the path are omitted by default, and are represenred via
+   * {@link com.linkedin.data.schema.DataSchemaConstants#TYPEREF_REF} only if
+   * {@link SchemaVisitor#shouldIncludeTyperefsInPathSpec()} returns true.
+   *
+   * <p>The returned list is unmodifiable, but the underlying list may be mutated once the
+   * {@link SchemaVisitor#callbackOnContext(TraverserContext, DataSchemaTraverse.Order)} method finishes. Implementers
+   * who want to modify this list locally, or are sensitive to this mutation should make a copy of this list during the
+   * callback.</p>
    */
-  ArrayDeque<String> getSchemaPathSpec();
+  List<String> getSchemaPathSpec();
 
   /**
    * This attribute tells how currentSchema stored in the context is linked from its parentSchema

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.40.15
+version=29.41.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The current schema traversal mechanism copies the ArrayDeque with all path specs and traverse specs. This creates huge allocations that are immediately garbage collected. The problem is acute in services like voyager-api where the anti-abuse filter uses this mechanism to traverse all schemas referenced directly by any rest.li resource. A sample JFR for example showed 124GB of allocs in ~3 minutes, which caused service startup performance to be materially affected.

This PR optimizes this mechanism by maintaining a single ArrayList internally and using integer limits to keep track of position in the list. It also changes the return type to List instead of ArrayDeque and returns an immutable list to avoid callers from modifying it.