### PR TITLE
[SchemaTranslator] handle self-referential avro aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.41.5] - 2023-01-11
+Handle Avro self-referential aliases in Avro to Proto schema translation.
 
 ## [29.41.4] - 2023-01-09
 change the innitialize size of resolvedProperties to 0 in order to save memory pre-allocated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.41.5] - 2023-01-11
+
 ## [29.41.4] - 2023-01-09
 change the innitialize size of resolvedProperties to 0 in order to save memory pre-allocated
 
@@ -5432,7 +5434,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.5...master
+[29.41.5]: https://github.com/linkedin/rest.li/compare/v29.41.4...v29.41.5
 [29.41.4]: https://github.com/linkedin/rest.li/compare/v29.41.3...v29.41.4
 [29.41.3]: https://github.com/linkedin/rest.li/compare/v29.41.2...v29.41.3
 [29.41.2]: https://github.com/linkedin/rest.li/compare/v29.41.1...v29.41.2

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -3066,6 +3066,11 @@ public class TestSchemaTranslator
                 // Translated union member property contains default value.
                 "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
                 "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : \"string\", \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\", \"optional\" : true }, { \"name\" : \"failure\", \"type\" : \"string\", \"doc\" : \"Failure message\", \"optional\" : true }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"success\" : \"Union with aliases.\", \"fieldDiscriminator\" : \"success\" }, \"optional\" : true } ] }"
+            },
+            {
+                // Avro schema with self-referential alias
+                "{ \"type\" : \"record\", \"namespace\" : \"com.linkedin\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ], \"aliases\" : [\"com.linkedin.Foo\"] }",
+                "{ \"type\" : \"record\", \"namespace\" : \"com.linkedin\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ], \"aliases\" : [\"com.linkedin.Foo\"] }"
             }
         };
   }

--- a/data/src/main/java/com/linkedin/data/schema/AbstractSchemaParser.java
+++ b/data/src/main/java/com/linkedin/data/schema/AbstractSchemaParser.java
@@ -43,6 +43,7 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -129,7 +130,12 @@ abstract public class AbstractSchemaParser implements PegasusSchemaParser
     {
       for (Name aliasName : aliasNames)
       {
-        ok &= bindNameToSchema(aliasName, schema);
+        // Avro allows for self referential aliases (where the alias is the same as the FQN).
+        // There is no need to bind a self-referential alias to itself.
+        if (!Objects.equals(aliasName.getFullName(), name.getFullName()))
+        {
+          ok &= bindNameToSchema(aliasName, schema);
+        }
       }
     }
     return ok;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.41.4
+version=29.41.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
Avro allows for self referential aliases (where the Avro alias is the same as the full name of the schema). This PR adds support for self referential aliases to SchemaTranslator, in particular `SchemaTranslator#avroToDataSchema`.

## Testing
Added unit tests to test for this case