### PR TITLE
encoder primitive schema's properties in PDL Encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.41.12] - 2023-03-27
+Encode PrimitiveSchema's properties in PdlEncoder
+
 ## [29.41.11] - 2023-03-09
 Updates Data.TraverseCallback to have a callback for 'endKey'.
 
@@ -5453,7 +5456,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.12...master
+[29.41.12]: https://github.com/linkedin/rest.li/compare/v29.41.11...v29.41.12
 [29.41.11]: https://github.com/linkedin/rest.li/compare/v29.41.10...v29.41.11
 [29.41.10]: https://github.com/linkedin/rest.li/compare/v29.41.9...v29.41.10
 [29.41.9]: https://github.com/linkedin/rest.li/compare/v29.41.8...v29.41.9

--- a/data/src/main/java/com/linkedin/data/schema/PdlBuilder.java
+++ b/data/src/main/java/com/linkedin/data/schema/PdlBuilder.java
@@ -137,6 +137,15 @@ abstract class PdlBuilder
    */
   PdlBuilder writeProperties(List<String> prefix, Map<String, Object> properties) throws IOException
   {
+    return writeProperties(prefix, properties, false);
+  }
+
+  /**
+   * Similar to {@link #writeProperties(List, Map)}, but take another parameter to indicate whether single properties
+   *  could be encoded as inline.
+   */
+  PdlBuilder writeProperties(List<String> prefix, Map<String, Object> properties, boolean inline) throws IOException
+  {
     List<Map.Entry<String, Object>> orderedProperties =  properties.entrySet().stream()
         .sorted(Map.Entry.comparingByKey())
         .collect(Collectors.toList());
@@ -161,7 +170,7 @@ abstract class PdlBuilder
         else
         {
           // encode value property like @x = { "y": { "z": "value" } }
-          writeProperty(pathParts, dm);
+          writeProperty(pathParts, dm, inline);
         }
       }
       else if (Boolean.TRUE.equals(value))
@@ -172,7 +181,7 @@ abstract class PdlBuilder
       }
       else
       {
-        writeProperty(pathParts, value);
+        writeProperty(pathParts, value, inline);
       }
     }
     return this;
@@ -183,10 +192,15 @@ abstract class PdlBuilder
    * @param path provides the property's full path.
    * @param value provides the property's value, it may be any valid pegasus Data binding type (DataList, DataMap,
    *              String, Int, Long, Float, Double, Boolean, ByteArray)
+   * @param inline whether the property could be coded as inline. If true, encoder will continue encoding in same line.
    */
-  private void writeProperty(List<String> path, Object value) throws IOException
-  {
-    indent().write("@").writePath(path).writeSpace().write("=").writeSpace().writeJson(value).newline();
+  private void writeProperty(List<String> path, Object value, boolean inline) throws IOException {
+    indent().write("@").writePath(path).writeSpace().write("=").writeSpace().writeJson(value);
+    if (inline) {
+      writeSpace();
+    } else {
+      newline();
+    }
   }
 
   /**

--- a/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
@@ -528,6 +528,7 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
 
   private void writePrimitive(PrimitiveDataSchema schema) throws IOException
   {
+    writeProperties(schema.getProperties());
     _builder.write(schema.getUnionMemberKey());
   }
 

--- a/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
@@ -528,7 +528,7 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
 
   private void writePrimitive(PrimitiveDataSchema schema) throws IOException
   {
-    writeProperties(schema.getProperties());
+    _builder.writeProperties(Collections.emptyList(), schema.getProperties(), true);
     _builder.write(schema.getUnionMemberKey());
   }
 

--- a/data/src/test/java/com/linkedin/data/schema/TestSchemaToPdlEncoder.java
+++ b/data/src/test/java/com/linkedin/data/schema/TestSchemaToPdlEncoder.java
@@ -20,6 +20,7 @@ import com.linkedin.data.DataMap;
 import com.linkedin.data.TestUtil;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -240,5 +241,38 @@ public class TestSchemaToPdlEncoder
         "      }",
         "    }",
         "}"), indentedSchema);
+  }
+
+  @Test
+  public void TestEncodePrimitiveSchemaProperties()
+  {
+    DataSchema primitiveIntSchemaWithProperties = new PrimitiveDataSchema(
+        DataSchema.Type.INT,
+        DataSchemaConstants.INTEGER_TYPE
+    )
+    {
+      @Override
+      public Map<String, Object> getProperties() {
+        Map<String, Object> primitiveIntMap = new HashMap<>();
+        primitiveIntMap.put("testKey", "testValue");
+        return primitiveIntMap;
+      }
+    };
+    RecordDataSchema recordDataSchema = new RecordDataSchema(new Name("TestRecord", null),
+        RecordDataSchema.RecordType.RECORD);
+    RecordDataSchema.Field field = new RecordDataSchema.Field(primitiveIntSchemaWithProperties);
+    field.setName("intField", null);
+    field.setRecord(recordDataSchema);
+    recordDataSchema.setFields(Arrays.asList(field), null);
+
+
+    String translatedSchema = SchemaToPdlEncoder.schemaToPdl(recordDataSchema,
+        SchemaToPdlEncoder.EncodingStyle.INDENTED);
+
+    assertEquals("record TestRecord {\n"
+        + "  intField:   @testKey = \"testValue\" int\n"
+        + "}",
+        translatedSchema);
+
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.41.11
+version=29.41.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
prior to this change, we ignore primitive schema's properties when encoding a PDL schema.

This behavior is not allowing us to properly encode properties that we intend to add to primitive schemas. 