### PR TITLE
use proper UTF8 encoding in AvroUtil.jsonFromGenericRecord, also deprecate AvroUtil and bump avro-util dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.41.10] - 2023-02-23
+use proper UTF8 encoding in AvroUtil.jsonFromGenericRecord, also deprecate AvroUtil and bump avro-util dependency
+
 ## [29.41.9] - 2023-02-15
 Handle infinity/-infinity/NaN in DataSchema -> Avro record data translation.
 
@@ -5447,7 +5450,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.10...master
+[29.41.10]: https://github.com/linkedin/rest.li/compare/v29.41.9...v29.41.10
 [29.41.9]: https://github.com/linkedin/rest.li/compare/v29.41.8...v29.41.9
 [29.41.8]: https://github.com/linkedin/rest.li/compare/v29.41.7...v29.41.8
 [29.41.7]: https://github.com/linkedin/rest.li/compare/v29.41.6...v29.41.7

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ project.ext.externalDependency = [
   'avro': 'org.apache.avro:avro:1.9.2',
   'avro_1_6': 'org.apache.avro:avro:1.6.3',
    // avro compatibility layer
-  'avroUtil': 'com.linkedin.avroutil1:helper-all:0.2.17',
+  'avroUtil': 'com.linkedin.avroutil1:helper-all:0.2.138',
   'caffeine': 'com.github.ben-manes.caffeine:caffeine:2.7.0',
   'cglib': 'cglib:cglib-nodep:2.2',
   'codemodel': 'com.sun.codemodel:codemodel:2.2',

--- a/data-avro/src/main/java/com/linkedin/data/avro/util/AvroUtil.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/util/AvroUtil.java
@@ -21,6 +21,7 @@ import com.linkedin.avroutil1.compatibility.AvroVersion;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -28,6 +29,11 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.Encoder;
 
+
+/**
+ * @deprecated please use {@link com.linkedin.avroutil1.compatibility.AvroCodecUtil}
+ */
+@Deprecated
 public class AvroUtil
 {
   public static String jsonFromGenericRecord(GenericRecord record) throws IOException
@@ -61,7 +67,7 @@ public class AvroUtil
     writer.setSchema(record.getSchema());
     writer.write(record, jsonEncoder);
     jsonEncoder.flush();
-    return outputStream.toString();
+    return outputStream.toString(StandardCharsets.UTF_8.name());
   }
 
   public static byte[] bytesFromGenericRecord(GenericRecord record) throws IOException
@@ -87,9 +93,8 @@ public class AvroUtil
 
   public static GenericRecord genericRecordFromJson(String json, Schema schema) throws IOException
   {
-    GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>();
+    GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(schema, schema);
     Decoder jsonDecoder = AvroCompatibilityHelper.newCompatibleJsonDecoder(schema, json);
-    reader.setSchema(schema);
     GenericRecord record = reader.read(null, jsonDecoder);
     return record;
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.41.9
+version=29.41.10
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
OutputStrean.toString() decodes bytes using the system default encoding, which might not be unicode, resulting in corrupt text