### PR TITLE
Add @Nullable annotations for pegasus java getters and setters with mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5527,7 +5527,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.45.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.45.1...master
+[29.45.1]: https://github.com/linkedin/rest.li/compare/v29.45.0...v29.45.1
 [29.45.0]: https://github.com/linkedin/rest.li/compare/v30.0.0...v29.45.0
 [30.0.0]: https://github.com/linkedin/rest.li/compare/v29.44.0...v30.0.0
 [29.44.0]: https://github.com/linkedin/rest.li/compare/v29.43.11...v29.44.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.45.1] - 2023-09-05
+- add @Nullable annotations to pegasus java getters and setters with mode
+
 ## [29.45.0] - 2023-08-25
 
 - Downgrade major version back to 29. Technically this is not semver-compatible

--- a/generator/src/main/java/com/linkedin/pegasus/generator/JavaDataTemplateGenerator.java
+++ b/generator/src/main/java/com/linkedin/pegasus/generator/JavaDataTemplateGenerator.java
@@ -1119,6 +1119,7 @@ public class JavaDataTemplateGenerator extends JavaCodeGeneratorBase
       final JMethod getterWithMode = templateClass.method(JMod.PUBLIC, type, getterName);
       addAccessorDoc(templateClass, getterWithMode, schemaField, "Getter");
       setDeprecatedAnnotationAndJavadoc(getterWithMode, schemaField);
+      getterWithMode.annotate(Nullable.class);
       JVar modeParam = getterWithMode.param(_getModeClass, "mode");
       final JBlock getterWithModeBody = getterWithMode.body();
 
@@ -1200,6 +1201,7 @@ public class JavaDataTemplateGenerator extends JavaCodeGeneratorBase
       addAccessorDoc(templateClass, setterWithMode, schemaField, "Setter");
       setDeprecatedAnnotationAndJavadoc(setterWithMode, schemaField);
       JVar param = setterWithMode.param(type, "value");
+      param.annotate(Nullable.class);
       JVar modeParam = setterWithMode.param(_setModeClass, "mode");
       JSwitch modeSwitch = setterWithMode.body()._switch(modeParam);
       JCase disallowNullCase = modeSwitch._case(JExpr.ref("DISALLOW_NULL"));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.45.0
+version=29.45.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Background
This PR adds `@Nullable` annotation to the Java data template generator that generates getters and setters for pegasus data models. Specifically:

1. For setters with mode, add `@Nullable` annotations. E.g. `Foo.setBar(blah, SetMode mode)` => `Foo.setBar(@Nullable blah, SetMode mode)` since `Foo.setBar(blah, SetMode.REMOVE_IF_NULL)` is null-safe.
2. For getters with mode, add `@Nullable` annotation. E.g. `Foo.getBar(GetMode mode)` => `@Nullable Foo.getBar(GetMode mode)`  since `Foo.getBar(GetMode.IGNORE_NULL)` is null-safe.

## Context
PSM recently introduced NullAway (https://github.com/uber/NullAway) as a requirement for LMS MPs. However, the library caught several false positives on Rest.Li generated java code, specifically on the cases mentioned above due to missing annotations. Adding these annotations should reduce the false positives from the library.

## Testing Done
Build in Java 8:
```
export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_212.jdk/Contents/Home/
./gradlew clean build
```
Generated local release and tested in Java 11 consumer (following workaround in [SI-31264](https://jira01.corp.linkedin.com:8443/browse/SI-31264) and [SI-30640](https://jira01.corp.linkedin.com:8443/browse/SI-30640)
`./scripts/local-release -s`

Example Getter with Mode (required field):
```

    /**
     * Getter for id
     * 
     * @see Post.Fields#id
     */
    @Nullable
    public com.linkedin.common.urn.Urn getId(GetMode mode) {
        switch (mode) {
            case STRICT:
                return getId();
            case DEFAULT:
            case NULL:
                if (_idField!= null) {
                    return _idField;
                } else {
                    Object __rawValue = super._map.get("id");
                    _idField = DataTemplateUtil.coerceCustomOutput(__rawValue, com.linkedin.common.urn.Urn.class);
                    return _idField;
                }
        }
        throw new IllegalStateException(("Unknown mode "+ mode));
    }
```

Example Setter with Mode (required field)
```
    /**
     * Setter for id
     * 
     * @see Post.Fields#id
     */
    public Post setId(
        @Nullable
        com.linkedin.common.urn.Urn value, SetMode mode) {
        switch (mode) {
            case DISALLOW_NULL:
                return setId(value);
            case REMOVE_OPTIONAL_IF_NULL:
                if (value == null) {
                    throw new IllegalArgumentException("Cannot remove mandatory field id of com.linkedin.contentapi.Post");
                } else {
                    CheckedUtil.putWithoutChecking(super._map, "id", DataTemplateUtil.coerceCustomInput(value, com.linkedin.common.urn.Urn.class));
                    _idField = value;
                }
                break;
            case REMOVE_IF_NULL:
                if (value == null) {
                    removeId();
                } else {
                    CheckedUtil.putWithoutChecking(super._map, "id", DataTemplateUtil.coerceCustomInput(value, com.linkedin.common.urn.Urn.class));
                    _idField = value;
                }
                break;
            case IGNORE_NULL:
                if (value!= null) {
                    CheckedUtil.putWithoutChecking(super._map, "id", DataTemplateUtil.coerceCustomInput(value, com.linkedin.common.urn.Urn.class));
                    _idField = value;
                }
                break;
        }
        return this;
    }
```
