### PR TITLE
add debug log to dual read caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.48.5] - 2023-12-12
+- add debug log to dual read caches
+
 ## [29.48.4] - 2023-12-06
 - correct where to increment the clusterNotFound count and adjust quarantine log level
 
@@ -5575,7 +5578,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.5...master
+[29.48.5]: https://github.com/linkedin/rest.li/compare/v29.48.4...v29.48.5
 [29.48.4]: https://github.com/linkedin/rest.li/compare/v29.48.3...v29.48.4
 [29.48.3]: https://github.com/linkedin/rest.li/compare/v29.48.2...v29.48.3
 [29.48.2]: https://github.com/linkedin/rest.li/compare/v29.48.1...v29.48.2

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitor.java
@@ -103,12 +103,6 @@ public abstract class DualReadLoadBalancerMonitor<T>
     _rateLimitedLogger.debug("Current entries on dual read caches: {}", entriesLogMsg);
   }
 
-  private String getEntriesMessage(boolean fromNewLb, CacheEntry<T> oldE, CacheEntry<T> newE)
-  {
-    return String.format("Old LB: {}, New LB: {}.",
-        fromNewLb? oldE : newE, fromNewLb? newE : oldE);
-  }
-
   abstract void incrementEntryOutOfSyncCount();
 
   abstract void decrementEntryOutOfSyncCount();
@@ -132,6 +126,12 @@ public abstract class DualReadLoadBalancerMonitor<T>
           }
         })
         .build();
+  }
+
+  private String getEntriesMessage(boolean fromNewLb, CacheEntry<T> oldE, CacheEntry<T> newE)
+  {
+    return String.format("Old LB: {}, New LB: {}.",
+        fromNewLb? oldE : newE, fromNewLb? newE : oldE);
   }
 
   private String getTimestamp() {

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
@@ -183,6 +183,11 @@ public class DualReadStateManager
    */
   public void checkAndSwitchMode(String d2ServiceName)
   {
+    if (_executorService.isShutdown())
+    {
+      return;
+    }
+
     _executorService.execute(() ->
     {
       boolean shouldCheck = _rateLimiter.tryAcquire();

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
@@ -185,6 +185,7 @@ public class DualReadStateManager
   {
     if (_executorService.isShutdown())
     {
+      LOG.info("Dual read mode executor is shut down already. Skipping getting the latest dual read mode.");
       return;
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.48.4
+version=29.48.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary 
We've seen the Cluster, Service, Uri properties OutOfSync metrics in DualReadLoadBalancer sensor being high for some apps (voyager-api-groups-dash, registration-mt, etc). The metric seems to increment on every update of the property (see attached screenshot of UriPropertiesOutOfSyncCount metric). It bumps up periodically, likely during downstream deployments.
<img width="594" alt="Screenshot 2023-12-12 at 9 15 17 AM" src="https://github.com/linkedin/rest.li/assets/38869079/7e2f563f-7394-4f29-8cf3-33b175f14985">

This change added debug logs to when entries are added/compared in the dual read caches to further debug the issue.

Another change is for SI-36476 where D2ClientJmxManager tries to find the right jmx name for d2 services being removed at shutdown (the name depends on dual read mode), causing the executor for getting the dual read mode throws errors since it's already shut down. Added a check to skip getting dual read mode if the executor is shut down (the last read dual read mode will be used).
