### PR TITLE
[Draft] Update use of java-doc related apis to use standard APIs so it can be Jdk 17 compatible

### DIFF
--- a/restli-tools/src/main/java/com/linkedin/restli/tools/idlgen/RestLiDoclet.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/idlgen/RestLiDoclet.java
@@ -17,224 +17,287 @@
 package com.linkedin.restli.tools.idlgen;
 
 
-import com.sun.javadoc.ClassDoc;
-import com.sun.javadoc.MethodDoc;
-import com.sun.javadoc.Parameter;
-import com.sun.javadoc.RootDoc;
-import com.sun.javadoc.Type;
-import com.sun.tools.javadoc.Main;
+import jdk.javadoc.doclet.Doclet;
+import jdk.javadoc.doclet.DocletEnvironment;
+import jdk.javadoc.doclet.Reporter;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticListener;
+import javax.tools.DocumentationTool;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
-/**
- * Custom Javadoc processor that merges documentation into the restspec.json. The embedded Javadoc
- * generator is basically a commandline tool wrapper and it runs in complete isolation from the rest
- * of the application. Due to the fact that the Javadoc tool instantiates RestLiDoclet, we cannot
- * cleanly integrate the output into the {@link RestLiResourceModelExporter} tool. Thus, we're just
- * dumping the docs into a static Map which can be accessed by {@link RestLiResourceModelExporter}.
- *
- * This class supports multiple runs of Javadoc Doclet API {@link Main#execute(String[])}.
- * Each run will be assigned an unique "Doclet ID", returned by
- * {@link #generateDoclet(String, java.io.PrintWriter, java.io.PrintWriter, java.io.PrintWriter, String[])}.
- * The Doclet ID should be subsequently used to initialize {@link DocletDocsProvider}.
- *
- * This class is thread-safe. However, #generateJavadoc() will be synchronized.
- *
- * @author dellamag
- * @see Main#execute(String, java.io.PrintWriter, java.io.PrintWriter, java.io.PrintWriter, String, String[])
- */
-public class RestLiDoclet
+public class RestLiDoclet implements Doclet
 {
   private static RestLiDoclet _currentDocLet = null;
 
   private final DocInfo _docInfo;
+  private final DocletEnvironment _docEnv;
+  private final Elements _elements;
 
-  /**
-   * Generate Javadoc and return associated Doclet ID.
-   * This method is synchronized.
-   *
-   * @param programName Name of the program (for error messages).
-   * @param errWriter PrintWriter to receive error messages.
-   * @param warnWriter PrintWriter to receive warning messages.
-   * @param noticeWriter PrintWriter to receive notice messages.
-   * @param args The command line parameters.
-   * @return an unique doclet ID which represent the subsequent Main#execute() run.
-   * @throws IllegalStateException if the generated doclet ID is already used. Try again.
-   * @throws IllegalArgumentException if Javadoc fails to generate docs.
-   */
+
   public static synchronized RestLiDoclet generateDoclet(String programName,
                                                          PrintWriter errWriter,
                                                          PrintWriter warnWriter,
                                                          PrintWriter noticeWriter,
-                                                         String[] args)
+                                                         String flatClassPath,
+                                                         List<String> analyzedSourceFiles
+                                                         )
   {
-    final int javadocRetCode = Main.execute(programName, errWriter, warnWriter, noticeWriter, RestLiDoclet.class.getName(), args);
-    if (javadocRetCode != 0)
-    {
-      throw new IllegalArgumentException("Javadoc failed with return code " + javadocRetCode);
+    noticeWriter.println("Generating Javadoc for " + programName);
+
+    DocumentationTool docTool = ToolProvider.getSystemDocumentationTool();
+    StandardJavaFileManager fileManager = docTool.getStandardFileManager(null, null, null);
+    Iterable<? extends JavaFileObject> fileObjects = fileManager.getJavaFileObjectsFromPaths(
+            analyzedSourceFiles.stream().map(Paths::get).collect(Collectors.toList()));
+
+
+
+
+    // Set up the Javadoc task options
+    List<String> taskOptions = new ArrayList<>();
+    taskOptions.add("-classpath");
+    taskOptions.add(flatClassPath);
+
+    // Create and run the Javadoc task
+    DocumentationTool.DocumentationTask task = docTool.getTask(errWriter,
+                                                               fileManager,
+                                                               new DiagnosticListener<JavaFileObject>() {
+                                                                 @Override
+                                                                 public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
+                                                                     switch (diagnostic.getKind()) {
+                                                                        case ERROR:
+                                                                          errWriter.println(diagnostic.getMessage(Locale.getDefault()));
+                                                                          break;
+                                                                        case WARNING:
+                                                                          warnWriter.println(diagnostic.getMessage(Locale.getDefault()));
+                                                                          break;
+                                                                        case NOTE:
+                                                                          noticeWriter.println(diagnostic.getMessage(Locale.getDefault()));
+                                                                          break;
+                                                                     }
+                                                                 }
+                                                               },
+                                                               RestLiDoclet.class,
+                                                               taskOptions,
+                                                               fileObjects);
+
+    boolean success = task.call();
+    if (!success) {
+      throw new IllegalArgumentException("Javadoc generation failed");
     }
 
     return _currentDocLet;
   }
 
-  /**
-   * Entry point for Javadoc Doclet.
-   *
-   * @param root {@link RootDoc} passed in by Javadoc
-   * @return is successful or not
-   */
-  public static boolean start(RootDoc root)
-  {
-    final DocInfo docInfo = new DocInfo();
-
-    for (ClassDoc classDoc : root.classes())
-    {
-      docInfo.setClassDoc(classDoc.qualifiedName(), classDoc);
-
-      for (MethodDoc methodDoc : classDoc.methods())
-      {
-        docInfo.setMethodDoc(MethodIdentity.create(methodDoc), methodDoc);
-      }
-    }
-
-    _currentDocLet = new RestLiDoclet(docInfo);
-
-    return true;
-  }
-
-  private RestLiDoclet(DocInfo docInfo)
+  private RestLiDoclet(DocInfo docInfo, DocletEnvironment docEnv)
   {
     _docInfo = docInfo;
+    _docEnv = docEnv;
+    _elements = docEnv.getElementUtils();
   }
 
-  /**
-   * Query Javadoc {@link ClassDoc} for the specified resource class.
-   *
-   * @param resourceClass resource class to be queried
-   * @return corresponding {@link ClassDoc}
-   */
-  public ClassDoc getClassDoc(Class<?> resourceClass)
+  public TypeElement getClassDoc(Class<?> resourceClass)
   {
     return _docInfo.getClassDoc(resourceClass.getCanonicalName());
   }
 
-  /**
-   * Query Javadoc {@link MethodDoc} for the specified Java method.
-   *
-   * @param method Java method to be queried
-   * @return corresponding {@link MethodDoc}
-   */
-  public MethodDoc getMethodDoc(Method method)
+  public ExecutableElement getMethodDoc(Method method)
   {
     final MethodIdentity methodId = MethodIdentity.create(method);
     return _docInfo.getMethodDoc(methodId);
   }
 
-  private static class DocInfo
-  {
-    public ClassDoc getClassDoc(String className)
-    {
-      return _classNameToClassDoc.get(className);
+  public List<String> getDeprecatedTags(Element element) {
+    List<String> deprecatedTags = new ArrayList<>();
+    Deprecated deprecatedAnnotation = element.getAnnotation(Deprecated.class);
+    if (deprecatedAnnotation != null) {
+      String deprecatedComment = _elements.getDocComment(element);
+      deprecatedTags.add(deprecatedComment);
     }
-
-    public MethodDoc getMethodDoc(MethodIdentity methodId)
-    {
-      return _methodIdToMethodDoc.get(methodId);
-    }
-
-    public void setClassDoc(String className, ClassDoc classDoc)
-    {
-      _classNameToClassDoc.put(className, classDoc);
-    }
-
-    public void setMethodDoc(MethodIdentity methodId, MethodDoc methodDoc)
-    {
-      _methodIdToMethodDoc.put(methodId, methodDoc);
-    }
-
-    private final Map<String, ClassDoc> _classNameToClassDoc = new HashMap<>();
-    private final Map<MethodIdentity, MethodDoc> _methodIdToMethodDoc = new HashMap<>();
+    return deprecatedTags;
   }
 
-  private static class MethodIdentity
-  {
-    public static MethodIdentity create(Method method)
-    {
+  public Map<String, String> getParamTags(ExecutableElement method) {
+    Map<String, String> paramTags = new HashMap<>();
+    for (VariableElement parameter : method.getParameters()) {
+      String paramName = parameter.getSimpleName().toString();
+      String paramComment = _elements.getDocComment(parameter);
+      if (paramComment != null) {
+        paramTags.put(paramName, paramComment);
+      }
+    }
+    return paramTags;
+  }
+
+  public com.sun.source.doctree.DocCommentTree getDocCommentTree(Method method) {
+    TypeElement typeElement = getClassDoc(method.getDeclaringClass());
+    if (typeElement == null) {
+      return null;
+    }
+
+    for (Element element : typeElement.getEnclosedElements()) {
+      if (element.getSimpleName().toString().equals(method.getName())) {
+        return _docEnv.getDocTrees().getDocCommentTree(element);
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public void init(Locale locale,
+                   Reporter reporter) {
+    // no-ops
+  }
+
+  @Override
+  public String getName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
+  public Set<? extends Option> getSupportedOptions() {
+    return Set.of();
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latest();
+  }
+
+  @Override
+  public boolean run(DocletEnvironment docEnv) {
+    final DocInfo docInfo = new DocInfo();
+
+    // Iterate through the TypeElements (class and interface declarations)
+    for (Element element : docEnv.getIncludedElements()) {
+      if (element instanceof TypeElement) {
+        TypeElement typeElement = (TypeElement) element;
+        docInfo.setClassDoc(typeElement.getQualifiedName().toString(), typeElement);
+
+        // Iterate through the methods of the TypeElement
+        for (Element enclosedElement : typeElement.getEnclosedElements()) {
+          if (enclosedElement instanceof ExecutableElement) {
+            ExecutableElement methodElement = (ExecutableElement) enclosedElement;
+            docInfo.setMethodDoc(MethodIdentity.create(methodElement), methodElement);
+          }
+        }
+      }
+    }
+
+    _currentDocLet = new RestLiDoclet(docInfo, docEnv);
+
+    return true;
+  }
+
+  public String getDocComment(Element element) {
+    return _elements.getDocComment(element);
+  }
+
+  private static class DocInfo {
+    public TypeElement getClassDoc(String className) {
+      return classNameToClassDoc.get(className);
+    }
+
+    public ExecutableElement getMethodDoc(MethodIdentity methodId) {
+      return methodIdToMethodDoc.get(methodId);
+    }
+
+    public void setClassDoc(String className, TypeElement classDoc) {
+      classNameToClassDoc.put(className, classDoc);
+    }
+
+    public void setMethodDoc(MethodIdentity methodId, ExecutableElement methodDoc) {
+      methodIdToMethodDoc.put(methodId, methodDoc);
+    }
+
+    private final Map<String, TypeElement> classNameToClassDoc = new HashMap<>();
+    private final Map<MethodIdentity, ExecutableElement> methodIdToMethodDoc = new HashMap<>();
+  }
+
+  private static class MethodIdentity {
+    public static MethodIdentity create(Method method) {
       final List<String> parameterTypeNames = new ArrayList<>();
 
       // type parameters are not included in identity because of differences between reflection and Doclet:
       // e.g. for Collection<Void>:
       //   reflection Type.toString() -> Collection<Void>
       //   Doclet Type.toString() -> Collection
-      for (Class<?> paramClass: method.getParameterTypes())
-      {
+      for (Class<?> paramClass : method.getParameterTypes()) {
         parameterTypeNames.add(paramClass.getCanonicalName());
       }
 
       return new MethodIdentity(method.getDeclaringClass().getName() + "." + method.getName(), parameterTypeNames);
     }
 
-    public static MethodIdentity create(MethodDoc method)
-    {
+    public static MethodIdentity create(ExecutableElement method) {
       final List<String> parameterTypeNames = new ArrayList<>();
-      for (Parameter param: method.parameters())
-      {
-        Type type = param.type();
-        parameterTypeNames.add(type.qualifiedTypeName() + type.dimension());
+      for (VariableElement param : method.getParameters()) {
+        TypeMirror type = param.asType();
+        parameterTypeNames.add(type.toString());
       }
 
-      return new MethodIdentity(method.qualifiedName(), parameterTypeNames);
+      return new MethodIdentity(method.getEnclosingElement().toString() + "." + method.getSimpleName().toString(),
+                                parameterTypeNames);
     }
 
-    private MethodIdentity(String methodQualifiedName, List<String> parameterTypeNames)
-    {
-      _methodQualifiedName = methodQualifiedName;
-      _parameterTypeNames = parameterTypeNames;
-    }
-
-    @Override
-    public int hashCode()
-    {
-      return new HashCodeBuilder(17, 29).
-          append(_methodQualifiedName).
-          append(_parameterTypeNames).
-          toHashCode();
+    private MethodIdentity(String methodQualifiedName, List<String> parameterTypeNames) {
+      this.methodQualifiedName = methodQualifiedName;
+      this.parameterTypeNames = parameterTypeNames;
     }
 
     @Override
-    public boolean equals(Object obj)
-    {
-      if (this == obj)
-      {
+    public int hashCode() {
+      return new HashCodeBuilder(17, 29)
+              .append(methodQualifiedName)
+              .append(parameterTypeNames)
+              .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
         return true;
       }
 
-      if (obj == null)
-      {
+      if (obj == null) {
         return false;
       }
 
-      if (getClass() != obj.getClass())
-      {
+      if (getClass() != obj.getClass()) {
         return false;
       }
 
       final MethodIdentity other = (MethodIdentity) obj;
-      return new EqualsBuilder().
-          append(_methodQualifiedName, other._methodQualifiedName).
-          append(_parameterTypeNames, other._parameterTypeNames).
-          isEquals();
+      return new EqualsBuilder()
+              .append(methodQualifiedName, other.methodQualifiedName)
+              .append(parameterTypeNames, other.parameterTypeNames)
+              .isEquals();
     }
 
-    private final String _methodQualifiedName;
-    private final List<String> _parameterTypeNames;
+    private final String methodQualifiedName;
+    private final List<String> parameterTypeNames;
   }
 }


### PR DESCRIPTION
Replace the use of old `com.sun.javadoc` apis which are deprecated since JDK9 and removed since JDK 17.

Our CI/CD is using JDK8 for testing so that needs update too.