### PR TITLE
Fixed race conditions and bugs in xds client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- fix xDS client bugs and race conditions
 
 ## [29.46.6] - 2023-10-04
 - simplify symlink subscription in xds flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.46.7] - 2023-10-10
 - fix xDS client bugs and race conditions
 
 ## [29.46.6] - 2023-10-04
@@ -5549,7 +5551,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.7...master
+[29.46.7]: https://github.com/linkedin/rest.li/compare/v29.46.6...v29.46.7
 [29.46.6]: https://github.com/linkedin/rest.li/compare/v29.46.5...v29.46.6
 [29.46.5]: https://github.com/linkedin/rest.li/compare/v29.45.1...v29.45.2
 [29.46.4]: https://github.com/linkedin/rest.li/compare/v29.46.3...v29.46.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -199,7 +199,9 @@ public class D2ClientBuilder
                   _config.failoutConfigProviderFactory,
                   _config.failoutRedirectStrategy,
                   _config.serviceDiscoveryEventEmitter,
-                  _config.dualReadStateManager
+                  _config.dualReadStateManager,
+                  _config.xdsExecutorService,
+                  _config.xdsStreamReadyTimeout
     );
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
@@ -638,6 +640,19 @@ public class D2ClientBuilder
 
   public D2ClientBuilder setDualReadStateManager(DualReadStateManager dualReadStateManager) {
     _config.dualReadStateManager = dualReadStateManager;
+    return this;
+  }
+
+  /**
+   * Single-threaded executor service for xDS communication.
+   */
+  public D2ClientBuilder setXdsExecutorService(ScheduledExecutorService xdsExecutorService) {
+    _config.xdsExecutorService = xdsExecutorService;
+    return this;
+  }
+
+  public D2ClientBuilder setXdsStreamReadyTimeout(long xdsStreamReadyTimeout) {
+    _config.xdsStreamReadyTimeout = xdsStreamReadyTimeout;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -125,6 +125,9 @@ public class D2ClientConfig
   public ServiceDiscoveryEventEmitter serviceDiscoveryEventEmitter = new LogOnlyServiceDiscoveryEventEmitter(); // default to use log-only emitter
   public DualReadStateManager dualReadStateManager = null;
 
+  public ScheduledExecutorService xdsExecutorService = null;
+  public Long xdsStreamReadyTimeout = null;
+
   public D2ClientConfig()
   {
   }
@@ -190,7 +193,9 @@ public class D2ClientConfig
                  FailoutConfigProviderFactory failoutConfigProviderFactory,
                  FailoutRedirectStrategy failoutRedirectStrategy,
                  ServiceDiscoveryEventEmitter serviceDiscoveryEventEmitter,
-                 DualReadStateManager dualReadStateManager)
+                 DualReadStateManager dualReadStateManager,
+                 ScheduledExecutorService xdsExecutorService,
+                 Long xdsStreamReadyTimeout)
   {
     this.zkHosts = zkHosts;
     this.xdsServer = xdsServer;
@@ -254,5 +259,7 @@ public class D2ClientConfig
     this.failoutRedirectStrategy = failoutRedirectStrategy;
     this.serviceDiscoveryEventEmitter = serviceDiscoveryEventEmitter;
     this.dualReadStateManager = dualReadStateManager;
+    this.xdsExecutorService = xdsExecutorService;
+    this.xdsStreamReadyTimeout = xdsStreamReadyTimeout;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 public class XdsClientImpl extends XdsClient
 {
   private static final Logger _log = LoggerFactory.getLogger(XdsClientImpl.class);
-  private static final long DEFAULT_READY_TIMEOUT_MILLIS = 5000L;
+  private static final long DEFAULT_READY_TIMEOUT_MILLIS = 2000L;
 
   private final Map<String, ResourceSubscriber> _d2NodeSubscribers = new HashMap<>();
   private final Map<String, ResourceSubscriber> _d2SymlinkNodeSubscribers = new HashMap<>();
@@ -70,6 +70,7 @@ public class XdsClientImpl extends XdsClient
   private ScheduledFuture<?> _readyTimeoutFuture;
   private final long _readyTimeoutMillis;
 
+  @Deprecated
   public XdsClientImpl(Node node, ManagedChannel managedChannel, ScheduledExecutorService executorService)
   {
     this(node, managedChannel, executorService, DEFAULT_READY_TIMEOUT_MILLIS);
@@ -82,7 +83,6 @@ public class XdsClientImpl extends XdsClient
     _managedChannel = managedChannel;
     _executorService = executorService;
   }
-
 
   @Override
   void watchXdsResource(String resourceName, ResourceType type, ResourceWatcher watcher)

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 public class XdsClientImpl extends XdsClient
 {
   private static final Logger _log = LoggerFactory.getLogger(XdsClientImpl.class);
-  private static final long DEFAULT_READY_TIMEOUT_MILLIS = 2000L;
+  public static final long DEFAULT_READY_TIMEOUT_MILLIS = 2000L;
 
   private final Map<String, ResourceSubscriber> _d2NodeSubscribers = new HashMap<>();
   private final Map<String, ResourceSubscriber> _d2SymlinkNodeSubscribers = new HashMap<>();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.46.6
+version=29.46.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Summary
--------
Fix three issues:
- `XdsClientImpl` currently fails to detect connection failure to the ADS server. Connection failure leads to no notification to the `StreamObserver` since `onError` and `onCompleted` are terminal notifications. Instead, the `onReady` notification needs to be relied on to detect successful connection establishment.
- There were some race conditions
  - `startRpcStream` public method didn't use the single-threaded executor for execution. It also didn't check for an already existing stream, which could lead to multiple ads streams.
  - It didn't account for backed off client state, when retries are exponentially backed off due to repeat failures. In such cases, stream could still get started due to external method calls.
- Allow passing custom executor for the xDS client for custom monitoring and IC handling.

Testing Done
----------
Built local snapshot and deployed against `toki`. Typically it seems to take **1 sec** for the stream to get ready. Tested against various scenarios:
- Successful connection
- Pinned observer; connection failure on startup.
- Pinned observer; observer crashes while running.
- Pinned observer; observer starts up again.

**Normal state**
```
2023/10/06 14:14:31.752 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream started, connected to server: main.indis-registry-observer.ei-ltx1.atd.disco.linkedin.com:32123
2023/10/06 14:14:31.753 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/clusters/NonExistentCluster
2023/10/06 14:14:31.754 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/clusters/NonExistentCluster]
2023/10/06 14:14:32.739 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream ready, cancelled timeout task: true
2023/10/06 14:14:32.742 INFO [XdsLoadBalancer] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Enabled primary stores
2023/10/06 14:14:46.672 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/services/dataVaultAccessControlList
2023/10/06 14:14:46.673 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/services/dataVaultAccessControlList]
2023/10/06 14:18:57.778 INFO [ClusterLoadBalancerSubscriber] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] getting new ClusterInfoItem for cluster TokiBackend: _clusterProperties = ClusterProperties [_clusterName=TokiBackend, _prioritizedSchemes=[], _properties={}, _bannedUris=[], _partitionProperties=com.linkedin.d2.balancer.properties.NullPartitionProperties@1aa51757, _sslSessionValidationStrings=[toki-restli-backend], _darkClusterConfigMap={darkTokiBackend={multiplier=1.0, dispatcherMaxRequestsToBuffer=1, dispatcherOutboundTargetRate=0.0, darkClusterStrategyList=[RELATIVE_TRAFFIC], transportClientProperties={http.streamingTimeout=30000, http.idleTimeout=30000, http.protocolVersion=HTTP_2, http.maxHeaderSize=16384, http.maxResponseSize=20971520, http.requestTimeout=30000}, dispatcherBufferedRequestExpiryInSeconds=1}}, _delegated=false]
```

**Connection failure on startup (Observer pinned and crashed)**
```
2023/10/06 15:11:24.422 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream started, connected to server: ltx1-app4252.stg.linkedin.com:32123
2023/10/06 15:11:24.424 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/clusters/NonExistentCluster
2023/10/06 15:11:24.426 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/clusters/NonExistentCluster]
2023/10/06 15:11:29.284 WARN [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream not ready within 5000 milliseconds
2023/10/06 15:11:29.286 INFO [XdsLoadBalancer] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Enabled backup stores
2023/10/06 15:13:18.556 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream ready, cancelled timeout task: false
```

**Start observer; immediately the stream becomes ready, and all the pending subscription requests are sent again**
```
2023/10/06 15:13:18.556 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream ready, cancelled timeout task: false
2023/10/06 15:13:18.557 INFO [XdsLoadBalancer] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Enabled primary stores
2023/10/06 15:13:18.560 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/clusters/DataVaultAclService
2023/10/06 15:13:18.561 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/clusters/DataVaultAclService]
2023/10/06 15:13:18.563 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/clusters/TokiBackend
2023/10/06 15:13:18.563 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/clusters/TokiBackend]
2023/10/06 15:13:18.563 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/clusters/LixBackend
2023/10/06 15:13:18.564 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/clusters/LixBackend]
2023/10/06 15:13:18.564 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/clusters/DataVaultChangeMgmt
2023/10/06 15:13:18.565 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/clusters/DataVaultChangeMgmt]
2023/10/06 15:13:18.565 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/services/dataVaultAccessControlList
2023/10/06 15:13:18.565 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/services/dataVaultAccessControlList]
2023/10/06 15:13:18.565 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/services/dataVaultAclChanges
2023/10/06 15:13:18.566 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/services/dataVaultAclChanges]
2023/10/06 15:13:18.568 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/services/lixClientContexts
2023/10/06 15:13:18.568 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/services/lixClientContexts]
2023/10/06 15:13:18.568 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE resource /d2/services/tokiBackend
2023/10/06 15:13:18.568 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/services/tokiBackend]
2023/10/06 15:13:18.569 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE_MAP resource /d2/uris/DataVaultAclService
2023/10/06 15:13:18.569 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE_MAP request for resources: [/d2/uris/DataVaultAclService]
2023/10/06 15:13:18.569 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE_MAP resource /d2/uris/TokiBackend
2023/10/06 15:13:18.570 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE_MAP request for resources: [/d2/uris/TokiBackend]
2023/10/06 15:13:18.570 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE_MAP resource /d2/uris/LixBackend
2023/10/06 15:13:18.570 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE_MAP request for resources: [/d2/uris/LixBackend]
2023/10/06 15:13:18.571 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Subscribe D2_NODE_MAP resource /d2/uris/DataVaultChangeMgmt
2023/10/06 15:13:18.571 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE_MAP request for resources: [/d2/uris/DataVaultChangeMgmt]
``` 

**The local filestore is also updated immediately**
```
[sgupta8@sgupta8-ld2 toki]$ ls -ahl /tmp/d2/indis/uris/TokiBackend.ini
-rw-r--r-- 1 sgupta8 eng 753 Oct  6 15:13 /tmp/d2/indis/uris/TokiBackend.ini
```

**Test Observer crash**
```
2023/10/06 15:16:34.302 ERROR [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream closed with status UNAVAILABLE: Network closed for unknown reason. Cause: null
2023/10/06 15:16:34.302 INFO [XdsLoadBalancer] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Enabled backup stores
2023/10/06 15:16:34.302 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Retry ADS stream in 0 ns
2023/10/06 15:16:34.312 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream started, connected to server: ltx1-app4252.stg.linkedin.com:32123
2023/10/06 15:16:34.313 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE request for resources: [/d2/clusters/DataVaultAclService, /d2/clusters/TokiBackend, /d2/services/dataVaultAclChanges, /d2/clusters/NonExistentCluster, /d2/clusters/LixBackend, /d2/services/tokiBackend, /d2/clusters/DataVaultChangeMgmt, /d2/services/dataVaultAccessControlList, /d2/services/lixClientContexts]
2023/10/06 15:16:34.316 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Sending D2_NODE_MAP request for resources: [/d2/uris/LixBackend, /d2/uris/TokiBackend, /d2/uris/DataVaultChangeMgmt, /d2/uris/DataVaultAclService]
2023/10/06 15:16:39.309 WARN [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream not ready within 5000 milliseconds
```

**Start Observer again after crash**
```
2023/10/06 15:18:23.929 INFO [XdsClientImpl] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] ADS stream ready, cancelled timeout task: false
2023/10/06 15:18:23.930 INFO [XdsLoadBalancer] [D2 xDS PropertyEventExecutor-6-1] [toki-war] [] Enabled primary stores
```

**Filestore is updated again**
```
[sgupta8@sgupta8-ld2 toki]$ ls -ahl /tmp/d2/indis/uris/TokiBackend.ini
-rw-r--r-- 1 sgupta8 eng 753 Oct  6 15:18 /tmp/d2/indis/uris/TokiBackend.ini
```