### PR TITLE
Add support for domain socket on m1 mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.49.5] - 2024-01-11
+
+## [29.4.5] - 2024-01-11
+- Added KQueue support for domain sockets.
+- 
 ## [29.49.4] - 2024-01-04
 - Make warm-up to respect dual read mode, and separate warmup configs for indis.
 
@@ -5606,7 +5611,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.5...master
+[29.49.5]: https://github.com/linkedin/rest.li/compare/v29.49.4...v29.49.5
 [29.49.4]: https://github.com/linkedin/rest.li/compare/v29.49.3...v29.49.4
 [29.49.3]: https://github.com/linkedin/rest.li/compare/v29.49.2...v29.49.3
 [29.49.2]: https://github.com/linkedin/rest.li/compare/v29.49.1...v29.49.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,8 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.49.5] - 2024-01-11
-
-## [29.4.5] - 2024-01-11
 - Added KQueue support for domain sockets.
-- 
+
 ## [29.49.4] - 2024-01-04
 - Make warm-up to respect dual read mode, and separate warmup configs for indis.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.4
+version=29.49.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelPoolFactory.java
@@ -38,7 +38,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 /**
@@ -97,19 +97,8 @@ public class HttpChannelPoolFactory implements ChannelPoolFactory
     _tcpNoDelay = tcpNoDelay;
     _channelPoolWaiterTimeout = channelPoolWaiterTimeout;
 
-    final Class channelClass;
-    if (org.apache.commons.lang.StringUtils.isEmpty(udsAddress)) {
-      channelClass = NioSocketChannel.class;
-    } else {
-      if (Epoll.isAvailable()) {
-        channelClass = EpollDomainSocketChannel.class;
-      } else if (KQueue.isAvailable()){
-        channelClass = KQueueDomainSocketChannel.class;
-      } else {
-        throw new IllegalStateException("Neither Epoll or Kqueue domain socket transport available");
-      }
-    }
-    Bootstrap bootstrap = new Bootstrap().channel(channelClass);
+    Bootstrap bootstrap = !StringUtils.isEmpty(udsAddress) ?
+        new Bootstrap().channel(getDomainSocketClass()) : new Bootstrap().channel(NioSocketChannel.class);
 
     _bootstrap = bootstrap
         .group(eventLoopGroup)

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelPoolFactory.java
@@ -28,17 +28,13 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.group.ChannelGroup;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueDomainSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import java.net.SocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 
 /**

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
@@ -38,6 +38,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
+import org.apache.commons.lang3.StringUtils;
 
 
 /**
@@ -119,19 +120,8 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
     _maxContentLength = maxContentLength;
     _tcpNoDelay = tcpNoDelay;
 
-    final Class channelClass;
-    if (org.apache.commons.lang.StringUtils.isEmpty(udsAddress)) {
-      channelClass = NioSocketChannel.class;
-    } else {
-      if (Epoll.isAvailable()) {
-        channelClass = EpollDomainSocketChannel.class;
-      } else if (KQueue.isAvailable()){
-        channelClass = KQueueDomainSocketChannel.class;
-      } else {
-        throw new IllegalStateException("Neither Epoll or Kqueue domain socket transport available");
-      }
-    }
-    Bootstrap bootstrap = new Bootstrap().channel(channelClass);
+    Bootstrap bootstrap = !StringUtils.isEmpty(udsAddress) ?
+        new Bootstrap().channel(getDomainSocketClass()) : new Bootstrap().channel(NioSocketChannel.class);
 
     _bootstrap = bootstrap
         .group(eventLoopGroup)

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
@@ -28,17 +28,13 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.group.ChannelGroup;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueDomainSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import java.net.SocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 
 /**

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolFactory.java
@@ -23,6 +23,11 @@ package com.linkedin.r2.transport.http.client.common;
 
 import com.linkedin.r2.transport.http.client.AsyncPool;
 import io.netty.channel.Channel;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.unix.DomainSocketChannel;
 import java.net.SocketAddress;
 
 /**
@@ -36,4 +41,14 @@ public interface ChannelPoolFactory
    * and destruction of the channels.
    */
   AsyncPool<Channel> getPool(SocketAddress address);
+
+  default Class<? extends DomainSocketChannel> getDomainSocketClass() {
+    if (Epoll.isAvailable()) {
+     return EpollDomainSocketChannel.class;
+    } else if (KQueue.isAvailable()){
+      return KQueueDomainSocketChannel.class;
+    } else {
+      throw new IllegalStateException("Neither Epoll or Kqueue domain socket transport available");
+    }
+  }
 }


### PR DESCRIPTION
Epoll domain sockets arent supported on M1 mac. In these cases Kqueue should be used. This changes the factories to check if epoll or kqueue is available when creating the domain socket channel.