### PR TITLE
Split getPotentialClients between subsetting and not-subsetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.41.7] - 2023-02-13
 Split getPotentialClients impl between subsetting and not-subsetting cases
 
 ## [29.41.6] - 2023-01-25
@@ -5439,7 +5441,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.7...master
+[29.41.7]: https://github.com/linkedin/rest.li/compare/v29.41.6...v29.41.7
 [29.41.6]: https://github.com/linkedin/rest.li/compare/v29.41.5...v29.41.6
 [29.41.5]: https://github.com/linkedin/rest.li/compare/v29.41.4...v29.41.5
 [29.41.4]: https://github.com/linkedin/rest.li/compare/v29.41.3...v29.41.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+Split getPotentialClients impl between subsetting and not-subsetting cases
 
 ## [29.41.6] - 2023-01-25
 Fix Async R2 Servlet deadlock condition

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.41.6
+version=29.41.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
~55% of CPU usage consumed during getPotentialClients is used for constructing weightedUris as shown in the following flamegraph with the Stream collecting.
<img width="1147" alt="Screenshot 2023-02-09 at 11 57 01 AM" src="https://user-images.githubusercontent.com/1134608/217923528-dd04fc04-b421-4165-b30a-ddb1d9e3ab1e.png">

To minimize this operation, this change is to avoid doing it for clusters that don't have subsetting enabled.