### PR TITLE
Expose enumeration of clusters to `ZKFailoutConfigProvider`.

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/ZKFailoutConfigProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clusterfailout/ZKFailoutConfigProvider.java
@@ -20,6 +20,8 @@ import com.linkedin.d2.balancer.LoadBalancerState;
 import com.linkedin.d2.balancer.LoadBalancerStateItem;
 import com.linkedin.d2.balancer.properties.FailoutProperties;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -88,6 +90,10 @@ public abstract class ZKFailoutConfigProvider implements FailoutConfigProvider, 
   {
     final FailedoutClusterManager failedoutClusterManager = _failedoutClusterManagers.get(clusterName);
     return failedoutClusterManager != null ? failedoutClusterManager.getFailoutConfig() : null;
+  }
+
+  public Set<String> getClusters() {
+    return new HashSet<>(_failedoutClusterManagers.keySet());
   }
 
   @Override


### PR DESCRIPTION
This assists higher level functions that need to gather data from all of the failout configs. It is left off the interface since the interface should support implementations which do not have a defined set of known clusters.