### PR TITLE
Add a WIRE_COMPATIBLE compatibility checker level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.49.8] - 2024-01-19
+- add WIRE_COMPATIBLE compatility checker mode.
+
 ## [29.49.7] - 2024-01-18
 adjust dual read monitoring data match logic and log rate limiter
 
@@ -5615,7 +5618,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.8...master
+[29.49.8]: https://github.com/linkedin/rest.li/compare/v29.49.7...v29.49.8
 [29.49.7]: https://github.com/linkedin/rest.li/compare/v29.49.6...v29.49.7
 [29.49.6]: https://github.com/linkedin/rest.li/compare/v29.49.5...v29.49.6
 [29.49.5]: https://github.com/linkedin/rest.li/compare/v29.49.4...v29.49.5

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityChecker.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityChecker.java
@@ -553,7 +553,7 @@ public class CompatibilityChecker
 
     if (!newerOnlySymbols.isEmpty())
     {
-      appendMessage(CompatibilityMessage.Impact.BREAKS_OLD_READER,
+      appendMessage(CompatibilityMessage.Impact.ENUM_VALUE_ADDED,
                     "new enum added symbols %s",
                     newerOnlySymbols);
     }

--- a/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
+++ b/data/src/main/java/com/linkedin/data/schema/compatibility/CompatibilityMessage.java
@@ -73,7 +73,11 @@ public class CompatibilityMessage extends Message
     /**
      * Enum symbol order changed, which is a compatible change.
      */
-    ENUM_SYMBOLS_ORDER_CHANGE(false);
+    ENUM_SYMBOLS_ORDER_CHANGE(false),
+    /**
+     * New enum value added, which is wire compatible change. However, old readers may not be able to handle it.
+     */
+    ENUM_VALUE_ADDED(false);
 
     private final boolean _error;
 

--- a/data/src/test/java/com/linkedin/data/schema/compatibility/TestCompatibilityChecker.java
+++ b/data/src/test/java/com/linkedin/data/schema/compatibility/TestCompatibilityChecker.java
@@ -491,7 +491,6 @@ public class TestCompatibilityChecker
         "[ { \"type\" : \"enum\", \"name\" : \"a.b.Enum\", \"symbols\" : [ \"B\", \"D\", \"E\" ] } ]",
         _dataAndSchema,
         true,
-        "ERROR :: BREAKS_OLD_READER :: /union/a.b.Enum/symbols :: new enum added symbols E",
         "ERROR :: BREAKS_NEW_READER :: /union/a.b.Enum/symbols :: new enum removed symbols A, C"
       },
       {
@@ -499,7 +498,6 @@ public class TestCompatibilityChecker
         "[ \"string\", { \"type\" : \"enum\", \"name\" : \"a.b.Enum\", \"symbols\" : [ \"B\", \"D\", \"E\" ] }, \"int\" ]",
         _dataAndSchema,
         true,
-        "ERROR :: BREAKS_OLD_READER :: /union/a.b.Enum/symbols :: new enum added symbols E",
         "ERROR :: BREAKS_NEW_READER :: /union/a.b.Enum/symbols :: new enum removed symbols A, C"
       },
       {
@@ -787,7 +785,6 @@ public class TestCompatibilityChecker
         "{ \"type\" : \"enum\", \"name\" : \"a.b.Enum\", \"symbols\" : [ \"B\", \"D\", \"E\" ] }",
         _dataAndSchema,
         true,
-        "ERROR :: BREAKS_OLD_READER :: /a.b.Enum/symbols :: new enum added symbols E",
         "ERROR :: BREAKS_NEW_READER :: /a.b.Enum/symbols :: new enum removed symbols A, C"
       },
       {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.7
+version=29.49.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityReport.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/compatibility/CompatibilityReport.java
@@ -26,7 +26,7 @@ public class CompatibilityReport
    *   <li>[RS-C] - String describing a restspec change that is backward compatible.</li>
    *   <li>[RS-I] - String describing a restspec change that is backward incompatible.</li>
    *   <li>[MD-C] - String describing a model(PDSC) change that is backward compatible.</li>
-   *   <li>[MD-C] - String describing a model(PDSC) change that is backward incompatible.</li>
+   *   <li>[MD-I] - String describing a model(PDSC) change that is backward incompatible.</li>
    *   <li>[RS-COMPAT] - Boolean indicating if the full compatibility check was restspec backward compatible for the provided compatibilityLevel</li>
    *   <li>[MD-COMPAT] - Boolean indicating if the full compatibility check was model backward compatible for the provided compatibilityLevel</li>
    * </ul>

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityInfo.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityInfo.java
@@ -31,7 +31,7 @@ public class CompatibilityInfo
     COMPATIBLE,
 
     /**
-     * Serialization and deserialization is backwards compatible, but the change may be mishandled by clients
+     * Old readers can deserialize changes serialized by new writers, but may not be able to handle them correctly.
      * Currently only used for adding new enum values.
      **/
     WIRE_COMPATIBLE

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityInfo.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityInfo.java
@@ -28,7 +28,13 @@ public class CompatibilityInfo
   public enum Level
   {
     INCOMPATIBLE,
-    COMPATIBLE
+    COMPATIBLE,
+
+    /**
+     * Serialization and deserialization is backwards compatible, but the change may be mishandled by clients
+     * Currently only used for adding new enum values.
+     **/
+    WIRE_COMPATIBLE
   }
 
   public enum Type
@@ -48,6 +54,7 @@ public class CompatibilityInfo
     TYPE_UNKNOWN(Level.INCOMPATIBLE, "Type cannot be resolved: %s"),
     VALUE_NOT_EQUAL(Level.INCOMPATIBLE, "Current value \"%2$s\" does not match the previous value \"%1$s\""),
     VALUE_WRONG_OPTIONALITY(Level.INCOMPATIBLE, "\"%s\" may not be removed because it exists in the previous version"),
+    ENUM_VALUE_ADDED(Level.WIRE_COMPATIBLE, "%s, new enum value may break old readers"),
     TYPE_BREAKS_OLD_READER(Level.INCOMPATIBLE, "%s, breaks old readers"),
     TYPE_BREAKS_NEW_READER(Level.INCOMPATIBLE, "%s, breaks new readers"),
     TYPE_BREAKS_NEW_AND_OLD_READERS(Level.INCOMPATIBLE, "%s, breaks new and old readers"),

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityLevel.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityLevel.java
@@ -28,6 +28,7 @@ public enum CompatibilityLevel
 {
   OFF,
   IGNORE,
+  WIRE_COMPATIBLE,
   BACKWARDS,
   EQUIVALENT;
 

--- a/restli-tools/src/test/pegasus/com/linkedin/restli/tools/pegasusSchemaSnapshotTest/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasus/com/linkedin/restli/tools/pegasusSchemaSnapshotTest/BirthInfo.pdl
@@ -6,4 +6,10 @@ record BirthInfo {
   year: int
 
   location: optional Location
+
+  eyeColor: enum Color {
+    BLUE
+    BROWN
+    OTHER
+  }
 }

--- a/restli-tools/src/test/pegasusSchemaSnapshot/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/BirthInfo.pdl
@@ -7,4 +7,9 @@ record BirthInfo {
     longitude: float
     name: optional string
   }
+  eyeColor: enum Color {
+    BLUE
+    BROWN
+    OTHER
+  }
 }

--- a/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/BirthInfo.pdl
@@ -11,4 +11,10 @@ record BirthInfo {
     longitude: float
     name: optional string
   }
+  eyeColor: enum Color {
+    BLUE
+    BROWN
+    GREEN
+    OTHER
+  }
 }

--- a/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/Date.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/compatibleSchemaSnapshot/Date.pdl
@@ -1,0 +1,5 @@
+record Date {
+  day: int
+  month: int
+  year: int
+}

--- a/restli-tools/src/test/pegasusSchemaSnapshot/incompatibleSchemaSnapshot/BirthInfo.pdl
+++ b/restli-tools/src/test/pegasusSchemaSnapshot/incompatibleSchemaSnapshot/BirthInfo.pdl
@@ -12,4 +12,9 @@ record BirthInfo {
     name: optional string
   }
   name: string
+  eyeColor: enum Color {
+    BLUE
+    BROWN
+    OTHER
+  }
 }


### PR DESCRIPTION
Adding new enumeration values has special consideration in the compatibility checker. Even though such changes are compatible on the wire level (don't break deserialization for old clients), they are still considered backwards incompatible by the checker. The documentation explains why: `However, it’s still not possible to guarantee backward compatibility, even with the “$UNKNOWN” symbol available. It’s possible that clients did not handle the “$UNKNOWN” symbol in the best possible way, and even if they did it may be that they cannot do anything other than fail if they encounter a enum symbol they do not recognize.`

This patch adds a new parameter to the compatibility checker to handle this special scenario. Adding new enumeration values will still fail under the BACKWARDS and EQUIVALENT levels, but will be allowed under the WIRE_COMPATIBLE level.