### PR TITLE
fix dual read data match log

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitor.java
@@ -79,7 +79,7 @@ public abstract class DualReadLoadBalancerMonitor<T>
       if (!isEqual(entry, newEntry))
       {
         _rateLimitedLogger.warn("Received mismatched properties from dual read. Old LB: {}, New LB: {}",
-            entry, newEntry);
+            fromNewLb ? entry : newEntry, fromNewLb ? newEntry : entry);
         incrementEntryOutOfSyncCount(); // increment the out-of-sync count for the entry received later
       }
       else


### PR DESCRIPTION
Fix an error in dual read data match logging. The logging for new LB (xDS) and old LB (ZK) should be flipped depending on which LB's data come in later.
 