### PR TITLE
Remove reset toggling stores option in LoadBalancerClientCli to remove Java 17 incompatible code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [30.0.0] - 2023-08-15
+- Remove resetTogglingStores functionality from LoadBalancerClientCli, which is incompatible with Java 17
+
 ## [29.44.0] - 2023-08-06
 - dynamically switch jmx/sensor names based on dual read mode and source type
 
@@ -5515,7 +5518,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.44.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v30.0.0...master
+[30.0.0]: https://github.com/linkedin/rest.li/compare/v29.44.0...v30.0.0
 [29.44.0]: https://github.com/linkedin/rest.li/compare/v29.43.11...v29.44.0
 [29.43.11]: https://github.com/linkedin/rest.li/compare/v29.43.10...v29.43.11
 [29.43.10]: https://github.com/linkedin/rest.li/compare/v29.43.9...v29.43.10

--- a/d2-int-test/build.gradle
+++ b/d2-int-test/build.gradle
@@ -11,7 +11,6 @@ dependencies {
   compile externalDependency.commonsIo
   compile externalDependency.commonsHttpClient
   compile externalDependency.zookeeper
-  compile externalDependency.jdkTools
   compile externalDependency.netty
   testCompile externalDependency.testng
   testCompile externalDependency.commonsIo

--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -2,18 +2,6 @@ plugins {
     id "com.google.protobuf" version "0.8.10"
 }
 
-// internal api inaccessible starting 1.9
-if (JavaVersion.current() > JavaVersion.VERSION_1_9) {
-  project.tasks.withType(JavaCompile) {
-    options.compilerArgs += [ "--add-exports", "jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED" ]
-  }
-  javadoc {
-    options {
-      addStringOption('-add-exports', 'jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED')
-    }
-  }
-}
-
 dependencies {
   compile project(':degrader')
   compile project(':r2-core')
@@ -32,7 +20,6 @@ dependencies {
   compile externalDependency.zookeeper
   compile externalDependency.jacksonCore
   compile externalDependency.jacksonDataBind
-  compile externalDependency.jdkTools
   compile externalDependency.zero_allocation_hashing
   compile externalDependency.xchart
   compileOnly externalDependency.findbugs

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.44.0
+version=30.0.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This is needed to allow us make restli compatible with Java 17. The only functionality that's removed is the ability to `resetTogglingStores` from the `LoadBalancerClientCli`, which is unused elsewhere in the codebase.

This change is needed for #929