### PR TITLE
fix publishing uri and cluster properties for symlink clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.48.7] - 2023-12-13
+- fix publishing uri and cluster properties for symlink clusters
+
 ## [29.48.6] - 2023-12-12
 - Rename next to nextPageToken in standardized models for cursor based pagination
 
@@ -5581,7 +5584,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.7...master
+[29.48.7]: https://github.com/linkedin/rest.li/compare/v29.48.6...v29.48.7
 [29.48.6]: https://github.com/linkedin/rest.li/compare/v29.48.5...v29.48.6
 [29.48.5]: https://github.com/linkedin/rest.li/compare/v29.48.4...v29.48.5
 [29.48.4]: https://github.com/linkedin/rest.li/compare/v29.48.3...v29.48.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -694,6 +694,11 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
     return count;
   }
 
+  public Set<String> getClusters()
+  {
+    return _uriProperties.keySet();
+  }
+
   public Set<String> getServicesForCluster(String clusterName)
   {
     Set<String> services = _servicesPerCluster.get(clusterName);

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
@@ -120,6 +120,11 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
     return _stateUpdater.getFirstValidPartitionId();
   }
 
+  public int getTotalHostsInAllPartitions()
+  {
+    return _stateUpdater.getTotalHostsInAllPartitions();
+  }
+
   /**
    * Exposed for testings
    */

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -159,8 +159,7 @@ public class StateUpdater
   int getTotalHostsInAllPartitions()
   {
     return _partitionLoadBalancerStateMap.values().stream()
-        .map(partitionState -> partitionState.getTrackerClients().size())
-        .mapToInt(Integer::intValue)
+        .mapToInt(partitionState -> partitionState.getTrackerClients().size())
         .sum();
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -154,6 +154,17 @@ public class StateUpdater
   }
 
   /**
+   * Return the total tracker clients in all partitions regardless of their statuses.
+   */
+  int getTotalHostsInAllPartitions()
+  {
+    return _partitionLoadBalancerStateMap.values().stream()
+        .map(partitionState -> partitionState.getTrackerClients().size())
+        .mapToInt(Integer::intValue)
+        .sum();
+  }
+
+  /**
    * Return the first valid partition id. This is mainly used for monitoring at least one valid partition.
    */
   int getFirstValidPartitionId()

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/SymlinkUtil.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/SymlinkUtil.java
@@ -64,4 +64,9 @@ public class SymlinkUtil
   {
     return (firstSymlinkIndex(path) < 0) ? false : true;
   }
+
+  public static boolean isSymlinkNodeOrPath(String nodeNameOrPath)
+  {
+    return nodeNameOrPath != null && nodeNameOrPath.indexOf(SYMLINK_PREFIX) >= 0;
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmx.java
@@ -146,6 +146,28 @@ public class RelativeLoadBalancerStrategyJmx implements RelativeLoadBalancerStra
   }
 
   @Override
+  public int getTotalHostsInAllPartitionsCount()
+  {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_INT_METRICS;
+    }
+
+    return _strategy.getTotalHostsInAllPartitions();
+  }
+
+  @Override
+  public int getTotalHostsCount()
+  {
+    if (isPartitionDataUnavailable())
+    {
+      return DEFAULT_INT_METRICS;
+    }
+
+    return _strategy.getPartitionState(_strategy.getFirstValidPartitionId()).getTrackerClientStateMap().size();
+  }
+
+  @Override
   public int getUnhealthyHostsCount()
   {
     if (isPartitionDataUnavailable())

--- a/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/RelativeLoadBalancerStrategyJmxMBean.java
@@ -52,6 +52,18 @@ public interface RelativeLoadBalancerStrategyJmxMBean
 
   /**
    *
+   * @return the number of total hosts in all partitions regardless of their status
+   */
+  int getTotalHostsInAllPartitionsCount();
+
+  /**
+   *
+   * @return the number of total hosts regardless of their status
+   */
+  int getTotalHostsCount();
+
+  /**
+   *
    * @return the number of unhealthy hosts
    */
   int getUnhealthyHostsCount();

--- a/d2/src/main/java/com/linkedin/d2/jmx/SimpleLoadBalancerStateJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/SimpleLoadBalancerStateJmx.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.jmx;
 
 import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.discovery.stores.zk.SymlinkUtil;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -39,6 +40,12 @@ public class SimpleLoadBalancerStateJmx implements SimpleLoadBalancerStateJmxMBe
   public int getClusterCount()
   {
     return _state.getClusterCount();
+  }
+
+  @Override
+  public long getSymlinkClusterCount()
+  {
+    return _state.getClusters().stream().filter(SymlinkUtil::isSymlinkNodeOrPath).count();
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/jmx/SimpleLoadBalancerStateJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/SimpleLoadBalancerStateJmxMBean.java
@@ -25,6 +25,8 @@ public interface SimpleLoadBalancerStateJmxMBean
 
   int getClusterCount();
 
+  long getSymlinkClusterCount();
+
   int getServiceCount();
 
   long getVersion();

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -256,25 +257,20 @@ public class XdsToD2PropertiesAdaptor
           try
           {
             ClusterProperties clusterProperties = toClusterProperties(update.getNodeData());
-            // For symlink clusters, ClusterLoadBalancerSubscriber subscribed to the symlinks, instead of the actual node, in event bus,
-            // so we need to publish under the symlink names. Also, rarely and possibly, the original cluster could have subscribers
-            // too when calls are made directly to the original cluster, so we publish for it too.
+            // For symlink clusters, ClusterLoadBalancerSubscriber subscribed to the symlinks instead of the actual node in event bus,
+            // so we need to publish under the symlink names.
             // For other clusters, publish under its original name. Note that these clusters could be either:
             // 1) regular clusters requested normally.
             // 2) clusters that were pointed by a symlink previously, but no longer the case after the symlink points to other clusters.
             // For case #2: the symlinkAndActualNode map will no longer has an entry for this cluster (removed in
             // D2SymlinkNodeResourceWatcher::onChanged), thus the updates will be published under the original cluster name
             // (like "FooCluster-prod-ltx1"), which has no symlink subscribers anyway, so no harm to publish.
-            _clusterEventBus.publishInitialize(clusterName, clusterProperties);
-            String symlinkName = getSymlink(clusterName);
-            if (symlinkName != null)
-            {
-              _clusterEventBus.publishInitialize(symlinkName, clusterProperties);
-            }
+            String publishName = StringUtils.defaultIfEmpty(getSymlink(clusterName), clusterName);
+            _clusterEventBus.publishInitialize(publishName, clusterProperties);
 
             if (_dualReadStateManager != null)
             {
-              _dualReadStateManager.reportData(clusterName, clusterProperties, true);
+              _dualReadStateManager.reportData(publishName, clusterProperties, true);
             }
           }
           catch (PropertySerializationException e)
@@ -419,16 +415,6 @@ public class XdsToD2PropertiesAdaptor
       _initFetchStart = System.nanoTime();
     }
 
-    // For symlink clusters, UriLoadBalancerSubscriber subscribed to the symlinks, instead of the actual node, in event bus,
-    // so we need to publish under the symlink names. Also, rarely but possibly, the original cluster could have subscribers
-    // too when calls are made directly to the original cluster, so we publish for it too.
-    // For other clusters, publish under its original name. Note that these clusters could be either:
-    // 1) regular clusters requested normally.
-    // 2) clusters that were pointed by a symlink previously, but no longer the case after the symlink points to other clusters.
-    // For case #2: the actualResourceToSymlink map will no longer has an entry for this cluster (removed in
-    // D2SymlinkNodeResourceWatcher::onChanged), thus the updates will be published under the original cluster name
-    // (like "FooCluster-prod-ltx1"), which has no subscribers anyway, so no harm to publish. Yet, we still emit the tracking
-    // events about receiving uri updates of this cluster for measuring update propagation latencies.
     @Override
     public void onChanged(XdsClient.D2URIMapUpdate update)
     {
@@ -448,18 +434,23 @@ public class XdsToD2PropertiesAdaptor
             emitSDStatusUpdateReceiptEvents(updates);
           }
           _currentData = updates;
-          UriProperties mergedUriProperties = _uriPropertiesMerger.merge(_clusterName, _currentData.values());
 
-          _uriEventBus.publishInitialize(_clusterName, mergedUriProperties);
-          String symlinkName = getSymlink(_clusterName);
-          if (symlinkName != null)
-          {
-            _uriEventBus.publishInitialize(symlinkName, mergedUriProperties);
-          }
+          // For symlink clusters, UriLoadBalancerSubscriber subscribed to the symlinks instead of the actual node in event bus,
+          // so we need to publish under the symlink names.
+          // For other clusters, publish under its original name. Note that these clusters could be either:
+          // 1) regular clusters requested normally.
+          // 2) clusters that were pointed by a symlink previously, but no longer the case after the symlink points to other clusters.
+          // For case #2: the actualResourceToSymlink map will no longer has an entry for this cluster (removed in
+          // D2SymlinkNodeResourceWatcher::onChanged), thus the updates will be published under the original cluster name
+          // (like "FooCluster-prod-ltx1"), which has no subscribers anyway, so no harm to publish. Yet, we still emit the tracking
+          // events about receiving uri updates of this cluster for measuring update propagation latencies.
+          String publishName = StringUtils.defaultIfEmpty(getSymlink(_clusterName), _clusterName);
+          UriProperties mergedUriProperties = _uriPropertiesMerger.merge(publishName, _currentData.values());
+          _uriEventBus.publishInitialize(publishName, mergedUriProperties);
 
           if (_dualReadStateManager != null)
           {
-            _dualReadStateManager.reportData(_clusterName, mergedUriProperties, true);
+            _dualReadStateManager.reportData(publishName, mergedUriProperties, true);
           }
         }
         catch (PropertySerializationException e)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.48.6
+version=29.48.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
gcn-39955
After switched to observer-only mode, job-postings-mt was not able to make downstream calls to d2 services under a symlink cluster. We found that although the uri nodes were fetched correctly for symlink cluster, it was merged with the real cluster name, instead of the symlink cluster name (e.g: FooCluster-prod-ltx1 instead of $FooClusterMaster). The cluster name in the merged uri properties is used (by UriLoadBalancerSubscriber) to find d2 services associated with it, which fails since the services are managed under the symlink cluster name.

This change:
1. merges the uri properties under the symlink cluster name. 
2. report the uri properties to dual read monitoring under the symlink cluster name. 
3. removed the additional publishing under the real cluster name when it's publish for symlink cluster.
4. added jmx metrics to count the number of symlink clusters, the number of total hosts (tracker clients) for each d2 service in default partition and all partitions. 

## Test Done
Unit tests. 

Manual testing with QEI d2-proxy with observer-only config (<property name="indisConfigProvider.dualReadMode" value="NEW_LB_ONLY"/>):
curli -v "d2://cart" --d2-proxy-url "http://localhost:21360/d2/" -X OPTIONS --force-insecure-d2
< Content-Type: application/json
< x-linkedin-processing-colo: ei-ltx1
< x-linkedin-processing-machine: ltx1-app4245.stg.linkedin.com
{
  "models": {
    "com.linkedin.payments.ContactInfo": {
      "namespace": "com.linkedin.payments",
      "name": "ContactInfo",
      "doc": "Contact Information.",
      "fields": [
        {
          "type": "string",
          "name": "firstName",
          "doc": "First name."
        },
………
      ],
      "type": "record"
    }
  },
  "resources": {
    "com.linkedin.payments.client.cart": {
      "schema": "com.linkedin.payments.Cart",
      "path": "/cart",
      "namespace": "com.linkedin.payments.client",
      "name": "cart",
      "doc": "Cart restli resource. Handles all the operations to the cart.\n\ngenerated from: com.linkedin.oms.bps.rest.impl.CartResource",
      "collection": {
..............
        "supports": [
          "create",
          "update"
        ],
        "methods": [
          {
            "method": "create",
            "javaMethodName": "create"
          },
          {
            "method": "update",
            "javaMethodName": "update"
          }
        ]
      },
      "resourceClass": "com.linkedin.oms.bps.rest.impl.CartResource"
    }
  }
}