### PR TITLE
Fix ByteBuffer errors to be compatible with Java 8 runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.46.3] - 2023-09-26
+- Fix ByteBuffer errors to be compatible with Java 8 runtimes.
+
 ## [29.46.2] - 2023-09-25
 - add service/cluster-not-found count to simple load balancer jmx. And add entry-out-of-sync count to dual read monitoring.
 
@@ -5536,7 +5539,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.3...master
+[29.46.3]: https://github.com/linkedin/rest.li/compare/v29.46.2...v29.46.3
 [29.46.2]: https://github.com/linkedin/rest.li/compare/v29.46.1...v29.46.2
 [29.46.1]: https://github.com/linkedin/rest.li/compare/v29.46.0...v29.46.1
 [29.46.0]: https://github.com/linkedin/rest.li/compare/v29.45.1...v29.46.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.46.2
+version=29.46.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/li-jersey-uri/src/main/java/com/linkedin/jersey/api/uri/UriComponent.java
+++ b/li-jersey-uri/src/main/java/com/linkedin/jersey/api/uri/UriComponent.java
@@ -73,6 +73,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
+import java.nio.Buffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -831,7 +832,9 @@ public class UriComponent {
         if (bb == null)
             bb = ByteBuffer.allocate(1);
         else
-            bb.clear();
+            // Fix java.lang.NoSuchMethodError: java.nio.ByteBuffer.clear()Ljava/nio/ByteBuffer based on the suggestions from
+            // https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+            ((Buffer)bb).clear();
 
         while (true) {
             // Decode the hex digits
@@ -849,7 +852,9 @@ public class UriComponent {
 
             // Check if the byte buffer needs to be increased in size
             if (bb.position() == bb.capacity()) {
-                bb.flip();
+                // Fix java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer based on the suggestions from
+                // https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+                ((Buffer)bb).flip();
                 // Create a new byte buffer with the maximum number of possible
                 // octets, hence resize should only occur once
                 ByteBuffer bb_new = ByteBuffer.allocate(s.length() / 3);
@@ -857,8 +862,9 @@ public class UriComponent {
                 bb = bb_new;
             }
         }
-
-        bb.flip();
+        // Fix java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer based on the suggestions from
+        // https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip
+        ((Buffer)bb).flip();
         return bb;
     }
 


### PR DESCRIPTION
**Background**

The root cause is that, after compiling ResLi in Java 11, the new Java 11 implementation was preferred over the Java 8 implementation. However, since the new implementation was introduced after Java 8, a NoSuchMethodError occurred for Java 8 consumers. To resolve the issue, we chose an implementation that exists in both Java 8 and Java 11.

**Changes**

This PR will apply the same fix to URIDecoderUtils.java as was done in the prior PR to [URIDecoderUtils.java](https://github.com/linkedin/rest.li/blob/master/restli-common/src/main/java/com/linkedin/restli/internal/common/URIDecoderUtils.java#L204).

**Tests Done**
 
Followed the instructions provided by the team who reported the issue and tested locally using curli command.