### PR TITLE
INDIS: defining next generation announcements and wiring up to existing D2 announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.42.5] - 2023-06-08
+- Add a new service discovery announcer `IndisAnnouncer` and wire it into existing Zookeeper flow
 
 ## [29.42.4] - 2023-06-02
 - Add log message in RestClient for ScatterGatherStrategy map URIs empty case

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.42.5] - 2023-06-08
+
 ## [29.42.4] - 2023-06-02
 - Add log message in RestClient for ScatterGatherStrategy map URIs empty case
 
@@ -5475,7 +5477,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.42.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.42.5...master
+[29.42.5]: https://github.com/linkedin/rest.li/compare/v29.42.4...v29.42.5
 [29.42.4]: https://github.com/linkedin/rest.li/compare/v29.42.3...v29.42.4
 [29.42.3]: https://github.com/linkedin/rest.li/compare/v29.42.2...v29.42.3
 [29.42.2]: https://github.com/linkedin/rest.li/compare/v29.42.1...v29.42.2

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -20,6 +20,8 @@
 
 package com.linkedin.d2.balancer.servers;
 
+import com.linkedin.d2.discovery.event.IndisAnnouncer;
+import com.linkedin.d2.discovery.event.NoopIndisAnnouncer;
 import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.Collections;
@@ -96,6 +98,8 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
 
   private ServiceDiscoveryEventEmitter _eventEmitter;
 
+  private final IndisAnnouncer _announcer;
+
   /**
    * Field that indicates if the user requested the server to be up or down. If it is requested to be up,
    * it will try to bring up the server again on ZK if the connection goes down, or a new store is set
@@ -154,11 +158,11 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
       boolean isDarkWarmupEnabled, String warmupClusterName, int warmupDuration, ScheduledExecutorService executorService)
   {
     this(server, initialIsUp, isDarkWarmupEnabled, warmupClusterName, warmupDuration, executorService,
-        new LogOnlyServiceDiscoveryEventEmitter()); // default to use log-only event emitter
+        new LogOnlyServiceDiscoveryEventEmitter(), new NoopIndisAnnouncer()); // default to use log-only event emitter
   }
 
   public ZooKeeperAnnouncer(ZooKeeperServer server, boolean initialIsUp,
-      boolean isDarkWarmupEnabled, String warmupClusterName, int warmupDuration, ScheduledExecutorService executorService, ServiceDiscoveryEventEmitter eventEmitter)
+      boolean isDarkWarmupEnabled, String warmupClusterName, int warmupDuration, ScheduledExecutorService executorService, ServiceDiscoveryEventEmitter eventEmitter, IndisAnnouncer announcer)
   {
     _server = server;
     // initialIsUp is used for delay mark up. If it's false, there won't be markup when the announcer is started.
@@ -174,6 +178,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     _warmupDuration = warmupDuration;
     _executorService = executorService;
     _eventEmitter = eventEmitter;
+    _announcer = announcer;
 
     _server.setServiceDiscoveryEventHelper(this);
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -98,7 +98,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
 
   private ServiceDiscoveryEventEmitter _eventEmitter;
 
-  private final IndisAnnouncer _announcer;
+  private IndisAnnouncer _indisAnnouncer;
 
   /**
    * Field that indicates if the user requested the server to be up or down. If it is requested to be up,
@@ -162,7 +162,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
   }
 
   public ZooKeeperAnnouncer(ZooKeeperServer server, boolean initialIsUp,
-      boolean isDarkWarmupEnabled, String warmupClusterName, int warmupDuration, ScheduledExecutorService executorService, ServiceDiscoveryEventEmitter eventEmitter, IndisAnnouncer announcer)
+      boolean isDarkWarmupEnabled, String warmupClusterName, int warmupDuration, ScheduledExecutorService executorService, ServiceDiscoveryEventEmitter eventEmitter, IndisAnnouncer indisAnnouncer)
   {
     _server = server;
     // initialIsUp is used for delay mark up. If it's false, there won't be markup when the announcer is started.
@@ -178,7 +178,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     _warmupDuration = warmupDuration;
     _executorService = executorService;
     _eventEmitter = eventEmitter;
-    _announcer = announcer;
+    _indisAnnouncer = indisAnnouncer;
 
     _server.setServiceDiscoveryEventHelper(this);
   }
@@ -268,6 +268,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
 
   private synchronized void doMarkUp(Callback<None> callback)
   {
+    _indisAnnouncer.emitAnnouncement(_cluster, _uri.getHost(), _uri.getPort(), IndisAnnouncer.HealthStatus.READY);
     final Callback<None> markUpCallback = new Callback<None>()
     {
       @Override
@@ -461,6 +462,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
   private synchronized void doMarkDown(Callback<None> callback)
   {
     _markDownStartAtRef.set(System.currentTimeMillis());
+    _indisAnnouncer.emitAnnouncement(_cluster, _uri.getHost(), _uri.getPort(), IndisAnnouncer.HealthStatus.DOWN);
     _server.markDown(_cluster, _uri, new Callback<None>()
     {
       @Override
@@ -709,6 +711,10 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
 
   public void setEventEmitter(ServiceDiscoveryEventEmitter emitter) {
     _eventEmitter = emitter;
+  }
+
+  public void setIndisAnnouncer(IndisAnnouncer indisAnnouncer) {
+    _indisAnnouncer = indisAnnouncer;
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -102,7 +102,7 @@ public class
                      final Callback<None> callback)
   {
     try {
-      _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort());
+      _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort(), partitionDataMap, uriSpecificProperties);
     } catch (Exception e) {
       _log.warn(String.format("Failed to announce cluster %s to INDIS", clusterName), e);
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -69,6 +69,12 @@ public class
     _store = store;
   }
 
+  public ZooKeeperServer(ZooKeeperEphemeralStore<UriProperties> store, IndisAnnouncer indisAnnouncer)
+  {
+    _store = store;
+    _indisAnnouncer = indisAnnouncer;
+  }
+
   public String getConnectString() {
     return _store.getConnectString();
   }
@@ -119,7 +125,7 @@ public class
 
     try {
       // we separate the INDIS and Zookeeper markUp actions as they are independent of each other -- the success or
-      // failure of the INDIS announcement shouldn't affect the Zookeeper markDown below
+      // failure of the INDIS announcement shouldn't affect the Zookeeper markUp below
       _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort(), uri.getPath(), partitionDataMap,
           uriSpecificProperties, d2UriProperties);
     } catch (Exception e) {

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -107,6 +107,13 @@ public class
       @Override
       public void onSuccess(None none)
       {
+        try {
+          _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort());
+        } catch (Exception e) {
+          _log.warn(String.format("Failed to announce cluster %s to INDIS", clusterName), e);
+        }
+
+
         Map<URI, Map<Integer, PartitionData>> partitionDesc = new HashMap<>();
         partitionDesc.put(uri, partitionDataMap);
 
@@ -142,7 +149,6 @@ public class
           info(_log, sb);
         }
         _store.put(clusterName, new UriProperties(clusterName, partitionDesc, myUriSpecificProperties), callback);
-        _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort());
       }
 
       @Override
@@ -195,6 +201,12 @@ public class
   @Override
   public void markDown(final String clusterName, final URI uri, final Callback<None> callback)
   {
+    try {
+      _indisAnnouncer.deannounce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort());
+    } catch (Exception e) {
+      _log.warn(String.format("Failed to deannounce cluster %s to INDIS", clusterName), e);
+    }
+
     Callback<UriProperties> getCallback = new Callback<UriProperties>()
     {
       @Override
@@ -220,7 +232,6 @@ public class
           Map<URI, Map<Integer, PartitionData>> partitionData = new HashMap<>(2);
           partitionData.put(uri, Collections.emptyMap());
           _store.removePartial(clusterName, new UriProperties(clusterName, partitionData), callback);
-          _indisAnnouncer.deannounce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort());
         }
 
       }

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -102,7 +102,10 @@ public class
                      final Callback<None> callback)
   {
     try {
-      _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort(), partitionDataMap, uriSpecificProperties);
+      // we separate the INDIS and Zookeeper markUp actions as they are independent of each other -- the success or
+      // failure of the INDIS announcement shouldn't affect the Zookeeper markDown below
+      _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort(), uri.getPath(), partitionDataMap,
+          uriSpecificProperties);
     } catch (Exception e) {
       _log.warn(String.format("Failed to announce cluster %s to INDIS", clusterName), e);
     }
@@ -199,8 +202,10 @@ public class
   @Override
   public void markDown(final String clusterName, final URI uri, final Callback<None> callback)
   {
+    // we separate the INDIS and Zookeeper markDown actions as they are independent of each other -- the success or
+    // failure of the INDIS deannouncement shouldn't affect the Zookeeper markDown below
     try {
-      _indisAnnouncer.deannounce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort());
+      _indisAnnouncer.deannounce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort(), uri.getPath());
     } catch (Exception e) {
       _log.warn(String.format("Failed to deannounce cluster %s to INDIS", clusterName), e);
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -44,14 +44,13 @@ import org.slf4j.LoggerFactory;
 import static com.linkedin.d2.discovery.util.LogUtil.info;
 import static com.linkedin.d2.discovery.util.LogUtil.warn;
 
-// TODO move indisannouncer to this class
 public class
         ZooKeeperServer implements LoadBalancerServer
 {
   private static final Logger _log = LoggerFactory.getLogger(ZooKeeperServer.class);
 
-  // we set a default NoopIndisAnnouncer so that even if the user doesn't provide an announcer the class functions without
-  // throwing a NPE when marking up or down
+  // we set a default NoopIndisAnnouncer so that even if the user doesn't provide an announcer the class
+  // functions without throwing a NPE when marking up or down
   private IndisAnnouncer _indisAnnouncer = new NoopIndisAnnouncer();
 
   private volatile ZooKeeperEphemeralStore<UriProperties> _store;
@@ -102,18 +101,17 @@ public class
                      final Map<String, Object> uriSpecificProperties,
                      final Callback<None> callback)
   {
+    try {
+      _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort());
+    } catch (Exception e) {
+      _log.warn(String.format("Failed to announce cluster %s to INDIS", clusterName), e);
+    }
+
     final Callback<None> doPutCallback = new Callback<None>()
     {
       @Override
       public void onSuccess(None none)
       {
-        try {
-          _indisAnnouncer.announce(clusterName, uri.getScheme(), uri.getHost(), uri.getPort());
-        } catch (Exception e) {
-          _log.warn(String.format("Failed to announce cluster %s to INDIS", clusterName), e);
-        }
-
-
         Map<URI, Map<Integer, PartitionData>> partitionDesc = new HashMap<>();
         partitionDesc.put(uri, partitionDataMap);
 

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -7,5 +7,14 @@ package com.linkedin.d2.discovery.event;
  */
 public interface IndisAnnouncer {
   void emitAnnouncement(String cluster, String host, int port,
-      ServiceDiscoveryEventEmitter.StatusUpdateActionType actionType, String uriProperties);
+      HealthStatus healthStatus);
+
+  enum HealthStatus {
+    // Ready to serve traffic
+    READY,
+    // Running but not ready to serve traffic (or intentionally taken out of service). Expected to be READY in the future
+    UP,
+    // Not running; in some error state. Not expected to be READY without intervention.
+    DOWN
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -1,13 +1,11 @@
 package com.linkedin.d2.discovery.event;
 
-import java.util.List;
-
-
 /**
  * This interfaces handles annoucning and deannouncing in LinkedIn's Next Generation Service Discovery ([In]Dis).
  * It will be implemented internally, and we provide a default implementation {@link NoopIndisAnnouncer}
  * that open-source restli users can use (or provide their own implementation for their own service discovery system)
  */
 public interface IndisAnnouncer {
-  void emitIndisAnnouncement(List<String> clustersClaimed, String host, int port, String tracingId, long timestamp);
+  void emitAnnouncement(String cluster, String host, int port,
+      ServiceDiscoveryEventEmitter.StatusUpdateActionType actionType, String uriProperties);
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -11,8 +11,8 @@ import java.util.Map;
 public interface IndisAnnouncer {
   void start();
   void stop();
-  void announce(String cluster, String protocol, String host, int port, Map<Integer, PartitionData> partitionDataMap,
+  void announce(String cluster, String protocol, String host, int port, String path, Map<Integer, PartitionData> partitionDataMap,
       Map<String, Object> uriSpecificProperties);
 
-  void deannounce(String cluster, String protocol, String host, int port);
+  void deannounce(String cluster, String protocol, String host, int port, String path);
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -1,6 +1,7 @@
 package com.linkedin.d2.discovery.event;
 
 import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.UriProperties;
 import java.util.Map;
 
 /**
@@ -12,7 +13,7 @@ public interface IndisAnnouncer {
   void start();
   void stop();
   void announce(String cluster, String protocol, String host, int port, String path, Map<Integer, PartitionData> partitionDataMap,
-      Map<String, Object> uriSpecificProperties);
+      Map<String, Object> uriSpecificProperties, UriProperties d2UriProperties);
 
   void deannounce(String cluster, String protocol, String host, int port, String path);
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -1,5 +1,8 @@
 package com.linkedin.d2.discovery.event;
 
+import com.linkedin.d2.balancer.properties.PartitionData;
+import java.util.Map;
+
 /**
  * This interfaces handles announcing and deannouncing in LinkedIn's Next Generation Service Discovery ([In]Dis).
  * It will be implemented internally, and we provide a default implementation {@link NoopIndisAnnouncer}
@@ -8,7 +11,8 @@ package com.linkedin.d2.discovery.event;
 public interface IndisAnnouncer {
   void start();
   void stop();
-  void announce(String cluster, String protocol, String host, int port);
+  void announce(String cluster, String protocol, String host, int port, Map<Integer, PartitionData> partitionDataMap,
+      Map<String, Object> uriSpecificProperties);
 
   void deannounce(String cluster, String protocol, String host, int port);
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -6,15 +6,7 @@ package com.linkedin.d2.discovery.event;
  * that open-source restli users can use (or provide their own implementation for their own service discovery system)
  */
 public interface IndisAnnouncer {
-  void emitAnnouncement(String cluster, String host, int port,
-      HealthStatus healthStatus);
+  void announce(String cluster, String protocol, String host, int port);
 
-  enum HealthStatus {
-    // Ready to serve traffic
-    READY,
-    // Running but not ready to serve traffic (or intentionally taken out of service). Expected to be READY in the future
-    UP,
-    // Not running; in some error state. Not expected to be READY without intervention.
-    DOWN
-  }
+  void deannounce(String cluster, String protocol, String host, int port);
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -1,0 +1,13 @@
+package com.linkedin.d2.discovery.event;
+
+import java.util.List;
+
+
+/**
+ * This interfaces handles annoucning and deannouncing in LinkedIn's Next Generation Service Discovery ([In]Dis).
+ * It will be implemented internally, and we provide a default implementation {@link NoopIndisAnnouncer}
+ * that open-source restli users can use (or provide their own implementation for their own service discovery system)
+ */
+public interface IndisAnnouncer {
+  void emitIndisAnnouncement(List<String> clustersClaimed, String host, int port, String tracingId, long timestamp);
+}

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -1,11 +1,13 @@
 package com.linkedin.d2.discovery.event;
 
 /**
- * This interfaces handles annoucning and deannouncing in LinkedIn's Next Generation Service Discovery ([In]Dis).
+ * This interfaces handles announcing and deannouncing in LinkedIn's Next Generation Service Discovery ([In]Dis).
  * It will be implemented internally, and we provide a default implementation {@link NoopIndisAnnouncer}
  * that open-source restli users can use (or provide their own implementation for their own service discovery system)
  */
 public interface IndisAnnouncer {
+  void start();
+  void stop();
   void announce(String cluster, String protocol, String host, int port);
 
   void deannounce(String cluster, String protocol, String host, int port);

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/IndisAnnouncer.java
@@ -2,6 +2,7 @@ package com.linkedin.d2.discovery.event;
 
 import com.linkedin.d2.balancer.properties.PartitionData;
 import com.linkedin.d2.balancer.properties.UriProperties;
+import java.net.URI;
 import java.util.Map;
 
 /**
@@ -10,10 +11,8 @@ import java.util.Map;
  * that open-source restli users can use (or provide their own implementation for their own service discovery system)
  */
 public interface IndisAnnouncer {
-  void start();
-  void stop();
-  void announce(String cluster, String protocol, String host, int port, String path, Map<Integer, PartitionData> partitionDataMap,
+  void announce(String cluster, URI uri, Map<Integer, PartitionData> partitionDataMap,
       Map<String, Object> uriSpecificProperties, UriProperties d2UriProperties);
 
-  void deannounce(String cluster, String protocol, String host, int port, String path);
+  void deannounce(String cluster, URI uri);
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -1,5 +1,9 @@
 package com.linkedin.d2.discovery.event;
 
+import com.linkedin.d2.balancer.properties.PartitionData;
+import java.util.Map;
+
+
 public class NoopIndisAnnouncer implements IndisAnnouncer {
   @Override
   public void start() {
@@ -12,7 +16,8 @@ public class NoopIndisAnnouncer implements IndisAnnouncer {
   }
 
   @Override
-  public void announce(String cluster, String protocol, String host, int port) {
+  public void announce(String cluster, String protocol, String host, int port,
+      Map<Integer, PartitionData> partitionDataMap, Map<String, Object> uriSpecificProperties) {
     // do nothing
   }
 

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -4,10 +4,9 @@ import java.util.List;
 
 
 public class NoopIndisAnnouncer implements IndisAnnouncer {
-
   @Override
-  public void emitIndisAnnouncement(List<String> clustersClaimed, String host, int port, String tracingId,
-      long timestamp) {
+  public void emitAnnouncement(String cluster, String host, int port,
+      ServiceDiscoveryEventEmitter.StatusUpdateActionType actionType, String uriProperties) {
     // do nothing
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -2,6 +2,16 @@ package com.linkedin.d2.discovery.event;
 
 public class NoopIndisAnnouncer implements IndisAnnouncer {
   @Override
+  public void start() {
+    // do nothing
+  }
+
+  @Override
+  public void stop() {
+    // do nothing
+  }
+
+  @Override
   public void announce(String cluster, String protocol, String host, int port) {
     // do nothing
   }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -16,13 +16,12 @@ public class NoopIndisAnnouncer implements IndisAnnouncer {
   }
 
   @Override
-  public void announce(String cluster, String protocol, String host, int port,
-      Map<Integer, PartitionData> partitionDataMap, Map<String, Object> uriSpecificProperties) {
+  public void announce(String cluster, String protocol, String host, int port, String path, Map<Integer, PartitionData> partitionDataMap, Map<String, Object> uriSpecificProperties) {
     // do nothing
   }
 
   @Override
-  public void deannounce(String cluster, String protocol, String host, int port) {
+  public void deannounce(String cluster, String protocol, String host, int port, String path) {
     // do nothing
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -2,28 +2,19 @@ package com.linkedin.d2.discovery.event;
 
 import com.linkedin.d2.balancer.properties.PartitionData;
 import com.linkedin.d2.balancer.properties.UriProperties;
+import java.net.URI;
 import java.util.Map;
 
 
 public class NoopIndisAnnouncer implements IndisAnnouncer {
   @Override
-  public void start() {
-    // do nothing
-  }
-
-  @Override
-  public void stop() {
-    // do nothing
-  }
-
-  @Override
-  public void announce(String cluster, String protocol, String host, int port, String path, Map<Integer,
+  public void announce(String cluster, URI uri, Map<Integer,
       PartitionData> partitionDataMap, Map<String, Object> uriSpecificProperties, UriProperties d2UriProperties) {
     // do nothing
   }
 
   @Override
-  public void deannounce(String cluster, String protocol, String host, int port, String path) {
+  public void deannounce(String cluster, URI uri) {
     // do nothing
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -2,8 +2,12 @@ package com.linkedin.d2.discovery.event;
 
 public class NoopIndisAnnouncer implements IndisAnnouncer {
   @Override
-  public void emitAnnouncement(String cluster, String host, int port,
-      HealthStatus healthStatus) {
+  public void announce(String cluster, String protocol, String host, int port) {
+    // do nothing
+  }
+
+  @Override
+  public void deannounce(String cluster, String protocol, String host, int port) {
     // do nothing
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -1,12 +1,9 @@
 package com.linkedin.d2.discovery.event;
 
-import java.util.List;
-
-
 public class NoopIndisAnnouncer implements IndisAnnouncer {
   @Override
   public void emitAnnouncement(String cluster, String host, int port,
-      ServiceDiscoveryEventEmitter.StatusUpdateActionType actionType, String uriProperties) {
+      HealthStatus healthStatus) {
     // do nothing
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -1,6 +1,7 @@
 package com.linkedin.d2.discovery.event;
 
 import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.UriProperties;
 import java.util.Map;
 
 
@@ -16,7 +17,8 @@ public class NoopIndisAnnouncer implements IndisAnnouncer {
   }
 
   @Override
-  public void announce(String cluster, String protocol, String host, int port, String path, Map<Integer, PartitionData> partitionDataMap, Map<String, Object> uriSpecificProperties) {
+  public void announce(String cluster, String protocol, String host, int port, String path, Map<Integer,
+      PartitionData> partitionDataMap, Map<String, Object> uriSpecificProperties, UriProperties d2UriProperties) {
     // do nothing
   }
 

--- a/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/event/NoopIndisAnnouncer.java
@@ -1,0 +1,13 @@
+package com.linkedin.d2.discovery.event;
+
+import java.util.List;
+
+
+public class NoopIndisAnnouncer implements IndisAnnouncer {
+
+  @Override
+  public void emitIndisAnnouncement(List<String> clustersClaimed, String host, int port, String tracingId,
+      long timestamp) {
+    // do nothing
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/servers/ZooKeeperServerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/servers/ZooKeeperServerTest.java
@@ -115,8 +115,8 @@ public class ZooKeeperServerTest
     assertEquals(properties.getPartitionDataMap(URI_1).get(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getWeight(), 0.5d);
     assertEquals(properties.Uris().size(), 1);
 
-    verify(_indisAnnouncer).announce(CLUSTER_1, URI_1.getScheme(), URI_1.getHost(), URI_1.getPort(), URI_1.getPath()
-        , properties.getPartitionDataMap(URI_1), Collections.emptyMap(), properties);
+    verify(_indisAnnouncer).announce(CLUSTER_1, URI_1, properties.getPartitionDataMap(URI_1),
+        Collections.emptyMap(), properties);
 
     // test mark up when already up call
     markUp(_server, CLUSTER_1, URI_1, 2d);
@@ -137,7 +137,7 @@ public class ZooKeeperServerTest
     // bring down uri 1
     reset(_indisAnnouncer);
     markDown(_server, CLUSTER_1, URI_1);
-    verify(_indisAnnouncer).deannounce(CLUSTER_1, URI_1.getScheme(), URI_1.getHost(), URI_1.getPort(), URI_1.getPath());
+    verify(_indisAnnouncer).deannounce(CLUSTER_1, URI_1);
     properties = _store.get(CLUSTER_1);
     assertNotNull(properties);
     assertEquals(properties.getPartitionDataMap(URI_2).get(DefaultPartitionAccessor.DEFAULT_PARTITION_ID).getWeight(), 1.5d);
@@ -196,8 +196,7 @@ public class ZooKeeperServerTest
         ImmutableMap.of(URI_2, properties.getPartitionDataMap(URI_2)),
         ImmutableMap.of(URI_2, _uri2SpecificProperties));
 
-    verify(_indisAnnouncer).announce(CLUSTER_1, URI_2.getScheme(), URI_2.getHost(), URI_2.getPort(), URI_2.getPath()
-        , _partitionWeight, _uri2SpecificProperties, propertiesForUri2);
+    verify(_indisAnnouncer).announce(CLUSTER_1, URI_2, _partitionWeight, _uri2SpecificProperties, propertiesForUri2);
 
     // bring down uri1 and bring it back up again with properties
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.42.4
+version=29.42.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This defines a next-generation service discovery announcement framework (called INDIS), separate from the Zookeeper framework, and wires it in to the existing D2 so that we double write to both systems

Testing done: unit test for `ZookeeperServer` modified to check that `markUp` and `markDown` calls `announce` and `deannounce` with the right parameters