### PR TITLE
Add missing interface method in LoadBalancerWithFacilitiesDelegator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.43.2] - 2023-06-21
+- Add missing interface method in LoadBalancerWithFacilitiesDelegator
+
 ## [29.43.1] - 2023-06-20
 - mute SD update receipt event for initial request on a new cluster
 
@@ -5481,7 +5484,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.2...master
+[29.43.2]: https://github.com/linkedin/rest.li/compare/v29.43.1...v29.43.2
 [29.43.1]: https://github.com/linkedin/rest.li/compare/v29.43.0...v29.43.1
 [29.43.0]: https://github.com/linkedin/rest.li/compare/v29.42.4...v29.43.0
 [29.42.4]: https://github.com/linkedin/rest.li/compare/v29.42.3...v29.42.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesDelegator.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesDelegator.java
@@ -2,7 +2,9 @@ package com.linkedin.d2.balancer;
 
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.util.None;
+import com.linkedin.d2.balancer.properties.ClusterProperties;
 import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.d2.balancer.util.ClusterInfoProvider;
 import com.linkedin.d2.balancer.util.hashing.HashRingProvider;
 import com.linkedin.d2.balancer.util.partitions.PartitionInfoProvider;
@@ -11,6 +13,8 @@ import com.linkedin.r2.message.Request;
 import com.linkedin.r2.message.RequestContext;
 import com.linkedin.r2.transport.common.TransportClientFactory;
 import com.linkedin.r2.transport.common.bridge.client.TransportClient;
+import org.apache.commons.lang3.tuple.Pair;
+
 
 /**
  * Abstract class implementing the delegating methods for {@link LoadBalancerWithFacilities}
@@ -83,5 +87,18 @@ public abstract class LoadBalancerWithFacilitiesDelegator implements LoadBalance
   public ServiceProperties getLoadBalancedServiceProperties(String serviceName) throws ServiceUnavailableException
   {
     return _loadBalancer.getLoadBalancedServiceProperties(serviceName);
+  }
+
+  @Override
+  public void getLoadBalancedServiceProperties(String serviceName, Callback<ServiceProperties> clientCallback)
+  {
+    _loadBalancer.getLoadBalancedServiceProperties(serviceName, clientCallback);
+  }
+
+  @Override
+  public void getLoadBalancedClusterAndUriProperties(String clusterName,
+      Callback<Pair<ClusterProperties, UriProperties>> callback)
+  {
+    _loadBalancer.getLoadBalancedClusterAndUriProperties(clusterName, callback);
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.43.1
+version=29.43.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Add missing interface method in LoadBalancerWithFacilitiesDelegator so `WarmupLoadBalancer` will be able to delegate the new interface methods to the underlying load balancer.