### PR TITLE
Mark AlternativeKey annotation as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.41.7] - 2023-02-09
+Mark AlternativeKey annotation as deprecated.
+
 ## [29.41.6] - 2023-01-25
 Fix Async R2 Servlet deadlock condition
 
@@ -5438,7 +5441,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.7...master
+[29.41.7]: https://github.com/linkedin/rest.li/compare/v29.41.6...v29.41.7
 [29.41.6]: https://github.com/linkedin/rest.li/compare/v29.41.5...v29.41.6
 [29.41.5]: https://github.com/linkedin/rest.li/compare/v29.41.4...v29.41.5
 [29.41.4]: https://github.com/linkedin/rest.li/compare/v29.41.3...v29.41.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.41.6
+version=29.41.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/model/RestLiAnnotationReader.java
@@ -269,6 +269,7 @@ public final class RestLiAnnotationReader
    * @param model The {@link com.linkedin.restli.internal.server.model.ResourceModel} that we are building.
    * @param resourceClass The resource {@link java.lang.Class}.
    */
+  @SuppressWarnings("deprecation")
   private static void addAlternativeKeys(ResourceModel model, Class<?> resourceClass)
   {
     if (resourceClass.isAnnotationPresent(AlternativeKey.class) || resourceClass.isAnnotationPresent(AlternativeKeys.class))
@@ -305,6 +306,7 @@ public final class RestLiAnnotationReader
    * @param altKeyAnnotation The {@link com.linkedin.restli.server.annotations.AlternativeKey} annotation.
    * @return {@link com.linkedin.restli.server.AlternativeKey} object.
    */
+  @SuppressWarnings("deprecation")
   private static com.linkedin.restli.server.AlternativeKey<?, ?> buildAlternativeKey(String resourceName,
                                                                                      AlternativeKey altKeyAnnotation)
   {

--- a/restli-server/src/main/java/com/linkedin/restli/server/annotations/AlternativeKey.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/annotations/AlternativeKey.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Target;
 /**
  * @author Moira Tagle
  */
+@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface AlternativeKey

--- a/restli-server/src/main/java/com/linkedin/restli/server/annotations/AlternativeKeys.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/annotations/AlternativeKeys.java
@@ -29,6 +29,7 @@ import java.util.List;
  * This will become deprecated when rest.li upgrades to java 8.
  * @author Moira Tagle
  */
+@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface AlternativeKeys


### PR DESCRIPTION
In the future, we will no longer support AlternativeKey. Therefore, mark the AlternativeKey annotation as deprecated. 