### PR TITLE
Fix logging issues about dual read mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.43.11] - 2023-08-01
+- fix logging issues about observer host and dual read mode
+
 ## [29.43.10] - 2023-07-24
 - set log level of dual read mode changes to info.
 
@@ -5509,7 +5512,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.43.11...master
+[29.43.11]: https://github.com/linkedin/rest.li/compare/v29.43.10...v29.43.11
 [29.43.10]: https://github.com/linkedin/rest.li/compare/v29.43.9...v29.43.10
 [29.43.9]: https://github.com/linkedin/rest.li/compare/v29.43.8...v29.43.9
 [29.43.8]: https://github.com/linkedin/rest.li/compare/v29.43.7...v29.43.8

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
@@ -78,20 +78,27 @@ public class DualReadStateManager
 
   public void updateGlobal(DualReadModeProvider.DualReadMode mode)
   {
+    boolean updated = _dualReadMode != mode;
     _dualReadMode = mode;
-    LOG.info("Global dual read mode updated: {}", mode);
+    if (updated) {
+      LOG.info("Global dual read mode updated: {}", mode);
+    }
   }
 
   public void updateService(String service, DualReadModeProvider.DualReadMode mode)
   {
-    _serviceDualReadModes.put(service, mode);
-    LOG.info("Dual read mode for service {} updated: {}", service, mode);
+    DualReadModeProvider.DualReadMode oldMode = _serviceDualReadModes.put(service, mode);
+    if (oldMode != mode) {
+      LOG.info("Dual read mode for service {} updated: {}", service, mode);
+    }
   }
 
   public void updateCluster(String cluster, DualReadModeProvider.DualReadMode mode)
   {
-    _clusterDualReadModes.put(cluster, mode);
-    LOG.info("Dual read mode for cluster {} updated: {}", cluster, mode);
+    DualReadModeProvider.DualReadMode oldMode = _clusterDualReadModes.put(cluster, mode);
+    if (oldMode != mode) {
+      LOG.info("Dual read mode for cluster {} updated: {}", cluster, mode);
+    }
   }
 
   public DualReadModeProvider.DualReadMode getGlobalDualReadMode()
@@ -173,7 +180,7 @@ public class DualReadStateManager
         // Check and switch global dual read mode
         updateGlobal(_dualReadModeProvider.getDualReadMode());
 
-        // Check and switch service-level dual read mode}
+        // Check and switch service-level dual read mode
         if (d2ServiceName != null)
         {
           updateService(d2ServiceName, _dualReadModeProvider.getDualReadMode(d2ServiceName));

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -99,7 +99,7 @@ public class XdsClientImpl extends XdsClient
         AggregatedDiscoveryServiceGrpc.newStub(_managedChannel);
     _adsStream = new AdsStream(stub);
     _adsStream.start();
-    _log.info("ADS stream started");
+    _log.info("ADS stream started, connected to server: {}", _managedChannel.authority());
   }
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.43.10
+version=29.43.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
### Background 
Currently, the dual read mode is logged about being updated without checking whether it's really updated or just setting with the same existing value. Since cluster dual read mode depends on incoming requests to trigger an update when d2 services under that cluster is called, the cluster dual read mode is logged on every request.
 
### Changes
1. Fix the dual read mode logging to be logged only when there is an update.
2. When Ads stream is established, log about the Observer authority. It's just the DNS address. The resolved IP address should be logged in ManagedChannelImpl in grpc-core at:
`List<EquivalentAddressGroup> servers = resolutionResult.getAddresses();
channelLogger.log(ChannelLogLevel.INFO, "Address resolved: {0}", servers);`

### Tests Done
QEI deployment with toki