### PR TITLE
add property option to force publish idl and snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.41.3] - 2023-01-03
+Add option to force publish idl and snapshot
+
 ## [29.41.2] - 2022-12-21
 Enable enumeration of clusters in `ZKFailoutConfigProvider`.
 
@@ -5426,7 +5429,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.3...master
+[29.41.3]: https://github.com/linkedin/rest.li/compare/v29.41.2...v29.41.3
 [29.41.2]: https://github.com/linkedin/rest.li/compare/v29.41.1...v29.41.2
 [29.41.1]: https://github.com/linkedin/rest.li/compare/v29.41.0...v29.41.1
 [29.41.0]: https://github.com/linkedin/rest.li/compare/v29.40.15...v29.41.0

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -561,7 +561,9 @@ public class PegasusPlugin implements Plugin<Project>
 
   private static final Pattern TEST_DIR_REGEX = Pattern.compile("^(integ)?[Tt]est");
   private static final String SNAPSHOT_NO_PUBLISH = "rest.model.noPublish";
+  private static final String SNAPSHOT_FORCE_PUBLISH = "rest.model.forcePublish";
   private static final String IDL_NO_PUBLISH = "rest.idl.noPublish";
+  private static final String IDL_FORCE_PUBLISH = "rest.idl.forcePublish";
   private static final String SKIP_IDL_CHECK = "rest.idl.skipCheck";
   // gradle property to skip running GenerateRestModel task.
   // Note it affects GenerateRestModel task only, and does not skip tasks depends on GenerateRestModel.
@@ -1375,6 +1377,8 @@ public class PegasusPlugin implements Plugin<Project>
             task.setSuffix(SNAPSHOT_FILE_SUFFIX);
 
             task.onlyIf(t ->
+                isPropertyTrue(project, SNAPSHOT_FORCE_PUBLISH) ||
+                (
                     !isPropertyTrue(project, SNAPSHOT_NO_PUBLISH) &&
                     (
                       (
@@ -1389,7 +1393,8 @@ public class PegasusPlugin implements Plugin<Project>
                          checkRestModelTask.getSummaryTarget().exists() &&
                         !isResultEquivalent(checkRestModelTask.getSummaryTarget())
                       )
-                    ));
+                    ))
+                );
           });
 
       Task publishRestliIdlTask = project.getTasks()
@@ -1400,6 +1405,8 @@ public class PegasusPlugin implements Plugin<Project>
             task.setSuffix(IDL_FILE_SUFFIX);
 
             task.onlyIf(t ->
+                isPropertyTrue(project, IDL_FORCE_PUBLISH) ||
+                (
                     !isPropertyTrue(project, IDL_NO_PUBLISH) &&
                     (
                       (
@@ -1419,7 +1426,8 @@ public class PegasusPlugin implements Plugin<Project>
                                 !isResultEquivalent(checkIdlTask.getSummaryTarget()))
                          )
                       )
-                    ));
+                    ))
+                );
           });
 
       project.getLogger().info("API project selected for {} is {}",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.41.2
+version=29.41.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
our IDL publish is gated by complicated logic, therefore sometimes compatible IDL **change** will not be published.

These two option can override these complicated logic and force publish IDL or Snapshot