### PR TITLE
Make ValidationExtensionSchemaTask cacheable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.41.13] - 2023-05-15
+## [29.42.3] - 2023-05-18
 - Support for UDS sockets for HTTP/1
+- Make ValidationExtensionSchemaTask cacheable
 
 ## [29.42.2] - 2023-05-11
 - Fix synchronization on `RequestContext` to prevent `ConcurrentModificationException`.
@@ -5471,8 +5472,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.41.13...master
-[29.41.13]: https://github.com/linkedin/rest.li/compare/v29.42.2...v29.41.13
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.42.3...master
+[29.42.3]: https://github.com/linkedin/rest.li/compare/v29.42.2...v29.42.3
 [29.42.2]: https://github.com/linkedin/rest.li/compare/v29.42.1...v29.42.2
 [29.42.1]: https://github.com/linkedin/rest.li/compare/v29.42.0...v29.42.1
 [29.42.0]: https://github.com/linkedin/rest.li/compare/v29.41.12...v29.42.0

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
@@ -15,11 +15,14 @@
 */
 package com.linkedin.pegasus.gradle.tasks;
 
+import com.linkedin.pegasus.gradle.IOUtil;
 import com.linkedin.pegasus.gradle.PathingJarUtil;
 import com.linkedin.pegasus.gradle.PegasusPlugin;
 import com.linkedin.pegasus.gradle.internal.ArgumentFileGenerator;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,6 +60,7 @@ public class ValidateExtensionSchemaTask extends DefaultTask
   private FileCollection _resolverPath;
   private FileCollection _classPath;
   private boolean _enableArgFile;
+  private File _outputFile = new File(getProject().getBuildDir(), "reports/validateExtensionSchemas/output.txt");
 
   /**
    * Directory containing the extension schema files.
@@ -110,6 +114,15 @@ public class ValidateExtensionSchemaTask extends DefaultTask
     _enableArgFile = enable;
   }
 
+  @OutputFile
+  public File getOutputFile() {
+    return _outputFile;
+  }
+
+  public void setOutputFile(File outputFile) {
+    _outputFile = outputFile;
+  }
+
   @TaskAction
   public void validateExtensionSchema() throws IOException
   {
@@ -138,6 +151,8 @@ public class ValidateExtensionSchemaTask extends DefaultTask
       throw new GradleException("Error occurred generating pathing JAR.", e);
     }
 
+    ByteArrayOutputStream validationOutput = new ByteArrayOutputStream();
+
     getProject().javaexec(javaExecSpec -> {
       String resolverPathArg = resolverPathStr;
       if (isEnableArgFile())
@@ -149,6 +164,10 @@ public class ValidateExtensionSchemaTask extends DefaultTask
       javaExecSpec.setClasspath(_pathedClasspath);
       javaExecSpec.args(resolverPathArg);
       javaExecSpec.args(_inputDir.getAbsolutePath());
+      javaExecSpec.setStandardOutput(validationOutput);
+      javaExecSpec.setErrorOutput(validationOutput);
     });
+
+    IOUtil.writeText(getOutputFile(), validationOutput.toString(StandardCharsets.UTF_8));
   }
 }

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
@@ -168,6 +168,6 @@ public class ValidateExtensionSchemaTask extends DefaultTask
       javaExecSpec.setErrorOutput(validationOutput);
     });
 
-    IOUtil.writeText(getOutputFile(), validationOutput.toString(StandardCharsets.UTF_8));
+    IOUtil.writeText(getOutputFile(), validationOutput.toString(StandardCharsets.UTF_8.name()));
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.41.13
+version=29.42.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This is done through creating an output file for the task, which contains the stdout and stderr