### PR TITLE
Keep the old convention in publish.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java: [8, 11] # TODO: Add 11 once build issues are resolved
+        java: [8, 11]
     name: Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: 11
+        java: [11]
     name: Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.46.1] - 2023-09-20
+- Keep the old convention (using a variable java of type matrix) in publish.yml
+
 ## [29.46.0] - 2023-09-05
 - Rewrite the Java Doc logic in Java 11 APIs and use multi-release jar to be backward compatible with Java 8 consumers
 
@@ -5530,7 +5533,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.1...master
+[29.46.1]: https://github.com/linkedin/rest.li/compare/v29.46.0...v29.46.1
 [29.46.0]: https://github.com/linkedin/rest.li/compare/v29.45.1...v29.46.0
 [29.45.1]: https://github.com/linkedin/rest.li/compare/v29.45.0...v29.45.1
 [29.45.0]: https://github.com/linkedin/rest.li/compare/v30.0.0...v29.45.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.46.0
+version=29.46.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
To maintain consistency, let's use a variable of type `matrix` in both `build.yml` and `publish.yml`, even though technically we don't need `matrix` in `publish.yml` since we are only using a **single** Java version to publish a RestLi version.