### PR TITLE
Use Node instead of D2Node and D2URIMap instead of NodeMap for xDS flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.47.0] - 2023-11-13
+- Use Node(Map) instead of D2node(Map)
+
 ## [29.46.9] - 2023-11-02
 - Update FieldDef so that it will lazily cache the hashCode.
 
@@ -5557,7 +5560,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.46.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.47.0...master
+[29.47.0]: https://github.com/linkedin/rest.li/compare/v29.46.9...v29.47.0
 [29.46.9]: https://github.com/linkedin/rest.li/compare/v29.46.8...v29.46.9
 [29.46.8]: https://github.com/linkedin/rest.li/compare/v29.46.7...v29.46.8
 [29.46.7]: https://github.com/linkedin/rest.li/compare/v29.46.6...v29.46.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.47.0] - 2023-11-13
-- Use Node(Map) instead of D2node(Map)
+- Use Node instead of D2Node and D2URIMap instead of NodeMap for xDS flow
 
 ## [29.46.9] - 2023-11-02
 - Update FieldDef so that it will lazily cache the hashCode.

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.d2.balancer.properties;
 
-import com.google.protobuf.Struct;
+import com.google.protobuf.ByteString;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.util.JacksonUtil;
 import com.linkedin.d2.discovery.PropertyBuilder;
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.linkedin.d2.balancer.properties.util.PropertyUtil.mapGet;
-import static com.linkedin.d2.balancer.properties.util.PropertyUtil.protoStructToMap;
 
 
 /**
@@ -87,11 +86,13 @@ public class ClusterPropertiesJsonSerializer implements
     return clusterProperties;
   }
   
-  public ClusterProperties fromStruct(Struct struct, long version) throws PropertySerializationException
+  public ClusterProperties fromBytes(ByteString bytes, long version) throws PropertySerializationException
   {
     try
     {
-      ClusterProperties clusterProperties = fromMap(protoStructToMap(struct));
+      @SuppressWarnings("unchecked")
+      Map<String, Object> untyped = JacksonUtil.getObjectMapper().readValue(bytes.newInput(), HashMap.class);
+      ClusterProperties clusterProperties = fromMap(untyped);
       clusterProperties.setVersion(version);
       return clusterProperties;
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.balancer.properties;
 
+import com.google.protobuf.ByteString;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.util.JacksonUtil;
 import com.linkedin.d2.discovery.PropertyBuilder;
@@ -79,6 +80,29 @@ public class ClusterPropertiesJsonSerializer implements
 
   @Override
   public ClusterProperties fromBytes(byte[] bytes, long version) throws PropertySerializationException
+  {
+    ClusterProperties clusterProperties = fromBytes(bytes);
+    clusterProperties.setVersion(version);
+    return clusterProperties;
+  }
+  
+  @Override
+  public ClusterProperties fromBytes(ByteString bytes) throws PropertySerializationException
+  {
+    try
+    {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> untyped = JacksonUtil.getObjectMapper().readValue(bytes.newInput(), HashMap.class);
+      return fromMap(untyped);
+    }
+    catch (Exception e)
+    {
+      throw new PropertySerializationException(e);
+    }
+  }
+
+  @Override
+  public ClusterProperties fromBytes(ByteString bytes, long version) throws PropertySerializationException
   {
     ClusterProperties clusterProperties = fromBytes(bytes);
     clusterProperties.setVersion(version);

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.d2.balancer.properties;
 
-import com.google.protobuf.ByteString;
+import com.google.protobuf.Struct;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.util.JacksonUtil;
 import com.linkedin.d2.discovery.PropertyBuilder;
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.linkedin.d2.balancer.properties.util.PropertyUtil.mapGet;
+import static com.linkedin.d2.balancer.properties.util.PropertyUtil.protoStructToMap;
 
 
 /**
@@ -86,27 +87,18 @@ public class ClusterPropertiesJsonSerializer implements
     return clusterProperties;
   }
   
-  @Override
-  public ClusterProperties fromBytes(ByteString bytes) throws PropertySerializationException
+  public ClusterProperties fromStruct(Struct struct, long version) throws PropertySerializationException
   {
     try
     {
-      @SuppressWarnings("unchecked")
-      Map<String, Object> untyped = JacksonUtil.getObjectMapper().readValue(bytes.newInput(), HashMap.class);
-      return fromMap(untyped);
+      ClusterProperties clusterProperties = fromMap(protoStructToMap(struct));
+      clusterProperties.setVersion(version);
+      return clusterProperties;
     }
     catch (Exception e)
     {
       throw new PropertySerializationException(e);
     }
-  }
-
-  @Override
-  public ClusterProperties fromBytes(ByteString bytes, long version) throws PropertySerializationException
-  {
-    ClusterProperties clusterProperties = fromBytes(bytes);
-    clusterProperties.setVersion(version);
-    return clusterProperties;
   }
 
   @SuppressWarnings("unchecked")

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.balancer.properties;
 
 
+import com.google.protobuf.ByteString;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategy;
 import com.linkedin.d2.balancer.util.JacksonUtil;
@@ -196,6 +197,29 @@ public class ServicePropertiesJsonSerializer implements
 
   @Override
   public ServiceProperties fromBytes(byte[] bytes, long version) throws PropertySerializationException
+  {
+    ServiceProperties serviceProperties = fromBytes(bytes);
+    serviceProperties.setVersion(version);
+    return serviceProperties;
+  }
+
+  @Override
+  public ServiceProperties fromBytes(ByteString bytes) throws PropertySerializationException
+  {
+    try
+    {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> untyped = JacksonUtil.getObjectMapper().readValue(bytes.newInput(), Map.class);
+      return fromMap(untyped);
+    }
+    catch (Exception e)
+    {
+      throw new PropertySerializationException(e);
+    }
+  }
+
+  @Override
+  public ServiceProperties fromBytes(ByteString bytes, long version) throws PropertySerializationException
   {
     ServiceProperties serviceProperties = fromBytes(bytes);
     serviceProperties.setVersion(version);

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
@@ -17,7 +17,7 @@
 package com.linkedin.d2.balancer.properties;
 
 
-import com.google.protobuf.ByteString;
+import com.google.protobuf.Struct;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategy;
 import com.linkedin.d2.balancer.util.JacksonUtil;
@@ -38,8 +38,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.d2.balancer.properties.util.PropertyUtil.mapGet;
-import static com.linkedin.d2.balancer.properties.util.PropertyUtil.mapGetOrDefault;
+import static com.linkedin.d2.balancer.properties.util.PropertyUtil.*;
 
 
 /**
@@ -203,27 +202,18 @@ public class ServicePropertiesJsonSerializer implements
     return serviceProperties;
   }
 
-  @Override
-  public ServiceProperties fromBytes(ByteString bytes) throws PropertySerializationException
+  public ServiceProperties fromStruct(Struct struct, long version) throws PropertySerializationException
   {
     try
     {
-      @SuppressWarnings("unchecked")
-      Map<String, Object> untyped = JacksonUtil.getObjectMapper().readValue(bytes.newInput(), Map.class);
-      return fromMap(untyped);
+      ServiceProperties serviceProperties = fromMap(protoStructToMap(struct));
+      serviceProperties.setVersion(version);
+      return serviceProperties;
     }
     catch (Exception e)
     {
       throw new PropertySerializationException(e);
     }
-  }
-
-  @Override
-  public ServiceProperties fromBytes(ByteString bytes, long version) throws PropertySerializationException
-  {
-    ServiceProperties serviceProperties = fromBytes(bytes);
-    serviceProperties.setVersion(version);
-    return serviceProperties;
   }
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
@@ -17,7 +17,7 @@
 package com.linkedin.d2.balancer.properties;
 
 
-import com.google.protobuf.Struct;
+import com.google.protobuf.ByteString;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.subsetting.SubsettingStrategy;
 import com.linkedin.d2.balancer.util.JacksonUtil;
@@ -38,7 +38,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.d2.balancer.properties.util.PropertyUtil.*;
+import static com.linkedin.d2.balancer.properties.util.PropertyUtil.mapGet;
+import static com.linkedin.d2.balancer.properties.util.PropertyUtil.mapGetOrDefault;
 
 
 /**
@@ -202,11 +203,13 @@ public class ServicePropertiesJsonSerializer implements
     return serviceProperties;
   }
 
-  public ServiceProperties fromStruct(Struct struct, long version) throws PropertySerializationException
+  public ServiceProperties fromBytes(ByteString bytes, long version) throws PropertySerializationException
   {
     try
     {
-      ServiceProperties serviceProperties = fromMap(protoStructToMap(struct));
+      @SuppressWarnings("unchecked")
+      Map<String, Object> untyped = JacksonUtil.getObjectMapper().readValue(bytes.newInput(), Map.class);
+      ServiceProperties serviceProperties = fromMap(untyped);
       serviceProperties.setVersion(version);
       return serviceProperties;
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/UriPropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/UriPropertiesJsonSerializer.java
@@ -24,13 +24,12 @@ import com.linkedin.d2.discovery.PropertyBuilder;
 import com.linkedin.d2.discovery.PropertySerializationException;
 import com.linkedin.d2.discovery.PropertySerializer;
 import indis.XdsD2;
-import java.util.Collections;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UriPropertiesJsonSerializer implements PropertySerializer<UriProperties>, PropertyBuilder<UriProperties>
 {
@@ -129,32 +128,6 @@ public class UriPropertiesJsonSerializer implements PropertySerializer<UriProper
           partitions.put(partition.getKey(), new PartitionData(partition.getValue()));
         }
         partitionDesc.put(URI.create(entry.getKey()), partitions);
-      }
-
-
-      Map<URI, Map<Integer, PartitionData>> partitionDescFromWeights = new HashMap<>(uri.getWeightsCount());
-      for (Map.Entry<String, Double> entry : uri.getWeightsMap().entrySet())
-      {
-        partitionDescFromWeights.put(URI.create(entry.getKey()), Collections.singletonMap(
-            DefaultPartitionAccessor.DEFAULT_PARTITION_ID,
-            new PartitionData(entry.getValue())
-        ));
-      }
-
-      // if both partitionDesc and weights exist, check consistency
-      if (!partitionDesc.isEmpty() && !partitionDescFromWeights.isEmpty())
-      {
-        if (!partitionDesc.equals(partitionDescFromWeights))
-        {
-          _log.error("Inconsistency detected between partitionDesc and weights {} {}",
-              partitionDesc, partitionDescFromWeights);
-        }
-      }
-
-      // always trust partitionDesc over weights
-      if (partitionDesc.isEmpty())
-      {
-        partitionDesc = partitionDescFromWeights;
       }
 
       return new UriProperties(

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/UriPropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/UriPropertiesJsonSerializer.java
@@ -16,18 +16,18 @@
 
 package com.linkedin.d2.balancer.properties;
 
-
+import com.google.protobuf.ByteString;
 import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.util.JacksonUtil;
 import com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor;
 import com.linkedin.d2.discovery.PropertyBuilder;
 import com.linkedin.d2.discovery.PropertySerializationException;
 import com.linkedin.d2.discovery.PropertySerializer;
-import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -103,6 +103,29 @@ public class UriPropertiesJsonSerializer implements PropertySerializer<UriProper
 
   @Override
   public UriProperties fromBytes(byte[] bytes, long version) throws PropertySerializationException
+  {
+    UriProperties uriProperties = fromBytes(bytes);
+    uriProperties.setVersion(version);
+    return uriProperties;
+  }
+
+  @Override
+  public UriProperties fromBytes(ByteString bytes) throws PropertySerializationException
+  {
+    try
+    {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> untyped = JacksonUtil.getObjectMapper().readValue(bytes.newInput(), HashMap.class);
+      return fromMap(untyped);
+    }
+    catch (Exception e)
+    {
+      throw new PropertySerializationException(e);
+    }
+  }
+
+  @Override
+  public UriProperties fromBytes(ByteString bytes, long version) throws PropertySerializationException
   {
     UriProperties uriProperties = fromBytes(bytes);
     uriProperties.setVersion(version);

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/util/PropertyUtil.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/util/PropertyUtil.java
@@ -20,6 +20,7 @@ import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.linkedin.util.ArgumentUtil;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -162,6 +163,9 @@ public class PropertyUtil
    */
   public static Map<String, Object> protoStructToMap(Struct struct)
   {
+    if (struct.getFieldsCount() == 0) {
+      return Collections.emptyMap();
+    }
     Map<String, Object> map = new HashMap<>(struct.getFieldsMap().size());
     for (Map.Entry<String, Value> entry : struct.getFieldsMap().entrySet())
     {

--- a/d2/src/main/java/com/linkedin/d2/discovery/PropertySerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/PropertySerializer.java
@@ -16,9 +16,6 @@
 
 package com.linkedin.d2.discovery;
 
-import com.google.protobuf.ByteString;
-
-
 public interface PropertySerializer<T>
 {
   byte[] toBytes(T property);
@@ -26,19 +23,6 @@ public interface PropertySerializer<T>
   T fromBytes(byte[] bytes) throws PropertySerializationException;
 
   default T fromBytes(byte[] bytes, long version) throws PropertySerializationException
-  {
-    return fromBytes(bytes);
-  }
-
-  default T fromBytes(ByteString bytes) throws PropertySerializationException
-  {
-    // This default implementation provides no benefit over calling fromByte(byte[]) as it creates a copy of the
-    // underlying byte array. More efficient implementations should use ByteString#newInput to read the underlying
-    // buffer without copying it.
-    return fromBytes(bytes.toByteArray());
-  }
-
-  default T fromBytes(ByteString bytes, long version) throws PropertySerializationException
   {
     return fromBytes(bytes);
   }

--- a/d2/src/main/java/com/linkedin/d2/discovery/PropertySerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/PropertySerializer.java
@@ -16,6 +16,9 @@
 
 package com.linkedin.d2.discovery;
 
+import com.google.protobuf.ByteString;
+
+
 public interface PropertySerializer<T>
 {
   byte[] toBytes(T property);
@@ -23,6 +26,19 @@ public interface PropertySerializer<T>
   T fromBytes(byte[] bytes) throws PropertySerializationException;
 
   default T fromBytes(byte[] bytes, long version) throws PropertySerializationException
+  {
+    return fromBytes(bytes);
+  }
+
+  default T fromBytes(ByteString bytes) throws PropertySerializationException
+  {
+    // This default implementation provides no benefit over calling fromByte(byte[]) as it creates a copy of the
+    // underlying byte array. More efficient implementations should use ByteString#newInput to read the underlying
+    // buffer without copying it.
+    return fromBytes(bytes.toByteArray());
+  }
+
+  default T fromBytes(ByteString bytes, long version) throws PropertySerializationException
   {
     return fromBytes(bytes);
   }

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/SymlinkAwareZooKeeper.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/SymlinkAwareZooKeeper.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.d2.discovery.stores.zk;
 
-import com.google.protobuf.ByteString;
 import com.linkedin.d2.discovery.PropertySerializationException;
 import com.linkedin.d2.discovery.PropertySerializer;
 import org.apache.zookeeper.AsyncCallback;
@@ -595,19 +594,6 @@ public class SymlinkAwareZooKeeper extends AbstractZooKeeper
       try
       {
         return new String(bytes, "UTF-8");
-      }
-      catch (UnsupportedEncodingException e)
-      {
-        throw new PropertySerializationException(e);
-      }
-    }
-
-    @Override
-    public String fromBytes(ByteString bytes) throws PropertySerializationException
-    {
-      try
-      {
-        return bytes.toString("UTF-8");
       }
       catch (UnsupportedEncodingException e)
       {

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/SymlinkAwareZooKeeper.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/SymlinkAwareZooKeeper.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.discovery.stores.zk;
 
+import com.google.protobuf.ByteString;
 import com.linkedin.d2.discovery.PropertySerializationException;
 import com.linkedin.d2.discovery.PropertySerializer;
 import org.apache.zookeeper.AsyncCallback;
@@ -594,6 +595,19 @@ public class SymlinkAwareZooKeeper extends AbstractZooKeeper
       try
       {
         return new String(bytes, "UTF-8");
+      }
+      catch (UnsupportedEncodingException e)
+      {
+        throw new PropertySerializationException(e);
+      }
+    }
+
+    @Override
+    public String fromBytes(ByteString bytes) throws PropertySerializationException
+    {
+      try
+      {
+        return bytes.toString("UTF-8");
       }
       catch (UnsupportedEncodingException e)
       {

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/SymlinkAwareZooKeeper.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/SymlinkAwareZooKeeper.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.discovery.stores.zk;
 
+import com.google.protobuf.ByteString;
 import com.linkedin.d2.discovery.PropertySerializationException;
 import com.linkedin.d2.discovery.PropertySerializer;
 import org.apache.zookeeper.AsyncCallback;
@@ -594,6 +595,18 @@ public class SymlinkAwareZooKeeper extends AbstractZooKeeper
       try
       {
         return new String(bytes, "UTF-8");
+      }
+      catch (UnsupportedEncodingException e)
+      {
+        throw new PropertySerializationException(e);
+      }
+    }
+
+    public String fromBytes(ByteString bytes) throws PropertySerializationException
+    {
+      try
+      {
+        return bytes.toString("UTF-8");
       }
       catch (UnsupportedEncodingException e)
       {

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -24,8 +24,9 @@ import java.util.Map;
 
 public abstract class XdsClient
 {
-  private static final String NODE_TYPE_URL = "type.googleapis.com/indis.Node";
-  private static final String NODE_MAP_TYPE_URL = "type.googleapis.com/indis.NodeMap";
+  private static final String D2_NODE_TYPE_URL = "type.googleapis.com/indis.D2Node";
+  private static final String D2_SYMLINK_NODE_TYPE_URL = "type.googleapis.com/indis.D2SymlinkNode";
+  private static final String D2_URI_MAP_TYPE_URL = "type.googleapis.com/indis.D2URIMap";
 
   interface ResourceWatcher
   {
@@ -40,19 +41,19 @@ public abstract class XdsClient
     void onReconnect();
   }
 
-  interface NodeResourceWatcher extends ResourceWatcher
+  interface D2NodeResourceWatcher extends ResourceWatcher
   {
-    void onChanged(NodeUpdate update);
+    void onChanged(D2NodeUpdate update);
   }
 
-  interface SymlinkNodeResourceWatcher extends ResourceWatcher
+  interface D2SymlinkNodeResourceWatcher extends ResourceWatcher
   {
-    void onChanged(String resourceName, NodeUpdate update);
+    void onChanged(String resourceName, D2SymlinkNodeUpdate update);
   }
 
-  interface NodeMapResourceWatcher extends ResourceWatcher
+  interface D2URIMapResourceWatcher extends ResourceWatcher
   {
-    void onChanged(NodeMapUpdate update);
+    void onChanged(D2URIMapUpdate update);
   }
 
   interface ResourceUpdate
@@ -60,18 +61,18 @@ public abstract class XdsClient
   }
 
 
-  static final class NodeUpdate implements ResourceUpdate
+  static final class D2NodeUpdate implements ResourceUpdate
   {
     String _version;
-    XdsD2.Node _nodeData;
+    XdsD2.D2Node _nodeData;
 
-    NodeUpdate(String version, XdsD2.Node nodeData)
+    D2NodeUpdate(String version, XdsD2.D2Node nodeData)
     {
       _version = version;
       _nodeData = nodeData;
     }
 
-    XdsD2.Node getNodeData()
+    XdsD2.D2Node getNodeData()
     {
       return _nodeData;
     }
@@ -82,18 +83,40 @@ public abstract class XdsClient
     }
   }
 
-  static final class NodeMapUpdate implements ResourceUpdate
+  static final class D2SymlinkNodeUpdate implements ResourceUpdate
   {
     String _version;
-    Map<String, XdsD2.Node> _nodeDataMap;
+    XdsD2.D2SymlinkNode _nodeData;
 
-    NodeMapUpdate(String version, Map<String, XdsD2.Node> nodeDataMap)
+    D2SymlinkNodeUpdate(String version, XdsD2.D2SymlinkNode nodeData)
+    {
+      _version = version;
+      _nodeData = nodeData;
+    }
+
+    XdsD2.D2SymlinkNode getNodeData()
+    {
+      return _nodeData;
+    }
+
+    public String getVersion()
+    {
+      return _version;
+    }
+  }
+
+  static final class D2URIMapUpdate implements ResourceUpdate
+  {
+    String _version;
+    Map<String, XdsD2.D2URI> _nodeDataMap;
+
+    D2URIMapUpdate(String version, Map<String, XdsD2.D2URI> nodeDataMap)
     {
       _version = version;
       _nodeDataMap = nodeDataMap;
     }
 
-    public Map<String, XdsD2.Node> getNodeDataMap()
+    public Map<String, XdsD2.D2URI> getURIMap()
     {
       return _nodeDataMap;
     }
@@ -106,17 +129,21 @@ public abstract class XdsClient
 
   enum ResourceType
   {
-    UNKNOWN, NODE, NODE_MAP;
+    UNKNOWN, D2_NODE, D2_SYMLINK_NODE, D2_URI_MAP;
 
     static ResourceType fromTypeUrl(String typeUrl)
     {
-      if (typeUrl.equals(NODE_TYPE_URL))
+      if (typeUrl.equals(D2_NODE_TYPE_URL))
       {
-        return NODE;
+        return D2_NODE;
       }
-      if (typeUrl.equals(NODE_MAP_TYPE_URL))
+      if (typeUrl.equals(D2_SYMLINK_NODE_TYPE_URL))
       {
-        return NODE_MAP;
+        return D2_SYMLINK_NODE;
+      }
+      if (typeUrl.equals(D2_URI_MAP_TYPE_URL))
+      {
+        return D2_URI_MAP;
       }
       return UNKNOWN;
     }
@@ -125,10 +152,12 @@ public abstract class XdsClient
     {
       switch (this)
       {
-        case NODE:
-          return NODE_TYPE_URL;
-        case NODE_MAP:
-          return NODE_MAP_TYPE_URL;
+        case D2_NODE:
+          return D2_NODE_TYPE_URL;
+        case D2_SYMLINK_NODE:
+          return D2_SYMLINK_NODE_TYPE_URL;
+        case D2_URI_MAP:
+          return D2_URI_MAP_TYPE_URL;
         case UNKNOWN:
         default:
           throw new AssertionError("Unknown or missing case in enum switch: " + this);

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -24,9 +24,8 @@ import java.util.Map;
 
 public abstract class XdsClient
 {
-  private static final String D2_NODE_TYPE_URL = "type.googleapis.com/indis.D2Node";
-  private static final String D2_SYMLINK_NODE_TYPE_URL = "type.googleapis.com/indis.D2SymlinkNode";
-  private static final String D2_NODE_MAP_TYPE_URL = "type.googleapis.com/indis.D2NodeMap";
+  private static final String NODE_TYPE_URL = "type.googleapis.com/indis.Node";
+  private static final String NODE_MAP_TYPE_URL = "type.googleapis.com/indis.NodeMap";
 
   interface ResourceWatcher
   {
@@ -41,19 +40,19 @@ public abstract class XdsClient
     void onReconnect();
   }
 
-  interface D2NodeResourceWatcher extends ResourceWatcher
+  interface NodeResourceWatcher extends ResourceWatcher
   {
-    void onChanged(D2NodeUpdate update);
+    void onChanged(NodeUpdate update);
   }
 
-  interface D2SymlinkNodeResourceWatcher extends ResourceWatcher
+  interface SymlinkNodeResourceWatcher extends ResourceWatcher
   {
-    void onChanged(String resourceName, D2SymlinkNodeUpdate update);
+    void onChanged(String resourceName, NodeUpdate update);
   }
 
-  interface D2NodeMapResourceWatcher extends ResourceWatcher
+  interface NodeMapResourceWatcher extends ResourceWatcher
   {
-    void onChanged(D2NodeMapUpdate update);
+    void onChanged(NodeMapUpdate update);
   }
 
   interface ResourceUpdate
@@ -61,18 +60,18 @@ public abstract class XdsClient
   }
 
 
-  static final class D2NodeUpdate implements ResourceUpdate
+  static final class NodeUpdate implements ResourceUpdate
   {
     String _version;
-    XdsD2.D2Node _nodeData;
+    XdsD2.Node _nodeData;
 
-    D2NodeUpdate(String version, XdsD2.D2Node nodeData)
+    NodeUpdate(String version, XdsD2.Node nodeData)
     {
       _version = version;
       _nodeData = nodeData;
     }
 
-    XdsD2.D2Node getNodeData()
+    XdsD2.Node getNodeData()
     {
       return _nodeData;
     }
@@ -83,40 +82,18 @@ public abstract class XdsClient
     }
   }
 
-  static final class D2SymlinkNodeUpdate implements ResourceUpdate
+  static final class NodeMapUpdate implements ResourceUpdate
   {
     String _version;
-    XdsD2.D2SymlinkNode _nodeData;
+    Map<String, XdsD2.Node> _nodeDataMap;
 
-    D2SymlinkNodeUpdate(String version, XdsD2.D2SymlinkNode nodeData)
-    {
-      _version = version;
-      _nodeData = nodeData;
-    }
-
-    XdsD2.D2SymlinkNode getNodeData()
-    {
-      return _nodeData;
-    }
-
-    public String getVersion()
-    {
-      return _version;
-    }
-  }
-
-  static final class D2NodeMapUpdate implements ResourceUpdate
-  {
-    String _version;
-    Map<String, XdsD2.D2Node> _nodeDataMap;
-
-    D2NodeMapUpdate(String version, Map<String, XdsD2.D2Node> nodeDataMap)
+    NodeMapUpdate(String version, Map<String, XdsD2.Node> nodeDataMap)
     {
       _version = version;
       _nodeDataMap = nodeDataMap;
     }
 
-    public Map<String, XdsD2.D2Node> getNodeDataMap()
+    public Map<String, XdsD2.Node> getNodeDataMap()
     {
       return _nodeDataMap;
     }
@@ -129,21 +106,17 @@ public abstract class XdsClient
 
   enum ResourceType
   {
-    UNKNOWN, D2_NODE, D2_SYMLINK_NODE, D2_NODE_MAP;
+    UNKNOWN, NODE, NODE_MAP;
 
     static ResourceType fromTypeUrl(String typeUrl)
     {
-      if (typeUrl.equals(D2_NODE_TYPE_URL))
+      if (typeUrl.equals(NODE_TYPE_URL))
       {
-        return D2_NODE;
+        return NODE;
       }
-      if (typeUrl.equals(D2_SYMLINK_NODE_TYPE_URL))
+      if (typeUrl.equals(NODE_MAP_TYPE_URL))
       {
-        return D2_SYMLINK_NODE;
-      }
-      if (typeUrl.equals(D2_NODE_MAP_TYPE_URL))
-      {
-        return D2_NODE_MAP;
+        return NODE_MAP;
       }
       return UNKNOWN;
     }
@@ -152,12 +125,10 @@ public abstract class XdsClient
     {
       switch (this)
       {
-        case D2_NODE:
-          return D2_NODE_TYPE_URL;
-        case D2_SYMLINK_NODE:
-          return D2_SYMLINK_NODE_TYPE_URL;
-        case D2_NODE_MAP:
-          return D2_NODE_MAP_TYPE_URL;
+        case NODE:
+          return NODE_TYPE_URL;
+        case NODE_MAP:
+          return NODE_MAP_TYPE_URL;
         case UNKNOWN:
         default:
           throw new AssertionError("Unknown or missing case in enum switch: " + this);

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -24,8 +24,7 @@ import java.util.Map;
 
 public abstract class XdsClient
 {
-  private static final String D2_NODE_TYPE_URL = "type.googleapis.com/indis.D2Node";
-  private static final String D2_SYMLINK_NODE_TYPE_URL = "type.googleapis.com/indis.D2SymlinkNode";
+  private static final String NODE_TYPE_URL = "type.googleapis.com/indis.Node";
   private static final String D2_URI_MAP_TYPE_URL = "type.googleapis.com/indis.D2URIMap";
 
   interface ResourceWatcher
@@ -41,14 +40,14 @@ public abstract class XdsClient
     void onReconnect();
   }
 
-  interface D2NodeResourceWatcher extends ResourceWatcher
+  interface NodeResourceWatcher extends ResourceWatcher
   {
-    void onChanged(D2NodeUpdate update);
+    void onChanged(NodeUpdate update);
   }
 
-  interface D2SymlinkNodeResourceWatcher extends ResourceWatcher
+  interface SymlinkNodeResourceWatcher extends ResourceWatcher
   {
-    void onChanged(String resourceName, D2SymlinkNodeUpdate update);
+    void onChanged(String resourceName, NodeUpdate update);
   }
 
   interface D2URIMapResourceWatcher extends ResourceWatcher
@@ -61,40 +60,18 @@ public abstract class XdsClient
   }
 
 
-  static final class D2NodeUpdate implements ResourceUpdate
+  static final class NodeUpdate implements ResourceUpdate
   {
     String _version;
-    XdsD2.D2Node _nodeData;
+    XdsD2.Node _nodeData;
 
-    D2NodeUpdate(String version, XdsD2.D2Node nodeData)
+    NodeUpdate(String version, XdsD2.Node nodeData)
     {
       _version = version;
       _nodeData = nodeData;
     }
 
-    XdsD2.D2Node getNodeData()
-    {
-      return _nodeData;
-    }
-
-    public String getVersion()
-    {
-      return _version;
-    }
-  }
-
-  static final class D2SymlinkNodeUpdate implements ResourceUpdate
-  {
-    String _version;
-    XdsD2.D2SymlinkNode _nodeData;
-
-    D2SymlinkNodeUpdate(String version, XdsD2.D2SymlinkNode nodeData)
-    {
-      _version = version;
-      _nodeData = nodeData;
-    }
-
-    XdsD2.D2SymlinkNode getNodeData()
+    XdsD2.Node getNodeData()
     {
       return _nodeData;
     }
@@ -108,17 +85,17 @@ public abstract class XdsClient
   static final class D2URIMapUpdate implements ResourceUpdate
   {
     String _version;
-    Map<String, XdsD2.D2URI> _nodeDataMap;
+    Map<String, XdsD2.D2URI> _uriMap;
 
-    D2URIMapUpdate(String version, Map<String, XdsD2.D2URI> nodeDataMap)
+    D2URIMapUpdate(String version, Map<String, XdsD2.D2URI> uriMap)
     {
       _version = version;
-      _nodeDataMap = nodeDataMap;
+      _uriMap = uriMap;
     }
 
     public Map<String, XdsD2.D2URI> getURIMap()
     {
-      return _nodeDataMap;
+      return _uriMap;
     }
 
     public String getVersion()
@@ -129,17 +106,13 @@ public abstract class XdsClient
 
   enum ResourceType
   {
-    UNKNOWN, D2_NODE, D2_SYMLINK_NODE, D2_URI_MAP;
+    UNKNOWN, NODE, D2_URI_MAP;
 
     static ResourceType fromTypeUrl(String typeUrl)
     {
-      if (typeUrl.equals(D2_NODE_TYPE_URL))
+      if (typeUrl.equals(NODE_TYPE_URL))
       {
-        return D2_NODE;
-      }
-      if (typeUrl.equals(D2_SYMLINK_NODE_TYPE_URL))
-      {
-        return D2_SYMLINK_NODE;
+        return NODE;
       }
       if (typeUrl.equals(D2_URI_MAP_TYPE_URL))
       {
@@ -152,10 +125,8 @@ public abstract class XdsClient
     {
       switch (this)
       {
-        case D2_NODE:
-          return D2_NODE_TYPE_URL;
-        case D2_SYMLINK_NODE:
-          return D2_SYMLINK_NODE_TYPE_URL;
+        case NODE:
+          return NODE_TYPE_URL;
         case D2_URI_MAP:
           return D2_URI_MAP_TYPE_URL;
         case UNKNOWN:

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -56,7 +56,6 @@ public class XdsClientImpl extends XdsClient
   public static final long DEFAULT_READY_TIMEOUT_MILLIS = 2000L;
 
   private final Map<String, ResourceSubscriber> _d2NodeSubscribers = new HashMap<>();
-  private final Map<String, ResourceSubscriber> _d2SymlinkNodeSubscribers = new HashMap<>();
   private final Map<String, ResourceSubscriber> _d2NodeMapSubscribers = new HashMap<>();
 
   private final Node _node;
@@ -214,7 +213,7 @@ public class XdsClientImpl extends XdsClient
 
   private void handleD2NodeResponse(DiscoveryResponseData data)
   {
-    Map<String, D2NodeUpdate> updates = new HashMap<>();
+    Map<String, NodeUpdate> updates = new HashMap<>();
     List<String> errors = new ArrayList<>();
 
     for (Resource resource: data.getResourcesList())
@@ -222,8 +221,8 @@ public class XdsClientImpl extends XdsClient
       String resourceName = resource.getName();
       try
       {
-        XdsD2.D2Node d2Node = resource.getResource().unpack(XdsD2.D2Node.class);
-        updates.put(resourceName, new D2NodeUpdate(resource.getVersion(), d2Node));
+        XdsD2.Node d2Node = resource.getResource().unpack(XdsD2.Node.class);
+        updates.put(resourceName, new NodeUpdate(resource.getVersion(), d2Node));
       } catch (InvalidProtocolBufferException e)
       {
         _log.warn("Failed to unpack D2Node response", e);
@@ -234,31 +233,9 @@ public class XdsClientImpl extends XdsClient
     handleResourceUpdate(updates, data.getResourceType(), data.getNonce(), errors);
   }
 
-  private void handleD2SymlinkNodeResponse(DiscoveryResponseData data)
-  {
-    Map<String, D2SymlinkNodeUpdate> updates = new HashMap<>();
-    List<String> errors = new ArrayList<>();
-
-    for (Resource resource: data.getResourcesList())
-    {
-      String resourceName = resource.getName();
-      try
-      {
-        XdsD2.D2SymlinkNode symlinkNode = resource.getResource().unpack(XdsD2.D2SymlinkNode.class);
-        updates.put(resourceName, new D2SymlinkNodeUpdate(resource.getVersion(), symlinkNode));
-      } catch (InvalidProtocolBufferException e)
-      {
-        _log.warn("Failed to unpack D2SymlinkNode response", e);
-        errors.add("Failed to unpack D2SymlinkNode response");
-      }
-    }
-
-    handleResourceUpdate(updates, data.getResourceType(), data.getNonce(), errors);
-  }
-
   private void handleD2NodeMapResponse(DiscoveryResponseData data)
   {
-    Map<String, D2NodeMapUpdate> updates = new HashMap<>();
+    Map<String, NodeMapUpdate> updates = new HashMap<>();
     List<String> errors = new ArrayList<>();
 
     for (Resource resource: data.getResourcesList())
@@ -266,9 +243,9 @@ public class XdsClientImpl extends XdsClient
       String resourceName = resource.getName();
       try
       {
-        XdsD2.D2NodeMap d2NodeMap = resource.getResource().unpack(XdsD2.D2NodeMap.class);
-        Map<String, XdsD2.D2Node> nodeData = d2NodeMap.getNodesMap();
-        updates.put(resourceName, new D2NodeMapUpdate(resource.getVersion(), nodeData));
+        XdsD2.NodeMap nodeMap = resource.getResource().unpack(XdsD2.NodeMap.class);
+        Map<String, XdsD2.Node> nodeData = nodeMap.getNodesMap();
+        updates.put(resourceName, new NodeMapUpdate(resource.getVersion(), nodeData));
       } catch (InvalidProtocolBufferException e)
       {
         _log.warn("Failed to unpack D2NodeMap response", e);
@@ -325,11 +302,9 @@ public class XdsClientImpl extends XdsClient
   {
     switch (type)
     {
-      case D2_NODE:
+      case NODE:
         return _d2NodeSubscribers;
-      case D2_SYMLINK_NODE:
-        return _d2SymlinkNodeSubscribers;
-      case D2_NODE_MAP:
+      case NODE_MAP:
         return _d2NodeMapSubscribers;
       case UNKNOWN:
       default:
@@ -369,14 +344,15 @@ public class XdsClientImpl extends XdsClient
     {
       switch (_type)
       {
-        case D2_NODE:
-          ((D2NodeResourceWatcher) watcher).onChanged((D2NodeUpdate) update);
+        case NODE:
+          if (watcher instanceof  NodeResourceWatcher) {
+            ((NodeResourceWatcher) watcher).onChanged((NodeUpdate) update);
+          } else {
+            ((SymlinkNodeResourceWatcher) watcher).onChanged(_resource, (NodeUpdate) update);
+          }
           break;
-        case D2_SYMLINK_NODE:
-          ((D2SymlinkNodeResourceWatcher) watcher).onChanged(_resource, (D2SymlinkNodeUpdate) update);
-          break;
-        case D2_NODE_MAP:
-          ((D2NodeMapResourceWatcher) watcher).onChanged((D2NodeMapUpdate) update);
+        case NODE_MAP:
+          ((NodeMapResourceWatcher) watcher).onChanged((NodeMapUpdate) update);
           break;
         case UNKNOWN:
         default:
@@ -643,13 +619,10 @@ public class XdsClientImpl extends XdsClient
       ResourceType resourceType = response.getResourceType();
       switch (resourceType)
       {
-        case D2_NODE:
+        case NODE:
           handleD2NodeResponse(response);
           break;
-        case D2_SYMLINK_NODE:
-          handleD2SymlinkNodeResponse(response);
-          break;
-        case D2_NODE_MAP:
+        case NODE_MAP:
           handleD2NodeMapResponse(response);
           break;
         case UNKNOWN:

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -267,7 +267,7 @@ public class XdsClientImpl extends XdsClient
       try
       {
         XdsD2.D2URIMap uriMap = resource.getResource().unpack(XdsD2.D2URIMap.class);
-        Map<String, XdsD2.D2URI> nodeData = uriMap.getNodesMap();
+        Map<String, XdsD2.D2URI> nodeData = uriMap.getUrisMap();
         updates.put(resourceName, new D2URIMapUpdate(resource.getVersion(), nodeData));
       } catch (InvalidProtocolBufferException e)
       {

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -56,7 +56,8 @@ public class XdsClientImpl extends XdsClient
   public static final long DEFAULT_READY_TIMEOUT_MILLIS = 2000L;
 
   private final Map<String, ResourceSubscriber> _d2NodeSubscribers = new HashMap<>();
-  private final Map<String, ResourceSubscriber> _d2NodeMapSubscribers = new HashMap<>();
+  private final Map<String, ResourceSubscriber> _d2SymlinkNodeSubscribers = new HashMap<>();
+  private final Map<String, ResourceSubscriber> _d2URIMapSubscribers = new HashMap<>();
 
   private final Node _node;
   private final ManagedChannel _managedChannel;
@@ -213,7 +214,7 @@ public class XdsClientImpl extends XdsClient
 
   private void handleD2NodeResponse(DiscoveryResponseData data)
   {
-    Map<String, NodeUpdate> updates = new HashMap<>();
+    Map<String, D2NodeUpdate> updates = new HashMap<>();
     List<String> errors = new ArrayList<>();
 
     for (Resource resource: data.getResourcesList())
@@ -221,8 +222,8 @@ public class XdsClientImpl extends XdsClient
       String resourceName = resource.getName();
       try
       {
-        XdsD2.Node d2Node = resource.getResource().unpack(XdsD2.Node.class);
-        updates.put(resourceName, new NodeUpdate(resource.getVersion(), d2Node));
+        XdsD2.D2Node d2Node = resource.getResource().unpack(XdsD2.D2Node.class);
+        updates.put(resourceName, new D2NodeUpdate(resource.getVersion(), d2Node));
       } catch (InvalidProtocolBufferException e)
       {
         _log.warn("Failed to unpack D2Node response", e);
@@ -233,9 +234,9 @@ public class XdsClientImpl extends XdsClient
     handleResourceUpdate(updates, data.getResourceType(), data.getNonce(), errors);
   }
 
-  private void handleD2NodeMapResponse(DiscoveryResponseData data)
+  private void handleD2SymlinkNodeResponse(DiscoveryResponseData data)
   {
-    Map<String, NodeMapUpdate> updates = new HashMap<>();
+    Map<String, D2SymlinkNodeUpdate> updates = new HashMap<>();
     List<String> errors = new ArrayList<>();
 
     for (Resource resource: data.getResourcesList())
@@ -243,9 +244,31 @@ public class XdsClientImpl extends XdsClient
       String resourceName = resource.getName();
       try
       {
-        XdsD2.NodeMap nodeMap = resource.getResource().unpack(XdsD2.NodeMap.class);
-        Map<String, XdsD2.Node> nodeData = nodeMap.getNodesMap();
-        updates.put(resourceName, new NodeMapUpdate(resource.getVersion(), nodeData));
+        XdsD2.D2SymlinkNode symlinkNode = resource.getResource().unpack(XdsD2.D2SymlinkNode.class);
+        updates.put(resourceName, new D2SymlinkNodeUpdate(resource.getVersion(), symlinkNode));
+      } catch (InvalidProtocolBufferException e)
+      {
+        _log.warn("Failed to unpack D2SymlinkNode response", e);
+        errors.add("Failed to unpack D2SymlinkNode response");
+      }
+    }
+
+    handleResourceUpdate(updates, data.getResourceType(), data.getNonce(), errors);
+  }
+
+  private void handleD2URIMapResponse(DiscoveryResponseData data)
+  {
+    Map<String, D2URIMapUpdate> updates = new HashMap<>();
+    List<String> errors = new ArrayList<>();
+
+    for (Resource resource: data.getResourcesList())
+    {
+      String resourceName = resource.getName();
+      try
+      {
+        XdsD2.D2URIMap uriMap = resource.getResource().unpack(XdsD2.D2URIMap.class);
+        Map<String, XdsD2.D2URI> nodeData = uriMap.getNodesMap();
+        updates.put(resourceName, new D2URIMapUpdate(resource.getVersion(), nodeData));
       } catch (InvalidProtocolBufferException e)
       {
         _log.warn("Failed to unpack D2NodeMap response", e);
@@ -284,7 +307,7 @@ public class XdsClientImpl extends XdsClient
     for (ResourceSubscriber subscriber : _d2NodeSubscribers.values()) {
       subscriber.onError(error);
     }
-    for (ResourceSubscriber subscriber : _d2NodeMapSubscribers.values()) {
+    for (ResourceSubscriber subscriber : _d2URIMapSubscribers.values()) {
       subscriber.onError(error);
     }
   }
@@ -293,7 +316,7 @@ public class XdsClientImpl extends XdsClient
     for (ResourceSubscriber subscriber : _d2NodeSubscribers.values()) {
       subscriber.onReconnect();
     }
-    for (ResourceSubscriber subscriber : _d2NodeMapSubscribers.values()) {
+    for (ResourceSubscriber subscriber : _d2URIMapSubscribers.values()) {
       subscriber.onReconnect();
     }
   }
@@ -302,10 +325,12 @@ public class XdsClientImpl extends XdsClient
   {
     switch (type)
     {
-      case NODE:
+      case D2_NODE:
         return _d2NodeSubscribers;
-      case NODE_MAP:
-        return _d2NodeMapSubscribers;
+      case D2_SYMLINK_NODE:
+        return _d2SymlinkNodeSubscribers;
+      case D2_URI_MAP:
+        return _d2URIMapSubscribers;
       case UNKNOWN:
       default:
         throw new AssertionError("Unknown resource type");
@@ -344,15 +369,14 @@ public class XdsClientImpl extends XdsClient
     {
       switch (_type)
       {
-        case NODE:
-          if (watcher instanceof  NodeResourceWatcher) {
-            ((NodeResourceWatcher) watcher).onChanged((NodeUpdate) update);
-          } else {
-            ((SymlinkNodeResourceWatcher) watcher).onChanged(_resource, (NodeUpdate) update);
-          }
+        case D2_NODE:
+          ((D2NodeResourceWatcher) watcher).onChanged((D2NodeUpdate) update);
           break;
-        case NODE_MAP:
-          ((NodeMapResourceWatcher) watcher).onChanged((NodeMapUpdate) update);
+        case D2_SYMLINK_NODE:
+          ((D2SymlinkNodeResourceWatcher) watcher).onChanged(_resource, (D2SymlinkNodeUpdate) update);
+          break;
+        case D2_URI_MAP:
+          ((D2URIMapResourceWatcher) watcher).onChanged((D2URIMapUpdate) update);
           break;
         case UNKNOWN:
         default:
@@ -619,11 +643,14 @@ public class XdsClientImpl extends XdsClient
       ResourceType resourceType = response.getResourceType();
       switch (resourceType)
       {
-        case NODE:
+        case D2_NODE:
           handleD2NodeResponse(response);
           break;
-        case NODE_MAP:
-          handleD2NodeMapResponse(response);
+        case D2_SYMLINK_NODE:
+          handleD2SymlinkNodeResponse(response);
+          break;
+        case D2_URI_MAP:
+          handleD2URIMapResponse(response);
           break;
         case UNKNOWN:
           _log.warn("Received an unknown type of DiscoveryResponse\n{}", respNonce);

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -223,7 +223,7 @@ public class XdsToD2PropertiesAdaptor
               _dualReadStateManager.reportData(serviceName, serviceProperties, true);
             }
           }
-          catch (InvalidProtocolBufferException | PropertySerializationException e)
+          catch (PropertySerializationException e)
           {
             _log.error("Failed to parse D2 service properties from xDS update. Service name: " + serviceName, e);
           }
@@ -462,7 +462,7 @@ public class XdsToD2PropertiesAdaptor
             _dualReadStateManager.reportData(_clusterName, mergedUriProperties, true);
           }
         }
-        catch (InvalidProtocolBufferException | PropertySerializationException e)
+        catch (PropertySerializationException e)
         {
           _log.error("Failed to parse D2 uri properties from xDS update. Cluster name: " + _clusterName, e);
         }

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package indis;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 message Stat {
   // The zxid of the change that caused this znode to be created.
@@ -86,19 +87,22 @@ message D2URI {
   // The version of this announcement. When coming from ZK, this will be the node's mzxid.
   int64 version = 1;
 
+  // The time at which this announcement was last updated. When coming from ZK this will be the node's mtime.
+  google.protobuf.Timestamp modified_time = 2;
+
   // The name of the cluster this announcement belongs to. This is inferred from the original "clusterName" field.
-  string cluster_name = 2;
+  string cluster_name = 3;
 
   // The URI for this announcement, i.e. the host, port and context path that requests should be sent to.
-  string uri = 3;
+  string uri = 4;
 
   // The partitions and their corresponding weight for this announcement. This is inferred from the original
   // "partitionDesc" and "weights" fields. If "partitionDesc" is present in the original ZK node, it is always used
   // regardless of "weights". Otherwise, "weights" is assumed to be for partition 0, as specified in UriProperties.
-  map<int32, double> partition_desc = 4;
+  map<int32, double> partition_desc = 5;
 
   // Additional metadata for this announcement. This is inferred from the original "uriSpecificProperties" field.
-  google.protobuf.Struct uri_specific_properties = 5;
+  google.protobuf.Struct uri_specific_properties = 6;
 }
 
 message D2URIMap {

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -72,18 +72,21 @@ message D2URI {
   // The ZK stat of the node that contained this announcement.
   Stat stat = 1;
 
-  // The name of the cluster this announcement belongs to.
-  string clusterName = 2;
+  // The name of the cluster this announcement belongs to. This is inferred from the original "clusterName" field.
+  string cluster_name = 2;
 
   message PartitionData {
     // Maps the partition number to the desired D2 weight for that partition.
     map<int32, double> weights = 1;
   }
-  // The partitions for each URI contained in this announcement.
-  map<string, PartitionData> partitionDesc = 3;
+  // The partitions for each URI contained in this announcement. This is inferred from the original "partitionDesc" and
+  // "weights" fields. If "partitionDesc" is present in the original ZK node, it is always used regardless of "weights".
+  // Otherwise, "weights" is assumed to be for partition 0, as specified in UriProperties.
+  map<string, PartitionData> partition_desc = 3;
 
-  // Additional metadata for each URI in this announcement.
-  map<string, google.protobuf.Struct> uriSpecificProperties = 4;
+  // Additional metadata for each URI in this announcement. This is inferred from the original "uriSpecificProperties"
+  // fields.
+  map<string, google.protobuf.Struct> uri_specific_properties = 4;
 }
 
 message D2URIMap {

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -48,8 +48,9 @@ message D2NodeMap {
 // D2URI is a proto representation of com.linkedin.d2.balancer.properties.UriProperties. Note that a D2 UriProperties is
 // actually an announcement from a single machine for potentially multiple URIs. This class is a misnomer but it seems
 // important to be consistent with the old naming strategy as this new proto bridges the old type. The string keys in
-// the maps of the message below will be the URIs of this announcement. Here is a sample ZK announcement for additional
-// clarity:
+// the maps of the message below will be the URIs of this announcement.
+//
+// Here is a sample ZK announcement for additional clarity on what it originally looked like:
 //	{
 //		"weights": {
 //			"https://foo.stg.linkedin.com:18792/Toki/resources": 1.0

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -30,30 +30,32 @@ message Stat {
 }
 
 message D2Node {
-  // Deprecated in favor of Node
-  option deprecated = true;
   Stat stat = 1;
   google.protobuf.Struct data = 2;
 }
 
 message D2SymlinkNode {
-  // Deprecated in favor of Node
-  option deprecated = true;
   Stat stat = 1;
   string masterClusterNodePath = 2;
 }
 
 message D2NodeMap {
-  // Deprecated in favor of NodeMap
+  // Deprecated in favor of D2UriMap
   option deprecated = true;
   map<string, D2Node> nodes = 1;
 }
 
-message Node {
+message D2URI {
   Stat stat = 1;
-  bytes data = 2 ;
+  map<string, google.protobuf.Struct> uriSpecificProperties = 2;
+  message PartitionData {
+    map<int32, double> weights = 1;
+  }
+  map<string, PartitionData> partitionDesc = 3;
+  map<string, double> weights = 4;
+  string clusterName = 5;
 }
 
-message NodeMap {
-  map<string, Node> nodes = 1;
+message D2URIMap {
+  map<string, D2URI> nodes = 1;
 }

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -45,15 +45,45 @@ message D2NodeMap {
   map<string, D2Node> nodes = 1;
 }
 
+// D2URI is a proto representation of com.linkedin.d2.balancer.properties.UriProperties. Note that a D2 UriProperties is
+// actually an announcement from a single machine for potentially multiple URIs. This class is a misnomer but it seems
+// important to be consistent with the old naming strategy as this new proto bridges the old type. The string keys in
+// the maps of the message below will be the URIs of this announcement. Here is a sample ZK announcement for additional
+// clarity:
+//	{
+//		"weights": {
+//			"https://foo.stg.linkedin.com:18792/Toki/resources": 1.0
+//		},
+//		"partitionDesc": {
+//			"https://foo.stg.linkedin.com:18792/Toki/resources": {
+//				"0": {
+//					"weight": 1.0
+//				}
+//			}
+//		},
+//		"uriSpecificProperties": {
+//			"https://foo.stg.linkedin.com:18792/Toki/resources": {
+//				"com.linkedin.app.version": "0.1.76"
+//			}
+//		},
+//		"clusterName": "Toki"
+//	}
 message D2URI {
+  // The ZK stat of the node that contained this announcement.
   Stat stat = 1;
-  map<string, google.protobuf.Struct> uriSpecificProperties = 2;
+
+  // The name of the cluster this announcement belongs to.
+  string clusterName = 2;
+
   message PartitionData {
+    // Maps the partition number to the desired D2 weight for that partition.
     map<int32, double> weights = 1;
   }
+  // The partitions for each URI contained in this announcement.
   map<string, PartitionData> partitionDesc = 3;
-  map<string, double> weights = 4;
-  string clusterName = 5;
+
+  // Additional metadata for each URI in this announcement.
+  map<string, google.protobuf.Struct> uriSpecificProperties = 4;
 }
 
 message D2URIMap {

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -30,11 +30,15 @@ message Stat {
 }
 
 message D2Node {
+  // Deprecated in favor of Node
+  option deprecated = true;
   Stat stat = 1;
   google.protobuf.Struct data = 2;
 }
 
 message D2SymlinkNode {
+  // Deprecated in favor of Node
+  option deprecated = true;
   Stat stat = 1;
   string masterClusterNodePath = 2;
 }
@@ -43,6 +47,11 @@ message D2NodeMap {
   // Deprecated in favor of D2UriMap
   option deprecated = true;
   map<string, D2Node> nodes = 1;
+}
+
+message Node {
+  Stat stat = 1;
+  bytes data = 2 ;
 }
 
 // D2URI is a proto representation of com.linkedin.d2.balancer.properties.UriProperties. Note that a D2 UriProperties is

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -46,11 +46,15 @@ message D2NodeMap {
 }
 
 // D2URI is a proto representation of com.linkedin.d2.balancer.properties.UriProperties. Note that a D2 UriProperties is
-// actually an announcement from a single machine for potentially multiple URIs. This class is a misnomer but it seems
-// important to be consistent with the old naming strategy as this new proto bridges the old type. The string keys in
-// the maps of the message below will be the URIs of this announcement.
+// is designed to hold all the announcements of a cluster, which is why it's represented as a map of URI to data. The
+// UriProperties class is reused wholesale for serialization to write the data to ZK, which is why all fields are
+// actually maps, even though these maps only ever have one key in them. It is clear from the implementation of
+// ZooKeeperServer and ZooKeeperAnnouncer that there cannot ever be more than one URI in one ZK announcement, therefore
+// this new proto representation does not need to share the same shortcomings and can, instead, represent things more
+// linearly.
 //
-// Here is a sample ZK announcement for additional clarity on what it originally looked like:
+// Here is a sample ZK announcement in JSON serialized from a UriProperties for additional clarity on the fields that
+// are represented as maps when they do not need to be:
 //	{
 //		"weights": {
 //			"https://foo.stg.linkedin.com:18792/Toki/resources": 1.0
@@ -70,26 +74,24 @@ message D2NodeMap {
 //		"clusterName": "Toki"
 //	}
 message D2URI {
-  // The ZK stat of the node that contained this announcement.
-  Stat stat = 1;
+  // The version of this announcement. When coming from ZK, this will be the node's mzxid.
+  int64 version = 1;
 
   // The name of the cluster this announcement belongs to. This is inferred from the original "clusterName" field.
   string cluster_name = 2;
 
-  message PartitionData {
-    // Maps the partition number to the desired D2 weight for that partition.
-    map<int32, double> weights = 1;
-  }
-  // The partitions for each URI contained in this announcement. This is inferred from the original "partitionDesc" and
-  // "weights" fields. If "partitionDesc" is present in the original ZK node, it is always used regardless of "weights".
-  // Otherwise, "weights" is assumed to be for partition 0, as specified in UriProperties.
-  map<string, PartitionData> partition_desc = 3;
+  // The URI for this announcement, i.e. the host, port and context path that requests should be sent to.
+  string uri = 3;
 
-  // Additional metadata for each URI in this announcement. This is inferred from the original "uriSpecificProperties"
-  // fields.
-  map<string, google.protobuf.Struct> uri_specific_properties = 4;
+  // The partitions and their corresponding weight for this announcement. This is inferred from the original
+  // "partitionDesc" and "weights" fields. If "partitionDesc" is present in the original ZK node, it is always used
+  // regardless of "weights". Otherwise, "weights" is assumed to be for partition 0, as specified in UriProperties.
+  map<int32, double> partition_desc = 4;
+
+  // Additional metadata for this announcement. This is inferred from the original "uriSpecificProperties" field.
+  google.protobuf.Struct uri_specific_properties = 5;
 }
 
 message D2URIMap {
-  map<string, D2URI> nodes = 1;
+  map<string, D2URI> uris = 1;
 }

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -30,15 +30,30 @@ message Stat {
 }
 
 message D2Node {
+  // Deprecated in favor of Node
+  option deprecated = true;
   Stat stat = 1;
   google.protobuf.Struct data = 2;
 }
 
 message D2SymlinkNode {
+  // Deprecated in favor of Node
+  option deprecated = true;
   Stat stat = 1;
   string masterClusterNodePath = 2;
 }
 
 message D2NodeMap {
+  // Deprecated in favor of NodeMap
+  option deprecated = true;
   map<string, D2Node> nodes = 1;
+}
+
+message Node {
+  Stat stat = 1;
+  bytes data = 2 ;
+}
+
+message NodeMap {
+  map<string, Node> nodes = 1;
 }

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -182,6 +182,7 @@ public class TestXdsToD2PropertiesAdaptor {
     URI localhost = URI.create("https://localhost:8443");
     XdsD2.D2URI uri = XdsD2.D2URI.newBuilder()
         .setVersion(DUMMY_VERSION)
+        .setUri(localhost.toString())
         .setClusterName(PRIMARY_CLUSTER_NAME)
         .setUriSpecificProperties(Struct.newBuilder()
             .putFields("foo", Value.newBuilder().setStringValue("bar").build())

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -41,9 +41,7 @@ public class TestXdsToD2PropertiesAdaptor {
 
   private static final XdsClient.D2URIMapUpdate DUMMY_NODE_MAP_UPDATE = new XdsClient.D2URIMapUpdate("",
       Collections.emptyMap());
-  private static final XdsD2.Stat DUMMY_STAT = XdsD2.Stat.newBuilder()
-      .setMzxid(123)
-      .build();
+  private static final long DUMMY_VERSION = 123;
 
   @Test
   public void testListenToService()
@@ -179,21 +177,18 @@ public class TestXdsToD2PropertiesAdaptor {
   {
     URI localhost = URI.create("https://localhost:8443");
     XdsD2.D2URI uri = XdsD2.D2URI.newBuilder()
-        .setStat(DUMMY_STAT)
+        .setVersion(DUMMY_VERSION)
         .setClusterName(PRIMARY_CLUSTER_NAME)
-        .putUriSpecificProperties(localhost.toString(), Struct.newBuilder()
+        .setUriSpecificProperties(Struct.newBuilder()
             .putFields("foo", Value.newBuilder().setStringValue("bar").build())
             .build())
-        .putPartitionDesc(localhost.toString(), XdsD2.D2URI.PartitionData.newBuilder()
-            .putWeights(0, 42)
-            .putWeights(1, 27)
-            .build()
-        )
+        .putPartitionDesc(0, 42)
+        .putPartitionDesc(1, 27)
         .build();
 
     UriProperties properties = new UriPropertiesJsonSerializer().fromProto(uri);
     Assert.assertEquals(properties.getClusterName(), PRIMARY_CLUSTER_NAME);
-    Assert.assertEquals(properties.getVersion(), DUMMY_STAT.getMzxid());
+    Assert.assertEquals(properties.getVersion(), DUMMY_VERSION);
     Assert.assertEquals(properties.getUriSpecificProperties(),
         Collections.singletonMap(localhost, Collections.singletonMap("foo", "bar")));
     Assert.assertEquals(properties.getPartitionDesc(),

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -184,18 +184,6 @@ public class TestXdsToD2PropertiesAdaptor {
         .putUriSpecificProperties(localhost.toString(), Struct.newBuilder()
             .putFields("foo", Value.newBuilder().setStringValue("bar").build())
             .build())
-        .putWeights(localhost.toString(), 42)
-        .build();
-
-    UriProperties properties = new UriPropertiesJsonSerializer().fromProto(uri);
-    Assert.assertEquals(properties.getClusterName(), PRIMARY_CLUSTER_NAME);
-    Assert.assertEquals(properties.getVersion(), DUMMY_STAT.getMzxid());
-    Assert.assertEquals(properties.getUriSpecificProperties(),
-        Collections.singletonMap(localhost, Collections.singletonMap("foo", "bar")));
-    Assert.assertEquals(properties.getPartitionDesc(),
-        Collections.singletonMap(localhost, Collections.singletonMap(0, new PartitionData(42))));
-
-    XdsD2.D2URI uriWithPartitionDesc = XdsD2.D2URI.newBuilder(uri)
         .putPartitionDesc(localhost.toString(), XdsD2.D2URI.PartitionData.newBuilder()
             .putWeights(0, 42)
             .putWeights(1, 27)
@@ -203,8 +191,11 @@ public class TestXdsToD2PropertiesAdaptor {
         )
         .build();
 
-    // Check that weights is ignored if partitionDesc is present
-    properties = new UriPropertiesJsonSerializer().fromProto(uriWithPartitionDesc);
+    UriProperties properties = new UriPropertiesJsonSerializer().fromProto(uri);
+    Assert.assertEquals(properties.getClusterName(), PRIMARY_CLUSTER_NAME);
+    Assert.assertEquals(properties.getVersion(), DUMMY_STAT.getMzxid());
+    Assert.assertEquals(properties.getUriSpecificProperties(),
+        Collections.singletonMap(localhost, Collections.singletonMap("foo", "bar")));
     Assert.assertEquals(properties.getPartitionDesc(),
         Collections.singletonMap(localhost, ImmutableMap.of(
             0, new PartitionData(42),

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -234,7 +234,7 @@ public class TestXdsToD2PropertiesAdaptor {
   private void verifyClusterNodeUpdate(XdsToD2PropertiesAdaptorFixture fixture, String clusterName, String symlinkName,
       ClusterStoreProperties expectedPublishProp)
   {
-    XdsClient.D2NodeResourceWatcher watcher = (XdsClient.D2NodeResourceWatcher)
+    XdsClient.NodeResourceWatcher watcher = (XdsClient.NodeResourceWatcher)
         fixture._clusterWatcherArgumentCaptor.getValue();
     watcher.onChanged(getClusterNodeUpdate(clusterName));
     verify(fixture._clusterEventBus).publishInitialize(clusterName, expectedPublishProp);

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -1,23 +1,27 @@
 package com.linkedin.d2.xds;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.linkedin.d2.balancer.properties.ClusterProperties;
-import com.linkedin.d2.balancer.properties.ClusterPropertiesJsonSerializer;
 import com.linkedin.d2.balancer.properties.ClusterStoreProperties;
+import com.linkedin.d2.balancer.properties.PartitionData;
 import com.linkedin.d2.balancer.properties.ServiceProperties;
-import com.linkedin.d2.balancer.properties.ServicePropertiesJsonSerializer;
 import com.linkedin.d2.balancer.properties.ServiceStoreProperties;
 import com.linkedin.d2.balancer.properties.UriProperties;
+import com.linkedin.d2.balancer.properties.UriPropertiesJsonSerializer;
+import com.linkedin.d2.discovery.PropertySerializationException;
 import com.linkedin.d2.discovery.event.PropertyEventBus;
 import com.linkedin.d2.discovery.event.ServiceDiscoveryEventEmitter;
 import indis.XdsD2;
+import java.net.URI;
 import java.util.Collections;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.*;
@@ -35,33 +39,34 @@ public class TestXdsToD2PropertiesAdaptor {
   private static final String URI_SYMLINK_RESOURCE_NAME = URI_NODE_PREFIX + SYMLINK_NAME;
   private static final String PRIMARY_URI_RESOURCE_NAME = URI_NODE_PREFIX + PRIMARY_CLUSTER_NAME;
 
-  private static final XdsClient.NodeMapUpdate DUMMY_NODE_MAP_UPDATE = new XdsClient.NodeMapUpdate("",
+  private static final XdsClient.D2URIMapUpdate DUMMY_NODE_MAP_UPDATE = new XdsClient.D2URIMapUpdate("",
       Collections.emptyMap());
+  private static final XdsD2.Stat DUMMY_STAT = XdsD2.Stat.newBuilder()
+      .setMzxid(123)
+      .build();
 
   @Test
-  public void testListenToService() throws InvalidProtocolBufferException
+  public void testListenToService()
   {
     XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
     String serviceName = "FooService";
     fixture.getSpiedAdaptor().listenToService(serviceName);
 
-    verify(fixture._xdsClient).watchXdsResource(eq("/d2/services/" + serviceName), eq(XdsClient.ResourceType.NODE), any());
+    verify(fixture._xdsClient).watchXdsResource(eq("/d2/services/" + serviceName), eq(XdsClient.ResourceType.D2_NODE), any());
 
-    XdsClient.NodeResourceWatcher symlinkNodeWatcher =
-        (XdsClient.NodeResourceWatcher) fixture._clusterWatcherArgumentCaptor.getValue();
-    symlinkNodeWatcher.onChanged(new XdsClient.NodeUpdate("", XdsD2.Node.newBuilder()
-        .setData(
-            ByteString.copyFrom(
-                new ServicePropertiesJsonSerializer().toBytes(
-                    new ServiceProperties(
-                        serviceName,
-                        PRIMARY_CLUSTER_NAME,
-                        "",
-                        Collections.singletonList("relative")
-                    )
-                )
+    XdsClient.D2NodeResourceWatcher symlinkNodeWatcher =
+        (XdsClient.D2NodeResourceWatcher) fixture._clusterWatcherArgumentCaptor.getValue();
+    symlinkNodeWatcher.onChanged(new XdsClient.D2NodeUpdate("", XdsD2.D2Node.newBuilder()
+        .setData(Struct.newBuilder().putAllFields(
+            ImmutableMap.of(
+                "serviceName", getProtoStringValue(serviceName),
+                "clusterName", getProtoStringValue(PRIMARY_CLUSTER_NAME),
+                "path", getProtoStringValue(""),
+                "loadBalancerStrategyList", Value.newBuilder().setListValue(
+                    ListValue.newBuilder().addValues(getProtoStringValue("relative")).build()
+                ).build()
             )
-        )
+        ))
         .setStat(XdsD2.Stat.newBuilder().setMzxid(1L).build())
         .build())
     );
@@ -77,7 +82,7 @@ public class TestXdsToD2PropertiesAdaptor {
     XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
     fixture.getSpiedAdaptor().listenToCluster(PRIMARY_CLUSTER_NAME);
 
-    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_CLUSTER_RESOURCE_NAME), eq(XdsClient.ResourceType.NODE), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_CLUSTER_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_NODE), any());
     verifyClusterNodeUpdate(fixture, PRIMARY_CLUSTER_NAME, null, PRIMARY_CLUSTER_PROPERTIES);
   }
 
@@ -87,17 +92,17 @@ public class TestXdsToD2PropertiesAdaptor {
     XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
     fixture.getSpiedAdaptor().listenToCluster(SYMLINK_NAME);
 
-    verify(fixture._xdsClient).watchXdsResource(eq(CLUSTER_SYMLINK_RESOURCE_NAME), eq(XdsClient.ResourceType.NODE), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(CLUSTER_SYMLINK_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_SYMLINK_NODE), any());
 
-    XdsClient.SymlinkNodeResourceWatcher symlinkNodeWatcher =
-        (XdsClient.SymlinkNodeResourceWatcher) fixture._clusterWatcherArgumentCaptor.getValue();
+    XdsClient.D2SymlinkNodeResourceWatcher symlinkNodeWatcher =
+        (XdsClient.D2SymlinkNodeResourceWatcher) fixture._symlinkWatcherArgumentCaptor.getValue();
     symlinkNodeWatcher.onChanged(CLUSTER_SYMLINK_RESOURCE_NAME, getSymlinkNodeUpdate(PRIMARY_CLUSTER_RESOURCE_NAME));
 
-    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_CLUSTER_RESOURCE_NAME), eq(XdsClient.ResourceType.NODE), any());
-    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_URI_RESOURCE_NAME), eq(XdsClient.ResourceType.NODE_MAP), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_CLUSTER_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_NODE), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_URI_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_URI_MAP), any());
 
-    XdsClient.NodeResourceWatcher clusterNodeWatcher =
-        (XdsClient.NodeResourceWatcher) fixture._clusterWatcherArgumentCaptor.getValue();
+    XdsClient.D2NodeResourceWatcher clusterNodeWatcher =
+        (XdsClient.D2NodeResourceWatcher) fixture._clusterWatcherArgumentCaptor.getValue();
     clusterNodeWatcher.onChanged(getClusterNodeUpdate(PRIMARY_CLUSTER_NAME));
 
     verify(fixture._clusterEventBus).publishInitialize(SYMLINK_NAME, PRIMARY_CLUSTER_PROPERTIES);
@@ -109,9 +114,9 @@ public class TestXdsToD2PropertiesAdaptor {
 
     symlinkNodeWatcher.onChanged(CLUSTER_SYMLINK_RESOURCE_NAME, getSymlinkNodeUpdate(primaryClusterResourceName2));
 
-    verify(fixture._xdsClient).watchXdsResource(eq(primaryClusterResourceName2), eq(XdsClient.ResourceType.NODE), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(primaryClusterResourceName2), eq(XdsClient.ResourceType.D2_NODE), any());
     verify(fixture._xdsClient).watchXdsResource(eq(URI_NODE_PREFIX + PRIMARY_CLUSTER_NAME_2),
-        eq(XdsClient.ResourceType.NODE_MAP), any());
+        eq(XdsClient.ResourceType.D2_URI_MAP), any());
     verifyClusterNodeUpdate(fixture, PRIMARY_CLUSTER_NAME_2, SYMLINK_NAME, primaryClusterProperties2);
 
     // if the old primary cluster gets an update, it will be published under its original cluster name
@@ -129,7 +134,7 @@ public class TestXdsToD2PropertiesAdaptor {
     XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
     fixture.getSpiedAdaptor().listenToUris(PRIMARY_CLUSTER_NAME);
 
-    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_URI_RESOURCE_NAME), eq(XdsClient.ResourceType.NODE_MAP), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_URI_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_URI_MAP), any());
     verifyUriUpdate(fixture, PRIMARY_CLUSTER_NAME, null);
   }
 
@@ -139,16 +144,16 @@ public class TestXdsToD2PropertiesAdaptor {
     XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
     fixture.getSpiedAdaptor().listenToUris(SYMLINK_NAME);
 
-    verify(fixture._xdsClient).watchXdsResource(eq(URI_SYMLINK_RESOURCE_NAME), eq(XdsClient.ResourceType.NODE), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(URI_SYMLINK_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_SYMLINK_NODE), any());
 
-    XdsClient.SymlinkNodeResourceWatcher symlinkNodeWatcher =
-        (XdsClient.SymlinkNodeResourceWatcher) fixture._clusterWatcherArgumentCaptor.getValue();
+    XdsClient.D2SymlinkNodeResourceWatcher symlinkNodeWatcher =
+        (XdsClient.D2SymlinkNodeResourceWatcher) fixture._symlinkWatcherArgumentCaptor.getValue();
     symlinkNodeWatcher.onChanged(URI_SYMLINK_RESOURCE_NAME, getSymlinkNodeUpdate(PRIMARY_URI_RESOURCE_NAME));
 
-    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_URI_RESOURCE_NAME), eq(XdsClient.ResourceType.NODE_MAP), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(PRIMARY_URI_RESOURCE_NAME), eq(XdsClient.ResourceType.D2_URI_MAP), any());
 
-    XdsClient.NodeMapResourceWatcher watcher =
-        (XdsClient.NodeMapResourceWatcher) fixture._uriWatcherArgumentCaptor.getValue();
+    XdsClient.D2URIMapResourceWatcher watcher =
+        (XdsClient.D2URIMapResourceWatcher) fixture._uriWatcherArgumentCaptor.getValue();
     watcher.onChanged(DUMMY_NODE_MAP_UPDATE);
 
     UriProperties uriProps = getDefaultUriProperties(PRIMARY_CLUSTER_NAME);
@@ -159,7 +164,7 @@ public class TestXdsToD2PropertiesAdaptor {
     String primaryUriResourceName2 = URI_NODE_PREFIX + PRIMARY_CLUSTER_NAME_2;
     symlinkNodeWatcher.onChanged(URI_SYMLINK_RESOURCE_NAME, getSymlinkNodeUpdate(primaryUriResourceName2));
 
-    verify(fixture._xdsClient).watchXdsResource(eq(primaryUriResourceName2), eq(XdsClient.ResourceType.NODE_MAP), any());
+    verify(fixture._xdsClient).watchXdsResource(eq(primaryUriResourceName2), eq(XdsClient.ResourceType.D2_URI_MAP), any());
     verifyUriUpdate(fixture, PRIMARY_CLUSTER_NAME_2, SYMLINK_NAME);
 
     // if the old primary cluster gets an update, it will be published under its original cluster name
@@ -169,30 +174,62 @@ public class TestXdsToD2PropertiesAdaptor {
     verify(fixture._uriEventBus, times(2)).publishInitialize(PRIMARY_CLUSTER_NAME, uriProps);
   }
 
+  @Test
+  public void testURIPropertiesDeserialization() throws PropertySerializationException
+  {
+    URI localhost = URI.create("https://localhost:8443");
+    XdsD2.D2URI uri = XdsD2.D2URI.newBuilder()
+        .setStat(DUMMY_STAT)
+        .setClusterName(PRIMARY_CLUSTER_NAME)
+        .putUriSpecificProperties(localhost.toString(), Struct.newBuilder()
+            .putFields("foo", Value.newBuilder().setStringValue("bar").build())
+            .build())
+        .putWeights(localhost.toString(), 42)
+        .build();
+
+    UriProperties properties = new UriPropertiesJsonSerializer().fromProto(uri);
+    Assert.assertEquals(properties.getClusterName(), PRIMARY_CLUSTER_NAME);
+    Assert.assertEquals(properties.getVersion(), DUMMY_STAT.getMzxid());
+    Assert.assertEquals(properties.getUriSpecificProperties(),
+        Collections.singletonMap(localhost, Collections.singletonMap("foo", "bar")));
+    Assert.assertEquals(properties.getPartitionDesc(),
+        Collections.singletonMap(localhost, Collections.singletonMap(0, new PartitionData(42))));
+
+    XdsD2.D2URI uriWithPartitionDesc = XdsD2.D2URI.newBuilder(uri)
+        .putPartitionDesc(localhost.toString(), XdsD2.D2URI.PartitionData.newBuilder()
+            .putWeights(0, 42)
+            .putWeights(1, 27)
+            .build()
+        )
+        .build();
+
+    // Check that weights is ignored if partitionDesc is present
+    properties = new UriPropertiesJsonSerializer().fromProto(uriWithPartitionDesc);
+    Assert.assertEquals(properties.getPartitionDesc(),
+        Collections.singletonMap(localhost, ImmutableMap.of(
+            0, new PartitionData(42),
+            1, new PartitionData(27)
+        )));
+  }
+
   private static Value getProtoStringValue(String v)
   {
     return Value.newBuilder().setStringValue(v).build();
   }
 
-  private static XdsClient.NodeUpdate getSymlinkNodeUpdate(String primaryClusterResourceName)
+  private static XdsClient.D2SymlinkNodeUpdate getSymlinkNodeUpdate(String primaryClusterResourceName)
   {
-    return new XdsClient.NodeUpdate("",
-        XdsD2.Node.newBuilder()
-            .setData(ByteString.copyFromUtf8(primaryClusterResourceName))
+    return new XdsClient.D2SymlinkNodeUpdate("",
+        XdsD2.D2SymlinkNode.newBuilder()
+            .setMasterClusterNodePath(primaryClusterResourceName)
             .build()
     );
   }
 
-  private static XdsClient.NodeUpdate getClusterNodeUpdate(String clusterName)
+  private static XdsClient.D2NodeUpdate getClusterNodeUpdate(String clusterName)
   {
-    return new XdsClient.NodeUpdate("", XdsD2.Node.newBuilder()
-        .setData(
-            ByteString.copyFrom(
-                new ClusterPropertiesJsonSerializer().toBytes(
-                    new ClusterProperties(clusterName)
-                )
-            )
-        )
+    return new XdsClient.D2NodeUpdate("", XdsD2.D2Node.newBuilder()
+        .setData(Struct.newBuilder().putFields("clusterName", getProtoStringValue(clusterName)))
         .setStat(XdsD2.Stat.newBuilder().setMzxid(1L).build())
         .build()
     );
@@ -201,7 +238,7 @@ public class TestXdsToD2PropertiesAdaptor {
   private void verifyClusterNodeUpdate(XdsToD2PropertiesAdaptorFixture fixture, String clusterName, String symlinkName,
       ClusterStoreProperties expectedPublishProp)
   {
-    XdsClient.NodeResourceWatcher watcher = (XdsClient.NodeResourceWatcher)
+    XdsClient.D2NodeResourceWatcher watcher = (XdsClient.D2NodeResourceWatcher)
         fixture._clusterWatcherArgumentCaptor.getValue();
     watcher.onChanged(getClusterNodeUpdate(clusterName));
     verify(fixture._clusterEventBus).publishInitialize(clusterName, expectedPublishProp);
@@ -213,7 +250,7 @@ public class TestXdsToD2PropertiesAdaptor {
 
   private void verifyUriUpdate(XdsToD2PropertiesAdaptorFixture fixture, String clusterName, String symlinkName)
   {
-    XdsClient.NodeMapResourceWatcher watcher = (XdsClient.NodeMapResourceWatcher)
+    XdsClient.D2URIMapResourceWatcher watcher = (XdsClient.D2URIMapResourceWatcher)
         fixture._uriWatcherArgumentCaptor.getValue();
     watcher.onChanged(DUMMY_NODE_MAP_UPDATE);
     UriProperties uriProps = getDefaultUriProperties(clusterName);
@@ -242,6 +279,8 @@ public class TestXdsToD2PropertiesAdaptor {
     @Mock
     PropertyEventBus<UriProperties> _uriEventBus;
     @Captor
+    ArgumentCaptor<XdsClient.ResourceWatcher> _symlinkWatcherArgumentCaptor;
+    @Captor
     ArgumentCaptor<XdsClient.ResourceWatcher> _clusterWatcherArgumentCaptor;
     @Captor
     ArgumentCaptor<XdsClient.ResourceWatcher> _uriWatcherArgumentCaptor;
@@ -251,9 +290,11 @@ public class TestXdsToD2PropertiesAdaptor {
     XdsToD2PropertiesAdaptorFixture()
     {
       MockitoAnnotations.initMocks(this);
-      doNothing().when(_xdsClient).watchXdsResource(any(), eq(XdsClient.ResourceType.NODE),
+      doNothing().when(_xdsClient).watchXdsResource(any(), eq(XdsClient.ResourceType.D2_SYMLINK_NODE),
+          _symlinkWatcherArgumentCaptor.capture());
+      doNothing().when(_xdsClient).watchXdsResource(any(), eq(XdsClient.ResourceType.D2_NODE),
           _clusterWatcherArgumentCaptor.capture());
-      doNothing().when(_xdsClient).watchXdsResource(any(), eq(XdsClient.ResourceType.NODE_MAP),
+      doNothing().when(_xdsClient).watchXdsResource(any(), eq(XdsClient.ResourceType.D2_URI_MAP),
           _uriWatcherArgumentCaptor.capture());
       doNothing().when(_clusterEventBus).publishInitialize(any(), any());
       doNothing().when(_serviceEventBus).publishInitialize(any(), any());

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.46.8
+version=29.47.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The initial intent of using D2Node was to pre-deserialize the JSON, but because there is no way for the rest.li client to actually leverage this, it simply re-serializes the JSON then deserializes it again. This causes memory pressure along with validation errors as numerical typesa get mungled.