### PR TITLE
add back publish under original cluster name for symlink cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.49.2] - 2024-01-02
+- add back publish original cluster for symlink cluster
+
 ## [29.49.1] - 2023-12-21
 - Use a separate indis warmup executor service
 
@@ -5597,7 +5600,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.2...master
+[29.49.2]: https://github.com/linkedin/rest.li/compare/v29.49.1...v29.49.2
 [29.49.1]: https://github.com/linkedin/rest.li/compare/v29.49.0...v29.49.1
 [29.49.0]: https://github.com/linkedin/rest.li/compare/v29.48.9...v29.49.0
 [29.48.9]: https://github.com/linkedin/rest.li/compare/v29.48.8...v29.48.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.1
+version=29.49.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
In a [previous PR](https://github.com/linkedin/rest.li/pull/956), we removed publishing to the original cluster name (e.g: FooCluster-prod-ltx1) for a symlink cluster ($FooCluster). But there could be edge cases that the original cluster was subscribed by direct curli calls (like calling the colo-suffixed service: d2://FooService-prod-ltx1) or hard-coded custom code.

This change add this publish back.

## Test Done
Unit tests.
Tested with QEI d2-proxy, 
call d2 service "accountBalances" (which is under cluster "$OmsServiceMaster"):
`curli -v "d2://accountBalances" --d2-proxy-url "http://localhost:21360/d2/" -X OPTIONS --force-insecure-d2`
HTTP/1.1 200 OK
< Content-Type: application/json
< x-linkedin-processing-colo: ei-ltx1
< x-linkedin-processing-machine: ltx1-app6705.stg.linkedin.com
(was able to pick the host ltx1-app6705.stg.linkedin.com).


, and call d2 service "accountBalances-ei-ltx1" (which is under cluster "OmsService-ei-ltx1"):
`curli -v "d2://accountBalances-ei-ltx1" --d2-proxy-url "http://localhost:21360/d2/" -X OPTIONS --force-insecure-d2`
HTTP/1.1 200 OK
< Content-Type: application/json
< x-linkedin-processing-colo: ei-ltx1
< x-linkedin-processing-machine: ltx1-app7220.stg.linkedin.com
(was able to pick the host ltx1-app7220.stg.linkedin.com).



