### PR TITLE
[rest.li] Update SimpleLoadBalancer to use for loop instead of Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+## [29.48.1] - 2023-11-27
+- Update SimpleLoadBalancer to use for loop instead of Map
+
 ## [29.48.0] - 2023-11-13
 - Fix dual-read potential risk that newLb may impact oldLb
 
@@ -5562,7 +5565,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.1...master
+[29.48.1]: https://github.com/linkedin/rest.li/compare/v29.48.0...v29.48.1
 [29.48.0]: https://github.com/linkedin/rest.li/compare/v29.47.0...v29.48.0
 [29.47.0]: https://github.com/linkedin/rest.li/compare/v29.46.9...v29.47.0
 [29.46.9]: https://github.com/linkedin/rest.li/compare/v29.46.8...v29.46.9

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -892,10 +892,11 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
       }
       else
       {
-        Map<URI, Double> weightedUris = possibleUris.stream()
-            .collect(Collectors.toMap(
-                uri -> uri,
-                uri -> uris.getPartitionDataMap(uri).get(partitionId).getWeight()));
+        Map<URI, Double> weightedUris = new HashMap<>(possibleUris.size());
+        for (URI possibleUri : possibleUris)
+        {
+           weightedUris.put(possibleUri, uris.getPartitionDataMap(possibleUri).get(partitionId).getWeight());
+        }
 
         SubsettingState.SubsetItem subsetItem = _state.getClientsSubset(serviceName,
             serviceProperties.getMinClusterSubsetSize(), partitionId, weightedUris, version);


### PR DESCRIPTION
[rest.li] Update SimpleLoadBalancer to use for loop instead of Map

When running ODP analysis, we observed that SimpleLoadBalancer.getPotentialClients map collect uses around 4% CPU. Much of this seems Collector.toMap's uniqKeysMapAccumulator. In this scenario, this is performing unnecessary extra computation -- the keys of the Map we are creating come directly from a Set.

The updated implementation avoids the stream(...).collect(Collectors.toMap(...) and directly uses a for loop to populate the Map

<img width="671" alt="252851489-1cc65047-d39b-4f34-888f-b98e5f000d03" src="https://github.com/linkedin/rest.li/assets/6971410/0b1a3850-4d50-41d1-ba84-24ebeb3fdbb7">
