### PR TITLE
Make warmup to respect dual read mode, and separate warmup configs for indis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.49.4] - 2024-01-04
 - Make warm-up to respect dual read mode, and separate warmup configs for indis.
 
 ## [29.49.3] - 2024-01-03
@@ -5604,7 +5606,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.4...master
+[29.49.4]: https://github.com/linkedin/rest.li/compare/v29.49.3...v29.49.4
 [29.49.3]: https://github.com/linkedin/rest.li/compare/v29.49.2...v29.49.3
 [29.49.2]: https://github.com/linkedin/rest.li/compare/v29.49.1...v29.49.2
 [29.49.1]: https://github.com/linkedin/rest.li/compare/v29.49.0...v29.49.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Make warm-up to respect dual read mode, and separate warmup configs for indis.
+
 ## [29.49.3] - 2024-01-03
 - Fix rate limiter for dual-read mode switch
 

--- a/d2-test-api/src/main/java/com/linkedin/d2/balancer/util/TestLoadBalancer.java
+++ b/d2-test-api/src/main/java/com/linkedin/d2/balancer/util/TestLoadBalancer.java
@@ -47,15 +47,23 @@ public class TestLoadBalancer implements LoadBalancerWithFacilities, WarmUpServi
 
   private final AtomicInteger _requestCount = new AtomicInteger();
   private final AtomicInteger _completedRequestCount = new AtomicInteger();
-  private int _delayMs = 0;
+  private int _warmUpDelayMs = 0;
+  private int _serviceDataDelayMs = 0;
+
   private final int DELAY_STANDARD_DEVIATION = 10; //ms
   private final ScheduledExecutorService _executorService = Executors.newSingleThreadScheduledExecutor();
 
   public TestLoadBalancer() {}
 
-  public TestLoadBalancer(int delayMs)
+  public TestLoadBalancer(int warmUpDelayMs)
   {
-    _delayMs = delayMs;
+    this(warmUpDelayMs, 0);
+  }
+
+  public TestLoadBalancer(int warmUpDelayMs, int serviceDataDelayMs)
+  {
+    _warmUpDelayMs = warmUpDelayMs;
+    _serviceDataDelayMs = serviceDataDelayMs;
   }
 
   @Override
@@ -72,8 +80,8 @@ public class TestLoadBalancer implements LoadBalancerWithFacilities, WarmUpServi
     {
       _completedRequestCount.incrementAndGet();
       callback.onSuccess(None.none());
-    }, Math.max(0, _delayMs
-        // any kind of random delay works for the test
+    }, Math.max(0, _warmUpDelayMs
+        // +/- DELAY_STANDARD_DEVIATION ms (any kind of random delay works for the test)
         + ((int) new Random().nextGaussian() * DELAY_STANDARD_DEVIATION)), TimeUnit.MILLISECONDS);
   }
 
@@ -92,6 +100,14 @@ public class TestLoadBalancer implements LoadBalancerWithFacilities, WarmUpServi
   @Override
   public void getLoadBalancedServiceProperties(String serviceName, Callback<ServiceProperties> clientCallback)
   {
+    if (_serviceDataDelayMs > 0)
+    {
+      try {
+        Thread.sleep(_serviceDataDelayMs);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
     clientCallback.onSuccess(new ServiceProperties(serviceName, "clustername", "/foo", Arrays.asList("rr")));
   }
 

--- a/d2-test-api/src/main/java/com/linkedin/d2/balancer/util/TestLoadBalancer.java
+++ b/d2-test-api/src/main/java/com/linkedin/d2/balancer/util/TestLoadBalancer.java
@@ -50,7 +50,7 @@ public class TestLoadBalancer implements LoadBalancerWithFacilities, WarmUpServi
   private int _warmUpDelayMs = 0;
   private int _serviceDataDelayMs = 0;
 
-  private final int DELAY_STANDARD_DEVIATION = 10; //ms
+  private final int DELAY_STANDARD_DEVIATION = 5; //ms
   private final ScheduledExecutorService _executorService = Executors.newSingleThreadScheduledExecutor();
 
   public TestLoadBalancer() {}
@@ -75,14 +75,15 @@ public class TestLoadBalancer implements LoadBalancerWithFacilities, WarmUpServi
   @Override
   public void warmUpService(String serviceName, Callback<None> callback)
   {
+    double g = Math.min(1.0, Math.max(-1.0, new Random().nextGaussian()));
+    int actualDelay = Math.max(0,
+        _warmUpDelayMs + ((int) g * DELAY_STANDARD_DEVIATION)); // +/- DELAY_STANDARD_DEVIATION ms
     _requestCount.incrementAndGet();
     _executorService.schedule(() ->
     {
       _completedRequestCount.incrementAndGet();
       callback.onSuccess(None.none());
-    }, Math.max(0, _warmUpDelayMs
-        // +/- DELAY_STANDARD_DEVIATION ms (any kind of random delay works for the test)
-        + ((int) new Random().nextGaussian() * DELAY_STANDARD_DEVIATION)), TimeUnit.MILLISECONDS);
+    }, actualDelay, TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -178,7 +178,9 @@ public class D2ClientBuilder
                   _config.retryAggregatedIntervalNum,
                   _config.warmUp,
                   _config.warmUpTimeoutSeconds,
+                  _config.indisWarmUpTimeoutSeconds,
                   _config.warmUpConcurrentRequests,
+                  _config.indisWarmUpConcurrentRequests,
                   _config.downstreamServicesFetcher,
                   _config.indisDownstreamServicesFetcher,
                   _config.backupRequestsEnabled,
@@ -526,18 +528,33 @@ public class D2ClientBuilder
     return this;
   }
 
-  public D2ClientBuilder setWarmUpTimeoutSeconds(int warmUpTimeoutSeconds){
+  public D2ClientBuilder setWarmUpTimeoutSeconds(int warmUpTimeoutSeconds)
+  {
     _config.warmUpTimeoutSeconds = warmUpTimeoutSeconds;
     return this;
   }
 
-  public D2ClientBuilder setZookeeperReadWindowMs(int zookeeperReadWindowMs){
+  public D2ClientBuilder setIndisWarmUpTimeoutSeconds(int indisWarmUpTimeoutSeconds)
+  {
+    _config.indisWarmUpTimeoutSeconds = indisWarmUpTimeoutSeconds;
+    return this;
+  }
+
+  public D2ClientBuilder setZookeeperReadWindowMs(int zookeeperReadWindowMs)
+  {
     _config.zookeeperReadWindowMs = zookeeperReadWindowMs;
     return this;
   }
 
-  public D2ClientBuilder setWarmUpConcurrentRequests(int warmUpConcurrentRequests){
+  public D2ClientBuilder setWarmUpConcurrentRequests(int warmUpConcurrentRequests)
+  {
     _config.warmUpConcurrentRequests = warmUpConcurrentRequests;
+    return this;
+  }
+
+  public D2ClientBuilder setIndisWarmUpConcurrentRequests(int indisWarmUpConcurrentRequests)
+  {
+    _config.indisWarmUpConcurrentRequests = indisWarmUpConcurrentRequests;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -96,8 +96,10 @@ public class D2ClientConfig
   int retryAggregatedIntervalNum = RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM;
   public boolean warmUp = true;
   public int warmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
+  public int indisWarmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
   int zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
   public int warmUpConcurrentRequests = WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS;
+  public int indisWarmUpConcurrentRequests = WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS;
   public DownstreamServicesFetcher downstreamServicesFetcher = null;
   public DownstreamServicesFetcher indisDownstreamServicesFetcher = null;
   boolean backupRequestsEnabled = true;
@@ -168,7 +170,9 @@ public class D2ClientConfig
                  int retryAggregatedIntervalNum,
                  boolean warmUp,
                  int warmUpTimeoutSeconds,
+                 int indisWarmUpTimeoutSeconds,
                  int warmUpConcurrentRequests,
+                 int indisWarmUpConcurrentRequests,
                  DownstreamServicesFetcher downstreamServicesFetcher,
                  DownstreamServicesFetcher indisDownstreamServicesFetcher,
                  boolean backupRequestsEnabled,
@@ -235,7 +239,9 @@ public class D2ClientConfig
     this.retryAggregatedIntervalNum = retryAggregatedIntervalNum;
     this.warmUp = warmUp;
     this.warmUpTimeoutSeconds = warmUpTimeoutSeconds;
+    this.indisWarmUpTimeoutSeconds = indisWarmUpTimeoutSeconds;
     this.warmUpConcurrentRequests = warmUpConcurrentRequests;
+    this.indisWarmUpConcurrentRequests = indisWarmUpConcurrentRequests;
     this.downstreamServicesFetcher = downstreamServicesFetcher;
     this.indisDownstreamServicesFetcher = indisDownstreamServicesFetcher;
     this.backupRequestsEnabled = backupRequestsEnabled;

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -117,7 +117,7 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     {
       balancer = new WarmUpLoadBalancer(balancer, lastSeenLoadBalancer, config.startUpExecutorService, config.fsBasePath,
                                         config.d2ServicePath, config.downstreamServicesFetcher, config.warmUpTimeoutSeconds,
-                                        config.warmUpConcurrentRequests, config.dualReadStateManager);
+                                        config.warmUpConcurrentRequests, config.dualReadStateManager, false);
     }
 
     return balancer;

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -55,7 +55,7 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     {
       balancer = new WarmUpLoadBalancer(balancer, zkfsLoadBalancer, config.startUpExecutorService, config.fsBasePath,
         config.d2ServicePath, config.downstreamServicesFetcher, config.warmUpTimeoutSeconds,
-        config.warmUpConcurrentRequests, config.dualReadStateManager);
+        config.warmUpConcurrentRequests, config.dualReadStateManager, false);
     }
     return balancer;
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
@@ -153,7 +153,8 @@ public class WarmUpLoadBalancer extends LoadBalancerWithFacilitiesDelegator {
 
   private void prepareWarmUp(Callback<None> callback)
   {
-    AtomicBoolean hasTimedOut = new AtomicBoolean(false);
+    // not to be thread-safe, but just to be effectively final to be used in lambdas
+    final AtomicBoolean hasTimedOut = new AtomicBoolean(false);
 
     try {
       _downstreamServicesFetcher.getServiceNames(serviceNames -> {

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
@@ -77,7 +77,6 @@ public class WarmUpLoadBalancer extends LoadBalancerWithFacilitiesDelegator {
   private final String _printName; // name of this warmup load balancer based on it's indis or not.
   private volatile boolean _shuttingDown = false;
   private long _allStartTime;
-  private Future<?> _prepareTaskFuture = null;
   private List<String> _servicesToWarmUp = null;
 
   /**
@@ -125,10 +124,10 @@ public class WarmUpLoadBalancer extends LoadBalancerWithFacilitiesDelegator {
       public void onSuccess(None result) {
         _allStartTime = SystemClock.instance().currentTimeMillis();
 
-        _prepareTaskFuture = _executorService.submit(() -> prepareWarmUp());
+        Future<?> prepareTaskFuture = _executorService.submit(() -> prepareWarmUp());
         try
         {
-          _prepareTaskFuture.get(_warmUpTimeoutSeconds, TimeUnit.SECONDS);
+          prepareTaskFuture.get(_warmUpTimeoutSeconds, TimeUnit.SECONDS);
         }
         catch (TimeoutException e)
         {

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -73,7 +73,7 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
     {
       balancer = new WarmUpLoadBalancer(balancer, xdsLoadBalancer, config.indisStartUpExecutorService, config.indisFsBasePath,
           config.d2ServicePath, config.indisDownstreamServicesFetcher, config.warmUpTimeoutSeconds,
-          config.warmUpConcurrentRequests, config.dualReadStateManager);
+          config.warmUpConcurrentRequests, config.dualReadStateManager, true);
     }
 
     return balancer;

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -72,8 +72,8 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
     if (config.warmUp)
     {
       balancer = new WarmUpLoadBalancer(balancer, xdsLoadBalancer, config.indisStartUpExecutorService, config.indisFsBasePath,
-          config.d2ServicePath, config.indisDownstreamServicesFetcher, config.warmUpTimeoutSeconds,
-          config.warmUpConcurrentRequests, config.dualReadStateManager, true);
+          config.d2ServicePath, config.indisDownstreamServicesFetcher, config.indisWarmUpTimeoutSeconds,
+          config.indisWarmUpConcurrentRequests, config.dualReadStateManager, true);
     }
 
     return balancer;

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
@@ -402,17 +402,17 @@ public class WarmUpLoadBalancerTest
   public void testDualReadHitTimeout(DualReadModeProvider.DualReadMode mode, Boolean isIndis)
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    int timeoutMillis = 80;
+    int timeoutMillis = 15;
     createDefaultServicesIniFiles();
     setDualReadMode(mode);
 
     // 3 dual read fetches take 90ms
-    TestLoadBalancer balancer = new TestLoadBalancer(0, 30);
+    TestLoadBalancer balancer = new TestLoadBalancer(0, 10);
     AtomicInteger completedWarmUpCount = balancer.getCompletedRequestCount();
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),
         _tmpdir.getAbsolutePath(), MY_SERVICES_FS, _FSBasedDownstreamServicesFetcher, timeoutMillis,
         WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS, _dualReadStateManager, isIndis,
-        TestDataHelper.getTimeSupplier(30, TIME_FREEZED_CALL));
+        TestDataHelper.getTimeSupplier(10, TIME_FREEZED_CALL));
 
     FutureCallback<None> callback = new FutureCallback<>();
     warmUpLb.start(callback);
@@ -428,17 +428,17 @@ public class WarmUpLoadBalancerTest
   public void testDualReadCompleteWarmUpHitTimeout(DualReadModeProvider.DualReadMode mode, Boolean isIndis)
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    int timeoutMillis = 120;
+    int timeoutMillis = 40;
     createDefaultServicesIniFiles();
     setDualReadMode(mode);
 
-    // 3 dual read fetches take 90ms, 3 warmups take 3 * (30 +/- 5) ms
-    TestLoadBalancer balancer = new TestLoadBalancer(30, 30);
+    // 3 dual read fetches take 30ms, 3 warmups take 3 * (10 +/- 5) ms
+    TestLoadBalancer balancer = new TestLoadBalancer(10, 10);
     AtomicInteger completedWarmUpCount = balancer.getCompletedRequestCount();
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),
         _tmpdir.getAbsolutePath(), MY_SERVICES_FS, _FSBasedDownstreamServicesFetcher, timeoutMillis,
         WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS, _dualReadStateManager, isIndis,
-        TestDataHelper.getTimeSupplier(30, TIME_FREEZED_CALL));
+        TestDataHelper.getTimeSupplier(10, TIME_FREEZED_CALL));
 
     FutureCallback<None> callback = new FutureCallback<>();
     warmUpLb.start(callback);

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
@@ -376,7 +376,7 @@ public class WarmUpLoadBalancerTest
   public void testSuccessWithDualRead(DualReadModeProvider.DualReadMode mode, Boolean isIndis)
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    int timeoutMillis = 65;
+    int timeoutMillis = 80;
     createDefaultServicesIniFiles();
     setDualReadMode(mode);
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
@@ -73,7 +73,7 @@ public class WarmUpLoadBalancerTest
   private File _tmpdir;
   private DualReadModeProvider _dualReadModeProvider;
   private DualReadStateManager _dualReadStateManager;
-  private static final int[] TIME_FREEZED_CALLS = {5}; // the first call in warmUpServices which sets timeout
+  private static final int TIME_FREEZED_CALL = 5; // the first call in warmUpServices which sets timeout
 
   @BeforeMethod
   public void beforeTest() throws IOException
@@ -386,7 +386,7 @@ public class WarmUpLoadBalancerTest
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),
         _tmpdir.getAbsolutePath(), MY_SERVICES_FS, _FSBasedDownstreamServicesFetcher, timeoutMillis,
         WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS, _dualReadStateManager, isIndis,
-        TestDataHelper.getTimeSupplier(10, TIME_FREEZED_CALLS));
+        TestDataHelper.getTimeSupplier(10, TIME_FREEZED_CALL));
 
     FutureCallback<None> callback = new FutureCallback<>();
     warmUpLb.start(callback);
@@ -412,7 +412,7 @@ public class WarmUpLoadBalancerTest
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),
         _tmpdir.getAbsolutePath(), MY_SERVICES_FS, _FSBasedDownstreamServicesFetcher, timeoutMillis,
         WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS, _dualReadStateManager, isIndis,
-        TestDataHelper.getTimeSupplier(30, TIME_FREEZED_CALLS));
+        TestDataHelper.getTimeSupplier(30, TIME_FREEZED_CALL));
 
     FutureCallback<None> callback = new FutureCallback<>();
     warmUpLb.start(callback);
@@ -438,7 +438,7 @@ public class WarmUpLoadBalancerTest
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),
         _tmpdir.getAbsolutePath(), MY_SERVICES_FS, _FSBasedDownstreamServicesFetcher, timeoutMillis,
         WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS, _dualReadStateManager, isIndis,
-        TestDataHelper.getTimeSupplier(30, TIME_FREEZED_CALLS));
+        TestDataHelper.getTimeSupplier(30, TIME_FREEZED_CALL));
 
     FutureCallback<None> callback = new FutureCallback<>();
     warmUpLb.start(callback);
@@ -471,7 +471,7 @@ public class WarmUpLoadBalancerTest
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),
         _tmpdir.getAbsolutePath(), MY_SERVICES_FS, _FSBasedDownstreamServicesFetcher, timeoutMillis,
         WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS, _dualReadStateManager, isIndis,
-        TestDataHelper.getTimeSupplier(0, TIME_FREEZED_CALLS));
+        TestDataHelper.getTimeSupplier(0, TIME_FREEZED_CALL));
 
     FutureCallback<None> callback = new FutureCallback<>();
     warmUpLb.start(callback);

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
@@ -375,11 +375,11 @@ public class WarmUpLoadBalancerTest
   public void testSuccessWithDualRead(DualReadModeProvider.DualReadMode mode, Boolean isIndis)
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    int warmUpTimeout = 3;
+    int warmUpTimeout = 4;
     createDefaultServicesIniFiles();
     setDualReadMode(mode);
 
-    // 3 dual read fetches take 1.5s, 3 warmups take at most 3 * (500 +/- 10) ms
+    // 3 dual read fetches take 1.5s, 3 warmups take at most 3 * (500 +/- 10) ms. Total at most is 3030 ms.
     TestLoadBalancer balancer = new TestLoadBalancer(500, 500);
     AtomicInteger completedWarmUpCount = balancer.getCompletedRequestCount();
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),

--- a/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancerTest.java
@@ -402,17 +402,17 @@ public class WarmUpLoadBalancerTest
   public void testDualReadHitTimeout(DualReadModeProvider.DualReadMode mode, Boolean isIndis)
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    int timeoutMillis = 15;
+    int timeoutMillis = 80;
     createDefaultServicesIniFiles();
     setDualReadMode(mode);
 
     // 3 dual read fetches take 90ms
-    TestLoadBalancer balancer = new TestLoadBalancer(0, 10);
+    TestLoadBalancer balancer = new TestLoadBalancer(0, 30);
     AtomicInteger completedWarmUpCount = balancer.getCompletedRequestCount();
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),
         _tmpdir.getAbsolutePath(), MY_SERVICES_FS, _FSBasedDownstreamServicesFetcher, timeoutMillis,
         WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS, _dualReadStateManager, isIndis,
-        TestDataHelper.getTimeSupplier(10, TIME_FREEZED_CALL));
+        TestDataHelper.getTimeSupplier(30, TIME_FREEZED_CALL));
 
     FutureCallback<None> callback = new FutureCallback<>();
     warmUpLb.start(callback);
@@ -428,17 +428,17 @@ public class WarmUpLoadBalancerTest
   public void testDualReadCompleteWarmUpHitTimeout(DualReadModeProvider.DualReadMode mode, Boolean isIndis)
       throws InterruptedException, ExecutionException, TimeoutException
   {
-    int timeoutMillis = 40;
+    int timeoutMillis = 120;
     createDefaultServicesIniFiles();
     setDualReadMode(mode);
 
-    // 3 dual read fetches take 30ms, 3 warmups take 3 * (10 +/- 5) ms
-    TestLoadBalancer balancer = new TestLoadBalancer(10, 10);
+    // 3 dual read fetches take 90ms, 3 warmups take 3 * (30 +/- 5) ms
+    TestLoadBalancer balancer = new TestLoadBalancer(30, 30);
     AtomicInteger completedWarmUpCount = balancer.getCompletedRequestCount();
     LoadBalancer warmUpLb = new WarmUpLoadBalancer(balancer, balancer, Executors.newSingleThreadScheduledExecutor(),
         _tmpdir.getAbsolutePath(), MY_SERVICES_FS, _FSBasedDownstreamServicesFetcher, timeoutMillis,
         WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS, _dualReadStateManager, isIndis,
-        TestDataHelper.getTimeSupplier(10, TIME_FREEZED_CALL));
+        TestDataHelper.getTimeSupplier(30, TIME_FREEZED_CALL));
 
     FutureCallback<None> callback = new FutureCallback<>();
     warmUpLb.start(callback);

--- a/d2/src/test/java/com/linkedin/d2/xds/XdsToD2SampleClient.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/XdsToD2SampleClient.java
@@ -89,7 +89,7 @@ public class XdsToD2SampleClient
 
     XdsChannelFactory xdsChannelFactory = new XdsChannelFactory(sslContext, xdsServer);
     XdsClient xdsClient = new XdsClientImpl(node, xdsChannelFactory.createChannel(),
-        Executors.newSingleThreadScheduledExecutor());
+        Executors.newSingleThreadScheduledExecutor(), XdsClientImpl.DEFAULT_READY_TIMEOUT_MILLIS);
 
     DualReadStateManager dualReadStateManager = new DualReadStateManager(
         () -> DualReadModeProvider.DualReadMode.DUAL_READ,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.3
+version=29.49.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary 
Current warmup starts for both ZK and xDS regardless of dual read mode, and the logic of fetching dual read mode (service data) blocks the warmup timeout which fails app startup.

This change: 
1. make warmup to respect the dual read mode per d2 service.
2. move the blocking service data fetching logic into a separate task and set a timeout, so that it won't blocks the warmup timeout callback to be called (so startup still has a chance to complete).
3. add separate configs for Indis warmup timeout and concurrent requests. We could tune them in the future as needed depending on how rate limiting on Indis observer will go. And wait for indis warmup (thus use the indis warmup timeout config) under observer-only mode during startup (instead of waiting for zk warmup). 
4. add checks to dual read load balancer monitoring to skip putting duplicate data into the report caches (which incorrectly increase outOfSync metric).

## Testing Done
1. added unit tests
2. tested with d2-proxy warming up some 200 services under different dual read modes, see the corresponding container PR for logs.