### PR TITLE
enable passing settings to custom partition accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.43.6] - 2023-07-10
+
 ## [29.43.5] - 2023-06-27
 - Remove a delegated method in LoadBalancerWithFacilitiesDelegator
 
@@ -5493,7 +5495,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.6...master
+[29.43.6]: https://github.com/linkedin/rest.li/compare/v29.43.5...v29.43.6
 [29.43.5]: https://github.com/linkedin/rest.li/compare/v29.43.4...v29.43.5
 [29.43.4]: https://github.com/linkedin/rest.li/compare/v29.43.3...v29.43.4
 [29.43.3]: https://github.com/linkedin/rest.li/compare/v29.43.2...v29.43.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.43.6] - 2023-07-10
+- Enable passing settings to custom partition accessor
 
 ## [29.43.5] - 2023-06-27
 - Remove a delegated method in LoadBalancerWithFacilitiesDelegator

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/partitions/BasePartitionAccessor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/partitions/BasePartitionAccessor.java
@@ -18,6 +18,8 @@
 package com.linkedin.d2.balancer.util.partitions;
 
 import java.net.URI;
+import java.util.Objects;
+
 
 /**
  * BasePartitionAccessor returns partitionId according to the given URI.
@@ -33,5 +35,13 @@ public interface BasePartitionAccessor
    * @throws PartitionAccessException see {@link PartitionAccessException}
    */
   int getPartitionId(URI uri) throws PartitionAccessException;
+
+  /**
+   * Given the setting of the partition accessor, check if the setting can be supported
+   * @return true if supportable
+   */
+  default boolean checkSupportable(String settings) {
+    return Objects.equals(getClass().getSimpleName(), settings);
+  }
 }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/partitions/PartitionAccessorFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/partitions/PartitionAccessorFactory.java
@@ -90,8 +90,8 @@ public class PartitionAccessorFactory
       return DefaultPartitionAccessor.getInstance();
     }
 
-    List<String> requestedClassList = customizedProperties.getPartitionAccessorList();
-    if (requestedClassList == null || requestedClassList.isEmpty())
+    List<String> partitionAccessorSettingsList = customizedProperties.getPartitionAccessorList();
+    if (partitionAccessorSettingsList == null || partitionAccessorSettingsList.isEmpty())
     {
       // If the no classList is defined, use the first class registered
       BasePartitionAccessor partitionAccessor = partitionAccessors.get(0);
@@ -99,13 +99,13 @@ public class PartitionAccessorFactory
           + " (out of " + partitionAccessors.size() + ") registration");
       return new CustomizedPartitionAccessor(customizedProperties, partitionAccessor);
     }
-    for (String className : requestedClassList)
+    for (String setting : partitionAccessorSettingsList)
     {
       for (BasePartitionAccessor accessor : partitionAccessors)
       {
-        if (className.equals(accessor.getClass().getSimpleName()))
+        if (accessor.checkSupportable(setting))
         {
-          _log.info("Use matched partitionAccessor for cluster: " + clusterName + ", class: " + accessor.getClass().getSimpleName());
+          _log.info("Use matched partitionAccessor for cluster: " + clusterName + ", class: " + accessor.getClass().getSimpleName() + ", setting: " + setting);
           return new CustomizedPartitionAccessor(customizedProperties, accessor);
         }
       }

--- a/d2/src/test/java/com/linkedin/d2/discovery/util/TestD2Config.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/util/TestD2Config.java
@@ -45,6 +45,7 @@ import com.linkedin.d2.discovery.stores.zk.ZooKeeper;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperEphemeralStore;
 import com.linkedin.d2.discovery.stores.zk.ZooKeeperPermanentStore;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -444,7 +445,7 @@ public class TestD2Config
 
       @Override
       public boolean checkSupportable(String settings) {
-        return "TestPartitionAccessor1!Settings".equals(settings);
+        return settings.startsWith("TestPartitionAccessor1!");
       }
     };
 
@@ -485,7 +486,9 @@ public class TestD2Config
     final String legalUri2 = "/cap?wid=99&id=176&randid=301";
     final String legalUri3 = "/seas?id=3324";
     final String illegalUri = "/?id=1000000000000000000000000000000000000000000000111111111";
-
+    Field realAccessorField = accessor.getClass().getDeclaredField("_partitionAccessor");
+    realAccessorField.setAccessible(true);
+    assertEquals(TestPartitionAccessor1.class, realAccessorField.get(accessor).getClass());
     assertEquals(0, accessor.getPartitionId(URI.create(legalUri1)));
     assertEquals(1, accessor.getPartitionId(URI.create(legalUri2)));
     assertEquals(2, accessor.getPartitionId(URI.create(legalUri3)));

--- a/d2/src/test/java/com/linkedin/d2/discovery/util/TestD2Config.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/util/TestD2Config.java
@@ -392,6 +392,106 @@ public class TestD2Config
     assertEquals(0, accessor.getPartitionId(URI.create(illegalUri)));
   }
 
+  // Test PartitionAccessorFactory: match ClassList with custom matching logic
+  @Test
+  public static void testPartitionAccessorFactoryWithCustomMatchingLogic() throws IOException, InterruptedException, URISyntaxException, Exception
+  {
+    @SuppressWarnings("serial")
+    final Map<String,List<String>> clustersData = new HashMap<String,List<String>>()
+    {{
+      put("partitioned-cluster", Arrays.asList(new String[]{"partitioned-service-1", "partitioned-service-2"}));
+    }};
+
+    final Map<String, Object> partitionProperties = new HashMap<>();
+    Map<String, Object> customized = new HashMap<>();
+    List<String> classList = Arrays.asList("TestPartitionAccessor1!Settings", "TestPartitionAccessor2");
+    customized.put("partitionType", "CUSTOM");
+    customized.put("partitionCount", "10");
+    customized.put("partitionAccessorList", classList);
+    partitionProperties.put("partitionProperties", customized);
+
+    final PartitionAccessorRegistry registry = new PartitionAccessorRegistry()
+    {
+      final private Map<String, List<BasePartitionAccessor>> _registry = new HashMap<>();
+
+      @Override
+      public void register(String clusterName, BasePartitionAccessor accessor)
+      {
+        List<BasePartitionAccessor> accessors = _registry.computeIfAbsent(clusterName, k -> new ArrayList<>());
+        accessors.add(accessor);
+      }
+
+      @Override
+      public List<BasePartitionAccessor> getPartitionAccessors(String clusterName)
+      {
+        return _registry.get(clusterName);
+      }
+    };
+
+    class TestPartitionAccessor1 implements PartitionAccessor
+    {
+      @Override
+      public int getPartitionId(URI uri) throws PartitionAccessException
+      {
+        return testGetPartitionId(uri);
+      }
+
+      @Override
+      public int getMaxPartitionId()
+      {
+        return 10;
+      }
+
+      @Override
+      public boolean checkSupportable(String settings) {
+        return "TestPartitionAccessor1!Settings".equals(settings);
+      }
+    };
+
+    class TestPartitionAccessor2 implements PartitionAccessor
+    {
+      @Override
+      public int getPartitionId(URI uri) throws PartitionAccessException
+      {
+        return 8;
+      }
+
+      @Override
+      public int getMaxPartitionId()
+      {
+        return 10;
+      }
+    };
+
+    PartitionAccessor testAccessor1 = new TestPartitionAccessor1();
+    PartitionAccessor testAccessor2 = new TestPartitionAccessor2();
+
+    registry.register("partitioned-cluster", DefaultPartitionAccessor.getInstance());
+    registry.register("partitioned-cluster", testAccessor1);
+    registry.register("partitioned-cluster", testAccessor2);
+
+    D2ConfigTestUtil d2Conf = new D2ConfigTestUtil(clustersData, partitionProperties);
+
+    assertEquals(d2Conf.runDiscovery(_zkHosts), 0);
+
+    verifyPartitionProperties("partitioned-cluster", partitionProperties);
+
+    final ClusterProperties clusterprops = getClusterProperties(_zkclient, "partitioned-cluster" );
+
+    final PartitionAccessor accessor = PartitionAccessorFactory.getPartitionAccessor("partitioned-cluster",
+        registry, clusterprops.getPartitionProperties());
+
+    final String legalUri1 = "/profiles?field=position&id=100";
+    final String legalUri2 = "/cap?wid=99&id=176&randid=301";
+    final String legalUri3 = "/seas?id=3324";
+    final String illegalUri = "/?id=1000000000000000000000000000000000000000000000111111111";
+
+    assertEquals(0, accessor.getPartitionId(URI.create(legalUri1)));
+    assertEquals(1, accessor.getPartitionId(URI.create(legalUri2)));
+    assertEquals(2, accessor.getPartitionId(URI.create(legalUri3)));
+    assertEquals(0, accessor.getPartitionId(URI.create(illegalUri)));
+  }
+
   // Test PartitionAccessorFactory: empty ClassList
   @Test
   public static void testPartitionAccessorFactoryWithEmptyClassList() throws IOException, InterruptedException, URISyntaxException, Exception

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.43.5
+version=29.43.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This feature enables pass custom settings to custom partition accessor so that the custom partition accessor can be configured from the server side.

design doc is here https://docs.google.com/document/d/1m4xeawvNHIvfM927LvzFwg8l1RrYwDuOV7-7TMeoQNg/edit#heading=h.nrawpetlys1f