### PR TITLE
Bump jfrog build-info-extractor-gradle to 4.32.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0'
+    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.32.0'
     classpath 'org.jacoco:org.jacoco.core:0.8.7'
   }
 }


### PR DESCRIPTION
[rest.li](http://rest.li/) open source new version release has been failing because of this error: https://github.com/linkedin/rest.li/actions/runs/5340449592/jobs/9697574024
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0.
     Searched in the following locations:
       - https://jcenter.bintray.com/org/jfrog/buildinfo/build-info-extractor-gradle/4.21.0/build-info-extractor-gradle-4.21.0.pom
       - https://jcenter.bintray.com/org/jfrog/buildinfo/build-info-extractor-gradle/4.21.0/build-info-extractor-gradle-4.21.0.jar