### PR TITLE
correct where to increment the clusterNotFound count and adjust quarantine log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.48.4] - 2023-12-06
+- correct where to increment the clusterNotFound count and adjust quarantine log level
+
 ## [29.48.3] - 2023-11-28
 - Add standardized models for cursor based pagination
 
@@ -5572,7 +5575,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.4...master
+[29.48.4]: https://github.com/linkedin/rest.li/compare/v29.48.3...v29.48.4
 [29.48.3]: https://github.com/linkedin/rest.li/compare/v29.48.2...v29.48.3
 [29.48.2]: https://github.com/linkedin/rest.li/compare/v29.48.1...v29.48.2
 [29.48.1]: https://github.com/linkedin/rest.li/compare/v29.48.0...v29.48.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -820,7 +820,6 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
         @Override
         public void onError(Throwable e)
         {
-          _clusterNotFoundStats.inc();
           finalCallback.onError(new ServiceUnavailableException(clusterName, "PEGA_1011. " + e.getMessage(), e));
         }
 
@@ -849,6 +848,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
       {
         warn(_log, "unable to find cluster: ", clusterName);
 
+        _clusterNotFoundStats.inc();
         die(pairCallback, clusterName, "PEGA_1012. no cluster properties in lb state");
         return;
       }

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/LoadBalancerQuarantine.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/LoadBalancerQuarantine.java
@@ -241,8 +241,10 @@ public class LoadBalancerQuarantine
         // Nothing to do for now. Just keep waiting
         if (_timeTilNextCheck > ERROR_REPORT_PERIOD)
         {
-          _rateLimitedLogger.error("Client {}  for service {} is being kept in quarantine for {} seconds, "
-              + "Please check to make sure it is healthy", _trackerClient.getUri(), _serviceName, (1.0 *_timeTilNextCheck / 1000));
+          _rateLimitedLogger.info("Host {} for service {} is being kept in quarantine for {} seconds, "
+              + "This is a capacity loss and could potentially cause availability issue. Please contact the service owner to"
+              + " make sure the host is healthy, if needed", _trackerClient.getUri(), _serviceName,
+              (1.0 *_timeTilNextCheck / 1000));
         }
         break;
       case SUCCESS:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.48.3
+version=29.48.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
##Summary##
Currently the clusterNotFound count is incremented when there is no Uris in the cluster in addition to when the cluster config is not found. This change moves it to a place which only increment for cluster config not found.

Also, changing the log level about long-quarantined hosts to Info instead of Error, because 1) often it's just a temporary small capacity which's not causing availability issue. 2) it floods the upstream app's log triggering alerts and/or creating EXC tickets that the upstream app owner is not responsible for. Clarified the log message to show the issue is the downstream host's health. 

##Test done##
build and test