### PR TITLE
Use a separate indis warmup executor service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.49.1] - 2023-12-21
+- Use a separate indis warmup executor service
+
 ## [29.49.0] - 2023-12-21
 - Bump minor version due to internal LinkedIn tooling requirement. No functional changes.
 
@@ -5594,7 +5597,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.1...master
+[29.49.1]: https://github.com/linkedin/rest.li/compare/v29.49.0...v29.49.1
 [29.49.0]: https://github.com/linkedin/rest.li/compare/v29.48.9...v29.49.0
 [29.48.9]: https://github.com/linkedin/rest.li/compare/v29.48.8...v29.48.9
 [29.48.8]: https://github.com/linkedin/rest.li/compare/v29.48.7...v29.48.8

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -541,6 +541,18 @@ public class D2ClientBuilder
     return this;
   }
 
+  public D2ClientBuilder setStartUpExecutorService(ScheduledExecutorService executorService)
+  {
+    _config.startUpExecutorService = executorService;
+    return this;
+  }
+
+  public D2ClientBuilder setIndisStartUpExecutorService(ScheduledExecutorService executorService)
+  {
+    _config.indisStartUpExecutorService = executorService;
+    return this;
+  }
+
   public D2ClientBuilder setDownstreamServicesFetcher(DownstreamServicesFetcher downstreamServicesFetcher)
   {
     _config.downstreamServicesFetcher = downstreamServicesFetcher;

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -104,6 +104,13 @@ public class D2ClientBuilder
       executorsToShutDown.add(_config.startUpExecutorService);
     }
 
+    if (_config.indisStartUpExecutorService == null)
+    {
+      _config.indisStartUpExecutorService =
+          Executors.newScheduledThreadPool(0, new NamedThreadFactory("INDIS D2 StartupOnlyExecutor"));
+      executorsToShutDown.add(_config.indisStartUpExecutorService);
+    }
+
     if (_config._executorService == null)
     {
       LOG.warn("No executor service passed as argument. Pass it for " +
@@ -189,6 +196,7 @@ public class D2ClientBuilder
                   _config.sslSessionValidatorFactory,
                   _config.zkConnectionToUseForLB,
                   _config.startUpExecutorService,
+                  _config.indisStartUpExecutorService,
                   _config.jmxManager,
                   _config.d2JmxManagerPrefix,
                   _config.zookeeperReadWindowMs,

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -114,6 +114,7 @@ public class D2ClientConfig
   public SslSessionValidatorFactory sslSessionValidatorFactory = null;
   ZKPersistentConnection zkConnectionToUseForLB = null;
   public ScheduledExecutorService startUpExecutorService = null;
+  public ScheduledExecutorService indisStartUpExecutorService = null;
   public JmxManager jmxManager = new NoOpJmxManager();
   public String d2JmxManagerPrefix = "UnknownPrefix";
   boolean enableRelativeLoadBalancer = false;
@@ -185,6 +186,7 @@ public class D2ClientConfig
                  SslSessionValidatorFactory sslSessionValidatorFactory,
                  ZKPersistentConnection zkConnection,
                  ScheduledExecutorService startUpExecutorService,
+                 ScheduledExecutorService indisStartUpExecutorService,
                  JmxManager jmxManager,
                  String d2JmxManagerPrefix,
                  int zookeeperReadWindowMs,
@@ -251,6 +253,7 @@ public class D2ClientConfig
     this.sslSessionValidatorFactory = sslSessionValidatorFactory;
     this.zkConnectionToUseForLB = zkConnection;
     this.startUpExecutorService = startUpExecutorService;
+    this.indisStartUpExecutorService = indisStartUpExecutorService;
     this.jmxManager = jmxManager;
     this.d2JmxManagerPrefix = d2JmxManagerPrefix;
     this.zookeeperReadWindowMs = zookeeperReadWindowMs;

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -71,7 +71,7 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
 
     if (config.warmUp)
     {
-      balancer = new WarmUpLoadBalancer(balancer, xdsLoadBalancer, config.startUpExecutorService, config.indisFsBasePath,
+      balancer = new WarmUpLoadBalancer(balancer, xdsLoadBalancer, config.indisStartUpExecutorService, config.indisFsBasePath,
           config.d2ServicePath, config.indisDownstreamServicesFetcher, config.warmUpTimeoutSeconds,
           config.warmUpConcurrentRequests, config.dualReadStateManager);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.0
+version=29.49.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary

As reported, some apps ramped to Indis timed out at warmup causing d2 client startup timeout, the warmup executor was a single-thread executor shared by ZK and Indis flow, leading to Indis warmup blocks ZK warmup.

While the RC fix will be reducing the rate limiting on Indis Observer, here we add a separate executor for indis warmup to prevent blocking/affecting ZK flow in the future.

## Test Done
build and test