### PR TITLE
Fix indis dual-read lix switch issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+## [29.49.2] - 2024-01-02
+- Fix rate limiter for dual-read mode switch
 
 ## [29.49.1] - 2023-12-21
 - Use a separate indis warmup executor service
@@ -5597,7 +5599,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.2...master
+[29.49.2]: https://github.com/linkedin/rest.li/compare/v29.49.1...v29.49.2
 [29.49.1]: https://github.com/linkedin/rest.li/compare/v29.49.0...v29.49.1
 [29.49.0]: https://github.com/linkedin/rest.li/compare/v29.48.9...v29.49.0
 [29.48.9]: https://github.com/linkedin/rest.li/compare/v29.48.8...v29.48.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-## [29.49.2] - 2024-01-02
+## [29.49.3] - 2024-01-03
 - Fix rate limiter for dual-read mode switch
 
 ## [29.49.2] - 2024-01-02
@@ -5602,7 +5602,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.3...master
+[29.49.3]: https://github.com/linkedin/rest.li/compare/v29.49.2...v29.49.3
 [29.49.2]: https://github.com/linkedin/rest.li/compare/v29.49.1...v29.49.2
 [29.49.1]: https://github.com/linkedin/rest.li/compare/v29.49.0...v29.49.1
 [29.49.0]: https://github.com/linkedin/rest.li/compare/v29.48.9...v29.49.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
@@ -188,16 +188,14 @@ public class DualReadStateManager
       LOG.info("Dual read mode executor is shut down already. Skipping getting the latest dual read mode.");
       return;
     }
-
+    if (d2ServiceName == null)
+    {
+      return;
+    }
     _executorService.execute(() ->
     {
-      if(d2ServiceName == null){
-        return;
-      }
-      RateLimiter serviceRateLimiter = _serviceToRateLimiterMap.computeIfAbsent(
-          d2ServiceName,
-          key -> RateLimiter.create((double) 1 / DUAL_READ_MODE_SWITCH_MIN_INTERVAL)
-      );
+      RateLimiter serviceRateLimiter = _serviceToRateLimiterMap.computeIfAbsent(d2ServiceName,
+          key -> RateLimiter.create((double) 1 / DUAL_READ_MODE_SWITCH_MIN_INTERVAL));
       boolean shouldCheck = serviceRateLimiter.tryAcquire();
       if (shouldCheck)
       {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.1
+version=29.49.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.2
+version=29.49.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## 1. Background
For gcn-39955
After [indis-dual-read lix](https://trex.corp.linkedin.com/trex/test/2081511207/iteration/4770044) switched to observer-only mode, job-postings-mt was not able to make downstream calls to d2 services under a symlink cluster(This issue has been fixed by #956 . Then D2 team tried to switch dual-read mode [lix](https://trex.corp.linkedin.com/trex/test/2081511207/iteration/4770044) from `Observer-only` to `DUAL_READ`, but it failed for partial downstream services.

## 2. Reproduce and investigation
### how to reproduce this :
- create a new test lix: https://trex.corp.linkedin.com/trex/test/2081519814/iteration/4770028
- change lix name from si.indis.client_read_mode to indis_automation_test  in container
- job-postings-mt bump up container snapshot and test in local ei.
- mint build && mint build-cfg -f dev && mint deploy -f dev in job-postings-mt


So we found,  after Lix switch from `Observer-only` to `DUAL_READ`, it will take a few minutes to update for partial downstream services. The root cause is  `all downstream services will use global rate-limit to update their dual-read mode which may cause partial services being starved and take a long time to update. 

## 3. Solution
After discussing with @bohhyang . We create a map, key is to downstream service name and value is the relative rate limiter for each service. So rate limiter will be service granularity. 

## 4. Test
- For rest.li(pegasus) repo, `./scripts/local-release -s` to create a snapshot
- Bump up pegasus version in container and for container `mint build && mint snapshot && mint release`
- Bump up `pegasus version` and `container version` in `job-postings-mt` and then `mint build && mint build-cfg -f dev && mint deploy -f dev in job-postings-mt`
- Check the service dual read mode(it's currently in `DUAL_READ` mode)
```
curli --fabric ei-ltx1 --pretty-print "https://zhonchen-mn2.linkedin.biz:9607/jobPostingsMt/resources/jobPostings/2147622124?action=purchase" --data '{"owner":"urn:li:contract:92952029", "isFreemiumPromotion": true,
"jobPurchaseBillingParams":{"dailyBudget":{"currencyCode":"USD", "amount":"116"}, "unitCost":{"currencyCode":"USD","amount":"3"},
"costType":"COST_PER_VIEW"}, "viewer":"urn:li:system:0"}' --dv-auth=SELF
```
<img width="1575" alt="image" src="https://github.com/linkedin/rest.li/assets/150380879/5d1ea454-4452-440b-b227-80d38bfed60a">
We found all the downstream services switch to `DUAL_READ` mode
- switch the lix from `DUAL_READ` to  `Observer-only`, after 5 minutes, call 
```
curli --fabric ei-ltx1 --pretty-print "https://zhonchen-mn2.linkedin.biz:9607/jobPostingsMt/resources/jobPostings/2147622124?action=purchase" --data '{"owner":"urn:li:contract:92952029", "isFreemiumPromotion": true,
"jobPurchaseBillingParams":{"dailyBudget":{"currencyCode":"USD", "amount":"116"}, "unitCost":{"currencyCode":"USD","amount":"3"},
"costType":"COST_PER_VIEW"}, "viewer":"urn:li:system:0"}' --dv-auth=SELF
```
We found the service is in `Observer-only`
<img width="1595" alt="image" src="https://github.com/linkedin/rest.li/assets/150380879/add425ec-2854-48d5-8d9b-33ac05e6e0e3">

- switch the lix from `Observer-only` to  `DUAL_READ`, after 5 minutes, call 
```
curli --fabric ei-ltx1 --pretty-print "https://zhonchen-mn2.linkedin.biz:9607/jobPostingsMt/resources/jobPostings/2147622124?action=purchase" --data '{"owner":"urn:li:contract:92952029", "isFreemiumPromotion": true,
"jobPurchaseBillingParams":{"dailyBudget":{"currencyCode":"USD", "amount":"116"}, "unitCost":{"currencyCode":"USD","amount":"3"},
"costType":"COST_PER_VIEW"}, "viewer":"urn:li:system:0"}' --dv-auth=SELF
```
We found all downstream services are  in `DUAL_READ`
<img width="1588" alt="image" src="https://github.com/linkedin/rest.li/assets/150380879/efe14ac6-4d1d-47e9-80f1-ccbe3ec2e777">
