### PR TITLE
add service/cluster-not-found count to simple load balancer jmx. And add entry-out-of-sync count to dual read monitoring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.46.2] - 2023-09-25
+- add service/cluster-not-found count to simple load balancer jmx. And add entry-out-of-sync count to dual read monitoring.
+
 ## [29.46.1] - 2023-09-20
 - Keep the old convention (using a variable java of type matrix) in publish.yml
 
@@ -5533,7 +5536,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.2...master
+[29.46.2]: https://github.com/linkedin/rest.li/compare/v29.46.1...v29.46.2
 [29.46.1]: https://github.com/linkedin/rest.li/compare/v29.46.0...v29.46.1
 [29.46.0]: https://github.com/linkedin/rest.li/compare/v29.45.1...v29.46.0
 [29.45.1]: https://github.com/linkedin/rest.li/compare/v29.45.0...v29.45.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmx.java
@@ -29,6 +29,11 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
   private final AtomicInteger _clusterPropertiesEvictCount = new AtomicInteger();
   private final AtomicInteger _uriPropertiesEvictCount = new AtomicInteger();
 
+  private final AtomicInteger _servicePropertiesOutOfSyncCount = new AtomicInteger();
+  private final AtomicInteger _clusterPropertiesOutOfSyncCount = new AtomicInteger();
+  private final AtomicInteger _uriPropertiesOutOfSyncCount = new AtomicInteger();
+
+
   @Override
   public int getServicePropertiesErrorCount()
   {
@@ -65,6 +70,21 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
     return _uriPropertiesEvictCount.get();
   }
 
+  @Override
+  public int getServicePropertiesOutOfSyncCount() {
+    return _servicePropertiesOutOfSyncCount.get();
+  }
+
+  @Override
+  public int getClusterPropertiesOutOfSyncCount() {
+    return _clusterPropertiesOutOfSyncCount.get();
+  }
+
+  @Override
+  public int getUriPropertiesOutOfSyncCount() {
+    return _uriPropertiesOutOfSyncCount.get();
+  }
+
   public void incrementServicePropertiesErrorCount()
   {
     _servicePropertiesErrorCount.incrementAndGet();
@@ -93,5 +113,35 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
   public void incrementUriPropertiesEvictCount()
   {
     _uriPropertiesEvictCount.incrementAndGet();
+  }
+
+  public void incrementServicePropertiesOutOfSyncCount()
+  {
+    _servicePropertiesOutOfSyncCount.incrementAndGet();
+  }
+
+  public void incrementClusterPropertiesOutOfSyncCount()
+  {
+    _clusterPropertiesOutOfSyncCount.incrementAndGet();
+  }
+
+  public void incrementUriPropertiesOutOfSyncCount()
+  {
+    _uriPropertiesOutOfSyncCount.incrementAndGet();
+  }
+
+  public void decrementServicePropertiesOutOfSyncCount()
+  {
+    _servicePropertiesOutOfSyncCount.decrementAndGet();
+  }
+
+  public void decrementClusterPropertiesOutOfSyncCount()
+  {
+    _clusterPropertiesOutOfSyncCount.decrementAndGet();
+  }
+
+  public void decrementUriPropertiesOutOfSyncCount()
+  {
+    _uriPropertiesOutOfSyncCount.decrementAndGet();
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmxMBean.java
@@ -18,15 +18,28 @@ package com.linkedin.d2.balancer.dualread;
 
 public interface DualReadLoadBalancerJmxMBean
 {
+  // Error count is incremented only when data of the same version is unequal
   int getServicePropertiesErrorCount();
 
   int getClusterPropertiesErrorCount();
 
   int getUriPropertiesErrorCount();
 
+  // Evict count is incremented when cache grows to the max size and entries get evicted.
   int getServicePropertiesEvictCount();
 
   int getClusterPropertiesEvictCount();
 
   int getUriPropertiesEvictCount();
+
+  // Entries become out of sync when:
+  // 1) data of the same version is unequal.
+  // OR. 2) data of a newer version is received in one cache before the other cache receives the older version to compare.
+  // Note that entries in each cache are counted individually.
+  // For example: A1 != A2 is considered as TWO entries being out of sync.
+  int getServicePropertiesOutOfSyncCount();
+
+  int getClusterPropertiesOutOfSyncCount();
+
+  int getUriPropertiesOutOfSyncCount();
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -103,6 +103,8 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
   private final LoadBalancerState _state;
   private final Stats _serviceUnavailableStats;
   private final Stats _serviceAvailableStats;
+  private final Stats _serviceNotFoundStats; // service is not present in service discovery system
+  private final Stats _clusterNotFoundStats; // cluster is not present in service discovery system
   private final long              _timeout;
   private final TimeUnit          _unit;
   private final ScheduledExecutorService _executor;
@@ -137,6 +139,8 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     _state = state;
     _serviceUnavailableStats = serviceUnavailableStats;
     _serviceAvailableStats = serviceAvailableStats;
+    _serviceNotFoundStats = new Stats(1000);
+    _clusterNotFoundStats = new Stats(1000);
     _timeout = timeout;
     _unit = unit;
     _executor = executor;
@@ -149,6 +153,16 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     {
       _failoutConfigProvider = null;
     }
+  }
+
+  public Stats getServiceNotFoundStats()
+  {
+    return _serviceNotFoundStats;
+  }
+
+  public Stats getClusterNotFoundStats()
+  {
+    return _clusterNotFoundStats;
   }
 
   public Stats getServiceUnavailableStats()
@@ -749,6 +763,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
         @Override
         public void onError(Throwable e)
         {
+          _serviceNotFoundStats.inc();
           finalCallback.onError(new ServiceUnavailableException(serviceName, "PEGA_1011. " + e.getMessage(), e));
         }
 
@@ -808,6 +823,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
         @Override
         public void onError(Throwable e)
         {
+          _clusterNotFoundStats.inc();
           finalCallback.onError(new ServiceUnavailableException(clusterName, "PEGA_1011. " + e.getMessage(), e));
         }
 

--- a/d2/src/main/java/com/linkedin/d2/jmx/SimpleLoadBalancerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/SimpleLoadBalancerJmx.java
@@ -40,6 +40,16 @@ public class SimpleLoadBalancerJmx implements SimpleLoadBalancerJmxMBean
   }
 
   @Override
+  public long getServiceNotFoundCount() {
+    return _loadBalancer.getServiceNotFoundStats().getCount();
+  }
+
+  @Override
+  public long getClusterNotFoundCount() {
+    return _loadBalancer.getClusterNotFoundStats().getCount();
+  }
+
+  @Override
   public String toString()
   {
     return "SimpleLoadBalancerJmx [_loadBalancer=" + _loadBalancer + "]";

--- a/d2/src/main/java/com/linkedin/d2/jmx/SimpleLoadBalancerJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/SimpleLoadBalancerJmxMBean.java
@@ -22,5 +22,9 @@ public interface SimpleLoadBalancerJmxMBean
 
   long getClientNotFoundCount();
 
+  long getServiceNotFoundCount();
+
+  long getClusterNotFoundCount();
+
   String toString();
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.46.1
+version=29.46.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Background
We had issues where Observer accidentally deleted all cluster properties, but we weren't able to see that the client is failing to get clusters on any ingraph metric but only via digging into logs.
For dual read, we've been only monitoring when the data is mismatched, but not when data is received on side (like ZK) but not on the other side (like xDS).

## Changes
1. Added service and cluster not found counter to simple load balancer jmx, which gets incremented when timeout happens at fetching the resource.
2. Added entry out-of-sync count to dual read monitoring, which gets incremented when data is either mis-match or received on one side but not on the other (until a new version is received on the first side), and gets decremented when the data matches.