### PR TITLE
Update zero-allocation-hashing and xx hash method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.48.10] - 2023-12-20
+- Update `zero-allocation-hashing` and use method `xx` rather than `xx_39`.
+
 ## [29.48.9] - 2023-12-20
 - No-op proxy detector for xDS gRPC channel builder.
 - Warning for unsupported `zero-allocation-hashing` library versions.
@@ -5591,7 +5594,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.10...master
+[29.48.10]: https://github.com/linkedin/rest.li/compare/v29.48.9...v29.48.10
 [29.48.9]: https://github.com/linkedin/rest.li/compare/v29.48.8...v29.48.9
 [29.48.8]: https://github.com/linkedin/rest.li/compare/v29.48.7...v29.48.8
 [29.48.7]: https://github.com/linkedin/rest.li/compare/v29.48.6...v29.48.7

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ project.ext.externalDependency = [
   'spock': 'org.spockframework:spock-core:1.3-groovy-2.5',
   'testng': 'org.testng:testng:6.13.1',
   'velocity': 'org.apache.velocity:velocity-engine-core:2.2',
-  'zero_allocation_hashing': 'net.openhft:zero-allocation-hashing:0.7',
+  'zero_allocation_hashing': 'net.openhft:zero-allocation-hashing:0.16',
   'zookeeper': 'org.apache.zookeeper:zookeeper:3.6.3',
   'hdrhistogram': 'org.hdrhistogram:HdrHistogram:2.1.9',
   'xchart': 'org.knowm.xchart:xchart:3.2.2',

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/MPConsistentHashRing.java
@@ -53,16 +53,7 @@ public class MPConsistentHashRing<T> implements Ring<T>
   public static final int DEFAULT_POINTS_PER_HOST = 1;
 
   private static final Logger LOG = LoggerFactory.getLogger(ConsistentHashRing.class);
-  static {
-    try {
-      LongHashFunction.class.getMethod("xx_r39", long.class);
-    } catch (NoSuchMethodException ex) {
-      LOG.error("Required method xx_r39 not found, this means an unsupported version of the "
-          + "zero-allocation-hashing library is being used. Do not use later than 0.7 if you want to use pegasus", ex);
-      throw new RuntimeException(ex);
-    }
-  }
-  private static final LongHashFunction HASH_FUNCTION_0 = LongHashFunction.xx_r39(0xDEADBEEF);
+  private static final LongHashFunction HASH_FUNCTION_0 = LongHashFunction.xx(0xDEADBEEF);
   private static final Charset UTF8 = Charset.forName("UTF-8");
   /* we will only use the lower 32 bit of the hash code to avoid overflow */
   private static final long MASK = 0x00000000FFFFFFFFL;
@@ -114,7 +105,7 @@ public class MPConsistentHashRing<T> implements Ring<T>
     _hashFunctions = new LongHashFunction[_numProbes];
     for (int i = 0; i < _numProbes; i++)
     {
-      _hashFunctions[i] = LongHashFunction.xx_r39(i);
+      _hashFunctions[i] = LongHashFunction.xx(i);
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/XXHash.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/hashing/XXHash.java
@@ -26,7 +26,7 @@ import net.openhft.hashing.LongHashFunction;
 public class XXHash implements HashFunction<String[]> {
   //In order to ensure the consistency of the hashing function,
   // we seed the hash function in the beginning with fixed seed.
-  private static final LongHashFunction hashFunction = LongHashFunction.xx_r39(0xDEADBEEF);
+  private static final LongHashFunction hashFunction = LongHashFunction.xx(0xDEADBEEF);
 
   @Override
   public int hash(String[] keyTokens) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.48.9
+version=29.48.10
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Summary
----------
The `zero-allocation-hashing` library versions > `0.7` are missing the method `LongHashFunction.xx_r39` required by pegasus, thus causing failures. However, it appears that the newer versions are being increasingly used by OSS libraries and thus with LI too. 

It looks like they just renamed `xx_r39` (xxHash algo release 39) to `xx` to stop tying it to a particular release: https://github.com/OpenHFT/Zero-Allocation-Hashing/commit/658079a50903c32c54f2ab5c86243244b3ac60ed

Thus, it should be safe for us to move over to `xx`.