### PR TITLE
mute SD update receipt event for initial request on a new cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.43.1] - 2023-06-20
+- mute SD update receipt event for initial request on a new cluster
+
 ## [29.43.0] - 2023-06-16
 - Implement rest.li xDS service discovery flow and DualRead loadbalancer
 
@@ -5478,7 +5481,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.1...master
+[29.43.1]: https://github.com/linkedin/rest.li/compare/v29.43.0...v29.43.1
 [29.43.0]: https://github.com/linkedin/rest.li/compare/v29.42.4...v29.43.0
 [29.42.4]: https://github.com/linkedin/rest.li/compare/v29.42.3...v29.42.4
 [29.42.3]: https://github.com/linkedin/rest.li/compare/v29.42.2...v29.42.3

--- a/d2/src/test/java/com/linkedin/d2/util/TestDataHelper.java
+++ b/d2/src/test/java/com/linkedin/d2/util/TestDataHelper.java
@@ -210,5 +210,10 @@ public class TestDataHelper {
       _initialRequestDurations.forEach(duration -> assertTrue(duration >= 0, "incorrect durations"));
       assertEquals(succeededFlags, _initialRequestSucceededFlags, "incorrect succeeded flags");
     }
+
+    public void verifyZeroEmissionOfSDStatusUpdateReceiptEvents() {
+      assertTrue(_receiptMarkUpClusters.isEmpty());
+      assertTrue(_receiptMarkDownClusters.isEmpty());
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.43.0
+version=29.43.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
Newly deployed clients are currently emitting SD update receipt event for clusters that they request for the first time, which ends up become a false spike in the end-to-end update propagation latency (from when an server update happened to a client received). This change mutes the event for the initial requests.

## Testing Done
./gradlew build