### PR TITLE
Refactor ZookeeperServer: put uri property building logic to a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.43.3] - 2023-06-22
+## [29.43.4] - 2023-06-22
 - Refactor ZookeeperServer, making functionality to generate URI properties for node accessible to subclasses
 
 ## [29.43.3] - 2023-06-22
@@ -5490,7 +5490,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.4...master
+[29.43.4]: https://github.com/linkedin/rest.li/compare/v29.43.3...v29.43.4
 [29.43.3]: https://github.com/linkedin/rest.li/compare/v29.43.2...v29.43.3
 [29.43.2]: https://github.com/linkedin/rest.li/compare/v29.43.1...v29.43.2
 [29.43.1]: https://github.com/linkedin/rest.li/compare/v29.43.0...v29.43.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.43.3] - 2023-06-22
+- Refactor ZookeeperServer, making functionality to generate URI properties for node accessible to subclasses
+
+## [29.43.3] - 2023-06-22
 - Bump jfrog build-info-extractor-gradle to 4.32.0
 
 ## [29.43.2] - 2023-06-21

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -96,19 +96,6 @@ public class
       @Override
       public void onSuccess(None none)
       {
-        Map<URI, Map<Integer, PartitionData>> partitionDesc = new HashMap<>();
-        partitionDesc.put(uri, partitionDataMap);
-
-        Map<URI, Map<String, Object>> myUriSpecificProperties;
-        if (uriSpecificProperties != null && !uriSpecificProperties.isEmpty())
-        {
-          myUriSpecificProperties = new HashMap<>();
-          myUriSpecificProperties.put(uri, uriSpecificProperties);
-        }
-        else
-        {
-          myUriSpecificProperties = Collections.emptyMap();
-        }
 
         if (_log.isInfoEnabled())
         {
@@ -130,7 +117,7 @@ public class
           sb.append("}");
           info(_log, sb);
         }
-        _store.put(clusterName, new UriProperties(clusterName, partitionDesc, myUriSpecificProperties), callback);
+        _store.put(clusterName, constructUriPropertiesForNode(clusterName, uri, partitionDataMap, uriSpecificProperties), callback);
 
       }
 
@@ -370,6 +357,23 @@ public class
     {
       warn(_log, "unable to shut down propertly.. got interrupt exception while waiting");
     }
+  }
+
+  protected UriProperties constructUriPropertiesForNode(final String clusterName, final URI uri, final Map<Integer, PartitionData> partitionDataMap, final Map<String, Object> uriSpecificProperties) {
+    Map<URI, Map<Integer, PartitionData>> partitionDesc = new HashMap<>();
+    partitionDesc.put(uri, partitionDataMap);
+
+    Map<URI, Map<String, Object>> uriToUriSpecificProperties;
+    if (uriSpecificProperties != null && !uriSpecificProperties.isEmpty())
+    {
+      uriToUriSpecificProperties = new HashMap<>();
+      uriToUriSpecificProperties.put(uri, uriSpecificProperties);
+    }
+    else
+    {
+      uriToUriSpecificProperties = Collections.emptyMap();
+    }
+    return new UriProperties(clusterName, partitionDesc, uriToUriSpecificProperties);
   }
 
   private void storeGet(final String clusterName, final Callback<UriProperties> callback)

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -16,14 +16,6 @@
 
 package com.linkedin.d2.balancer.servers;
 
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
@@ -34,13 +26,18 @@ import com.linkedin.d2.balancer.properties.PropertyKeys;
 import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.d2.discovery.event.D2ServiceDiscoveryEventHelper;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperEphemeralStore;
-
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.d2.discovery.util.LogUtil.info;
-import static com.linkedin.d2.discovery.util.LogUtil.warn;
+import static com.linkedin.d2.discovery.util.LogUtil.*;
 
 public class
         ZooKeeperServer implements LoadBalancerServer
@@ -348,29 +345,23 @@ public class
     {
       callback.get(5, TimeUnit.SECONDS);
       info(_log, "shutting down complete");
-    }
-    catch (TimeoutException e)
-    {
+    } catch (TimeoutException e) {
       warn(_log, "unable to shut down propertly");
-    }
-    catch (InterruptedException | ExecutionException e)
-    {
+    } catch (InterruptedException | ExecutionException e) {
       warn(_log, "unable to shut down propertly.. got interrupt exception while waiting");
     }
   }
 
-  protected UriProperties constructUriPropertiesForNode(final String clusterName, final URI uri, final Map<Integer, PartitionData> partitionDataMap, final Map<String, Object> uriSpecificProperties) {
+  protected UriProperties constructUriPropertiesForNode(final String clusterName, final URI uri,
+      final Map<Integer, PartitionData> partitionDataMap, final Map<String, Object> uriSpecificProperties) {
     Map<URI, Map<Integer, PartitionData>> partitionDesc = new HashMap<>();
     partitionDesc.put(uri, partitionDataMap);
 
     Map<URI, Map<String, Object>> uriToUriSpecificProperties;
-    if (uriSpecificProperties != null && !uriSpecificProperties.isEmpty())
-    {
+    if (uriSpecificProperties != null && !uriSpecificProperties.isEmpty()) {
       uriToUriSpecificProperties = new HashMap<>();
       uriToUriSpecificProperties.put(uri, uriSpecificProperties);
-    }
-    else
-    {
+    } else {
       uriToUriSpecificProperties = Collections.emptyMap();
     }
     return new UriProperties(clusterName, partitionDesc, uriToUriSpecificProperties);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.43.3
+version=29.43.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## What does this do?

This refactors ZookeeperServer, moving the functionality to generate a `UriProperties` object into a protected helper function. This makes the code slightly cleaner and also enables any class that extends `ZookeeperServer` to have access to every parameter that `ZookeeperServer` writes to ZK.

## Testing done
`ZooKeeperServerTest` continues to pass, and I've confirmed that the function gets full code coverage. We could also add unit tests specifically for this, though I've heard that [testing protected methods is an anti-pattern](https://stackoverflow.com/questions/5601730/should-private-protected-methods-be-under-unit-test)? 


![Screenshot 2023-06-22 at 12 02 04 PM](https://github.com/linkedin/rest.li/assets/7916986/2b37094e-5443-4dd2-9f88-c927f85e3c30)

