### PR TITLE
Let FieldDef lazy-calculate and cache hash code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.46.9] - 2023-11-02
+- Update FieldDef so that it will lazily cache the hashCode.
+
 ## [29.46.8] - 2023-10-11
 - add metrics about xds connection status and count
 
@@ -5554,7 +5557,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.9...master
+[29.46.9]: https://github.com/linkedin/rest.li/compare/v29.46.8...v29.46.9
 [29.46.8]: https://github.com/linkedin/rest.li/compare/v29.46.7...v29.46.8
 [29.46.7]: https://github.com/linkedin/rest.li/compare/v29.46.6...v29.46.7
 [29.46.6]: https://github.com/linkedin/rest.li/compare/v29.46.5...v29.46.6

--- a/data/src/main/java/com/linkedin/data/template/FieldDef.java
+++ b/data/src/main/java/com/linkedin/data/template/FieldDef.java
@@ -37,6 +37,7 @@ public class FieldDef<T>
   private final DataSchema _dataSchema;
   private final Class<?> _dataClass;
   private final RecordDataSchema.Field _field;
+  private final int _hashCode;
 
   public FieldDef(String name, Class<T> type)
   {
@@ -48,6 +49,7 @@ public class FieldDef<T>
     _name = name;
     _type = type;
     _dataSchema = dataSchema;
+    _hashCode = computeHashCode();
     /**
      * FieldDefs representing context, pagination, or things relating to synchronization will not
      * have schemas, so dataSchema and thus dataClass can be null.
@@ -126,6 +128,11 @@ public class FieldDef<T>
 
   @Override
   public int hashCode()
+  {
+      return _hashCode;
+  }
+
+  private int computeHashCode()
   {
     return 13*_name.hashCode() + 17*_type.hashCode() + 23*(_dataSchema == null? 1 :_dataSchema.hashCode());
   }

--- a/data/src/main/java/com/linkedin/data/template/FieldDef.java
+++ b/data/src/main/java/com/linkedin/data/template/FieldDef.java
@@ -37,7 +37,7 @@ public class FieldDef<T>
   private final DataSchema _dataSchema;
   private final Class<?> _dataClass;
   private final RecordDataSchema.Field _field;
-  private final int _hashCode;
+  private Integer _hashCode;
 
   public FieldDef(String name, Class<T> type)
   {
@@ -49,7 +49,6 @@ public class FieldDef<T>
     _name = name;
     _type = type;
     _dataSchema = dataSchema;
-    _hashCode = computeHashCode();
     /**
      * FieldDefs representing context, pagination, or things relating to synchronization will not
      * have schemas, so dataSchema and thus dataClass can be null.
@@ -129,6 +128,11 @@ public class FieldDef<T>
   @Override
   public int hashCode()
   {
+      if (_hashCode == null) {
+          // If this method is called by multiple thread, there might be multiple concurrent write
+          // here, but since the hashCode should be the same it is tolerable
+          _hashCode = computeHashCode();
+      }
       return _hashCode;
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.46.8
+version=29.46.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Sometimes `_dataSchema` could be very complex and makes computing hash code for this class extremely slow. Since all data fields participated in hash code calculation is final, we should able to calculate it at construction time and avoid paying the cost repeatedly.