### PR TITLE
bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- bump minor version
 
 ## [29.48.9] - 2023-12-20
 - No-op proxy detector for xDS gRPC channel builder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.49.0] - 2023-12-21
 - bump minor version
 
 ## [29.48.9] - 2023-12-20
@@ -5592,7 +5594,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.48.9...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.0...master
+[29.49.0]: https://github.com/linkedin/rest.li/compare/v29.48.9...v29.49.0
 [29.48.9]: https://github.com/linkedin/rest.li/compare/v29.48.8...v29.48.9
 [29.48.8]: https://github.com/linkedin/rest.li/compare/v29.48.7...v29.48.8
 [29.48.7]: https://github.com/linkedin/rest.li/compare/v29.48.6...v29.48.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.49.0] - 2023-12-21
-- bump minor version
+- Bump minor version due to internal LinkedIn tooling requirement. No functional changes.
 
 ## [29.48.9] - 2023-12-20
 - No-op proxy detector for xDS gRPC channel builder.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.48.9
+version=29.49.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
As in the title. Container PR will require the new pegasus code. We need to bump the minor version so that MPs which bump container but pin pegasus to a lower version can get build errors (patch version difference won't work, need minor version bump) hinting to bump the corresponding pegasus version too. Otherwise, their build will succeed but the app will crash at runtime since the old pegasus doesn’t have the new code. 