### PR TITLE
updated PegasusPlugin to still register restModel tasks even if IDL files dir is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.43.9] - 2023-07-18
+- add `rest.idl.autoGeneration.enabled` property in `PegasusPlugin` to support IDL files auto generation
+  - If this property is true, plugin will create rest client gradle tasks even if IDL dir is empty.
+
 ## [29.43.8] - 2023-07-13
 - Add support for gRPC-downstream extension annotations (`@grpcExtension`, `@grpcService`).
 
@@ -5502,7 +5506,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.9...master
+[29.43.9]: https://github.com/linkedin/rest.li/compare/v29.43.8...v29.43.9
 [29.43.8]: https://github.com/linkedin/rest.li/compare/v29.43.7...v29.43.8
 [29.43.7]: https://github.com/linkedin/rest.li/compare/v29.43.6...v29.43.7
 [29.43.6]: https://github.com/linkedin/rest.li/compare/v29.43.5...v29.43.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.43.9] - 2023-07-18
-- add `rest.idl.autoGeneration.enabled` property in `PegasusPlugin` to support IDL files auto generation
+- add `rest.idl.processEmptyIdlDir` property in `PegasusPlugin` to support IDL files auto generation
   - If this property is true, plugin will create rest client gradle tasks even if IDL dir is empty.
 
 ## [29.43.8] - 2023-07-13

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -562,6 +562,7 @@ public class PegasusPlugin implements Plugin<Project>
   private static final Pattern TEST_DIR_REGEX = Pattern.compile("^(integ)?[Tt]est");
   private static final String SNAPSHOT_NO_PUBLISH = "rest.model.noPublish";
   private static final String SNAPSHOT_FORCE_PUBLISH = "rest.model.forcePublish";
+  private static final String IDL_AUTO_GENERATION_ENABLED = "rest.idl.autoGeneration.enabled";
   private static final String IDL_NO_PUBLISH = "rest.idl.noPublish";
   private static final String IDL_FORCE_PUBLISH = "rest.idl.forcePublish";
   private static final String SKIP_IDL_CHECK = "rest.idl.skipCheck";
@@ -1991,11 +1992,11 @@ public class PegasusPlugin implements Plugin<Project>
   {
     // idl directory for api project
     File idlDir = project.file(getIdlPath(project, sourceSet));
-    if (SharedFileUtils.getSuffixedFiles(project, idlDir, IDL_FILE_SUFFIX).isEmpty())
+    if (SharedFileUtils.getSuffixedFiles(project, idlDir, IDL_FILE_SUFFIX).isEmpty() && !isPropertyTrue(project,
+        IDL_AUTO_GENERATION_ENABLED))
     {
       return;
     }
-
     File generatedRestClientDir = project.file(getGeneratedDirPath(project, sourceSet, REST_GEN_TYPE)
         + File.separatorChar + "java");
 

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -562,7 +562,7 @@ public class PegasusPlugin implements Plugin<Project>
   private static final Pattern TEST_DIR_REGEX = Pattern.compile("^(integ)?[Tt]est");
   private static final String SNAPSHOT_NO_PUBLISH = "rest.model.noPublish";
   private static final String SNAPSHOT_FORCE_PUBLISH = "rest.model.forcePublish";
-  private static final String IDL_AUTO_GENERATION_ENABLED = "rest.idl.autoGeneration.enabled";
+  private static final String PROCESS_EMPTY_IDL_DIR = "rest.idl.processEmptyIdlDir";
   private static final String IDL_NO_PUBLISH = "rest.idl.noPublish";
   private static final String IDL_FORCE_PUBLISH = "rest.idl.forcePublish";
   private static final String SKIP_IDL_CHECK = "rest.idl.skipCheck";
@@ -1993,7 +1993,7 @@ public class PegasusPlugin implements Plugin<Project>
     // idl directory for api project
     File idlDir = project.file(getIdlPath(project, sourceSet));
     if (SharedFileUtils.getSuffixedFiles(project, idlDir, IDL_FILE_SUFFIX).isEmpty() && !isPropertyTrue(project,
-        IDL_AUTO_GENERATION_ENABLED))
+        PROCESS_EMPTY_IDL_DIR))
     {
       return;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.43.8
+version=29.43.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/idlgen/RestLiResourceModelExporter.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/idlgen/RestLiResourceModelExporter.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.restli.tools.idlgen;
 
-
 import com.linkedin.pegasus.generator.GeneratorResult;
 import com.linkedin.restli.common.RestConstants;
 import com.linkedin.restli.internal.server.model.ResourceModel;
@@ -27,22 +26,16 @@ import com.linkedin.restli.restspec.ResourceSchema;
 import com.linkedin.restli.restspec.RestSpecCodec;
 import com.linkedin.restli.server.RestLiConfig;
 import com.linkedin.restli.server.util.FileClassNameScanner;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import org.apache.commons.io.output.NullWriter;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +52,7 @@ public class RestLiResourceModelExporter
 
   /**
    * @param apiName the name of the API
-   * @param classpath classpath to to load the resources. this is purely for Javadoc Doclet {@link RestLiDoclet}
+   * @param classpath classpath to load the resources. this is purely for Javadoc Doclet {@link RestLiDoclet}
    * @param sourcePaths paths to scan for resource Java source files. this is purely for Javadoc Doclet {@link RestLiDoclet}
    * @param resourcePackages packages to scan for resources
    * @param outdir directory in which to output the IDL files
@@ -110,7 +103,7 @@ public class RestLiResourceModelExporter
 
   /**
    * @param apiName the name of the API
-   * @param classpath classpath to to load the resources. this is purely for Javadoc Doclet {@link RestLiDoclet}
+   * @param classpath classpath to load the resources. this is purely for Javadoc Doclet {@link RestLiDoclet}
    * @param sourcePaths paths to scan for resource Java source files. this is purely for Javadoc Doclet {@link RestLiDoclet}
    *                    if both resourcePackages and resourceClasses is null, all classes defined in the directories will be scanned
    * @param resourcePackages packages to scan for resources


### PR DESCRIPTION
Details: Allow creating rest model gradle tasks even if there are no IDL files are present at project evaluation time if `rest.idl.processEmptyIdlDir` is set to true for the project.

###Testing Done 
build