### PR TITLE
Adjust dual read monitoring data match logic and remove log rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.49.7] - 2024-01-18
+adjust dual read monitoring data match logic and log rate limiter
+
 ## [29.49.6] - 2024-01-12
 - fix dualread monitoring log
 
@@ -5612,7 +5615,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.7...master
+[29.49.7]: https://github.com/linkedin/rest.li/compare/v29.49.6...v29.49.7
 [29.49.6]: https://github.com/linkedin/rest.li/compare/v29.49.5...v29.49.6
 [29.49.5]: https://github.com/linkedin/rest.li/compare/v29.49.4...v29.49.5
 [29.49.4]: https://github.com/linkedin/rest.li/compare/v29.49.3...v29.49.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/UriProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/UriProperties.java
@@ -163,7 +163,8 @@ public class UriProperties
   public String toString()
   {
     return "UriProperties [_clusterName=" + _clusterName + ", _urisBySchemeAndPartition="
-        + _urisBySchemeAndPartition + ", _partitions=" + _partitionDesc + ", _uriSpecificProperties=" + _uriSpecificProperties + "]";
+        + _urisBySchemeAndPartition + ", _partitions=" + _partitionDesc + ", _uriSpecificProperties="
+        + _uriSpecificProperties + "]";
   }
 
   @Override
@@ -218,9 +219,18 @@ public class UriProperties
         return false;
     }
     else if (!_uriSpecificProperties.equals(other._uriSpecificProperties))
-      return false;
+    {
+      // only two effectively empty uri specific properties maps are equal
+      return isEffectivelyEmpty(_uriSpecificProperties)
+          && isEffectivelyEmpty(other._uriSpecificProperties);
+    }
 
     return true;
   }
 
+  private static boolean isEffectivelyEmpty(Map<URI, Map<String, Object>> m)
+  {
+    // the map is empty OR all inner maps are actually empty
+    return m.isEmpty() || m.values().stream().allMatch(Map::isEmpty);
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/UriPropertiesMerger.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/UriPropertiesMerger.java
@@ -53,10 +53,6 @@ public class UriPropertiesMerger implements ZooKeeperPropertyMerger<UriPropertie
       }
     }
 
-    if (maxVersion == -1)
-    {
-      LOG.warn("Merged Uri properties for cluster {} has invalid version -1. It should be > -1.", propertyName);
-    }
     return new UriProperties(clusterName, partitionData, uriSpecificProperties, maxVersion);
   }
 

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStore.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStore.java
@@ -1029,7 +1029,7 @@ public class ZooKeeperEphemeralStore<T> extends ZooKeeperStore<T>
             long version = stat.getMzxid();
             if (version <= 0)
             {
-              LOG.warn("ZK data from {} has invalid version: {}", s, version);
+              LOG.warn("ZK data has invalid version: {}, from path {}", version, s);
             }
             T value = _serializer.fromBytes(bytes, version);
             _properties.put(childPath, value);

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -474,6 +474,10 @@ public class XdsToD2PropertiesAdaptor
     private void mergeAndPublishUris(String clusterName)
     {
       UriProperties mergedUriProperties = _uriPropertiesMerger.merge(clusterName, _currentData.values());
+      if (mergedUriProperties.getVersion() == -1)
+      {
+        LOG.warn("xDS UriProperties has invalid version -1. Raw uris: {}", _currentData.values());
+      }
       _uriEventBus.publishInitialize(clusterName, mergedUriProperties);
 
       if (_dualReadStateManager != null)

--- a/d2/src/test/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitorTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitorTest.java
@@ -30,20 +30,25 @@ public class DualReadLoadBalancerMonitorTest {
       doNothing().when(_mockJmx).incrementServicePropertiesErrorCount();
     }
 
-    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor getMonitor()
+    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor getServiceMonitor()
     {
       return new DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor(_mockJmx, TestDataHelper.getClock());
+    }
+
+    DualReadLoadBalancerMonitor.UriPropertiesDualReadMonitor getUriMonitor()
+    {
+      return new DualReadLoadBalancerMonitor.UriPropertiesDualReadMonitor(_mockJmx, TestDataHelper.getClock());
     }
   }
 
   @Test
-  public void testSkipPut()
+  public void testPut()
   {
     DualReadLoadBalancerMonitorTestFixure fixture = new DualReadLoadBalancerMonitorTestFixure();
-    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getMonitor();
+    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getServiceMonitor();
 
     // put in one entry for new lb
-    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1", true, 1);
+    putInService(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1", true, 1);
     verify(fixture._mockJmx).incrementServicePropertiesOutOfSyncCount();
     verifyNoMoreInteractions(fixture._mockJmx);
 
@@ -52,21 +57,29 @@ public class DualReadLoadBalancerMonitorTest {
     verifyServiceOnCache(monitor.getNewLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1");
     verifyNoMoreInteractions(fixture._mockJmx);
 
-    // put in same data with a different version will be skipped
+    // put in same data with a different version will succeed
     monitor.reportData(SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "2", true);
-    verifyServiceOnCache(monitor.getNewLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1");
+    verifyServiceOnCache(monitor.getNewLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "2");
+    verify(fixture._mockJmx, times(2)).incrementServicePropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+
+    // put in an entry to old lb with the same data but a different version (not read from FS) will succeed
+    monitor.reportData(SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1", false);
+    verifyServiceOnCache(monitor.getOldLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1");
+    verifyServiceOnCache(monitor.getNewLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "2");
+    verify(fixture._mockJmx, times(3)).incrementServicePropertiesOutOfSyncCount();
     verifyNoMoreInteractions(fixture._mockJmx);
   }
 
   @Test
-  public void testMatch()
+  public void testServiceDataMatch()
   {
     DualReadLoadBalancerMonitorTestFixure fixture = new DualReadLoadBalancerMonitorTestFixure();
-    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getMonitor();
+    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getServiceMonitor();
 
     // put in one new lb entry and one old lb entry, with different data and version
-    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
-    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1", false, 1);
+    putInService(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
+    putInService(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1", false, 1);
     verify(fixture._mockJmx, times(2)).incrementServicePropertiesOutOfSyncCount();
     verifyNoMoreInteractions(fixture._mockJmx);
 
@@ -79,12 +92,12 @@ public class DualReadLoadBalancerMonitorTest {
     verifyNoMoreInteractions(fixture._mockJmx);
 
     // put the new lb one back in
-    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
+    putInService(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
     verify(fixture._mockJmx, times(3)).incrementServicePropertiesOutOfSyncCount();
     verifyNoMoreInteractions(fixture._mockJmx);
 
-    // Data match only (version differs): put in an old lb entry that matches the data of the new lb one
-    // will remove the new lb one
+    // Data match, version differs but "-1" will be matched as an exception: put in an old lb entry that matches
+    // the data of the new lb one will remove the new lb one
     monitor.reportData(SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "2", false);
     Assert.assertEquals(monitor.getNewLbCache().size(), 0);
     verifyServiceOnCache(monitor.getOldLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1");
@@ -92,15 +105,35 @@ public class DualReadLoadBalancerMonitorTest {
     verifyNoMoreInteractions(fixture._mockJmx);
   }
 
+  @Test // since uri version read from FS is "-1|x", test for this case specifically
+  public void testUriDataMatch()
+  {
+    DualReadLoadBalancerMonitorTestFixure fixture = new DualReadLoadBalancerMonitorTestFixure();
+    DualReadLoadBalancerMonitor.UriPropertiesDualReadMonitor monitor = fixture.getUriMonitor();
+
+    // put in one new lb entry and one old lb entry, with different data and version
+    putInUri(monitor, CLUSTER_NAME, PROPERTIES_1, "1|2", true, 1);
+    putInUri(monitor, CLUSTER_NAME, PROPERTIES_2, "-1|2", false, 1);
+    verify(fixture._mockJmx, times(2)).incrementUriPropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+
+    // data match, version differs with version read FS
+    monitor.reportData(CLUSTER_NAME, PROPERTIES_2, "2|2", true);
+    Assert.assertEquals(monitor.getOldLbCache().size(), 0);
+    verifyUriOnCache(monitor.getNewLbCache(), CLUSTER_NAME, PROPERTIES_1, "1|2");
+    verify(fixture._mockJmx).decrementUriPropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+  }
+
   @Test
   public void testMismatch()
   {
     DualReadLoadBalancerMonitorTestFixure fixture = new DualReadLoadBalancerMonitorTestFixure();
-    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getMonitor();
+    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getServiceMonitor();
 
     // put in one new lb entry and one old lb entry, with different data and version
-    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
-    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1", false, 1);
+    putInService(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
+    putInService(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1", false, 1);
     verify(fixture._mockJmx, times(2)).incrementServicePropertiesOutOfSyncCount();
     verifyNoMoreInteractions(fixture._mockJmx);
 
@@ -114,7 +147,7 @@ public class DualReadLoadBalancerMonitorTest {
     verifyNoMoreInteractions(fixture._mockJmx);
   }
 
-  private void putInOneEntry(DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor,
+  private void putInService(DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor,
       String name, ServiceStoreProperties prop, String version, boolean isFromNewLb, int expectedSizeAfter)
   {
     monitor.reportData(name, prop, version, isFromNewLb);
@@ -128,6 +161,26 @@ public class DualReadLoadBalancerMonitorTest {
       String name, ServiceProperties prop, String v)
   {
     DualReadLoadBalancerMonitor.CacheEntry<ServiceProperties> entry = cache.getIfPresent(name);
+    Assert.assertNotNull(entry);
+    Assert.assertEquals(entry._data, prop);
+    Assert.assertEquals(entry._version, v);
+  }
+
+  private void putInUri(DualReadLoadBalancerMonitor.UriPropertiesDualReadMonitor monitor,
+      String name, UriProperties prop, String version, boolean isFromNewLb, int expectedSizeAfter)
+  {
+    monitor.reportData(name, prop, version, isFromNewLb);
+    Cache<String, DualReadLoadBalancerMonitor.CacheEntry<UriProperties>> cache =
+        isFromNewLb ? monitor.getNewLbCache() : monitor.getOldLbCache();
+    Assert.assertEquals(cache.size(), expectedSizeAfter);
+    verifyUriOnCache(cache, name, prop, version);
+  }
+
+  private void verifyUriOnCache(Cache<String, DualReadLoadBalancerMonitor.CacheEntry<UriProperties>> cache,
+      String name, UriProperties prop, String v)
+  {
+    DualReadLoadBalancerMonitor.CacheEntry<UriProperties> entry = cache.getIfPresent(name);
+    Assert.assertNotNull(entry);
     Assert.assertEquals(entry._data, prop);
     Assert.assertEquals(entry._version, v);
   }
@@ -168,8 +221,7 @@ public class DualReadLoadBalancerMonitorTest {
       String expected)
   {
     DualReadLoadBalancerMonitor.UriPropertiesDualReadMonitor monitor =
-        new DualReadLoadBalancerMonitor.UriPropertiesDualReadMonitor(
-            new DualReadLoadBalancerJmx(), TestDataHelper.getClock());
+        new DualReadLoadBalancerMonitorTestFixure().getUriMonitor();
 
     Assert.assertEquals(monitor.getEntriesMessage(isFromNewLb, oldE, newE),
         expected,

--- a/d2/src/test/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitorTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitorTest.java
@@ -1,15 +1,136 @@
 package com.linkedin.d2.balancer.dualread;
 
+import com.google.common.cache.Cache;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.properties.ServiceStoreProperties;
 import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.d2.util.TestDataHelper;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static com.linkedin.d2.util.TestDataHelper.*;
+import static org.mockito.Mockito.*;
 
 
 public class DualReadLoadBalancerMonitorTest {
+
+  private static class DualReadLoadBalancerMonitorTestFixure
+  {
+    @Mock
+    DualReadLoadBalancerJmx _mockJmx;
+
+    DualReadLoadBalancerMonitorTestFixure()
+    {
+      MockitoAnnotations.initMocks(this);
+      doNothing().when(_mockJmx).incrementServicePropertiesOutOfSyncCount();
+      doNothing().when(_mockJmx).decrementUriPropertiesOutOfSyncCount();
+      doNothing().when(_mockJmx).incrementServicePropertiesErrorCount();
+    }
+
+    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor getMonitor()
+    {
+      return new DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor(_mockJmx, TestDataHelper.getClock());
+    }
+  }
+
+  @Test
+  public void testSkipPut()
+  {
+    DualReadLoadBalancerMonitorTestFixure fixture = new DualReadLoadBalancerMonitorTestFixure();
+    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getMonitor();
+
+    // put in one entry for new lb
+    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1", true, 1);
+    verify(fixture._mockJmx).incrementServicePropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+
+    // put in duplicate entry will be skipped
+    monitor.reportData(SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1", true);
+    verifyServiceOnCache(monitor.getNewLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1");
+    verifyNoMoreInteractions(fixture._mockJmx);
+
+    // put in same data with a different version will be skipped
+    monitor.reportData(SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "2", true);
+    verifyServiceOnCache(monitor.getNewLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "1");
+    verifyNoMoreInteractions(fixture._mockJmx);
+  }
+
+  @Test
+  public void testMatch()
+  {
+    DualReadLoadBalancerMonitorTestFixure fixture = new DualReadLoadBalancerMonitorTestFixure();
+    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getMonitor();
+
+    // put in one new lb entry and one old lb entry, with different data and version
+    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
+    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1", false, 1);
+    verify(fixture._mockJmx, times(2)).incrementServicePropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+
+    // Exact match (data and version all the same): put in an old lb entry that matches the new lb one
+    // will remove the new lb one
+    monitor.reportData(SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", false);
+    Assert.assertEquals(monitor.getNewLbCache().size(), 0);
+    verifyServiceOnCache(monitor.getOldLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1");
+    verify(fixture._mockJmx).decrementServicePropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+
+    // put the new lb one back in
+    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
+    verify(fixture._mockJmx, times(3)).incrementServicePropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+
+    // Data match only (version differs): put in an old lb entry that matches the data of the new lb one
+    // will remove the new lb one
+    monitor.reportData(SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "2", false);
+    Assert.assertEquals(monitor.getNewLbCache().size(), 0);
+    verifyServiceOnCache(monitor.getOldLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1");
+    verify(fixture._mockJmx, times(2)).decrementServicePropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+  }
+
+  @Test
+  public void testMismatch()
+  {
+    DualReadLoadBalancerMonitorTestFixure fixture = new DualReadLoadBalancerMonitorTestFixure();
+    DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor = fixture.getMonitor();
+
+    // put in one new lb entry and one old lb entry, with different data and version
+    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1", true, 1);
+    putInOneEntry(monitor, SERVICE_NAME, SERVICE_STORE_PROPERTIES_2, "1", false, 1);
+    verify(fixture._mockJmx, times(2)).incrementServicePropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+
+    // Mismatch (version is the same but data differs): put in a new lb entry that mismatch the old lb one
+    // will remove the old lb one
+    monitor.reportData(SERVICE_NAME, SERVICE_STORE_PROPERTIES_3, "1", true);
+    Assert.assertEquals(monitor.getOldLbCache().size(), 0);
+    verifyServiceOnCache(monitor.getNewLbCache(), SERVICE_NAME, SERVICE_STORE_PROPERTIES_1, "-1");
+    verify(fixture._mockJmx).incrementServicePropertiesErrorCount();
+    verify(fixture._mockJmx, times(3)).incrementServicePropertiesOutOfSyncCount();
+    verifyNoMoreInteractions(fixture._mockJmx);
+  }
+
+  private void putInOneEntry(DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor monitor,
+      String name, ServiceStoreProperties prop, String version, boolean isFromNewLb, int expectedSizeAfter)
+  {
+    monitor.reportData(name, prop, version, isFromNewLb);
+    Cache<String, DualReadLoadBalancerMonitor.CacheEntry<ServiceProperties>> cache =
+        isFromNewLb ? monitor.getNewLbCache() : monitor.getOldLbCache();
+    Assert.assertEquals(cache.size(), expectedSizeAfter);
+    verifyServiceOnCache(cache, name, prop, version);
+  }
+
+  private void verifyServiceOnCache(Cache<String, DualReadLoadBalancerMonitor.CacheEntry<ServiceProperties>> cache,
+      String name, ServiceProperties prop, String v)
+  {
+    DualReadLoadBalancerMonitor.CacheEntry<ServiceProperties> entry = cache.getIfPresent(name);
+    Assert.assertEquals(entry._data, prop);
+    Assert.assertEquals(entry._version, v);
+  }
 
   @DataProvider
   public Object[][] getEntriesMessageDataProvider()

--- a/d2/src/test/java/com/linkedin/d2/util/TestDataHelper.java
+++ b/d2/src/test/java/com/linkedin/d2/util/TestDataHelper.java
@@ -2,6 +2,9 @@ package com.linkedin.d2.util;
 
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.PropertyKeys;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.properties.ServiceStoreProperties;
 import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.d2.discovery.event.D2ServiceDiscoveryEventHelper;
 import com.linkedin.d2.discovery.event.ServiceDiscoveryEventEmitter;
@@ -24,7 +27,17 @@ import static org.testng.Assert.*;
 
 
 public class TestDataHelper {
+  public static final String SERVICE_NAME = "testService";
+  public static final String PATH = "/testService";
+  public static final List<String> STRATEGY_LIST_1 = Collections.singletonList("relative");
+  public static final List<String> STRATEGY_LIST_2 = Collections.singletonList("degrader");
   public static final String CLUSTER_NAME = "TestCluster";
+  public static final ServiceProperties SERVICE_PROPERTIES_1;
+  public static final ServiceProperties SERVICE_PROPERTIES_2;
+  public static final ServiceProperties SERVICE_PROPERTIES_3;
+  public static final ServiceStoreProperties SERVICE_STORE_PROPERTIES_1;
+  public static final ServiceStoreProperties SERVICE_STORE_PROPERTIES_2;
+  public static final ServiceStoreProperties SERVICE_STORE_PROPERTIES_3;
   public static final String HOST_1 = "google.com";
   public static final String HOST_2 = "linkedin.com";
   public static final String HOST_3 = "youtube.com";
@@ -59,6 +72,16 @@ public class TestDataHelper {
     1, new PartitionData(3));
 
   static {
+    SERVICE_PROPERTIES_1 = new ServiceProperties(SERVICE_NAME, CLUSTER_NAME, PATH, STRATEGY_LIST_1);
+    SERVICE_STORE_PROPERTIES_1 = new ServiceStoreProperties(SERVICE_PROPERTIES_1, null, null);
+
+    SERVICE_PROPERTIES_2 = new ServiceProperties(SERVICE_NAME, CLUSTER_NAME, PATH, STRATEGY_LIST_2);
+    SERVICE_STORE_PROPERTIES_2 = new ServiceStoreProperties(SERVICE_PROPERTIES_2, null, null);
+
+    SERVICE_PROPERTIES_3 = new ServiceProperties(SERVICE_NAME, CLUSTER_NAME, PATH, STRATEGY_LIST_1,
+        Collections.singletonMap(PropertyKeys.RELATIVE_LATENCY_HIGH_THRESHOLD_FACTOR, 8.0));
+    SERVICE_STORE_PROPERTIES_3 = new ServiceStoreProperties(SERVICE_PROPERTIES_3, null, null);
+
     PROPERTIES_1 = new UriProperties(CLUSTER_NAME, Collections.singletonMap(URI_1, MAP_1));
     PROPERTIES_2 = new UriProperties(CLUSTER_NAME, Collections.singletonMap(URI_2, MAP_2));
     PROPERTIES_3 = new UriProperties(CLUSTER_NAME, Collections.singletonMap(URI_3, MAP_3));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.6
+version=29.49.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Dual read monitoring have been having tons of false-positive uri property mismatches. We used a rate limiter logger which was flooded by uri logs and starved critical logs from service and cluster properties.

## Changes
1. Eliminate two kinds of mismatches: 1)  uriSpecificProperties from xDS flow having inner empty maps will be treated the same as an empty uriSpecificProperties. 2) data read from FS has a version of "-1". Allow data match if (at least) one data is read FS.
2. Use unlimited logger for service and cluster property warn logs, while keep using a rate limiter logger for uri warn logs.
3. adjust log messages to show the property type, name, data and version, in both LBs clearly.

## Test Done
Unit tests.

Manual test with QEI d2-proxy. 
Log snippet shows the data matches sequence for service "workplaceTypeTaxonomyVersions", its cluster "DataMan" and the uris (I turned debug level log to info level just to show the logs):
```
2024/01/19 08:51:29.322 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0qjayMYGSaFtuedww==] Added new entry ServiceStoreProperties for workplaceTypeTaxonomyVersions for New LB.
2024/01/19 08:51:29.322 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0qjayMYGSaFtuedww==] Current entries of ServiceStoreProperties for workplaceTypeTaxonomyVersions: 
Old LB: null
New LB: CacheEntry{_version=253657044435, _timeStamp='2024/01/19 08:51:29.321', _data=ServiceStoreProperties [_stableServiceProperties=ServiceProperties [_clusterName=DataMan, _path=/workplaceTypeTaxonomyVersions, _serviceName=workplaceTypeTaxonomyVersions, _loadBalancerStrategyList=[relative, degrader], _loadBalancerStrategyProperties={http.loadBalancer.pointsPerWeight=100, http.loadBalancer.lowEmittingInterval=20000, http.loadBalancer.highEmittingInterval=150000, http.loadBalancer.updateIntervalMs=5000, http.loadBalancer.consistentHashAlgorithm=distributionBased, http.loadBalancer.ringRampFactor=2.0, http.loadBalancer.highWaterMark=3000.0, http.loadBalancer.quarantine.maxPercent=0.1, http.loadBalancer.lowWaterMark=500.0}, _transportClientProperties={http.idleTimeout=10500000, allowedClientOverrideKeys=http.protocolVersion, http.poolSize=100, http.protocolVersion=HTTP_2, http.maxResponseSize=20971520, http.sslIdleTimeout=10500000, http.requestTimeout=10000}, _relativeStrategyProperties={highErrorRate=0.1, lowErrorRate=0.02, downStep=0.2, enableFastRecovery=true, relativeLatencyLowThresholdFactor=4.0, relativeLatencyHighThresholdFactor=5.0, slowStartThreshold=0.16, quarantineProperties={quarantineMaxPercent=0.1}, initialHealthScore=0.01, ringProperties={consistentHashAlgorithm=distributionBased}, upStep=0.05, emittingIntervalMs=150000}, _degraderProperties={degrader.minCallCount=1, degrader.highErrorRate=0.1, degrader.lowLatency=3000, degrader.downStep=0.05, degrader.highLatency=5000, degrader.initialDropRate=0.99, degrader.slowStartThreshold=0.16, degrader.lowErrorRate=0.02}, prioritizedSchemes=[https], bannedUris=[], serviceMetadata={}, backupRequests=[], enableClusterSubsetting=false, minimumClusterSubsetSize=-1], _canaryConfigs=null, _canaryDistributionStrategy=null]}
2024/01/19 08:51:29.668 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0qot/cmC3hYTrXTuA==] Matched ServiceStoreProperties for workplaceTypeTaxonomyVersions. 
Old LB: CacheEntry{_version=253657044435, _timeStamp='2024/01/19 08:51:29.668', _data=ServiceStoreProperties [_stableServiceProperties=ServiceProperties [_clusterName=DataMan, _path=/workplaceTypeTaxonomyVersions, _serviceName=workplaceTypeTaxonomyVersions, _loadBalancerStrategyList=[relative, degrader], _loadBalancerStrategyProperties={http.loadBalancer.pointsPerWeight=100, http.loadBalancer.lowEmittingInterval=20000, http.loadBalancer.highEmittingInterval=150000, http.loadBalancer.updateIntervalMs=5000, http.loadBalancer.consistentHashAlgorithm=distributionBased, http.loadBalancer.ringRampFactor=2.0, http.loadBalancer.highWaterMark=3000.0, http.loadBalancer.quarantine.maxPercent=0.1, http.loadBalancer.lowWaterMark=500.0}, _transportClientProperties={http.idleTimeout=10500000, allowedClientOverrideKeys=http.protocolVersion, http.poolSize=100, http.protocolVersion=HTTP_2, http.maxResponseSize=20971520, http.sslIdleTimeout=10500000, http.requestTimeout=10000}, _relativeStrategyProperties={highErrorRate=0.1, lowErrorRate=0.02, downStep=0.2, enableFastRecovery=true, relativeLatencyLowThresholdFactor=4.0, relativeLatencyHighThresholdFactor=5.0, slowStartThreshold=0.16, quarantineProperties={quarantineMaxPercent=0.1}, initialHealthScore=0.01, ringProperties={consistentHashAlgorithm=distributionBased}, upStep=0.05, emittingIntervalMs=150000}, _degraderProperties={degrader.minCallCount=1, degrader.highErrorRate=0.1, degrader.lowLatency=3000, degrader.downStep=0.05, degrader.highLatency=5000, degrader.initialDropRate=0.99, degrader.slowStartThreshold=0.16, degrader.lowErrorRate=0.02}, prioritizedSchemes=[https], bannedUris=[], serviceMetadata={}, backupRequests=[], enableClusterSubsetting=false, minimumClusterSubsetSize=-1], _canaryConfigs=null, _canaryDistributionStrategy=null]}
New LB: CacheEntry{_version=253657044435, _timeStamp='2024/01/19 08:51:29.321', _data=ServiceStoreProperties [_stableServiceProperties=ServiceProperties [_clusterName=DataMan, _path=/workplaceTypeTaxonomyVersions, _serviceName=workplaceTypeTaxonomyVersions, _loadBalancerStrategyList=[relative, degrader], _loadBalancerStrategyProperties={http.loadBalancer.pointsPerWeight=100, http.loadBalancer.lowEmittingInterval=20000, http.loadBalancer.highEmittingInterval=150000, http.loadBalancer.updateIntervalMs=5000, http.loadBalancer.consistentHashAlgorithm=distributionBased, http.loadBalancer.ringRampFactor=2.0, http.loadBalancer.highWaterMark=3000.0, http.loadBalancer.quarantine.maxPercent=0.1, http.loadBalancer.lowWaterMark=500.0}, _transportClientProperties={http.idleTimeout=10500000, allowedClientOverrideKeys=http.protocolVersion, http.poolSize=100, http.protocolVersion=HTTP_2, http.maxResponseSize=20971520, http.sslIdleTimeout=10500000, http.requestTimeout=10000}, _relativeStrategyProperties={highErrorRate=0.1, lowErrorRate=0.02, downStep=0.2, enableFastRecovery=true, relativeLatencyLowThresholdFactor=4.0, relativeLatencyHighThresholdFactor=5.0, slowStartThreshold=0.16, quarantineProperties={quarantineMaxPercent=0.1}, initialHealthScore=0.01, ringProperties={consistentHashAlgorithm=distributionBased}, upStep=0.05, emittingIntervalMs=150000}, _degraderProperties={degrader.minCallCount=1, degrader.highErrorRate=0.1, degrader.lowLatency=3000, degrader.downStep=0.05, degrader.highLatency=5000, degrader.initialDropRate=0.99, degrader.slowStartThreshold=0.16, degrader.lowErrorRate=0.02}, prioritizedSchemes=[https], bannedUris=[], serviceMetadata={}, backupRequests=[], enableClusterSubsetting=false, minimumClusterSubsetSize=-1], _canaryConfigs=null, _canaryDistributionStrategy=null]}
2024/01/19 08:51:29.669 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0qot/cmC3hYTrXTuA==] Current entries of ServiceStoreProperties for workplaceTypeTaxonomyVersions: 
Old LB: null
New LB: null

2024/01/19 08:51:30.143 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0qv9q3dngdZSKCk0A==] Added new entry ClusterStoreProperties for DataMan for New LB.
2024/01/19 08:51:30.143 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0qv9q3dngdZSKCk0A==] Current entries of ClusterStoreProperties for DataMan: 
Old LB: null
New LB: CacheEntry{_version=253657044272, _timeStamp='2024/01/19 08:51:30.143', _data=ClusterStoreProperties [_stableClusterProperties=ClusterProperties [_clusterName=DataMan, _prioritizedSchemes=[], _properties={}, _bannedUris=[], _partitionProperties=com.linkedin.d2.balancer.properties.NullPartitionProperties@6df0a51e, _sslSessionValidationStrings=[dataman], _darkClusterConfigMap={}, _delegated=false], _canaryConfigs=null, _canaryDistributionStrategy=null, _failoutProperties=null]}
2024/01/19 08:51:30.160 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0qwOS5ilZCYy6w7tg==] Added new entry UriProperties for DataMan for New LB.
2024/01/19 08:51:30.160 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0qwOS5ilZCYy6w7tg==] Current entries of UriProperties for DataMan: 
Old LB: null
New LB: CacheEntry{_version=253607588919|2, _timeStamp='2024/01/19 08:51:30.160', _data=UriProperties [_clusterName=DataMan, _urisBySchemeAndPartition={https={0=[https://ltx1-app5667.stg.linkedin.com:3874/dataman, https://ltx1-app6217.stg.linkedin.com:3874/dataman]}}, _partitions={https://ltx1-app5667.stg.linkedin.com:3874/dataman={0=[ weight =1.0 ]}, https://ltx1-app6217.stg.linkedin.com:3874/dataman={0=[ weight =1.0 ]}}, _uriSpecificProperties={https://ltx1-app5667.stg.linkedin.com:3874/dataman={}, https://ltx1-app6217.stg.linkedin.com:3874/dataman={}}]}

2024/01/19 08:51:30.416 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0q0IKLLrOFoNYaC8A==] Matched ClusterStoreProperties for DataMan. 
Old LB: CacheEntry{_version=253657044272, _timeStamp='2024/01/19 08:51:30.416', _data=ClusterStoreProperties [_stableClusterProperties=ClusterProperties [_clusterName=DataMan, _prioritizedSchemes=[], _properties={}, _bannedUris=[], _partitionProperties=com.linkedin.d2.balancer.properties.NullPartitionProperties@6df0a51e, _sslSessionValidationStrings=[dataman], _darkClusterConfigMap={}, _delegated=false], _canaryConfigs=null, _canaryDistributionStrategy=null, _failoutProperties=null]}
New LB: CacheEntry{_version=253657044272, _timeStamp='2024/01/19 08:51:30.143', _data=ClusterStoreProperties [_stableClusterProperties=ClusterProperties [_clusterName=DataMan, _prioritizedSchemes=[], _properties={}, _bannedUris=[], _partitionProperties=com.linkedin.d2.balancer.properties.NullPartitionProperties@6df0a51e, _sslSessionValidationStrings=[dataman], _darkClusterConfigMap={}, _delegated=false], _canaryConfigs=null, _canaryDistributionStrategy=null, _failoutProperties=null]}
2024/01/19 08:51:30.416 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0q0IKLLrOFoNYaC8A==] Current entries of ClusterStoreProperties for DataMan: 
Old LB: null
New LB: null

2024/01/19 08:51:30.441 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0q0gdDgbUuAqeczSw==] Matched UriProperties for DataMan that only differ in version. 
Old LB: CacheEntry{_version=-1|2, _timeStamp='2024/01/19 08:51:30.441', _data=UriProperties [_clusterName=DataMan, _urisBySchemeAndPartition={https={0=[https://ltx1-app5667.stg.linkedin.com:3874/dataman, https://ltx1-app6217.stg.linkedin.com:3874/dataman]}}, _partitions={https://ltx1-app5667.stg.linkedin.com:3874/dataman={0=[ weight =1.0 ]}, https://ltx1-app6217.stg.linkedin.com:3874/dataman={0=[ weight =1.0 ]}}, _uriSpecificProperties={}]}
New LB: CacheEntry{_version=253607588919|2, _timeStamp='2024/01/19 08:51:30.160', _data=UriProperties [_clusterName=DataMan, _urisBySchemeAndPartition={https={0=[https://ltx1-app5667.stg.linkedin.com:3874/dataman, https://ltx1-app6217.stg.linkedin.com:3874/dataman]}}, _partitions={https://ltx1-app5667.stg.linkedin.com:3874/dataman={0=[ weight =1.0 ]}, https://ltx1-app6217.stg.linkedin.com:3874/dataman={0=[ weight =1.0 ]}}, _uriSpecificProperties={https://ltx1-app5667.stg.linkedin.com:3874/dataman={}, https://ltx1-app6217.stg.linkedin.com:3874/dataman={}}]}
2024/01/19 08:51:30.441 INFO [DualReadLoadBalancerMonitor] [__r2d2DefaultClient__.r2d2Client.d2Executor-4-1] [d2-proxy] [AAYPT0q0gdDgbUuAqeczSw==] Current entries of UriProperties for DataMan: 
Old LB: null
New LB: null
```