### PR TITLE
Fix the remaining ByteBuffer errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.46.4] - 2023-09-27
+- Perform a more extensive search and fix the remaining ByteBuffer errors to be compatible with Java 8 runtimes.
+
 ## [29.46.3] - 2023-09-26
 - Fix ByteBuffer errors to be compatible with Java 8 runtimes.
 
@@ -5539,7 +5542,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.4...master
+[29.46.4]: https://github.com/linkedin/rest.li/compare/v29.46.3...v29.46.4
 [29.46.3]: https://github.com/linkedin/rest.li/compare/v29.46.2...v29.46.3
 [29.46.2]: https://github.com/linkedin/rest.li/compare/v29.46.1...v29.46.2
 [29.46.1]: https://github.com/linkedin/rest.li/compare/v29.46.0...v29.46.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.46.4] - 2023-09-27
-- Perform a more extensive search and fix the remaining ByteBuffer errors to be compatible with Java 8 runtimes.
+- Conduct a more thorough search and fix the remaining ByteBuffer errors to be compatible with Java 8 runtimes.
 
 ## [29.46.3] - 2023-09-26
 - Fix ByteBuffer errors to be compatible with Java 8 runtimes.

--- a/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
@@ -33,6 +33,7 @@ import com.linkedin.data.schema.MapDataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.data.template.DataTemplateUtil;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.AbstractMap;
 import java.util.ArrayDeque;
@@ -292,7 +293,7 @@ public class DataTranslator implements DataTranslatorContext
         case BYTES:
           ByteBuffer byteBuffer = (ByteBuffer) value;
           ByteString byteString = ByteString.copy(byteBuffer);
-          byteBuffer.rewind();
+          ((Buffer)byteBuffer).rewind();
           result = byteString;
           break;
         case ENUM:

--- a/data/src/main/java/com/linkedin/data/codec/BufferChain.java
+++ b/data/src/main/java/com/linkedin/data/codec/BufferChain.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Reader;
+import java.nio.Buffer;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -261,11 +262,11 @@ public class BufferChain
     {
       _currentIndex++;
       _currentBuffer = _bufferList.get(_currentIndex);
-      _currentBuffer.position(0);
+      ((Buffer)_currentBuffer).position(0);
     }
     else
     {
-      _currentBuffer.position(pos._position);
+      ((Buffer)_currentBuffer).position(pos._position);
     }
     return this;
   }
@@ -424,10 +425,10 @@ public class BufferChain
     else
     {
       buffer = _currentBuffer.slice();
-      buffer.limit(length);
-      _currentBuffer.position(_currentBuffer.position() + length);
+      ((Buffer)buffer).limit(length);
+      ((Buffer)_currentBuffer).position(_currentBuffer.position() + length);
     }
-    buffer.flip();
+    ((Buffer)buffer).flip();
     return buffer;
   }
 
@@ -634,7 +635,7 @@ public class BufferChain
 
     ByteBuffer byteBuffer = ByteBuffer.wrap(array, arrayStart, bytesInCurrentBuffer);
     byteBuffer.order(_order);
-    _currentBuffer.position(newPosition);
+    ((Buffer)_currentBuffer).position(newPosition);
     if (bufferList == null)
       bufferList = new ArrayList<>();
     bufferList.add(byteBuffer);
@@ -653,11 +654,11 @@ public class BufferChain
       _decoder.reset();
       CharBuffer charBuffer = CharBuffer.allocate(numBytes); // char should be smaller than # of bytes in buffer.
       int limit = _currentBuffer.limit();
-      _currentBuffer.limit(_currentBuffer.position() + numBytes);
+      ((Buffer)_currentBuffer).limit(_currentBuffer.position() + numBytes);
       checkCoderResult(_decoder.decode(_currentBuffer, charBuffer, true));
-      _currentBuffer.limit(limit);
+      ((Buffer)_currentBuffer).limit(limit);
       _decoder.flush(charBuffer);
-      charBuffer.flip();
+      ((Buffer)charBuffer).flip();
       result = charBuffer.toString();
     }
     else
@@ -947,7 +948,7 @@ public class BufferChain
   {
     if (_currentBuffer.remaining() > 0)
     {
-      _currentBuffer.limit(_currentBuffer.position());
+      ((Buffer)_currentBuffer).limit(_currentBuffer.position());
     }
     rewind();
     int size = 0;
@@ -979,7 +980,7 @@ public class BufferChain
     for (ByteBuffer buffer : _bufferList)
     {
       // out.println("limit " + buffer.limit());
-      buffer.rewind();
+      ((Buffer)buffer).rewind();
       // out.println("limit after rewind " + buffer.limit());
     }
     _currentIndex = 0;
@@ -1015,7 +1016,7 @@ public class BufferChain
       if (bytesRead != -1)
       {
         int newPosition = _currentBuffer.position() + bytesRead;
-        _currentBuffer.position(newPosition);
+        ((Buffer)_currentBuffer).position(newPosition);
       }
       if (bytesRead < remaining)
       {
@@ -1036,7 +1037,7 @@ public class BufferChain
   {
     if (_currentBuffer.remaining() > 0)
     {
-      _currentBuffer.limit(_currentBuffer.position());
+      ((Buffer)_currentBuffer).limit(_currentBuffer.position());
     }
     rewind();
     for (ByteBuffer buffer : _bufferList)
@@ -1235,7 +1236,7 @@ public class BufferChain
   {
     if (_currentBuffer.remaining() < size)
     {
-      _currentBuffer.limit(_currentBuffer.position());
+      ((Buffer)_currentBuffer).limit(_currentBuffer.position());
       _currentBuffer = allocateByteBuffer(size);
       _currentIndex++;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.46.3
+version=29.46.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
**Background**

As a follow-up to the previous [PR](https://github.com/linkedin/rest.li/pull/937), I am conducting a more thorough search for potential ByteBuffer errors in RestLi.

**Changes**

Searched for usages of the following "problematic" methods and cast to Buffer based on suggestions from [stackoverflow](https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip). 

ByteBuffer position(int newPosition)
ByteBuffer limit(int newLimit)
ByteBuffer mark()
ByteBuffer reset()
ByteBuffer clear()
ByteBuffer flip()
ByteBuffer rewind()

**Tests Done**

Followed the instructions provided by the team who reported the issue and tested locally.