### PR TITLE
Get line/col number in PDL schema encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-- Add support for returning location of schema elements from the PDL schema encoder.
 
+## [29.42.1] - 2023-05-11
+- Add support for returning location of schema elements from the PDL schema encoder.
+  
 ## [29.42.0] - 2023-05-02
 - Remove the overriding of content-length for HEADER requests as per HTTP Spec
   More details about this issue can be found @ https://jira01.corp.linkedin.com:8443/browse/SI-31814
@@ -5463,7 +5465,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.42.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.42.1...master
+[29.42.1]: https://github.com/linkedin/rest.li/compare/v29.42.0...v29.42.1
 [29.42.0]: https://github.com/linkedin/rest.li/compare/v29.41.12...v29.42.0
 [29.41.12]: https://github.com/linkedin/rest.li/compare/v29.41.11...v29.41.12
 [29.41.11]: https://github.com/linkedin/rest.li/compare/v29.41.10...v29.41.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add support for returning location of schema elements from the PDL schema encoder.
 
 ## [29.42.0] - 2023-05-02
 - Remove the overriding of content-length for HEADER requests as per HTTP Spec

--- a/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
@@ -147,7 +147,7 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
       _writer = out;
       _writeLocations = Collections.emptyMap();
     }
-    _encodingStyle = EncodingStyle.INDENTED;
+    setEncodingStyle(EncodingStyle.INDENTED);
     _trackWriteLocations = returnContextLocations;
   }
 
@@ -159,6 +159,18 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
   public void setEncodingStyle(EncodingStyle encodingStyle)
   {
     _encodingStyle = encodingStyle;
+
+    // When counting column numbers, CompactPDLBuilder treats ',' as whitespace
+    if (_writer instanceof LineColumnNumberWriter)
+    {
+      if (_encodingStyle == EncodingStyle.COMPACT)
+      {
+        ((LineColumnNumberWriter) _writer).setIsWhitespaceFunction(c -> Character.isWhitespace(c) || c == ',');
+      } else
+      {
+        ((LineColumnNumberWriter) _writer).setIsWhitespaceFunction(Character::isWhitespace);
+      }
+    }
   }
 
   /**
@@ -172,18 +184,6 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
   {
     // Initialize a new builder for the preferred encoding style
     _builder = _encodingStyle.newBuilderInstance(_writer);
-
-    // When counting column numbers, CompactPDLBuilder treats ',' as whitespace
-    if (_writer instanceof LineColumnNumberWriter)
-    {
-      if (_encodingStyle == EncodingStyle.COMPACT)
-      {
-        ((LineColumnNumberWriter) _writer).setIsWhitespaceFunction(c -> Character.isWhitespace(c) || c == ',');
-      } else
-      {
-        ((LineColumnNumberWriter) _writer).setIsWhitespaceFunction(Character::isWhitespace);
-      }
-    }
 
     // Set and write root namespace/package
     if (schema instanceof NamedDataSchema)

--- a/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
@@ -136,10 +136,7 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
     if (returnContextLocations) {
       _writeLocations = new IdentityHashMap<>();
       // Wrap the Writer to track line/column numbers to report to elementWriteListener
-      LineColumnNumberWriter lineColumnNumberWriter = new LineColumnNumberWriter(out);
-      // When counting column numbers, CompactPDLBuilder treats ',' as whitespace
-      lineColumnNumberWriter.setIsWhitespaceFunction(c -> Character.isWhitespace(c) || c == ',');
-      _writer = lineColumnNumberWriter;
+      _writer = new LineColumnNumberWriter(out);
     } else {
       _writer = out;
       _writeLocations = Collections.emptyMap();
@@ -169,6 +166,15 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
   {
     // Initialize a new builder for the preferred encoding style
     _builder = _encodingStyle.newBuilderInstance(_writer);
+
+    // When counting column numbers, CompactPDLBuilder treats ',' as whitespace
+    if (_writer instanceof LineColumnNumberWriter) {
+      if (_encodingStyle == EncodingStyle.COMPACT) {
+        ((LineColumnNumberWriter) _writer).setIsWhitespaceFunction(c -> Character.isWhitespace(c) || c == ',');
+      } else {
+        ((LineColumnNumberWriter) _writer).setIsWhitespaceFunction(Character::isWhitespace);
+      }
+    }
 
     // Set and write root namespace/package
     if (schema instanceof NamedDataSchema)

--- a/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
@@ -133,11 +133,13 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
    */
   public SchemaToPdlEncoder(Writer out, boolean returnContextLocations)
   {
-    if (returnContextLocations) {
+    if (returnContextLocations)
+    {
       _writeLocations = new IdentityHashMap<>();
       // Wrap the Writer to track line/column numbers to report to elementWriteListener
       _writer = new LineColumnNumberWriter(out);
-    } else {
+    } else
+    {
       _writer = out;
       _writeLocations = Collections.emptyMap();
     }
@@ -168,10 +170,13 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
     _builder = _encodingStyle.newBuilderInstance(_writer);
 
     // When counting column numbers, CompactPDLBuilder treats ',' as whitespace
-    if (_writer instanceof LineColumnNumberWriter) {
-      if (_encodingStyle == EncodingStyle.COMPACT) {
+    if (_writer instanceof LineColumnNumberWriter)
+    {
+      if (_encodingStyle == EncodingStyle.COMPACT)
+      {
         ((LineColumnNumberWriter) _writer).setIsWhitespaceFunction(c -> Character.isWhitespace(c) || c == ',');
-      } else {
+      } else
+      {
         ((LineColumnNumberWriter) _writer).setIsWhitespaceFunction(Character::isWhitespace);
       }
     }
@@ -331,7 +336,8 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
     }
   }
 
-  public Map<Object, PdlSchemaParser.ParseLocation> getWriteLocations() {
+  public Map<Object, PdlSchemaParser.ParseLocation> getWriteLocations()
+  {
     return _writeLocations;
   }
 
@@ -930,14 +936,18 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
     }
   }
 
-  void markSchemaElementStartLocation() {
-    if (_trackWriteLocations) {
+  void markSchemaElementStartLocation()
+  {
+    if (_trackWriteLocations)
+    {
       ((LineColumnNumberWriter) _writer).saveCurrentPosition();
     }
   }
 
-  private void recordSchemaElementLocation(Object schemaElement) {
-    if (_trackWriteLocations) {
+  private void recordSchemaElementLocation(Object schemaElement)
+  {
+    if (_trackWriteLocations)
+    {
       LineColumnNumberWriter.CharacterPosition startPosition = ((LineColumnNumberWriter) _writer).popSavedPosition();
       LineColumnNumberWriter.CharacterPosition endPosition =
           ((LineColumnNumberWriter) _writer).getLastNonWhitespacePosition();

--- a/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
+++ b/data/src/main/java/com/linkedin/data/schema/SchemaToPdlEncoder.java
@@ -116,6 +116,8 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
 
   /**
    * Construct a .pdl source code encoder.
+   * The encoding style defaults to {@link EncodingStyle#INDENTED} but may be changed by calling
+   * {@link #setEncodingStyle(EncodingStyle)}.
    *
    * @param out provides the encoded .pdl destination.
    */
@@ -125,7 +127,9 @@ public class SchemaToPdlEncoder extends AbstractSchemaEncoder
   }
 
   /**
-   * Construct a .pdl source code encoder.
+   * Construct a .pdl source code encoder with the option to track line/column of schema elements during writing.
+   * The encoding style defaults to {@link EncodingStyle#INDENTED} but may be changed by calling
+   * {@link #setEncodingStyle(EncodingStyle)}.
    *
    * @param out provides the encoded .pdl destination.
    * @param returnContextLocations Enable recording the context locations of schema elements during parsing. The

--- a/data/src/main/java/com/linkedin/util/LineColumnNumberWriter.java
+++ b/data/src/main/java/com/linkedin/util/LineColumnNumberWriter.java
@@ -10,7 +10,7 @@ import java.util.function.Predicate;
 /**
  * Wraps a {@link Writer} and tracks current line and column numbers
  */
-public class LineColumnNumberWriter extends Writer
+public final class LineColumnNumberWriter extends Writer
 {
 
   private final Writer _writer;

--- a/data/src/main/java/com/linkedin/util/LineColumnNumberWriter.java
+++ b/data/src/main/java/com/linkedin/util/LineColumnNumberWriter.java
@@ -10,7 +10,8 @@ import java.util.function.Predicate;
 /**
  * Wraps a {@link Writer} and tracks current line and column numbers
  */
-public class LineColumnNumberWriter extends Writer {
+public class LineColumnNumberWriter extends Writer
+{
 
   private final Writer _writer;
   private final Stack<CharacterPosition> _savedPositionStack = new Stack<>();
@@ -25,7 +26,8 @@ public class LineColumnNumberWriter extends Writer {
    *
    * @param out a Writer object to provide the underlying stream.
    */
-  public LineColumnNumberWriter(Writer out) {
+  public LineColumnNumberWriter(Writer out)
+  {
     _writer = out;
     _column = 1;
     _line = 1;
@@ -37,14 +39,16 @@ public class LineColumnNumberWriter extends Writer {
   /**
    * Returns 1 based indices of row and column next character will be written to
    */
-  public CharacterPosition getCurrentPosition() {
+  public CharacterPosition getCurrentPosition()
+  {
     return new CharacterPosition(_line, _column);
   }
 
   /**
    * Returns 1 based indices of last row and column ignoring trailing whitespace characters
    */
-  public CharacterPosition getLastNonWhitespacePosition() {
+  public CharacterPosition getLastNonWhitespacePosition()
+  {
     return _lastNonWhitespacePosition;
   }
 
@@ -57,14 +61,16 @@ public class LineColumnNumberWriter extends Writer {
    * and then write four spaces followed by non-whitespace, the column number returned by
    * {@link #popSavedPosition()} will be x + 4.
    */
-  public void saveCurrentPosition() {
+  public void saveCurrentPosition()
+  {
     _savedPositionStack.push(new CharacterPosition(_line, _column));
   }
 
   /**
    * Retrieves row and column from the last time {@link #saveCurrentPosition()} was called
    */
-  public CharacterPosition popSavedPosition() {
+  public CharacterPosition popSavedPosition()
+  {
     return _savedPositionStack.pop();
   }
 
@@ -72,22 +78,27 @@ public class LineColumnNumberWriter extends Writer {
    * Override definition of whitespace used to adjust character positions to skip
    * whitespace. By default, the definition of whitespace is provided by {@link java.lang.Character#isWhitespace}
    */
-  public void setIsWhitespaceFunction(Predicate<Character> isWhitespaceFunction) {
+  public void setIsWhitespaceFunction(Predicate<Character> isWhitespaceFunction)
+  {
     _isWhitespaceFunction = isWhitespaceFunction;
   }
 
   @Override
-  public void write(char[] cbuf, int off, int len) throws IOException {
+  public void write(char[] cbuf, int off, int len) throws IOException
+  {
     _writer.write(cbuf, off, len);
-    for (; len > 0; len--) {
+    for (; len > 0; len--)
+    {
       char c = cbuf[off++];
       int lastLine = _line;
       int lastColumn = _column;
       updateCurrentPosition(c);
       _previousChar = c;
-      if (_isWhitespaceFunction.test(c)) {
+      if (_isWhitespaceFunction.test(c))
+      {
         updateSavedPositionsForWhitespace(lastLine, lastColumn);
-      } else {
+      } else
+      {
         _lastNonWhitespacePosition.line = lastLine;
         _lastNonWhitespacePosition.column = lastColumn;
       }
@@ -95,31 +106,40 @@ public class LineColumnNumberWriter extends Writer {
   }
 
   @Override
-  public void flush() throws IOException {
+  public void flush() throws IOException
+  {
     _writer.flush();
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() throws IOException
+  {
     _writer.close();
   }
 
   @Override
-  public String toString() {
+  public String toString()
+  {
     return _writer.toString();
   }
 
-  private void updateCurrentPosition(char c) {
-    if (_previousChar == '\r') {
-      if (c == '\n') {
+  private void updateCurrentPosition(char c)
+  {
+    if (_previousChar == '\r')
+    {
+      if (c == '\n')
+      {
         _column = 1;
-      } else {
+      } else
+      {
         _column = 2;
       }
-    } else if (c == '\n' || c == '\r') {
+    } else if (c == '\n' || c == '\r')
+    {
       _column = 1;
       ++_line;
-    } else {
+    } else
+    {
       ++_column;
     }
   }
@@ -129,13 +149,17 @@ public class LineColumnNumberWriter extends Writer {
    * remove leading whitespace. Once the first non-whitespace character is written, the current position will be
    * different from any saved positions and the current position will advance.
    */
-  private void updateSavedPositionsForWhitespace(int lastLine, int lastColumn) {
-    for (int i = _savedPositionStack.size() - 1; i >= 0; --i) {
+  private void updateSavedPositionsForWhitespace(int lastLine, int lastColumn)
+  {
+    for (int i = _savedPositionStack.size() - 1; i >= 0; --i)
+    {
       CharacterPosition savedCharacterPosition = _savedPositionStack.get(i);
-      if (savedCharacterPosition.line == lastLine && savedCharacterPosition.column == lastColumn) {
+      if (savedCharacterPosition.line == lastLine && savedCharacterPosition.column == lastColumn)
+      {
         savedCharacterPosition.line = _line;
         savedCharacterPosition.column = _column;
-      } else {
+      } else
+      {
         break;
       }
     }
@@ -144,12 +168,14 @@ public class LineColumnNumberWriter extends Writer {
   /**
    * Row and column numbers of a character in Writer output
    */
-  public static class CharacterPosition {
+  public static class CharacterPosition
+  {
 
     private int line;
     private int column;
 
-    CharacterPosition(int line, int column) {
+    CharacterPosition(int line, int column)
+    {
       this.line = line;
       this.column = column;
     }
@@ -157,23 +183,28 @@ public class LineColumnNumberWriter extends Writer {
     /**
      * 1-based index of line in writer output
      */
-    public int getLine() {
+    public int getLine()
+    {
       return line;
     }
 
     /**
      * 1-based index of column in writer output
      */
-    public int getColumn() {
+    public int getColumn()
+    {
       return column;
     }
 
     @Override
-    public boolean equals(Object o) {
-      if (this == o) {
+    public boolean equals(Object o)
+    {
+      if (this == o)
+      {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (o == null || getClass() != o.getClass())
+      {
         return false;
       }
       CharacterPosition characterPosition = (CharacterPosition) o;
@@ -181,12 +212,14 @@ public class LineColumnNumberWriter extends Writer {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
       return Objects.hash(line, column);
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
       return "CharacterPosition{" + "line=" + line + ", column=" + column + '}';
     }
   }

--- a/data/src/main/java/com/linkedin/util/LineColumnNumberWriter.java
+++ b/data/src/main/java/com/linkedin/util/LineColumnNumberWriter.java
@@ -1,0 +1,193 @@
+package com.linkedin.util;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Objects;
+import java.util.Stack;
+import java.util.function.Predicate;
+
+
+/**
+ * Wraps a {@link Writer} and tracks current line and column numbers
+ */
+public class LineColumnNumberWriter extends Writer {
+
+  private final Writer _writer;
+  private final Stack<CharacterPosition> _savedPositionStack = new Stack<>();
+  private int _column;
+  private int _line;
+  private int _previousChar;
+  private Predicate<Character> _isWhitespaceFunction;
+  private final CharacterPosition _lastNonWhitespacePosition;
+
+  /**
+   * Creates a new writer.
+   *
+   * @param out a Writer object to provide the underlying stream.
+   */
+  public LineColumnNumberWriter(Writer out) {
+    _writer = out;
+    _column = 1;
+    _line = 1;
+    _previousChar = -1;
+    _isWhitespaceFunction = (Character::isWhitespace);
+    _lastNonWhitespacePosition = new CharacterPosition(0, 0);
+  }
+
+  /**
+   * Returns 1 based indices of row and column next character will be written to
+   */
+  public CharacterPosition getCurrentPosition() {
+    return new CharacterPosition(_line, _column);
+  }
+
+  /**
+   * Returns 1 based indices of last row and column ignoring trailing whitespace characters
+   */
+  public CharacterPosition getLastNonWhitespacePosition() {
+    return _lastNonWhitespacePosition;
+  }
+
+  /**
+   * Saves current row and column to be retrieved later by calling {@link #popSavedPosition()}
+   *
+   * Saved positions are stored in a stack so that calls to saveCurrentPosition() and
+   * {@link #popSavedPosition()} can be nested. Saved positions are adjusted to skip whitespace to make it
+   * easier to get actual token start positions in indented output. If you call saveCurrentPosition() at column x
+   * and then write four spaces followed by non-whitespace, the column number returned by
+   * {@link #popSavedPosition()} will be x + 4.
+   */
+  public void saveCurrentPosition() {
+    _savedPositionStack.push(new CharacterPosition(_line, _column));
+  }
+
+  /**
+   * Retrieves row and column from the last time {@link #saveCurrentPosition()} was called
+   */
+  public CharacterPosition popSavedPosition() {
+    return _savedPositionStack.pop();
+  }
+
+  /**
+   * Override definition of whitespace used to adjust character positions to skip
+   * whitespace. By default, the definition of whitespace is provided by {@link java.lang.Character#isWhitespace}
+   */
+  public void setIsWhitespaceFunction(Predicate<Character> isWhitespaceFunction) {
+    _isWhitespaceFunction = isWhitespaceFunction;
+  }
+
+  @Override
+  public void write(char[] cbuf, int off, int len) throws IOException {
+    _writer.write(cbuf, off, len);
+    for (; len > 0; len--) {
+      char c = cbuf[off++];
+      int lastLine = _line;
+      int lastColumn = _column;
+      updateCurrentPosition(c);
+      _previousChar = c;
+      if (_isWhitespaceFunction.test(c)) {
+        updateSavedPositionsForWhitespace(lastLine, lastColumn);
+      } else {
+        _lastNonWhitespacePosition.line = lastLine;
+        _lastNonWhitespacePosition.column = lastColumn;
+      }
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    _writer.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    _writer.close();
+  }
+
+  @Override
+  public String toString() {
+    return _writer.toString();
+  }
+
+  private void updateCurrentPosition(char c) {
+    if (_previousChar == '\r') {
+      if (c == '\n') {
+        _column = 1;
+      } else {
+        _column = 2;
+      }
+    } else if (c == '\n' || c == '\r') {
+      _column = 1;
+      ++_line;
+    } else {
+      ++_column;
+    }
+  }
+
+  /**
+   * Any saved positions that are equal to the current row and column are set to the current position in order to
+   * remove leading whitespace. Once the first non-whitespace character is written, the current position will be
+   * different from any saved positions and the current position will advance.
+   */
+  private void updateSavedPositionsForWhitespace(int lastLine, int lastColumn) {
+    for (int i = _savedPositionStack.size() - 1; i >= 0; --i) {
+      CharacterPosition savedCharacterPosition = _savedPositionStack.get(i);
+      if (savedCharacterPosition.line == lastLine && savedCharacterPosition.column == lastColumn) {
+        savedCharacterPosition.line = _line;
+        savedCharacterPosition.column = _column;
+      } else {
+        break;
+      }
+    }
+  }
+
+  /**
+   * Row and column numbers of a character in Writer output
+   */
+  public static class CharacterPosition {
+
+    private int line;
+    private int column;
+
+    CharacterPosition(int line, int column) {
+      this.line = line;
+      this.column = column;
+    }
+
+    /**
+     * 1-based index of line in writer output
+     */
+    public int getLine() {
+      return line;
+    }
+
+    /**
+     * 1-based index of column in writer output
+     */
+    public int getColumn() {
+      return column;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      CharacterPosition characterPosition = (CharacterPosition) o;
+      return line == characterPosition.line && column == characterPosition.column;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(line, column);
+    }
+
+    @Override
+    public String toString() {
+      return "CharacterPosition{" + "line=" + line + ", column=" + column + '}';
+    }
+  }
+}

--- a/data/src/test/java/com/linkedin/util/TestLineColumnNumberWriter.java
+++ b/data/src/test/java/com/linkedin/util/TestLineColumnNumberWriter.java
@@ -6,10 +6,12 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class TestLineColumnNumberWriter {
+public class TestLineColumnNumberWriter
+{
 
   @Test
-  public void testHandlesDifferentNewlines() throws IOException {
+  public void testHandlesDifferentNewlines() throws IOException
+  {
     LineColumnNumberWriter writer = new LineColumnNumberWriter(new StringWriter());
     writer.write("1\n2\n3\n");
     Assert.assertEquals(writer.getCurrentPosition(), new LineColumnNumberWriter.CharacterPosition(4, 1));
@@ -20,7 +22,8 @@ public class TestLineColumnNumberWriter {
   }
 
   @Test
-  public void testSavedPositionIgnoresLeadingWhitespace() throws IOException {
+  public void testSavedPositionIgnoresLeadingWhitespace() throws IOException
+  {
     LineColumnNumberWriter writer = new LineColumnNumberWriter(new StringWriter());
     writer.write("123\n");
     writer.saveCurrentPosition();
@@ -35,7 +38,8 @@ public class TestLineColumnNumberWriter {
   }
 
   @Test
-  public void testGetLastNonWhitespacePosition() throws IOException {
+  public void testGetLastNonWhitespacePosition() throws IOException
+  {
     LineColumnNumberWriter writer = new LineColumnNumberWriter(new StringWriter());
     writer.write("123");
     Assert.assertEquals(writer.getLastNonWhitespacePosition(), new LineColumnNumberWriter.CharacterPosition(1, 3));

--- a/data/src/test/java/com/linkedin/util/TestLineColumnNumberWriter.java
+++ b/data/src/test/java/com/linkedin/util/TestLineColumnNumberWriter.java
@@ -1,0 +1,47 @@
+package com.linkedin.util;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestLineColumnNumberWriter {
+
+  @Test
+  public void testHandlesDifferentNewlines() throws IOException {
+    LineColumnNumberWriter writer = new LineColumnNumberWriter(new StringWriter());
+    writer.write("1\n2\n3\n");
+    Assert.assertEquals(writer.getCurrentPosition(), new LineColumnNumberWriter.CharacterPosition(4, 1));
+    writer.write("1\r\n2\r\n3\r\n");
+    Assert.assertEquals(writer.getCurrentPosition(), new LineColumnNumberWriter.CharacterPosition(7, 1));
+    writer.write("1\r2\r3\r");
+    Assert.assertEquals(writer.getCurrentPosition(), new LineColumnNumberWriter.CharacterPosition(10, 1));
+  }
+
+  @Test
+  public void testSavedPositionIgnoresLeadingWhitespace() throws IOException {
+    LineColumnNumberWriter writer = new LineColumnNumberWriter(new StringWriter());
+    writer.write("123\n");
+    writer.saveCurrentPosition();
+    writer.saveCurrentPosition();
+    writer.write(" \n ");
+    writer.write("456");
+    writer.saveCurrentPosition();
+    writer.write("   789");
+    Assert.assertEquals(writer.popSavedPosition(), new LineColumnNumberWriter.CharacterPosition(3, 8));
+    Assert.assertEquals(writer.popSavedPosition(), new LineColumnNumberWriter.CharacterPosition(3, 2));
+    Assert.assertEquals(writer.popSavedPosition(), new LineColumnNumberWriter.CharacterPosition(3, 2));
+  }
+
+  @Test
+  public void testGetLastNonWhitespacePosition() throws IOException {
+    LineColumnNumberWriter writer = new LineColumnNumberWriter(new StringWriter());
+    writer.write("123");
+    Assert.assertEquals(writer.getLastNonWhitespacePosition(), new LineColumnNumberWriter.CharacterPosition(1, 3));
+    writer.write("\n ");
+    Assert.assertEquals(writer.getLastNonWhitespacePosition(), new LineColumnNumberWriter.CharacterPosition(1, 3));
+    writer.write("4");
+    Assert.assertEquals(writer.getLastNonWhitespacePosition(), new LineColumnNumberWriter.CharacterPosition(2, 2));
+  }
+}

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/PdlEncoderTest.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/PdlEncoderTest.java
@@ -21,7 +21,10 @@ import com.linkedin.data.schema.AbstractSchemaEncoder.TypeReferenceFormat;
 import com.linkedin.data.schema.AbstractSchemaParser;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaResolver;
+import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.SchemaToPdlEncoder;
+import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.data.schema.grammar.PdlSchemaParser;
 import com.linkedin.data.schema.resolver.MultiFormatDataSchemaResolver;
 import com.linkedin.pegasus.generator.test.idl.EncodingStyle;
@@ -31,6 +34,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -147,6 +151,71 @@ public class PdlEncoderTest extends GeneratorTest
             "Encoding using the \"" + encodingStyle + "\" style resulted in a different/invalid schema.");
       }
     }
+  }
+
+  @Test(dataProvider = "pdlFilePaths")
+  public void testTrackWriteLocations(String pdlFilePath) throws IOException
+  {
+    assertRoundTripLineColumnNumbersMatch(pdlFilePath);
+  }
+
+  private void assertRoundTripLineColumnNumbersMatch(String relativeName) throws IOException {
+    String fullName = "com.linkedin.pegasus.generator.test.idl." + relativeName;
+    File file = new File(pegasusSrcDir, "/" + fullName.replace('.', '/') + ".pdl");
+
+    TypeReferenceFormat referenceFormat = TypeReferenceFormat.PRESERVE;
+
+    // Test all encoding styles
+    for (SchemaToPdlEncoder.EncodingStyle encodingStyle : SchemaToPdlEncoder.EncodingStyle.values()) {
+      String encoded = readAndStandardizeFormat(file, referenceFormat, encodingStyle);
+
+      DataSchemaResolver resolver = MultiFormatDataSchemaResolver.withBuiltinFormats(pegasusSrcDir.getAbsolutePath());
+      PdlSchemaParser parser = new PdlSchemaParser(resolver, true);
+      parser.parse(encoded);
+      Map<Object, PdlSchemaParser.ParseLocation> parsedLocations = parser.getParseLocations();
+      DataSchema parsed = extractSchema(parser, file.getAbsolutePath());
+
+      StringWriter writer = new StringWriter();
+      SchemaToPdlEncoder encoder = new SchemaToPdlEncoder(writer, true);
+      encoder.setTypeReferenceFormat(referenceFormat);
+      encoder.setEncodingStyle(encodingStyle);
+      encoder.encode(parsed);
+      Map<Object, PdlSchemaParser.ParseLocation> writeLocations = encoder.getWriteLocations();
+
+      for (Map.Entry<Object, PdlSchemaParser.ParseLocation> expected : parsedLocations.entrySet()) {
+        PdlSchemaParser.ParseLocation actual = writeLocations.get(expected.getKey());
+
+        Assert.assertNotNull(actual,
+            "Missing location for " + expected.getKey() + " in " + file.getAbsolutePath() + ":"
+                + expected.getValue().getStartLine() + ":" + expected.getValue().getStartColumn());
+        Assert.assertEquals(actual.getStartLine(), expected.getValue().getStartLine(),
+            "Start line for " + expected.getKey() + " in " + file.getAbsolutePath() + ":"
+                + expected.getValue().getStartLine() + ":" + expected.getValue().getStartColumn());
+        Assert.assertEquals(actual.getStartColumn(), expected.getValue().getStartColumn(),
+            "Start col for " + expected.getKey() + " in " + file.getAbsolutePath() + ":"
+                + expected.getValue().getStartLine() + ":" + expected.getValue().getStartColumn());
+        Assert.assertEquals(actual.getEndLine(), expected.getValue().getEndLine(),
+            "End line for " + expected.getKey() + " in " + file.getAbsolutePath() + ":"
+                + expected.getValue().getStartLine() + ":" + expected.getValue().getStartColumn());
+        Assert.assertEquals(actual.getEndColumn(), expected.getValue().getEndColumn(),
+            "End col for " + expected.getKey() + " in " + file.getAbsolutePath() + ":"
+                + expected.getValue().getStartLine() + ":" + expected.getValue().getStartColumn());
+      }
+
+      Assert.assertEquals(parsedLocations.size(), writeLocations.size(),
+          "Different numer of element locations for " + file.getAbsolutePath());
+    }
+  }
+
+  private String readAndStandardizeFormat(File file, TypeReferenceFormat typeReferenceFormat,
+      SchemaToPdlEncoder.EncodingStyle encodingStyle) throws IOException {
+    DataSchema parsed = parseSchema(file);
+    StringWriter writer = new StringWriter();
+    SchemaToPdlEncoder encoder = new SchemaToPdlEncoder(writer);
+    encoder.setEncodingStyle(encodingStyle);
+    encoder.setTypeReferenceFormat(typeReferenceFormat);
+    encoder.encode(parsed);
+    return writer.toString();
   }
 
   private DataSchema parseSchema(File file) throws IOException

--- a/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/PdlEncoderTest.java
+++ b/generator-test/src/test/java/com/linkedin/pegasus/generator/test/pdl/PdlEncoderTest.java
@@ -159,14 +159,16 @@ public class PdlEncoderTest extends GeneratorTest
     assertRoundTripLineColumnNumbersMatch(pdlFilePath);
   }
 
-  private void assertRoundTripLineColumnNumbersMatch(String relativeName) throws IOException {
+  private void assertRoundTripLineColumnNumbersMatch(String relativeName) throws IOException
+  {
     String fullName = "com.linkedin.pegasus.generator.test.idl." + relativeName;
     File file = new File(pegasusSrcDir, "/" + fullName.replace('.', '/') + ".pdl");
 
     TypeReferenceFormat referenceFormat = TypeReferenceFormat.PRESERVE;
 
     // Test all encoding styles
-    for (SchemaToPdlEncoder.EncodingStyle encodingStyle : SchemaToPdlEncoder.EncodingStyle.values()) {
+    for (SchemaToPdlEncoder.EncodingStyle encodingStyle : SchemaToPdlEncoder.EncodingStyle.values())
+    {
       String encoded = readAndStandardizeFormat(file, referenceFormat, encodingStyle);
 
       DataSchemaResolver resolver = MultiFormatDataSchemaResolver.withBuiltinFormats(pegasusSrcDir.getAbsolutePath());
@@ -182,7 +184,8 @@ public class PdlEncoderTest extends GeneratorTest
       encoder.encode(parsed);
       Map<Object, PdlSchemaParser.ParseLocation> writeLocations = encoder.getWriteLocations();
 
-      for (Map.Entry<Object, PdlSchemaParser.ParseLocation> expected : parsedLocations.entrySet()) {
+      for (Map.Entry<Object, PdlSchemaParser.ParseLocation> expected : parsedLocations.entrySet())
+      {
         PdlSchemaParser.ParseLocation actual = writeLocations.get(expected.getKey());
 
         Assert.assertNotNull(actual,
@@ -208,7 +211,8 @@ public class PdlEncoderTest extends GeneratorTest
   }
 
   private String readAndStandardizeFormat(File file, TypeReferenceFormat typeReferenceFormat,
-      SchemaToPdlEncoder.EncodingStyle encodingStyle) throws IOException {
+      SchemaToPdlEncoder.EncodingStyle encodingStyle) throws IOException
+  {
     DataSchema parsed = parseSchema(file);
     StringWriter writer = new StringWriter();
     SchemaToPdlEncoder encoder = new SchemaToPdlEncoder(writer);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.42.0
+version=29.42.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Add ability to get the line and column numbers of schema elements written out by SchemaToPDL encoder.