### PR TITLE
Support d2 symlink node in indis flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.46.5] - 2023-10-02
+- support d2 symlink in indis flow
+
 ## [29.46.4] - 2023-09-27
 - Conduct a more thorough search and fix the remaining ByteBuffer errors to be compatible with Java 8 runtimes.
 
@@ -5542,7 +5545,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.5...master
+[29.46.5]: https://github.com/linkedin/rest.li/compare/v29.45.1...v29.45.2
 [29.46.4]: https://github.com/linkedin/rest.li/compare/v29.46.3...v29.46.4
 [29.46.3]: https://github.com/linkedin/rest.li/compare/v29.46.2...v29.46.3
 [29.46.2]: https://github.com/linkedin/rest.li/compare/v29.46.1...v29.46.2

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public abstract class XdsClient
 {
   private static final String D2_NODE_TYPE_URL = "type.googleapis.com/indis.D2Node";
+  private static final String D2_SYMLINK_NODE_TYPE_URL = "type.googleapis.com/indis.D2SymlinkNode";
   private static final String D2_NODE_MAP_TYPE_URL = "type.googleapis.com/indis.D2NodeMap";
 
   interface ResourceWatcher
@@ -42,6 +43,11 @@ public abstract class XdsClient
   interface D2NodeResourceWatcher extends ResourceWatcher
   {
     void onChanged(D2NodeUpdate update);
+  }
+
+  interface D2SymlinkNodeResourceWatcher extends ResourceWatcher
+  {
+    void onChanged(String resourceName, D2SymlinkNodeUpdate update);
   }
 
   interface D2NodeMapResourceWatcher extends ResourceWatcher
@@ -76,6 +82,28 @@ public abstract class XdsClient
     }
   }
 
+  static final class D2SymlinkNodeUpdate implements ResourceUpdate
+  {
+    String _version;
+    XdsD2.D2SymlinkNode _nodeData;
+
+    D2SymlinkNodeUpdate(String version, XdsD2.D2SymlinkNode nodeData)
+    {
+      _version = version;
+      _nodeData = nodeData;
+    }
+
+    XdsD2.D2SymlinkNode getNodeData()
+    {
+      return _nodeData;
+    }
+
+    public String getVersion()
+    {
+      return _version;
+    }
+  }
+
   static final class D2NodeMapUpdate implements ResourceUpdate
   {
     String _version;
@@ -100,13 +128,18 @@ public abstract class XdsClient
 
   enum ResourceType
   {
-    UNKNOWN, D2_NODE, D2_NODE_MAP;
+    // TODO: add D2_SYMLINK_NODE type
+    UNKNOWN, D2_NODE, D2_SYMLINK_NODE, D2_NODE_MAP;
 
     static ResourceType fromTypeUrl(String typeUrl)
     {
       if (typeUrl.equals(D2_NODE_TYPE_URL))
       {
         return D2_NODE;
+      }
+      if (typeUrl.equals(D2_SYMLINK_NODE_TYPE_URL))
+      {
+        return D2_SYMLINK_NODE;
       }
       if (typeUrl.equals(D2_NODE_MAP_TYPE_URL))
       {
@@ -121,6 +154,8 @@ public abstract class XdsClient
       {
         case D2_NODE:
           return D2_NODE_TYPE_URL;
+        case D2_SYMLINK_NODE:
+          return D2_SYMLINK_NODE_TYPE_URL;
         case D2_NODE_MAP:
           return D2_NODE_MAP_TYPE_URL;
         case UNKNOWN:

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -128,7 +128,6 @@ public abstract class XdsClient
 
   enum ResourceType
   {
-    // TODO: add D2_SYMLINK_NODE type
     UNKNOWN, D2_NODE, D2_SYMLINK_NODE, D2_NODE_MAP;
 
     static ResourceType fromTypeUrl(String typeUrl)

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -547,7 +547,6 @@ public class XdsClientImpl extends XdsClient
       _responseReceived = true;
       String respNonce = response.getNonce();
       ResourceType resourceType = response.getResourceType();
-      // TODO: handle D2_SYMLINK_NODE type
       switch (resourceType)
       {
         case D2_NODE:

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -34,6 +34,11 @@ message D2Node {
   google.protobuf.Struct data = 2;
 }
 
+message D2SymlinkNode {
+  Stat stat = 1;
+  string masterClusterNodePath = 2;
+}
+
 message D2NodeMap {
   map<string, D2Node> nodes = 1;
 }

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -1,0 +1,237 @@
+package com.linkedin.d2.xds;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.linkedin.d2.balancer.properties.ClusterProperties;
+import com.linkedin.d2.balancer.properties.ClusterStoreProperties;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.properties.ServiceStoreProperties;
+import com.linkedin.d2.balancer.properties.UriProperties;
+import com.linkedin.d2.discovery.event.PropertyEventBus;
+import com.linkedin.d2.discovery.event.ServiceDiscoveryEventEmitter;
+import indis.XdsD2;
+import java.util.Collections;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+public class TestXdsToD2PropertiesAdaptor {
+  private static final String CLUSTER_NODE_PREFIX = "/d2/clusters/";
+  private static final String URI_NODE_PREFIX = "/d2/uris/";
+  private static final String SYMLINK_NAME = "$FooClusterMaster";
+  private static final String PRIMARY_CLUSTER_NAME = "FooClusterMaster-prod-ltx1";
+  private static final String PRIMARY_CLUSTER_NAME_2 = "FooClusterMaster-prod-lor1";
+  private static final String CLUSTER_SYMLINK_RESOURCE_NAME = CLUSTER_NODE_PREFIX + SYMLINK_NAME;
+  private static final String PRIMARY_CLUSTER_RESOURCE_NAME = CLUSTER_NODE_PREFIX + PRIMARY_CLUSTER_NAME;
+  private static final ClusterStoreProperties PRIMARY_CLUSTER_PROPERTIES = new ClusterStoreProperties(PRIMARY_CLUSTER_NAME);
+  private static final String URI_SYMLINK_RESOURCE_NAME = URI_NODE_PREFIX + SYMLINK_NAME;
+  private static final String PRIMARY_URI_RESOURCE_NAME = URI_NODE_PREFIX + PRIMARY_CLUSTER_NAME;
+
+  private static final XdsClient.D2NodeMapUpdate DUMMY_NODE_MAP_UPDATE = new XdsClient.D2NodeMapUpdate("",
+      Collections.emptyMap());
+
+  @Test
+  public void testListenToService()
+  {
+    XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
+    String serviceName = "FooService";
+    fixture.getSpiedAdaptor().listenToService(serviceName);
+
+    verify(fixture._xdsClient).watchXdsResource(eq("/d2/services/" + serviceName), eq(XdsClient.ResourceType.D2_NODE), any());
+
+    XdsClient.D2NodeResourceWatcher symlinkNodeWatcher =
+        (XdsClient.D2NodeResourceWatcher) fixture._watcherArgumentCaptor.getValue();
+    symlinkNodeWatcher.onChanged(new XdsClient.D2NodeUpdate("", XdsD2.D2Node.newBuilder()
+        .setData(Struct.newBuilder().putAllFields(
+            ImmutableMap.of(
+                "serviceName", getProtoStringValue(serviceName),
+                "clusterName", getProtoStringValue(PRIMARY_CLUSTER_NAME),
+                "path", getProtoStringValue(""),
+                "loadBalancerStrategyList", Value.newBuilder().setListValue(
+                    ListValue.newBuilder().addValues(getProtoStringValue("relative")).build()
+                ).build()
+            )
+        ))
+        .setStat(XdsD2.Stat.newBuilder().setMzxid(1L).build())
+        .build())
+    );
+    verify(fixture._serviceEventBus).publishInitialize(serviceName,
+        new ServiceStoreProperties(serviceName, PRIMARY_CLUSTER_NAME, "",
+            Collections.singletonList("relative"))
+    );
+  }
+
+  @Test
+  public void testListenToNormalCluster()
+  {
+    XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
+    fixture.getSpiedAdaptor().listenToCluster(PRIMARY_CLUSTER_NAME);
+
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_CLUSTER_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_NODE), any());
+    verifyClusterNodeUpdate(fixture, PRIMARY_CLUSTER_NAME, PRIMARY_CLUSTER_NAME, PRIMARY_CLUSTER_PROPERTIES);
+  }
+
+  @Test
+  public void testListenToClusterSymlink() {
+    XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
+    fixture.getSpiedAdaptor().listenToCluster(SYMLINK_NAME);
+
+    verify(fixture._xdsClient).watchXdsResource(eq(CLUSTER_SYMLINK_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_SYMLINK_NODE), any());
+
+    XdsClient.D2SymlinkNodeResourceWatcher symlinkNodeWatcher =
+        (XdsClient.D2SymlinkNodeResourceWatcher) fixture._watcherArgumentCaptor.getValue();
+    symlinkNodeWatcher.onChanged(CLUSTER_SYMLINK_RESOURCE_NAME, getSymlinkNodeUpdate(PRIMARY_CLUSTER_RESOURCE_NAME));
+
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_CLUSTER_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_NODE), any());
+
+    XdsClient.D2NodeResourceWatcher clusterNodeWatcher =
+        (XdsClient.D2NodeResourceWatcher) fixture._watcherArgumentCaptor.getValue();
+    clusterNodeWatcher.onChanged(getClusterNodeUpdate(PRIMARY_CLUSTER_NAME));
+
+    verify(fixture._clusterEventBus).publishInitialize(SYMLINK_NAME, PRIMARY_CLUSTER_PROPERTIES);
+
+    // test update symlink to a new primary cluster
+    String primaryClusterResourceName2 = CLUSTER_NODE_PREFIX + PRIMARY_CLUSTER_NAME_2;
+    ClusterStoreProperties primaryClusterProperties2 = new ClusterStoreProperties(PRIMARY_CLUSTER_NAME_2);
+
+    symlinkNodeWatcher.onChanged(CLUSTER_SYMLINK_RESOURCE_NAME, getSymlinkNodeUpdate(primaryClusterResourceName2));
+
+    verify(fixture._xdsClient).watchXdsResource(eq(primaryClusterResourceName2), eq(XdsClient.ResourceType.D2_NODE), any());
+    verifyClusterNodeUpdate(fixture, PRIMARY_CLUSTER_NAME_2, SYMLINK_NAME, primaryClusterProperties2);
+
+    // if the old primary cluster gets an update, it will be published under its original cluster name
+    // since the symlink points to the new primary cluster now.
+    clusterNodeWatcher.onChanged(getClusterNodeUpdate(PRIMARY_CLUSTER_NAME_2));
+
+    verify(fixture._clusterEventBus).publishInitialize(PRIMARY_CLUSTER_NAME, primaryClusterProperties2);
+  }
+
+  @Test
+  public void testListenToNormalUri()
+  {
+    XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
+    fixture.getSpiedAdaptor().listenToUris(PRIMARY_CLUSTER_NAME);
+
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_URI_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_NODE_MAP), any());
+    verifyUriUpdate(fixture, PRIMARY_CLUSTER_NAME, PRIMARY_CLUSTER_NAME);
+  }
+
+  @Test
+  public void testListenToUriSymlink()
+  {
+    XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
+    fixture.getSpiedAdaptor().listenToUris(SYMLINK_NAME);
+
+    verify(fixture._xdsClient).watchXdsResource(eq(URI_SYMLINK_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_SYMLINK_NODE), any());
+
+    XdsClient.D2SymlinkNodeResourceWatcher symlinkNodeWatcher =
+        (XdsClient.D2SymlinkNodeResourceWatcher) fixture._watcherArgumentCaptor.getValue();
+    symlinkNodeWatcher.onChanged(URI_SYMLINK_RESOURCE_NAME, getSymlinkNodeUpdate(PRIMARY_URI_RESOURCE_NAME));
+
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_URI_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_NODE_MAP), any());
+
+    XdsClient.D2NodeMapResourceWatcher watcher =
+        (XdsClient.D2NodeMapResourceWatcher) fixture._watcherArgumentCaptor.getValue();
+    watcher.onChanged(DUMMY_NODE_MAP_UPDATE);
+
+    verify(fixture._uriEventBus).publishInitialize(SYMLINK_NAME, getDefaultUriProperties(PRIMARY_CLUSTER_NAME));
+
+    // test update symlink to a new primary cluster
+    String primaryUriResourceName2 = URI_NODE_PREFIX + PRIMARY_CLUSTER_NAME_2;
+    symlinkNodeWatcher.onChanged(URI_SYMLINK_RESOURCE_NAME, getSymlinkNodeUpdate(primaryUriResourceName2));
+
+    verify(fixture._xdsClient).watchXdsResource(eq(primaryUriResourceName2), eq(XdsClient.ResourceType.D2_NODE_MAP), any());
+    verifyUriUpdate(fixture, PRIMARY_CLUSTER_NAME_2, SYMLINK_NAME);
+
+    // if the old primary cluster gets an update, it will be published under its original cluster name
+    // since the symlink points to the new primary cluster now.
+    watcher.onChanged(DUMMY_NODE_MAP_UPDATE);
+
+    verify(fixture._uriEventBus).publishInitialize(PRIMARY_CLUSTER_NAME, getDefaultUriProperties(PRIMARY_CLUSTER_NAME));
+  }
+
+  private static Value getProtoStringValue(String v)
+  {
+    return Value.newBuilder().setStringValue(v).build();
+  }
+
+  private static XdsClient.D2SymlinkNodeUpdate getSymlinkNodeUpdate(String primaryClusterResourceName)
+  {
+    return new XdsClient.D2SymlinkNodeUpdate("",
+        XdsD2.D2SymlinkNode.newBuilder()
+            .setMasterClusterNodePath(primaryClusterResourceName)
+            .build()
+    );
+  }
+
+  private static XdsClient.D2NodeUpdate getClusterNodeUpdate(String clusterName)
+  {
+    return new XdsClient.D2NodeUpdate("", XdsD2.D2Node.newBuilder()
+        .setData(Struct.newBuilder().putFields("clusterName", getProtoStringValue(clusterName)))
+        .setStat(XdsD2.Stat.newBuilder().setMzxid(1L).build())
+        .build()
+    );
+  }
+
+  private void verifyClusterNodeUpdate(XdsToD2PropertiesAdaptorFixture fixture, String clusterName, String expectedPublishName,
+      ClusterStoreProperties expectedPublishProp)
+  {
+    XdsClient.D2NodeResourceWatcher watcher = (XdsClient.D2NodeResourceWatcher) fixture._watcherArgumentCaptor.getValue();
+    watcher.onChanged(getClusterNodeUpdate(clusterName));
+    verify(fixture._clusterEventBus).publishInitialize(expectedPublishName, expectedPublishProp);
+  }
+
+  private void verifyUriUpdate(XdsToD2PropertiesAdaptorFixture fixture, String clusterName, String expectedPublishName)
+  {
+    XdsClient.D2NodeMapResourceWatcher watcher = (XdsClient.D2NodeMapResourceWatcher) fixture._watcherArgumentCaptor.getValue();
+    watcher.onChanged(DUMMY_NODE_MAP_UPDATE);
+    verify(fixture._uriEventBus).publishInitialize(expectedPublishName, getDefaultUriProperties(clusterName));
+  }
+
+  private UriProperties getDefaultUriProperties(String clusterName)
+  {
+    return new UriProperties(clusterName, Collections.emptyMap(), Collections.emptyMap(), -1);
+  }
+
+  private static class XdsToD2PropertiesAdaptorFixture
+  {
+    @Mock
+    XdsClient _xdsClient;
+    @Mock
+    ServiceDiscoveryEventEmitter _eventEmitter;
+    @Mock
+    PropertyEventBus<ClusterProperties> _clusterEventBus;
+    @Mock
+    PropertyEventBus<ServiceProperties> _serviceEventBus;
+    @Mock
+    PropertyEventBus<UriProperties> _uriEventBus;
+    @Captor
+    ArgumentCaptor<XdsClient.ResourceWatcher> _watcherArgumentCaptor;
+
+    XdsToD2PropertiesAdaptor _adaptor;
+
+    XdsToD2PropertiesAdaptorFixture()
+    {
+      MockitoAnnotations.initMocks(this);
+      doNothing().when(_xdsClient).watchXdsResource(any(), any(), _watcherArgumentCaptor.capture());
+      doNothing().when(_clusterEventBus).publishInitialize(any(), any());
+      doNothing().when(_serviceEventBus).publishInitialize(any(), any());
+      doNothing().when(_uriEventBus).publishInitialize(any(), any());
+    }
+
+    XdsToD2PropertiesAdaptor getSpiedAdaptor() {
+      _adaptor = spy(new XdsToD2PropertiesAdaptor(_xdsClient, null, _eventEmitter));
+      _adaptor.setClusterEventBus(_clusterEventBus);
+      _adaptor.setServiceEventBus(_serviceEventBus);
+      _adaptor.setUriEventBus(_uriEventBus);
+      return _adaptor;
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.46.4
+version=29.46.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Background 
We need to support D2 symlink (d2 single master/primary feature, [wiki](https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/Multi-Colo+Single+Master+Fast+Failover#MultiColoSingleMasterFastFailover-D2SingleMasterSupport)) in INDIS flow. 

The current ZK flow handles symlinks implicitly in SymlinkAwareZookeeper, which captures the data of a symlink node, immediately get the data of the actual master node, and send the fetched data to the symlink node callback. It can't be shared with INDIS flow.  

For symlink clusters, the event bus subscribers, like "ClusterLoadBalancerSubscriber", "UriLoadBalancerSubscriber" subscribe to the symlinks ($FooClusterMaster), instead of the actual master node (FooCluster-prod-ltx1), we need to publish to event bus under the symlink names.
For other clusters, we need to publish under its original name. Note that these clusters could be either:
1) regular clusters requested normally.
2) clusters that were pointed by a symlink previously, but no longer the case after the symlink points to other clusters.

## Changes
Subscribe to and handle d2 symlink node data in xDSClient and the xDS-to-d2 data adaptor.

## Test Done
build and unit tests.
Verified with Toki qei deployment that the normal service, cluster, and uri nodes can be fetched successfully. 
Will need to test fetching the symlink node with d2-proxy after release (due to SI-34767, the snapshot can't build with d2-proxy).