### PR TITLE
fix translation of float/double's -Infinity/Infinity/NaN

### DIFF
--- a/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
@@ -32,6 +32,7 @@ import com.linkedin.data.schema.FixedDataSchema;
 import com.linkedin.data.schema.MapDataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
+import com.linkedin.data.template.DataTemplateUtil;
 import java.nio.ByteBuffer;
 import java.util.AbstractMap;
 import java.util.ArrayDeque;
@@ -797,10 +798,10 @@ public class DataTranslator implements DataTranslatorContext
           result = ((Number) value).longValue();
           break;
         case FLOAT:
-          result = ((Number) value).floatValue();
+          result = DataTemplateUtil.coerceFloatOutput(value);
           break;
         case DOUBLE:
-          result = ((Number) value).doubleValue();
+          result = DataTemplateUtil.coerceDoubleOutput(value);
           break;
         case STRING:
           result = new Utf8((String) value);

--- a/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
@@ -543,10 +543,10 @@ public class DataTranslator implements DataTranslatorContext
           fieldVal = ((Number) fieldVal).longValue();
           break;
         case FLOAT:
-          fieldVal = ((Number) fieldVal).floatValue();
+          fieldVal = DataTemplateUtil.coerceFloatOutput(fieldVal);
           break;
         case DOUBLE:
-          fieldVal = ((Number) fieldVal).doubleValue();
+          fieldVal = DataTemplateUtil.coerceDoubleOutput(fieldVal);
           break;
         case STRING:
           fieldVal =  String.valueOf(fieldVal);

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -1075,6 +1075,40 @@ public class TestDataTranslator
     }
   }
 
+  @Test
+  public void testInfinityAndNan() throws IOException {
+    String schemaText =
+        "{\n" +
+          "  \"type\" : \"record\",\n" +
+          "  \"name\" : \"Foo\",\n" +
+          "  \"fields\" : [\n" +
+          "    { \"name\" : \"doubleRequired\", \"type\" : \"double\" }\n" +
+          "  ]\n" +
+          "}\n";
+    // First element is the input, second element is the expected output
+    Object[][] inputs = {
+        {
+            "{ \"doubleRequired\" : \"Infinity\"}",
+            Double.POSITIVE_INFINITY
+        }, {
+            "{ \"doubleRequired\" : \"NaN\"}",
+            Double.NaN
+        }, {
+            "{ \"doubleRequired\" : \"-Infinity\"}",
+            Double.NEGATIVE_INFINITY
+        }
+    };
+    RecordDataSchema recordDataSchema = (RecordDataSchema) TestUtil.dataSchemaFromString(schemaText);
+    for (Object[] input : inputs) {
+      DataMap dataMap = TestUtil.dataMapFromString((String) input[0]);
+      Schema avroSchema = SchemaTranslator.dataToAvroSchema(recordDataSchema);
+      GenericRecord avroRecord = DataTranslator.dataMapToGenericRecord(dataMap, recordDataSchema, avroSchema);
+      assertEquals(avroRecord.get("doubleRequired"), input[1]);
+    }
+
+
+  }
+
   private void testDataTranslation(String schemaText, String[][] row) throws IOException
   {
     boolean debug = false;


### PR DESCRIPTION
Bug fix -  The scenario is as follows:
* a data map contains a deserialized `Double.POSITIVE_INFINITY`, `Double.NEGATIVE_INFINITY`, or `Double.NaN` 
* a call to `DataTranslator#dataMapToGenericRecord` or `DataTranslator#dataMapToSpecificRecord` is made with the data map.

This flow throws an exception because those double values are serialized as strings (`Infinity`, `-Infinity`, `NaN`) and are then attempted to be deserialized directly into a Double (`ClassCastException: java.lang.String cannot be cast to java.lang.Number`).