### PR TITLE
Use no-op proxy detector for xDS gRPC managed channel builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.48.9] - 2023-12-20
+- No-op proxy detector for xDS gRPC channel builder.
+- Warning for unsupported `zero-allocation-hashing` library versions.
+
+
 ## [29.48.8] - 2023-12-19
 - add warn logs about invalid property versions
 
@@ -5587,7 +5592,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.9...master
+[29.48.9]: https://github.com/linkedin/rest.li/compare/v29.48.8...v29.48.9
 [29.48.8]: https://github.com/linkedin/rest.li/compare/v29.48.7...v29.48.8
 [29.48.7]: https://github.com/linkedin/rest.li/compare/v29.48.6...v29.48.7
 [29.48.6]: https://github.com/linkedin/rest.li/compare/v29.48.5...v29.48.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and what APIs have changed, if applicable.
 
 ## [29.48.7] - 2023-12-19
 - No-op proxy detector for xDS gRPC channel builder.
+- Warning for unsupported `zero-allocation-hashing` library versions.
 
 ## [29.48.6] - 2023-12-12
 - Rename next to nextPageToken in standardized models for cursor based pagination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and what APIs have changed, if applicable.
 - No-op proxy detector for xDS gRPC channel builder.
 - Warning for unsupported `zero-allocation-hashing` library versions.
 
-
 ## [29.48.8] - 2023-12-19
 - add warn logs about invalid property versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.48.7] - 2023-12-19
+- No-op proxy detector for xDS gRPC channel builder.
+
 ## [29.48.6] - 2023-12-12
 - Rename next to nextPageToken in standardized models for cursor based pagination
 
@@ -5581,7 +5584,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.7...master
+[29.48.7]: https://github.com/linkedin/rest.li/compare/v29.48.6...v29.48.7
 [29.48.6]: https://github.com/linkedin/rest.li/compare/v29.48.5...v29.48.6
 [29.48.5]: https://github.com/linkedin/rest.li/compare/v29.48.4...v29.48.5
 [29.48.4]: https://github.com/linkedin/rest.li/compare/v29.48.3...v29.48.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
@@ -57,7 +57,6 @@ public class MPConsistentHashRing<T> implements Ring<T>
     try {
       LongHashFunction.class.getMethod("xx_r39", long.class);
     } catch (NoSuchMethodException ex) {
-      // SI-36497
       LOG.error("Required method xx_r39 not found, this means an unsupported version of the "
           + "zero-allocation-hashing library is being used. Do not use later than 0.7 if you want to use pegasus", ex);
       throw new RuntimeException(ex);

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
@@ -58,7 +58,7 @@ public class MPConsistentHashRing<T> implements Ring<T>
       LongHashFunction.class.getMethod("xx_r39", long.class);
     } catch (NoSuchMethodException ex) {
       // SI-36497
-      LOG.error("Required method xx_39 not found, this means an supported version of the "
+      LOG.error("Required method xx_r39 not found, this means an unsupported version of the "
           + "zero-allocation-hashing library is being used. Do not use later than 0.7 if you want to use pegasus", ex);
       throw new RuntimeException(ex);
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
@@ -49,19 +49,20 @@ import org.slf4j.LoggerFactory;
  */
 public class MPConsistentHashRing<T> implements Ring<T>
 {
+  public static final int DEFAULT_NUM_PROBES = 21;
+  public static final int DEFAULT_POINTS_PER_HOST = 1;
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConsistentHashRing.class);
   static {
     try {
       LongHashFunction.class.getMethod("xx_r39", long.class);
     } catch (NoSuchMethodException ex) {
       // SI-36497
-      throw new RuntimeException("Required method xx_39 not found, this means an supported version of the "
-          + "zero-allocation-hashing library is being used. Do not use later than 0.0.7 if you want to use pegasus");
+      LOG.error("Required method xx_39 not found, this means an supported version of the "
+          + "zero-allocation-hashing library is being used. Do not use later than 0.7 if you want to use pegasus", ex);
+      throw new RuntimeException(ex);
     }
   }
-  public static final int DEFAULT_NUM_PROBES = 21;
-  public static final int DEFAULT_POINTS_PER_HOST = 1;
-
-  private static final Logger LOG = LoggerFactory.getLogger(ConsistentHashRing.class);
   private static final LongHashFunction HASH_FUNCTION_0 = LongHashFunction.xx_r39(0xDEADBEEF);
   private static final Charset UTF8 = Charset.forName("UTF-8");
   /* we will only use the lower 32 bit of the hash code to avoid overflow */

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
@@ -49,6 +49,15 @@ import org.slf4j.LoggerFactory;
  */
 public class MPConsistentHashRing<T> implements Ring<T>
 {
+  static {
+    try {
+      LongHashFunction.class.getMethod("xx_r39", long.class);
+    } catch (NoSuchMethodException ex) {
+      // SI-36497
+      throw new RuntimeException("Required method xx_39 not found, this means an supported version of the "
+          + "zero-allocation-hashing library is being used. Do not use later than 0.0.7 if you want to use pegasus");
+    }
+  }
   public static final int DEFAULT_NUM_PROBES = 21;
   public static final int DEFAULT_POINTS_PER_HOST = 1;
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
@@ -54,6 +54,7 @@ public class XdsChannelFactory
     }
 
     return builder.keepAliveTime(5, TimeUnit.MINUTES)
+        // No proxy wanted here; the default proxy detector can mistakenly detect forwarded ports as proxies.
         .proxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
         .build();
   }

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.xds;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import java.util.concurrent.TimeUnit;
@@ -53,6 +54,7 @@ public class XdsChannelFactory
     }
 
     return builder.keepAliveTime(5, TimeUnit.MINUTES)
+        .proxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR)
         .build();
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.48.8
+version=29.48.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.48.6
+version=29.48.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Summary
---------

1. `dali --gridproxy` command (required for some apps' local deployment, for eg. `launchpad-mt`) sets up local port forwarding that's incorrectly detected as a proxy by the gRPC managed channel. The fix is to use a no-op proxy detector. See more details about the investigation here: https://jira01.corp.linkedin.com:8443/browse/SI-36671
2. Regarding https://jira01.corp.linkedin.com:8443/browse/SI-36497, there was a request to indicate the issue of unexpected library versions to the app owner since it can be very tough to figure out, due to the error happening during the class loading phase.

Testing Done
-----------
1. Deployed `launchpad-mt` locally with a pegasus snapshot and the xDS stream works fine now:
```
2023/12/19 11:26:28.522 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [launchpad-mt] [AAYM4dfTTkhtyfOIDk89sw==] ADS stream started, connected to server: 10.153.115.54:32123
2023/12/19 11:26:28.524 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [launchpad-mt] [AAYM4dfVXRPra3B7y3acJQ==] Subscribe NODE resource /d2/clusters/NonExistentCluster
2023/12/19 11:26:28.526 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [launchpad-mt] [AAYM4dfVXRPra3B7y3acJQ==] Sending NODE request for resources: [/d2/clusters/NonExistentCluster]
2023/12/19 11:26:29.531 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [launchpad-mt] [AAYM4dfku5TNCJmeh+ny1g==] ADS stream ready, cancelled timeout task: true
2023/12/19 11:26:29.537 INFO [XdsLoadBalancer] [Indis xDS client executor-4-1] [launchpad-mt] [AAYM4dfku5TNCJmeh+ny1g==] Enabled primary stores
2023/12/19 11:26:29.540 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [launchpad-mt] [AAYM4dfk4yGMmVheGF+S8Q==] Subscribe NODE resource /d2/services/lixClientContexts
2023/12/19 11:26:29.541 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [launchpad-mt] [AAYM4dfk4yGMmVheGF+S8Q==] Sending NODE request for resources: [/d2/services/li
xClientContexts]
```
2. Deployed `thirdparty-device-signals-be` locally with the snapshot and updated `zero-allocation-hashing` version.
```
2023/12/19 13:10:05.302 ERROR [ConsistentHashRing] [DefaultLixDataRefresher. RunId = 1] [thirdparty-device-signals-be] [AAYM40phq
kAOtzODGc82xA==] Required method xx_39 not found, this means an supported version of the zero-allocation-hashing library is being
 used. Do not use later than 0.7 if you want to use pegasus
java.lang.NoSuchMethodException: net.openhft.hashing.LongHashFunction.xx_r39(long)
        at java.lang.Class.getMethod(Class.java:1786) ~[?:1.8.0_282]
        at com.linkedin.d2.balancer.util.hashing.MPConsistentHashRing.<clinit>(MPConsistentHashRing.java:58) ~[d2-29.48.7-SNAPSHO
T.jar:?]
        at com.linkedin.d2.balancer.strategies.MPConsistentHashRingFactory.createRing(MPConsistentHashRingFactory.java:43) ~[d2-2
9.48.7-SNAPSHOT.jar:?]
        at com.linkedin.d2.balancer.strategies.RingFactory.createRing(RingFactory.java:43) ~[d2-29.48.7-SNAPSHOT.jar:?]
        at com.linkedin.d2.balancer.strategies.DelegatingRingFactory.createRing(DelegatingRingFactory.java:120) ~[d2-29.48.7-SNAP
SHOT.jar:?]
        at com.linkedin.d2.balancer.strategies.relative.PartitionState.updateRing(PartitionState.java:174) ~[d2-29.48.7-SNAPSHOT.
jar:?]
        at com.linkedin.d2.balancer.strategies.relative.PartitionState.<init>(PartitionState.java:83) ~[d2-29.48.7-SNAPSHOT.jar:?
]
        at com.linkedin.d2.balancer.strategies.relative.PartitionState.<init>(PartitionState.java:61) ~[d2-29.48.7-SNAPSHOT.jar:?
]
        at com.linkedin.d2.balancer.strategies.relative.StateUpdater.initializePartition(StateUpdater.java:443) ~[d2-29.48.7-SNAP
SHOT.jar:?]
```