### PR TITLE
Fix conversion of R2 headers to Netty headers in requests.

### DIFF
--- a/r2-netty/src/main/java/com/linkedin/r2/netty/common/NettyRequestAdapter.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/common/NettyRequestAdapter.java
@@ -204,7 +204,7 @@ public class NettyRequestAdapter
       //   header field names MUST be treated as malformed (Section 8.1.2.6).
       String name = entry.getKey().toLowerCase();
       String value = entry.getValue();
-      headers.set(name, value);
+      headers.set(name, value == null ? "" : value);
     }
 
     // Split up cookies to allow for better header compression

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/handler/common/ClientEntityStreamHandler.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/handler/common/ClientEntityStreamHandler.java
@@ -73,11 +73,11 @@ public class ClientEntityStreamHandler extends ChannelDuplexHandler
 
       // Sets reader after the headers have been flushed on the channel
       OrderedEntityStreamReader orderedReader = new OrderedEntityStreamReader(ctx, new StreamReader(ctx));
-      ctx.write(request).addListener(future -> request.getEntityStream().setReader(orderedReader));
+      ctx.write(request, promise).addListener(future -> request.getEntityStream().setReader(orderedReader));
     }
     else
     {
-      ctx.write(msg);
+      ctx.write(msg, promise);
     }
   }
 

--- a/r2-netty/src/test/java/com/linkedin/r2/netty/common/TestNettyRequestAdapter.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/netty/common/TestNettyRequestAdapter.java
@@ -225,4 +225,11 @@ public class TestNettyRequestAdapter
     Assert.assertNotNull(cookies);
     Assert.assertEquals(cookies.size(), 10);
   }
+
+  @Test
+  public void testNullHeaderValue() throws Exception {
+    RestRequestBuilder restRequestBuilder = new RestRequestBuilder(new URI(ANY_URI));
+    restRequestBuilder.setHeader("a-header", null);
+    NettyRequestAdapter.toHttp2Headers(restRequestBuilder.build());
+  }
 }


### PR DESCRIPTION
If the headers have a `null` value, this will throw an NPE from Netty. In the context of this call this gets caught without logging making the issue difficult to detect (it manifests as a request timeout). Making `null` values treated as empty strings avoids the exception.