### PR TITLE
Set log level of dual read mode changes to info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.43.10] - 2023-07-24
+- set log level of dual read mode changes to info.
+
 ## [29.43.9] - 2023-07-18
 - add `rest.idl.processEmptyIdlDir` property in `PegasusPlugin` to support IDL files auto generation
   - If this property is true, plugin will create rest client gradle tasks even if IDL dir is empty.
@@ -5506,7 +5509,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.10...master
+[29.43.10]: https://github.com/linkedin/rest.li/compare/v29.43.9...v29.43.10
 [29.43.9]: https://github.com/linkedin/rest.li/compare/v29.43.8...v29.43.9
 [29.43.8]: https://github.com/linkedin/rest.li/compare/v29.43.7...v29.43.8
 [29.43.7]: https://github.com/linkedin/rest.li/compare/v29.43.6...v29.43.7

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
@@ -79,19 +79,19 @@ public class DualReadStateManager
   public void updateGlobal(DualReadModeProvider.DualReadMode mode)
   {
     _dualReadMode = mode;
-    LOG.debug("Global dual read mode updated: " + mode);
+    LOG.info("Global dual read mode updated: {}", mode);
   }
 
   public void updateService(String service, DualReadModeProvider.DualReadMode mode)
   {
     _serviceDualReadModes.put(service, mode);
-    LOG.debug("Dual read mode for service " + service + " updated: " + mode);
+    LOG.info("Dual read mode for service {} updated: {}", service, mode);
   }
 
   public void updateCluster(String cluster, DualReadModeProvider.DualReadMode mode)
   {
     _clusterDualReadModes.put(cluster, mode);
-    LOG.debug("Dual read mode for cluster " + cluster + " updated: " + mode);
+    LOG.info("Dual read mode for cluster {} updated: {}", cluster, mode);
   }
 
   public DualReadModeProvider.DualReadMode getGlobalDualReadMode()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.43.9
+version=29.43.10
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
For Pilot testing INDIS read path, we need to avoid the extra step of manually setting the log level to debug on test host. Given that the dual read mode will change very infrequently (only at testing), we set the log level to info. 