### PR TITLE
Adding `translated.from` annotation when using SchemaTranslator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ project.ext.externalDependency = [
   'parseq_restClient': 'com.linkedin.parseq:parseq-restli-client:5.1.2',
   'parseq_testApi': 'com.linkedin.parseq:parseq-test-api:5.1.2',
   'servletApi': 'javax.servlet:javax.servlet-api:3.1.0',
+  'skyScreamer': 'org.skyscreamer:jsonassert:1.5.1',
   'slf4jApi': 'org.slf4j:slf4j-api:1.7.30',
   'slf4jLog4j2': 'org.apache.logging.log4j:log4j-slf4j-impl:2.0.2',
   'snappy': 'org.iq80.snappy:snappy:0.4',

--- a/data-avro-generator/build.gradle
+++ b/data-avro-generator/build.gradle
@@ -2,6 +2,7 @@ dependencies {
   compile project(':data')
   compile project(':data-avro')
   compile externalDependency.avro
+  compile externalDependency.skyScreamer
   testCompile project(path: ':data', configuration: 'testArtifacts')
   testCompile externalDependency.testng
 }

--- a/data-avro/build.gradle
+++ b/data-avro/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   compile externalDependency.avro
   compile externalDependency.avroUtil
   testCompile externalDependency.testng
+  testCompile externalDependency.skyScreamer
   testCompile project(path: ':data', configuration: 'testArtifacts')
 }
 

--- a/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
@@ -18,12 +18,15 @@ package com.linkedin.data.avro;
 
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.ConfigurableSchemaComparator;
+import com.linkedin.avroutil1.compatibility.SchemaComparisonConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.DataMapBuilder;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaResolver;
 import com.linkedin.data.schema.DataSchemaTraverse;
+import com.linkedin.data.schema.NamedDataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.SchemaFormatType;
 import com.linkedin.data.schema.SchemaParser;
@@ -36,6 +39,7 @@ import com.linkedin.data.schema.validation.ValidationOptions;
 import com.linkedin.data.template.DataTemplateUtil;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -53,6 +57,7 @@ public class SchemaTranslator
   private static final Logger log = LoggerFactory.getLogger(SchemaTranslator.class);
 
   public static final String DATA_PROPERTY = "com.linkedin.data";
+  public static final String TRANSLATED_FROM_SOURCE_OPTION = "li.data.translated.from";
   public static final String SCHEMA_PROPERTY = "schema";
   public static final String OPTIONAL_DEFAULT_MODE_PROPERTY = "optionalDefaultMode";
   public static final String AVRO_FILE_EXTENSION = ".avsc";
@@ -166,9 +171,12 @@ public class SchemaTranslator
             {
               avroSchemaFromEmbedded.addProp(DATA_PROPERTY, embededSchemaPropertyVal);
             }
-            if (!avroSchemaFromEmbedded.equals(avroSchemaFromJson))
-            {
-              throw new IllegalArgumentException("Embedded schema does not translate to input Avro schema: " + avroSchemaInJson);
+            // Compare using configuration equivalent to STRICT, except ignore TRANSLATED_FROM_SOURCE_OPTION
+            if (!ConfigurableSchemaComparator.equals(avroSchemaFromEmbedded, avroSchemaFromJson,
+                new SchemaComparisonConfiguration(true, true, true, false, true, true,
+                    Collections.singleton((TRANSLATED_FROM_SOURCE_OPTION))))) {
+              throw new IllegalArgumentException(
+                  "Embedded schema does not translate to input Avro schema: " + avroSchemaInJson);
             }
           }
         }
@@ -186,6 +194,9 @@ public class SchemaTranslator
       String dataSchemaJson = dataSchema.toString();
       resultDataSchema = DataTemplateUtil.parseSchema(dataSchemaJson);
     }
+
+    // add translated from annotation if this is a named dataSchema
+    resultDataSchema = addTranslatedPropToNamedDataSchema(resultDataSchema);
     return resultDataSchema;
   }
 
@@ -317,6 +328,8 @@ public class SchemaTranslator
    */
   public static String dataToAvroSchemaJson(DataSchema dataSchema, DataToAvroSchemaTranslationOptions options) throws IllegalArgumentException
   {
+    dataSchema = addTranslatedPropToNamedDataSchema(dataSchema);
+
     // Create a copy of the schema before the actual translation, since the translation process ends up modifying the
     // schema for unions with aliases, and we don't want to disturb the original schema. Use PDL to preserve annotations.
     final DataSchema translatedDataSchema = DataTemplateUtil.parseSchema(
@@ -339,6 +352,26 @@ public class SchemaTranslator
 
     schemaTraverser.traverse(translatedDataSchema, callbacks);
     return SchemaToAvroJsonEncoder.schemaToAvro(translatedDataSchema, dataSchema, defaultValueOverrides, options);
+  }
+
+  /**
+   * Adds TRANSLATED_FROM_SOURCE_OPTION property to named data schemas if not already present.
+   * @param dataSchema the data schema to add the property to
+   * @return the data schema with the property added if applicable.
+   */
+  private static DataSchema addTranslatedPropToNamedDataSchema(DataSchema dataSchema) {
+    // Add translated from annotation if this is a named dataSchema
+    if (dataSchema instanceof NamedDataSchema) {
+      NamedDataSchema namedDataSchema = (NamedDataSchema) dataSchema;
+      // Add annotation if not already present
+      if (!namedDataSchema.getProperties().containsKey(TRANSLATED_FROM_SOURCE_OPTION)) {
+        Map<String, Object> properties = new HashMap<>(namedDataSchema.getProperties());
+        properties.put(TRANSLATED_FROM_SOURCE_OPTION, namedDataSchema.getFullName());
+        namedDataSchema.setProperties(properties);
+      }
+      dataSchema = namedDataSchema;
+    }
+    return dataSchema;
   }
 
   /**

--- a/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
@@ -33,6 +33,7 @@ import com.linkedin.data.schema.SchemaParser;
 import com.linkedin.data.schema.SchemaParserFactory;
 import com.linkedin.data.schema.PegasusSchemaParser;
 import com.linkedin.data.schema.SchemaToPdlEncoder;
+import com.linkedin.data.schema.TyperefDataSchema;
 import com.linkedin.data.schema.resolver.DefaultDataSchemaResolver;
 import com.linkedin.data.schema.resolver.FileDataSchemaResolver;
 import com.linkedin.data.schema.validation.ValidationOptions;
@@ -362,14 +363,24 @@ public class SchemaTranslator
   private static DataSchema addTranslatedPropToNamedDataSchema(DataSchema dataSchema) {
     // Add translated from annotation if this is a named dataSchema
     if (dataSchema instanceof NamedDataSchema) {
+      if (dataSchema instanceof TyperefDataSchema) {
+        ((TyperefDataSchema) dataSchema).setReferencedType(
+            addAnnotationToDataSchema(((TyperefDataSchema) dataSchema).getRef()));
+      } else {
+        return addAnnotationToDataSchema(dataSchema);
+      }
+    }
+    return dataSchema;
+  }
+
+  private static DataSchema addAnnotationToDataSchema(DataSchema dataSchema) {
+    if (dataSchema instanceof NamedDataSchema) {
       NamedDataSchema namedDataSchema = (NamedDataSchema) dataSchema;
-      // Add annotation if not already present
       if (!namedDataSchema.getProperties().containsKey(TRANSLATED_FROM_SOURCE_OPTION)) {
         Map<String, Object> properties = new HashMap<>(namedDataSchema.getProperties());
         properties.put(TRANSLATED_FROM_SOURCE_OPTION, namedDataSchema.getFullName());
         namedDataSchema.setProperties(properties);
       }
-      dataSchema = namedDataSchema;
     }
     return dataSchema;
   }

--- a/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
@@ -58,7 +58,7 @@ public class SchemaTranslator
   private static final Logger log = LoggerFactory.getLogger(SchemaTranslator.class);
 
   public static final String DATA_PROPERTY = "com.linkedin.data";
-  public static final String TRANSLATED_FROM_SOURCE_OPTION = "li.data.translated.from";
+  public static final String TRANSLATED_FROM_SOURCE_OPTION = "schema.translated.from.src";
   public static final String SCHEMA_PROPERTY = "schema";
   public static final String OPTIONAL_DEFAULT_MODE_PROPERTY = "optionalDefaultMode";
   public static final String AVRO_FILE_EXTENSION = ".avsc";

--- a/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
@@ -58,7 +58,7 @@ public class SchemaTranslator
   private static final Logger log = LoggerFactory.getLogger(SchemaTranslator.class);
 
   public static final String DATA_PROPERTY = "com.linkedin.data";
-  public static final String TRANSLATED_FROM_SOURCE_OPTION = "schema.translated.from.src";
+  public static final String TRANSLATED_FROM_SOURCE_OPTION = "translated.from";
   public static final String SCHEMA_PROPERTY = "schema";
   public static final String OPTIONAL_DEFAULT_MODE_PROPERTY = "optionalDefaultMode";
   public static final String AVRO_FILE_EXTENSION = ".avsc";

--- a/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
@@ -174,8 +174,8 @@ public class SchemaTranslator
             }
             // Compare using configuration equivalent to STRICT, except ignore TRANSLATED_FROM_SOURCE_OPTION
             if (!ConfigurableSchemaComparator.equals(avroSchemaFromEmbedded, avroSchemaFromJson,
-                new SchemaComparisonConfiguration(true, true, true, false, true, true,
-                    Collections.singleton((TRANSLATED_FROM_SOURCE_OPTION))))) {
+                SchemaComparisonConfiguration.STRICT.jsonPropNamesToIgnore(
+                    Collections.singleton(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION)))) {
               throw new IllegalArgumentException(
                   "Embedded schema does not translate to input Avro schema: " + avroSchemaInJson);
             }

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestCustomAvroSchema.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestCustomAvroSchema.java
@@ -329,8 +329,8 @@ public class TestCustomAvroSchema
     Assert.assertFalse(avroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION).isEmpty());
     Assert.assertTrue(
         ConfigurableSchemaComparator.equals(avroSchema, Schema.parse(fullAvroSchemaJson),
-            new SchemaComparisonConfiguration(true, true, true, false, true, true,
-                Collections.singleton((SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION)))));
+            SchemaComparisonConfiguration.STRICT.jsonPropNamesToIgnore(
+                Collections.singleton(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION))));
 
     if (debug)
     {

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -1886,8 +1886,8 @@ public class TestDataTranslator
         Assert.assertFalse(avroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION).isEmpty());
 
         Assert.assertTrue(ConfigurableSchemaComparator.equals(avroSchema, expectedAvroSchema,
-                new SchemaComparisonConfiguration(true, true, true, false, true, true,
-                    Collections.singleton((SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION)))));
+            SchemaComparisonConfiguration.STRICT.jsonPropNamesToIgnore(
+                Collections.singleton(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION))));
 
         //Have a DataMap from pegasus schema
         DataMap dataMap = TestUtil.dataMapFromString(dataMapString);

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -17,6 +17,8 @@
 package com.linkedin.data.avro;
 
 import com.google.common.collect.ImmutableMap;
+import com.linkedin.avroutil1.compatibility.ConfigurableSchemaComparator;
+import com.linkedin.avroutil1.compatibility.SchemaComparisonConfiguration;
 import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.TestUtil;
@@ -1879,7 +1881,13 @@ public class TestDataTranslator
 
         // AvroSchema translated needs to be as expected
         Schema expectedAvroSchema = Schema.parse(expectedAvroSchemaString);
-        assertEquals(avroSchema, expectedAvroSchema);
+
+        Assert.assertNotNull(avroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION));
+        Assert.assertFalse(avroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION).isEmpty());
+
+        Assert.assertTrue(ConfigurableSchemaComparator.equals(avroSchema, expectedAvroSchema,
+                new SchemaComparisonConfiguration(true, true, true, false, true, true,
+                    Collections.singleton((SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION)))));
 
         //Have a DataMap from pegasus schema
         DataMap dataMap = TestUtil.dataMapFromString(dataMapString);

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestFilteredSchemaDataTranslation.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestFilteredSchemaDataTranslation.java
@@ -97,8 +97,8 @@ public class TestFilteredSchemaDataTranslation
       Assert.assertFalse(filteredAvroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION).isEmpty());
 
       Assert.assertTrue(ConfigurableSchemaComparator.equals(filteredAvroSchema, expectedAvroSchema,
-          new SchemaComparisonConfiguration(true, true, true, false, true, true,
-              Collections.singleton((SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION)))));
+          SchemaComparisonConfiguration.STRICT.jsonPropNamesToIgnore(
+              Collections.singleton(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION))));
 
       while (i < row.length)
       {

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestFilteredSchemaDataTranslation.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestFilteredSchemaDataTranslation.java
@@ -17,6 +17,8 @@
 package com.linkedin.data.avro;
 
 
+import com.linkedin.avroutil1.compatibility.ConfigurableSchemaComparator;
+import com.linkedin.avroutil1.compatibility.SchemaComparisonConfiguration;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.TestUtil;
 import com.linkedin.data.avro.util.AvroUtil;
@@ -30,8 +32,10 @@ import com.linkedin.data.schema.util.Filters;
 
 import java.io.IOException;
 
+import java.util.Collections;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -88,7 +92,13 @@ public class TestFilteredSchemaDataTranslation
       Schema filteredAvroSchema = SchemaTranslator.dataToAvroSchema(filteredSchema);
 
       Schema expectedAvroSchema = Schema.parse(avroSchemaText);
-      assertEquals(filteredAvroSchema, expectedAvroSchema);
+
+      Assert.assertNotNull(filteredAvroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION));
+      Assert.assertFalse(filteredAvroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION).isEmpty());
+
+      Assert.assertTrue(ConfigurableSchemaComparator.equals(filteredAvroSchema, expectedAvroSchema,
+          new SchemaComparisonConfiguration(true, true, true, false, true, true,
+              Collections.singleton((SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION)))));
 
       while (i < row.length)
       {
@@ -127,6 +137,7 @@ public class TestFilteredSchemaDataTranslation
         "{ " +
         "  \"type\" : \"record\", " +
         "  \"name\" : \"Foo\", " +
+        "  \"li.data.translated.from\" : \"Foo\", " +
         "  \"fields\" : [ " +
         "    { \"name\" : \"a\", \"type\" : \"int\" }, " +
         "    { \"name\" : \"b\", \"type\" : \"int\", \"optional\" : true } " +

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestFilteredSchemaDataTranslation.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestFilteredSchemaDataTranslation.java
@@ -137,7 +137,7 @@ public class TestFilteredSchemaDataTranslation
         "{ " +
         "  \"type\" : \"record\", " +
         "  \"name\" : \"Foo\", " +
-        "  \"li.data.translated.from\" : \"Foo\", " +
+        "  \"schema.translated.from.src\" : \"Foo\", " +
         "  \"fields\" : [ " +
         "    { \"name\" : \"a\", \"type\" : \"int\" }, " +
         "    { \"name\" : \"b\", \"type\" : \"int\", \"optional\" : true } " +

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestFilteredSchemaDataTranslation.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestFilteredSchemaDataTranslation.java
@@ -137,7 +137,7 @@ public class TestFilteredSchemaDataTranslation
         "{ " +
         "  \"type\" : \"record\", " +
         "  \"name\" : \"Foo\", " +
-        "  \"schema.translated.from.src\" : \"Foo\", " +
+        "  \"translated.from\" : \"Foo\", " +
         "  \"fields\" : [ " +
         "    { \"name\" : \"a\", \"type\" : \"int\" }, " +
         "    { \"name\" : \"b\", \"type\" : \"int\", \"optional\" : true } " +

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -23,9 +23,11 @@ import com.linkedin.data.DataMap;
 import com.linkedin.data.TestUtil;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.JsonBuilder;
+import com.linkedin.data.schema.NamedDataSchema;
 import com.linkedin.data.schema.PegasusSchemaParser;
 import com.linkedin.data.schema.SchemaParser;
 import com.linkedin.data.schema.SchemaToJsonEncoder;
+import com.linkedin.data.schema.TyperefDataSchema;
 import com.linkedin.data.schema.validation.ValidationOptions;
 import java.io.BufferedReader;
 import java.io.File;
@@ -35,14 +37,18 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import org.apache.avro.Schema;
+import org.apache.avro.data.Json;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
+import org.codehaus.jackson.JsonNode;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONParser;
 import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -97,6 +103,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
+                    "  \"li.data.translated.from\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionWithAliasField\"," +
@@ -156,6 +163,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
+                    "  \"li.data.translated.from\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -220,6 +228,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
+                    "  \"li.data.translated.from\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -283,6 +292,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
+                    "  \"li.data.translated.from\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -342,6 +352,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
+                    "    \"li.data.translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -369,6 +380,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
+                    "    \"li.data.translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -430,6 +442,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
+                    "    \"li.data.translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -490,6 +503,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
+                    "    \"li.data.translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -546,6 +560,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
+                    "    \"li.data.translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -616,7 +631,7 @@ public class TestSchemaTranslator
                "             \"ref\"  : \"string\", " +
                "             \"compliance\" : [{\"dataType\":\"MEMBER_NAME\", \"format\": \"STRING\"}] } }] }",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"string\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"STRING\" } ] } ] }"
+               "{ \"type\" : \"record\", \"li.data.translated.from\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"string\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"STRING\" } ] } ] }"
            },
            {
                // Test Annotations propagation for TypeRef, reserved word, such as "validate", "java", should not be propagated
@@ -650,6 +665,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
+               "\"li.data.translated.from\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ " +
                "{ \"name\" : \"typedefField\", " +
@@ -674,6 +690,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
+               "\"li.data.translated.from\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ { " +
                "\"name\" : \"typedefField\", " +
@@ -702,7 +719,7 @@ public class TestSchemaTranslator
                "                                         \"ref\"  : \"int\", " +
                "\"compliance\" : [{\"dataType\":\"MEMBER_NAME\", \"format\": \"INTEGER\"}] } } }] }",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"int\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"INTEGER\" } ] } ] }",
+               "{ \"type\" : \"record\", \"li.data.translated.from\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"int\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"INTEGER\" } ] } ] }",
            },
            {
                // Test Annotations for TypeRef : three layer typerefs
@@ -722,6 +739,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
+               "\"li.data.translated.from\" : \"com.x.y.z.Foo\","+
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ " + "{ " +
                "\"name\" : \"typedefField\", " +
@@ -750,7 +768,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            },
            {
                // Test Annotations for TypeRef : one layer typeref, with field level has same property as Typeref and merged
@@ -773,7 +791,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            },
            {
                // Test Annotations for TypeRef : one layer typeref, with field level has same property's override and not merged
@@ -798,6 +816,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
+               "\"li.data.translated.from\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ { \"name\" : \"typedefMapField\", " +
                "\"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, " +
@@ -824,7 +843,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"otherannotation\" : \"None\", \"compliance\" : { \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\":\"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"otherannotation\" : \"None\", \"compliance\" : { \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            }
 
        };
@@ -840,11 +859,9 @@ public class TestSchemaTranslator
    transOptions.setTyperefPropertiesExcludeSet(new HashSet<>(Arrays.asList("validate", "java")));
 
    String avroSchemaText = SchemaTranslator.dataToAvroSchemaJson(schema, transOptions);
-
-   // JSON compare except TRANSLATED_FROM_SOURCE_OPTION in root
-   JSONAssert.assertEquals(expectedAvroSchemaAsString, avroSchemaText,
-       new CustomComparator(JSONCompareMode.LENIENT,
-           new Customization(TRANSLATED_FROM_SOURCE_OPTION, (o1, o2) -> true)));
+   DataMap avroSchemaAsDataMap = TestUtil.dataMapFromString(avroSchemaText);
+   DataMap fieldsPropertiesMap = TestUtil.dataMapFromString(expectedAvroSchemaAsString);
+   assertEquals(avroSchemaAsDataMap, fieldsPropertiesMap);
  }
 
   @Test(dataProvider = "toAvroSchemaDataTestTypeRefAnnotationPropagation")
@@ -856,11 +873,9 @@ public class TestSchemaTranslator
     transOptions.setTyperefPropertiesExcludeSet(new HashSet<>(Arrays.asList("validate", "java")));
 
     String avroSchemaText = SchemaTranslator.dataToAvroSchemaJson(schema, transOptions);
-
-    // JSON compare except TRANSLATED_FROM_SOURCE_OPTION in root
-    JSONAssert.assertEquals(expectedAvroSchemaAsString, avroSchemaText,
-        new CustomComparator(JSONCompareMode.LENIENT,
-            new Customization(TRANSLATED_FROM_SOURCE_OPTION, (o1, o2) -> true)));
+    DataMap avroSchemaAsDataMap = TestUtil.dataMapFromString(avroSchemaText);
+    DataMap fieldsPropertiesMap = TestUtil.dataMapFromString(expectedAvroSchemaAsString);
+    assertEquals(fieldsPropertiesMap, avroSchemaAsDataMap);
   }
 
 
@@ -900,7 +915,7 @@ public class TestSchemaTranslator
               // custom properties :
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END } ], \"version\" : 1 }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ], \"version\" : 1 }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ], \"version\" : 1 }",
               null,
               null,
               null
@@ -909,7 +924,7 @@ public class TestSchemaTranslator
               // required, optional not specified
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -918,7 +933,7 @@ public class TestSchemaTranslator
               // required and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -927,7 +942,7 @@ public class TestSchemaTranslator
               // required, optional is false
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : false } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -936,7 +951,7 @@ public class TestSchemaTranslator
               // required, optional is false and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42, \"optional\" : false } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -945,7 +960,7 @@ public class TestSchemaTranslator
               // optional is true
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -954,7 +969,7 @@ public class TestSchemaTranslator
               // optional and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true, \"default\" : 42 } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -963,7 +978,7 @@ public class TestSchemaTranslator
               // optional and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true, \"default\" : 42 } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -972,7 +987,7 @@ public class TestSchemaTranslator
               // optional and has default, enum type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"optional\" : true, \"default\" : \"APPLE\" } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }, \"null\" ], \"default\" : \"APPLE\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }, \"null\" ], \"default\" : \"APPLE\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -981,7 +996,7 @@ public class TestSchemaTranslator
               // optional and has default, enum type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"optional\" : true, \"default\" : \"APPLE\" } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -990,7 +1005,7 @@ public class TestSchemaTranslator
               // optional and has default with namespaced type
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ ] } ##T_END, \"default\" : {  }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] }, \"null\" ], \"default\" : {  } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] }, \"null\" ], \"default\" : {  } } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -999,7 +1014,7 @@ public class TestSchemaTranslator
               // optional and has default with namespaced type
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ ] } ##T_END, \"default\" : {  }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] } ], \"default\" : null } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1008,7 +1023,7 @@ public class TestSchemaTranslator
               // optional and has default value with multi-level nesting
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"c.d.baz\", \"fields\" : [ ] } } ] }, \"default\" : { \"baz\" : { } }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] }, \"null\" ], \"default\" : { \"baz\" : {  } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] }, \"null\" ], \"default\" : { \"baz\" : {  } } } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1017,7 +1032,7 @@ public class TestSchemaTranslator
               // optional and has default value with multi-level nesting
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"c.d.baz\", \"fields\" : [ ] } } ] }, \"default\" : { \"baz\" : { } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] } ], \"default\" : null } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1026,7 +1041,7 @@ public class TestSchemaTranslator
               // optional and has default but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"foo\", \"default\" : {  }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1035,7 +1050,7 @@ public class TestSchemaTranslator
               // optional and has default but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"foo\", \"default\" : { \"bar\" : {  } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -1044,7 +1059,7 @@ public class TestSchemaTranslator
               // required union without null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ] } ] }",
               null,
               null,
               null
@@ -1053,7 +1068,7 @@ public class TestSchemaTranslator
               // required union with null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"string\" ] ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\" ] } ] }",
               null,
               null,
               null
@@ -1062,7 +1077,7 @@ public class TestSchemaTranslator
               // optional union without null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1071,7 +1086,7 @@ public class TestSchemaTranslator
               // optional union with null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"int\", \"string\" ] ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1080,7 +1095,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\",\"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1089,7 +1104,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1098,7 +1113,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"string\" : \"abc\" }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1107,7 +1122,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\", \"string\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\", \"string\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1116,7 +1131,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1125,7 +1140,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1134,7 +1149,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 3rd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"string\" : \"abc\" }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1143,7 +1158,7 @@ public class TestSchemaTranslator
               // optional union with null and null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"int\", \"string\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1152,7 +1167,7 @@ public class TestSchemaTranslator
               // optional union but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"foo\", \"string\" ] ##T_END, \"default\" : { \"foo\" : { } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1161,7 +1176,7 @@ public class TestSchemaTranslator
               // optional union but with circular references with but with consistent defaults (the only default that works is null for circularly referenced unions)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"foo\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1170,7 +1185,7 @@ public class TestSchemaTranslator
               // typeref of fixed
               "##T_START { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] } ##T_END",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -1179,7 +1194,7 @@ public class TestSchemaTranslator
               // typeref of enum
               "##T_START { \"type\" : \"enum\", \"name\" : \"Fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END",
               allModes,
-              "{ \"type\" : \"enum\", \"name\" : \"Fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }",
+              "{ \"type\" : \"enum\", \"name\" : \"Fruits\", \"li.data.translated.from\" : \"Fruits\",  \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }",
               null,
               null,
               null
@@ -1188,7 +1203,7 @@ public class TestSchemaTranslator
               // typeref of fixed
               "##T_START { \"type\" : \"fixed\", \"name\" : \"Md5\", \"size\" : 16 } ##T_END",
               allModes,
-              "{ \"type\" : \"fixed\", \"name\" : \"Md5\", \"size\" : 16 }",
+              "{ \"type\" : \"fixed\", \"name\" : \"Md5\", \"li.data.translated.from\" : \"Md5\", \"size\" : 16 }",
               null,
               null,
               null
@@ -1251,7 +1266,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null in record field
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ] } ] }",
               null,
               null,
               null
@@ -1260,7 +1275,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and default is 1st member type and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"default\" : { \"string\" : \"abc\" } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ], \"default\" : \"abc\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ], \"default\" : \"abc\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1269,7 +1284,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and default is 1st member type and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"default\" : { \"int\" : 42 } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1278,7 +1293,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1287,7 +1302,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\", \"null\" ], \"default\" : \"abc\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\", \"null\" ], \"default\" : \"abc\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1296,7 +1311,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1305,7 +1320,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1314,7 +1329,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 2nd member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1323,7 +1338,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 2nd member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1332,7 +1347,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null 1st member
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ] } ] }",
               null,
               null,
               null
@@ -1341,7 +1356,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null 1st member, default is 1st member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"default\" : null } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -1350,7 +1365,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1359,7 +1374,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional, default is 1st member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : null } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1368,7 +1383,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional, default is last member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1377,7 +1392,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ] } ] }",
               null,
               null,
               null
@@ -1386,7 +1401,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"default\" : { \"int\" : 42 } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1395,7 +1410,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1404,7 +1419,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1413,7 +1428,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1422,7 +1437,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is last member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : null } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1431,7 +1446,7 @@ public class TestSchemaTranslator
               // array of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } } ] }",
               null,
               null,
               null
@@ -1440,7 +1455,7 @@ public class TestSchemaTranslator
               // array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"default\" : [ 42, 13 ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"default\" : [ 42, 13 ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1449,7 +1464,7 @@ public class TestSchemaTranslator
               // array of union with default, default value uses only 1st null member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"null\", \"string\" ] ##T_END }, \"default\" : [ null, null ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"null\", \"string\" ] }, \"default\" : [ null, null ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"null\", \"string\" ] }, \"default\" : [ null, null ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1458,7 +1473,7 @@ public class TestSchemaTranslator
               // optional array of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1467,7 +1482,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : [ 42, 13 ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : [ 42, 13 ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1476,7 +1491,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1485,7 +1500,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"string\" : \"abc\" } ] } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1494,7 +1509,7 @@ public class TestSchemaTranslator
               // map of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } } ] }",
               null,
               null,
               null
@@ -1503,7 +1518,7 @@ public class TestSchemaTranslator
               // map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"default\" : { \"m1\" : 42 } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"default\" : { \"m1\" : 42 } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1512,7 +1527,7 @@ public class TestSchemaTranslator
               // map of union with default, default value uses only 1st null member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"null\", \"string\" ] ##T_END }, \"default\" : { \"m1\" : null } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"null\", \"string\" ] }, \"default\" : { \"m1\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"null\", \"string\" ] }, \"default\" : { \"m1\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1521,7 +1536,7 @@ public class TestSchemaTranslator
               // optional map of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1530,7 +1545,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : { \"m1\" : 42 } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : { \"m1\" : 42 } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1539,7 +1554,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1548,7 +1563,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true, \"default\" : { \"m1\" : { \"string\" : \"abc\" } } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1576,7 +1591,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"f1\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" } ] } }, \"default\" : [  ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"f1\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" } ] } }, \"default\" : [  ] } ] }",
               null,
               null,
               null
@@ -1603,7 +1618,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" }, { \"name\" : \"f1\", \"type\" : \"double\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" }, { \"name\" : \"f1\", \"type\" : \"double\" } ] }",
               null,
               null,
               null
@@ -1634,7 +1649,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null }, { \"name\" : \"f1\", \"type\" : { \"type\" : \"record\", \"name\" : \"f1\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } }, { \"name\" : \"f2\", \"type\" : { \"type\" : \"record\", \"name\" : \"f2\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null }, { \"name\" : \"f1\", \"type\" : { \"type\" : \"record\", \"name\" : \"f1\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } }, { \"name\" : \"f2\", \"type\" : { \"type\" : \"record\", \"name\" : \"f2\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } } ] }",
               null,
               null,
               null
@@ -1666,7 +1681,7 @@ public class TestSchemaTranslator
                   "  ]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"Bar\", \"fields\" : [ { \"name\" : \"barbara\", \"type\" : { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"frank\", \"type\" : [ \"null\", \"string\" ], \"default\" : null } ] }, \"default\" : { \"frank\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Bar\", \"li.data.translated.from\" : \"Bar\", \"fields\" : [ { \"name\" : \"barbara\", \"type\" : { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"frank\", \"type\" : [ \"null\", \"string\" ], \"default\" : null } ] }, \"default\" : { \"frank\" : null } } ] }",
               null,
               null,
               null
@@ -1697,7 +1712,7 @@ public class TestSchemaTranslator
                   "  ]\n" +
                   "}\n",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"foo1\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"bar1\", \"type\" : [ \"string\", \"null\" ], \"default\" : \"abc\" } ] }, \"null\" ], \"default\" : { \"bar1\" : \"xyz\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"foo1\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"bar1\", \"type\" : [ \"string\", \"null\" ], \"default\" : \"abc\" } ] }, \"null\" ], \"default\" : { \"bar1\" : \"xyz\" } } ] }",
               emptyFooSchema,
               "{}",
               "{\"foo1\": {\"bar1\": \"xyz\"}}"
@@ -1718,7 +1733,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -1740,7 +1755,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -1762,7 +1777,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1785,7 +1800,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1807,7 +1822,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1830,7 +1845,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1853,7 +1868,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1877,7 +1892,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"null\", \"success\" : null, \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"null\", \"success\" : null, \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": null, \"failure\": null, \"fieldDiscriminator\": ##Q_STARTnull##Q_END}}"
@@ -1901,7 +1916,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1942,7 +1957,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"Bar\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BarResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BarResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } }, { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"Baz\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BazResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BazResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"Bar\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BarResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BarResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } }, { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"Baz\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BazResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BazResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } } ] }",
               null,
               null,
               null
@@ -1977,7 +1992,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"message\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"MessageRecord\", \"fields\" : [ { \"name\" : \"message\", \"type\" : { \"type\" : \"record\", \"name\" : \"MessageRecordMessage\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"MessageRecordMessageDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"message\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"message\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"MessageRecord\", \"fields\" : [ { \"name\" : \"message\", \"type\" : { \"type\" : \"record\", \"name\" : \"MessageRecordMessage\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"MessageRecordMessageDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"message\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -2001,7 +2016,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2026,7 +2041,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2051,7 +2066,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -2077,7 +2092,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -2108,7 +2123,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2139,7 +2154,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2170,7 +2185,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2201,7 +2216,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2225,7 +2240,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2243,7 +2258,7 @@ public class TestSchemaTranslator
               "   } ] " +
               " } ",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : \"f1\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : \"f1\" } ] }",
               null,
               null,
               null
@@ -2265,7 +2280,7 @@ public class TestSchemaTranslator
               "   } ] " +
               " } ",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
               null,
               null,
               null
@@ -2329,11 +2344,8 @@ public class TestSchemaTranslator
           DataMap expectedAvroDataMap = TestUtil.dataMapFromString(expected);
           DataMap resultAvroDataMap = TestUtil.dataMapFromString(avroTextFromSchema);
           Object dataProperty = resultAvroDataMap.remove(SchemaTranslator.DATA_PROPERTY);
+          assertEquals(resultAvroDataMap, expectedAvroDataMap);
 
-          // JSON compare except TRANSLATED_FROM_SOURCE_OPTION in root
-          JSONAssert.assertEquals(expected, avroTextFromSchema,
-              new CustomComparator(JSONCompareMode.LENIENT,
-                  new Customization(TRANSLATED_FROM_SOURCE_OPTION, (o1, o2) -> true)));
 
           // look for embedded schema
           assertNotNull(dataProperty);
@@ -2362,21 +2374,29 @@ public class TestSchemaTranslator
             DataMap resultAvroDataMap = TestUtil.dataMapFromString(avroTextFromSchema);
             assertFalse(resultAvroDataMap.containsKey(SchemaTranslator.DATA_PROPERTY));
           }
-//          assertEquals(avroTextFromSchema, expected);
-
-          // JSON compare except TRANSLATED_FROM_SOURCE_OPTION in root
-          JSONAssert.assertEquals(expected, avroTextFromSchema,
-              new CustomComparator(JSONCompareMode.LENIENT,
-                  new Customization(TRANSLATED_FROM_SOURCE_OPTION, (o1, o2) -> true)));
+          JSONAssert.assertEquals(expected, avroTextFromSchema, true);
         }
 
         String postTranslateSchemaText = schema.toString();
-//        assertEquals(postTranslateSchemaText, preTranslateSchemaText);
 
-        // JSON compare except TRANSLATED_FROM_SOURCE_OPTION in root
+        // Ignore TRANSLATED_FROM_SOURCE_OPTION in root as preTranslateSchemaText does not contain the option
         JSONAssert.assertEquals(preTranslateSchemaText, postTranslateSchemaText,
             new CustomComparator(JSONCompareMode.LENIENT,
                 new Customization(TRANSLATED_FROM_SOURCE_OPTION, (o1, o2) -> true)));
+        // But postTranslateSchemaText contains the option for NamedDataSchema types.
+        if (TestUtil.dataSchemaFromString(preTranslateSchemaText) instanceof TyperefDataSchema) {
+          // Test for ref type
+          if (TestUtil.dataSchemaFromString(
+              (((JSONObject) JSONParser.parseJSON(postTranslateSchemaText)).get(
+                  "ref")).toString()) instanceof NamedDataSchema) {
+            assertNotNull(((JSONObject) ((JSONObject) JSONParser.parseJSON(postTranslateSchemaText)).get("ref")).get(
+                TRANSLATED_FROM_SOURCE_OPTION));
+          }
+        } else if (TestUtil.dataSchemaFromString(preTranslateSchemaText) instanceof NamedDataSchema) {
+          // Test for Record/Fixed/Enum
+          assertNotNull(
+              ((JSONObject) JSONParser.parseJSON(postTranslateSchemaText)).get(TRANSLATED_FROM_SOURCE_OPTION));
+        }
 
         // make sure Avro accepts it
         Schema avroSchema = AvroCompatibilityHelper.parse(avroTextFromSchema);
@@ -2427,12 +2447,7 @@ public class TestSchemaTranslator
           // taking into account typeref.
           AvroToDataSchemaTranslationOptions avroToDataSchemaMode = new AvroToDataSchemaTranslationOptions(AvroToDataSchemaTranslationMode.VERIFY_EMBEDDED_SCHEMA);
           DataSchema embeddedSchema = SchemaTranslator.avroToDataSchema(avroTextFromSchema, avroToDataSchemaMode);
-//          assertEquals(embeddedSchema, schema.getDereferencedDataSchema());
-
-          // JSON compare except TRANSLATED_FROM_SOURCE_OPTION in root
-          JSONAssert.assertEquals(schema.getDereferencedDataSchema().toString(), embeddedSchema.toString(),
-              new CustomComparator(JSONCompareMode.LENIENT,
-                  new Customization(TRANSLATED_FROM_SOURCE_OPTION, (o1, o2) -> true)));
+          assertEquals(embeddedSchema, schema.getDereferencedDataSchema());
         }
       }
     }

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -103,7 +103,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
-                    "  \"schema.translated.from.src\" : \"test\"," +
+                    "  \"translated.from\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionWithAliasField\"," +
@@ -163,7 +163,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
-                    "  \"schema.translated.from.src\" : \"test\"," +
+                    "  \"translated.from\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -228,7 +228,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
-                    "  \"schema.translated.from.src\" : \"test\"," +
+                    "  \"translated.from\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -292,7 +292,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
-                    "  \"schema.translated.from.src\" : \"test\"," +
+                    "  \"translated.from\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -352,7 +352,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"schema.translated.from.src\" : \"test\"," +
+                    "    \"translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -380,7 +380,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"schema.translated.from.src\" : \"test\"," +
+                    "    \"translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -442,7 +442,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"schema.translated.from.src\" : \"test\"," +
+                    "    \"translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -503,7 +503,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"schema.translated.from.src\" : \"test\"," +
+                    "    \"translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -560,7 +560,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"schema.translated.from.src\" : \"test\"," +
+                    "    \"translated.from\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -631,7 +631,7 @@ public class TestSchemaTranslator
                "             \"ref\"  : \"string\", " +
                "             \"compliance\" : [{\"dataType\":\"MEMBER_NAME\", \"format\": \"STRING\"}] } }] }",
 
-               "{ \"type\" : \"record\", \"schema.translated.from.src\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"string\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"STRING\" } ] } ] }"
+               "{ \"type\" : \"record\", \"translated.from\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"string\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"STRING\" } ] } ] }"
            },
            {
                // Test Annotations propagation for TypeRef, reserved word, such as "validate", "java", should not be propagated
@@ -665,7 +665,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
-               "\"schema.translated.from.src\" : \"com.x.y.z.Foo\", " +
+               "\"translated.from\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ " +
                "{ \"name\" : \"typedefField\", " +
@@ -690,7 +690,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
-               "\"schema.translated.from.src\" : \"com.x.y.z.Foo\", " +
+               "\"translated.from\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ { " +
                "\"name\" : \"typedefField\", " +
@@ -719,7 +719,7 @@ public class TestSchemaTranslator
                "                                         \"ref\"  : \"int\", " +
                "\"compliance\" : [{\"dataType\":\"MEMBER_NAME\", \"format\": \"INTEGER\"}] } } }] }",
 
-               "{ \"type\" : \"record\", \"schema.translated.from.src\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"int\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"INTEGER\" } ] } ] }",
+               "{ \"type\" : \"record\", \"translated.from\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"int\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"INTEGER\" } ] } ] }",
            },
            {
                // Test Annotations for TypeRef : three layer typerefs
@@ -739,7 +739,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
-               "\"schema.translated.from.src\" : \"com.x.y.z.Foo\","+
+               "\"translated.from\" : \"com.x.y.z.Foo\","+
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ " + "{ " +
                "\"name\" : \"typedefField\", " +
@@ -768,7 +768,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"translated.from\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            },
            {
                // Test Annotations for TypeRef : one layer typeref, with field level has same property as Typeref and merged
@@ -791,7 +791,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"translated.from\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            },
            {
                // Test Annotations for TypeRef : one layer typeref, with field level has same property's override and not merged
@@ -816,7 +816,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
-               "\"schema.translated.from.src\" : \"com.x.y.z.Foo\", " +
+               "\"translated.from\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ { \"name\" : \"typedefMapField\", " +
                "\"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, " +
@@ -843,7 +843,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\":\"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"otherannotation\" : \"None\", \"compliance\" : { \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"translated.from\":\"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"otherannotation\" : \"None\", \"compliance\" : { \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            }
 
        };
@@ -915,7 +915,7 @@ public class TestSchemaTranslator
               // custom properties :
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END } ], \"version\" : 1 }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ], \"version\" : 1 }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ], \"version\" : 1 }",
               null,
               null,
               null
@@ -924,7 +924,7 @@ public class TestSchemaTranslator
               // required, optional not specified
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -933,7 +933,7 @@ public class TestSchemaTranslator
               // required and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -942,7 +942,7 @@ public class TestSchemaTranslator
               // required, optional is false
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : false } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -951,7 +951,7 @@ public class TestSchemaTranslator
               // required, optional is false and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42, \"optional\" : false } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -960,7 +960,7 @@ public class TestSchemaTranslator
               // optional is true
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -969,7 +969,7 @@ public class TestSchemaTranslator
               // optional and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true, \"default\" : 42 } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -978,7 +978,7 @@ public class TestSchemaTranslator
               // optional and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true, \"default\" : 42 } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -987,7 +987,7 @@ public class TestSchemaTranslator
               // optional and has default, enum type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"optional\" : true, \"default\" : \"APPLE\" } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }, \"null\" ], \"default\" : \"APPLE\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }, \"null\" ], \"default\" : \"APPLE\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -996,7 +996,7 @@ public class TestSchemaTranslator
               // optional and has default, enum type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"optional\" : true, \"default\" : \"APPLE\" } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1005,7 +1005,7 @@ public class TestSchemaTranslator
               // optional and has default with namespaced type
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ ] } ##T_END, \"default\" : {  }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] }, \"null\" ], \"default\" : {  } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] }, \"null\" ], \"default\" : {  } } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1014,7 +1014,7 @@ public class TestSchemaTranslator
               // optional and has default with namespaced type
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ ] } ##T_END, \"default\" : {  }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] } ], \"default\" : null } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1023,7 +1023,7 @@ public class TestSchemaTranslator
               // optional and has default value with multi-level nesting
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"c.d.baz\", \"fields\" : [ ] } } ] }, \"default\" : { \"baz\" : { } }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] }, \"null\" ], \"default\" : { \"baz\" : {  } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] }, \"null\" ], \"default\" : { \"baz\" : {  } } } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1032,7 +1032,7 @@ public class TestSchemaTranslator
               // optional and has default value with multi-level nesting
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"c.d.baz\", \"fields\" : [ ] } } ] }, \"default\" : { \"baz\" : { } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] } ], \"default\" : null } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1041,7 +1041,7 @@ public class TestSchemaTranslator
               // optional and has default but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"foo\", \"default\" : {  }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1050,7 +1050,7 @@ public class TestSchemaTranslator
               // optional and has default but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"foo\", \"default\" : { \"bar\" : {  } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -1059,7 +1059,7 @@ public class TestSchemaTranslator
               // required union without null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ] } ] }",
               null,
               null,
               null
@@ -1068,7 +1068,7 @@ public class TestSchemaTranslator
               // required union with null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"string\" ] ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\" ] } ] }",
               null,
               null,
               null
@@ -1077,7 +1077,7 @@ public class TestSchemaTranslator
               // optional union without null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1086,7 +1086,7 @@ public class TestSchemaTranslator
               // optional union with null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"int\", \"string\" ] ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1095,7 +1095,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\",\"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"translated.from\" : \"foo\",\"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1104,7 +1104,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1113,7 +1113,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"string\" : \"abc\" }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1122,7 +1122,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\", \"string\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\", \"string\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1131,7 +1131,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1140,7 +1140,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1149,7 +1149,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 3rd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"string\" : \"abc\" }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1158,7 +1158,7 @@ public class TestSchemaTranslator
               // optional union with null and null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"int\", \"string\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1167,7 +1167,7 @@ public class TestSchemaTranslator
               // optional union but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"foo\", \"string\" ] ##T_END, \"default\" : { \"foo\" : { } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1176,7 +1176,7 @@ public class TestSchemaTranslator
               // optional union but with circular references with but with consistent defaults (the only default that works is null for circularly referenced unions)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"foo\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1185,7 +1185,7 @@ public class TestSchemaTranslator
               // typeref of fixed
               "##T_START { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] } ##T_END",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -1194,7 +1194,7 @@ public class TestSchemaTranslator
               // typeref of enum
               "##T_START { \"type\" : \"enum\", \"name\" : \"Fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END",
               allModes,
-              "{ \"type\" : \"enum\", \"name\" : \"Fruits\", \"schema.translated.from.src\" : \"Fruits\",  \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }",
+              "{ \"type\" : \"enum\", \"name\" : \"Fruits\", \"translated.from\" : \"Fruits\",  \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }",
               null,
               null,
               null
@@ -1203,7 +1203,7 @@ public class TestSchemaTranslator
               // typeref of fixed
               "##T_START { \"type\" : \"fixed\", \"name\" : \"Md5\", \"size\" : 16 } ##T_END",
               allModes,
-              "{ \"type\" : \"fixed\", \"name\" : \"Md5\", \"schema.translated.from.src\" : \"Md5\", \"size\" : 16 }",
+              "{ \"type\" : \"fixed\", \"name\" : \"Md5\", \"translated.from\" : \"Md5\", \"size\" : 16 }",
               null,
               null,
               null
@@ -1266,7 +1266,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null in record field
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ] } ] }",
               null,
               null,
               null
@@ -1275,7 +1275,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and default is 1st member type and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"default\" : { \"string\" : \"abc\" } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ], \"default\" : \"abc\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ], \"default\" : \"abc\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1284,7 +1284,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and default is 1st member type and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"default\" : { \"int\" : 42 } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1293,7 +1293,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1302,7 +1302,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\", \"null\" ], \"default\" : \"abc\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\", \"null\" ], \"default\" : \"abc\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1311,7 +1311,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1320,7 +1320,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1329,7 +1329,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 2nd member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1338,7 +1338,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 2nd member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1347,7 +1347,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null 1st member
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ] } ] }",
               null,
               null,
               null
@@ -1356,7 +1356,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null 1st member, default is 1st member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"default\" : null } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -1365,7 +1365,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1374,7 +1374,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional, default is 1st member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : null } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1383,7 +1383,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional, default is last member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1392,7 +1392,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ] } ] }",
               null,
               null,
               null
@@ -1401,7 +1401,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"default\" : { \"int\" : 42 } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1410,7 +1410,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1419,7 +1419,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1428,7 +1428,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1437,7 +1437,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is last member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : null } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1446,7 +1446,7 @@ public class TestSchemaTranslator
               // array of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } } ] }",
               null,
               null,
               null
@@ -1455,7 +1455,7 @@ public class TestSchemaTranslator
               // array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"default\" : [ 42, 13 ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"default\" : [ 42, 13 ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1464,7 +1464,7 @@ public class TestSchemaTranslator
               // array of union with default, default value uses only 1st null member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"null\", \"string\" ] ##T_END }, \"default\" : [ null, null ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"null\", \"string\" ] }, \"default\" : [ null, null ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"null\", \"string\" ] }, \"default\" : [ null, null ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1473,7 +1473,7 @@ public class TestSchemaTranslator
               // optional array of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1482,7 +1482,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : [ 42, 13 ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : [ 42, 13 ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1491,7 +1491,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1500,7 +1500,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"string\" : \"abc\" } ] } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1509,7 +1509,7 @@ public class TestSchemaTranslator
               // map of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } } ] }",
               null,
               null,
               null
@@ -1518,7 +1518,7 @@ public class TestSchemaTranslator
               // map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"default\" : { \"m1\" : 42 } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"default\" : { \"m1\" : 42 } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1527,7 +1527,7 @@ public class TestSchemaTranslator
               // map of union with default, default value uses only 1st null member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"null\", \"string\" ] ##T_END }, \"default\" : { \"m1\" : null } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"null\", \"string\" ] }, \"default\" : { \"m1\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"null\", \"string\" ] }, \"default\" : { \"m1\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1536,7 +1536,7 @@ public class TestSchemaTranslator
               // optional map of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1545,7 +1545,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : { \"m1\" : 42 } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : { \"m1\" : 42 } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1554,7 +1554,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1563,7 +1563,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true, \"default\" : { \"m1\" : { \"string\" : \"abc\" } } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1591,7 +1591,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"f1\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" } ] } }, \"default\" : [  ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"f1\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" } ] } }, \"default\" : [  ] } ] }",
               null,
               null,
               null
@@ -1618,7 +1618,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" }, { \"name\" : \"f1\", \"type\" : \"double\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" }, { \"name\" : \"f1\", \"type\" : \"double\" } ] }",
               null,
               null,
               null
@@ -1649,7 +1649,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null }, { \"name\" : \"f1\", \"type\" : { \"type\" : \"record\", \"name\" : \"f1\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } }, { \"name\" : \"f2\", \"type\" : { \"type\" : \"record\", \"name\" : \"f2\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null }, { \"name\" : \"f1\", \"type\" : { \"type\" : \"record\", \"name\" : \"f1\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } }, { \"name\" : \"f2\", \"type\" : { \"type\" : \"record\", \"name\" : \"f2\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } } ] }",
               null,
               null,
               null
@@ -1681,7 +1681,7 @@ public class TestSchemaTranslator
                   "  ]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"Bar\", \"schema.translated.from.src\" : \"Bar\", \"fields\" : [ { \"name\" : \"barbara\", \"type\" : { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"frank\", \"type\" : [ \"null\", \"string\" ], \"default\" : null } ] }, \"default\" : { \"frank\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Bar\", \"translated.from\" : \"Bar\", \"fields\" : [ { \"name\" : \"barbara\", \"type\" : { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"frank\", \"type\" : [ \"null\", \"string\" ], \"default\" : null } ] }, \"default\" : { \"frank\" : null } } ] }",
               null,
               null,
               null
@@ -1712,7 +1712,7 @@ public class TestSchemaTranslator
                   "  ]\n" +
                   "}\n",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"foo1\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"bar1\", \"type\" : [ \"string\", \"null\" ], \"default\" : \"abc\" } ] }, \"null\" ], \"default\" : { \"bar1\" : \"xyz\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"foo1\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"bar1\", \"type\" : [ \"string\", \"null\" ], \"default\" : \"abc\" } ] }, \"null\" ], \"default\" : { \"bar1\" : \"xyz\" } } ] }",
               emptyFooSchema,
               "{}",
               "{\"foo1\": {\"bar1\": \"xyz\"}}"
@@ -1733,7 +1733,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -1755,7 +1755,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -1777,7 +1777,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1800,7 +1800,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1822,7 +1822,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1845,7 +1845,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1868,7 +1868,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1892,7 +1892,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"null\", \"success\" : null, \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"null\", \"success\" : null, \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": null, \"failure\": null, \"fieldDiscriminator\": ##Q_STARTnull##Q_END}}"
@@ -1916,7 +1916,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1957,7 +1957,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"Bar\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BarResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BarResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } }, { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"Baz\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BazResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BazResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"Bar\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BarResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BarResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } }, { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"Baz\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BazResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BazResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } } ] }",
               null,
               null,
               null
@@ -1992,7 +1992,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"message\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"MessageRecord\", \"fields\" : [ { \"name\" : \"message\", \"type\" : { \"type\" : \"record\", \"name\" : \"MessageRecordMessage\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"MessageRecordMessageDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"message\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"message\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"MessageRecord\", \"fields\" : [ { \"name\" : \"message\", \"type\" : { \"type\" : \"record\", \"name\" : \"MessageRecordMessage\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"MessageRecordMessageDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"message\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -2016,7 +2016,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2041,7 +2041,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2066,7 +2066,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -2092,7 +2092,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -2123,7 +2123,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2154,7 +2154,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2185,7 +2185,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2216,7 +2216,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2240,7 +2240,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2258,7 +2258,7 @@ public class TestSchemaTranslator
               "   } ] " +
               " } ",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : \"f1\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : \"f1\" } ] }",
               null,
               null,
               null
@@ -2280,7 +2280,7 @@ public class TestSchemaTranslator
               "   } ] " +
               " } ",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
               null,
               null,
               null

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslator.java
@@ -103,7 +103,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
-                    "  \"li.data.translated.from\" : \"test\"," +
+                    "  \"schema.translated.from.src\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionWithAliasField\"," +
@@ -163,7 +163,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
-                    "  \"li.data.translated.from\" : \"test\"," +
+                    "  \"schema.translated.from.src\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -228,7 +228,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
-                    "  \"li.data.translated.from\" : \"test\"," +
+                    "  \"schema.translated.from.src\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -292,7 +292,7 @@ public class TestSchemaTranslator
                 "{" +
                     "  \"type\": \"record\"," +
                     "  \"name\": \"test\"," +
-                    "  \"li.data.translated.from\" : \"test\"," +
+                    "  \"schema.translated.from.src\" : \"test\"," +
                     "  \"fields\": [" +
                     "    {" +
                     "      \"name\": \"unionTyperef\"," +
@@ -352,7 +352,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"li.data.translated.from\" : \"test\"," +
+                    "    \"schema.translated.from.src\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -380,7 +380,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"li.data.translated.from\" : \"test\"," +
+                    "    \"schema.translated.from.src\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -442,7 +442,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"li.data.translated.from\" : \"test\"," +
+                    "    \"schema.translated.from.src\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -503,7 +503,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"li.data.translated.from\" : \"test\"," +
+                    "    \"schema.translated.from.src\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -560,7 +560,7 @@ public class TestSchemaTranslator
                 "{" +
                     "    \"type\": \"record\"," +
                     "    \"name\": \"test\"," +
-                    "    \"li.data.translated.from\" : \"test\"," +
+                    "    \"schema.translated.from.src\" : \"test\"," +
                     "    \"fields\": [" +
                     "        {" +
                     "            \"name\": \"unionTyperef\"," +
@@ -631,7 +631,7 @@ public class TestSchemaTranslator
                "             \"ref\"  : \"string\", " +
                "             \"compliance\" : [{\"dataType\":\"MEMBER_NAME\", \"format\": \"STRING\"}] } }] }",
 
-               "{ \"type\" : \"record\", \"li.data.translated.from\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"string\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"STRING\" } ] } ] }"
+               "{ \"type\" : \"record\", \"schema.translated.from.src\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"string\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"STRING\" } ] } ] }"
            },
            {
                // Test Annotations propagation for TypeRef, reserved word, such as "validate", "java", should not be propagated
@@ -665,7 +665,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
-               "\"li.data.translated.from\" : \"com.x.y.z.Foo\", " +
+               "\"schema.translated.from.src\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ " +
                "{ \"name\" : \"typedefField\", " +
@@ -690,7 +690,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
-               "\"li.data.translated.from\" : \"com.x.y.z.Foo\", " +
+               "\"schema.translated.from.src\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ { " +
                "\"name\" : \"typedefField\", " +
@@ -719,7 +719,7 @@ public class TestSchemaTranslator
                "                                         \"ref\"  : \"int\", " +
                "\"compliance\" : [{\"dataType\":\"MEMBER_NAME\", \"format\": \"INTEGER\"}] } } }] }",
 
-               "{ \"type\" : \"record\", \"li.data.translated.from\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"int\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"INTEGER\" } ] } ] }",
+               "{ \"type\" : \"record\", \"schema.translated.from.src\" : \"com.x.y.z.Foo\", \"name\" : \"Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefField\", \"type\" : \"int\", \"compliance\" : [ { \"dataType\" : \"MEMBER_NAME\", \"format\" : \"INTEGER\" } ] } ] }",
            },
            {
                // Test Annotations for TypeRef : three layer typerefs
@@ -739,7 +739,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
-               "\"li.data.translated.from\" : \"com.x.y.z.Foo\","+
+               "\"schema.translated.from.src\" : \"com.x.y.z.Foo\","+
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ " + "{ " +
                "\"name\" : \"typedefField\", " +
@@ -768,7 +768,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            },
            {
                // Test Annotations for TypeRef : one layer typeref, with field level has same property as Typeref and merged
@@ -791,7 +791,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"compliance\" : { \"keysymbol\" : [ { \"dataType\" : \"MEMBER_NAME\" } ], \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            },
            {
                // Test Annotations for TypeRef : one layer typeref, with field level has same property's override and not merged
@@ -816,7 +816,7 @@ public class TestSchemaTranslator
 
                "{ \"type\" : \"record\", " +
                "\"name\" : \"Foo\", " +
-               "\"li.data.translated.from\" : \"com.x.y.z.Foo\", " +
+               "\"schema.translated.from.src\" : \"com.x.y.z.Foo\", " +
                "\"namespace\" : \"com.x.y.z\", " +
                "\"fields\" : [ { \"name\" : \"typedefMapField\", " +
                "\"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, " +
@@ -843,7 +843,7 @@ public class TestSchemaTranslator
                "  ]\n" +
                "}",
 
-               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\":\"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"otherannotation\" : \"None\", \"compliance\" : { \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
+               "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\":\"com.x.y.z.Foo\", \"namespace\" : \"com.x.y.z\", \"fields\" : [ { \"name\" : \"typedefMapField\", \"type\" : { \"type\" : \"map\", \"values\" : \"string\" }, \"otherannotation\" : \"None\", \"compliance\" : { \"/*\" : [ { \"dataType\" : \"MEMBER_ID\" } ] } } ] }",
            }
 
        };
@@ -915,7 +915,7 @@ public class TestSchemaTranslator
               // custom properties :
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END } ], \"version\" : 1 }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ], \"version\" : 1 }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ], \"version\" : 1 }",
               null,
               null,
               null
@@ -924,7 +924,7 @@ public class TestSchemaTranslator
               // required, optional not specified
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -933,7 +933,7 @@ public class TestSchemaTranslator
               // required and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42 } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -942,7 +942,7 @@ public class TestSchemaTranslator
               // required, optional is false
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : false } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -951,7 +951,7 @@ public class TestSchemaTranslator
               // required, optional is false and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"default\" : 42, \"optional\" : false } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\", \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -960,7 +960,7 @@ public class TestSchemaTranslator
               // optional is true
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -969,7 +969,7 @@ public class TestSchemaTranslator
               // optional and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true, \"default\" : 42 } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -978,7 +978,7 @@ public class TestSchemaTranslator
               // optional and has default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START \"int\" ##T_END, \"optional\" : true, \"default\" : 42 } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -987,7 +987,7 @@ public class TestSchemaTranslator
               // optional and has default, enum type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"optional\" : true, \"default\" : \"APPLE\" } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }, \"null\" ], \"default\" : \"APPLE\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }, \"null\" ], \"default\" : \"APPLE\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -996,7 +996,7 @@ public class TestSchemaTranslator
               // optional and has default, enum type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END, \"optional\" : true, \"default\" : \"APPLE\" } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"enum\", \"name\" : \"fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1005,7 +1005,7 @@ public class TestSchemaTranslator
               // optional and has default with namespaced type
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ ] } ##T_END, \"default\" : {  }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] }, \"null\" ], \"default\" : {  } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] }, \"null\" ], \"default\" : {  } } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1014,7 +1014,7 @@ public class TestSchemaTranslator
               // optional and has default with namespaced type
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ ] } ##T_END, \"default\" : {  }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [  ] } ], \"default\" : null } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1023,7 +1023,7 @@ public class TestSchemaTranslator
               // optional and has default value with multi-level nesting
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"c.d.baz\", \"fields\" : [ ] } } ] }, \"default\" : { \"baz\" : { } }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] }, \"null\" ], \"default\" : { \"baz\" : {  } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] }, \"null\" ], \"default\" : { \"baz\" : {  } } } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1032,7 +1032,7 @@ public class TestSchemaTranslator
               // optional and has default value with multi-level nesting
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"b.c.bar\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"c.d.baz\", \"fields\" : [ ] } } ] }, \"default\" : { \"baz\" : { } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"a.b.foo\", \"namespace\" : \"a.b\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"bar\", \"namespace\" : \"b.c\", \"fields\" : [ { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"baz\", \"namespace\" : \"c.d\", \"fields\" : [  ] } } ] } ], \"default\" : null } ] }",
               "{ \"type\" : \"record\", \"name\" : \"a.b.foo\", \"fields\" : [ ] }",
               emptyFooValue,
               null
@@ -1041,7 +1041,7 @@ public class TestSchemaTranslator
               // optional and has default but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"foo\", \"default\" : {  }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1050,7 +1050,7 @@ public class TestSchemaTranslator
               // optional and has default but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"foo\", \"default\" : { \"bar\" : {  } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -1059,7 +1059,7 @@ public class TestSchemaTranslator
               // required union without null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ] } ] }",
               null,
               null,
               null
@@ -1068,7 +1068,7 @@ public class TestSchemaTranslator
               // required union with null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"string\" ] ##T_END } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\" ] } ] }",
               null,
               null,
               null
@@ -1077,7 +1077,7 @@ public class TestSchemaTranslator
               // optional union without null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1086,7 +1086,7 @@ public class TestSchemaTranslator
               // optional union with null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"int\", \"string\" ] ##T_END, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1095,7 +1095,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\",\"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\",\"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1104,7 +1104,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\",  \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1113,7 +1113,7 @@ public class TestSchemaTranslator
               // optional union without null and default is 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"string\" ] ##T_END, \"default\" : { \"string\" : \"abc\" }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1122,7 +1122,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\", \"string\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\", \"string\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1131,7 +1131,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"int\" : 42 }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1140,7 +1140,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1149,7 +1149,7 @@ public class TestSchemaTranslator
               // optional union with null and non-null default, default is 3rd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"int\", \"null\", \"string\" ] ##T_END, \"default\" : { \"string\" : \"abc\" }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1158,7 +1158,7 @@ public class TestSchemaTranslator
               // optional union with null and null default, default is 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"int\", \"string\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1167,7 +1167,7 @@ public class TestSchemaTranslator
               // optional union but with circular references with inconsistent defaults, inconsistent because optional field has default, and also missing (which requires default to be null)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"foo\", \"string\" ] ##T_END, \"default\" : { \"foo\" : { } }, \"optional\" : true } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1176,7 +1176,7 @@ public class TestSchemaTranslator
               // optional union but with circular references with but with consistent defaults (the only default that works is null for circularly referenced unions)
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START [ \"null\", \"foo\" ] ##T_END, \"default\" : null, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"foo\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1185,7 +1185,7 @@ public class TestSchemaTranslator
               // typeref of fixed
               "##T_START { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] } ##T_END",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"Foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : \"int\" } ] }",
               null,
               null,
               null
@@ -1194,7 +1194,7 @@ public class TestSchemaTranslator
               // typeref of enum
               "##T_START { \"type\" : \"enum\", \"name\" : \"Fruits\", \"symbols\" : [ \"APPLE\", \"ORANGE\" ] } ##T_END",
               allModes,
-              "{ \"type\" : \"enum\", \"name\" : \"Fruits\", \"li.data.translated.from\" : \"Fruits\",  \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }",
+              "{ \"type\" : \"enum\", \"name\" : \"Fruits\", \"schema.translated.from.src\" : \"Fruits\",  \"symbols\" : [ \"APPLE\", \"ORANGE\" ] }",
               null,
               null,
               null
@@ -1203,7 +1203,7 @@ public class TestSchemaTranslator
               // typeref of fixed
               "##T_START { \"type\" : \"fixed\", \"name\" : \"Md5\", \"size\" : 16 } ##T_END",
               allModes,
-              "{ \"type\" : \"fixed\", \"name\" : \"Md5\", \"li.data.translated.from\" : \"Md5\", \"size\" : 16 }",
+              "{ \"type\" : \"fixed\", \"name\" : \"Md5\", \"schema.translated.from.src\" : \"Md5\", \"size\" : 16 }",
               null,
               null,
               null
@@ -1266,7 +1266,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null in record field
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ] } ] }",
               null,
               null,
               null
@@ -1275,7 +1275,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and default is 1st member type and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"default\" : { \"string\" : \"abc\" } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ], \"default\" : \"abc\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\" ], \"default\" : \"abc\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1284,7 +1284,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and default is 1st member type and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"default\" : { \"int\" : 42 } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"string\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1293,7 +1293,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1302,7 +1302,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\", \"null\" ], \"default\" : \"abc\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", \"int\", \"null\" ], \"default\" : \"abc\" } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1311,7 +1311,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1320,7 +1320,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1329,7 +1329,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 2nd member and not typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"string\" ], \"optional\" : true, \"default\" : { \"string\" : \"abc\" } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\", \"string\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1338,7 +1338,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, without null and optional, default is 2nd member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"string\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"string\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1347,7 +1347,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null 1st member
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ] } ] }",
               null,
               null,
               null
@@ -1356,7 +1356,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null 1st member, default is 1st member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"default\" : null } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -1365,7 +1365,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1374,7 +1374,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional, default is 1st member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : null } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1383,7 +1383,7 @@ public class TestSchemaTranslator
               // record field with union with typeref with null 1st member, and optional, default is last member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", ##T_START \"int\" ##T_END ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1392,7 +1392,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ] } ] }",
               null,
               null,
               null
@@ -1401,7 +1401,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"default\" : { \"int\" : 42 } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1410,7 +1410,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1419,7 +1419,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"int\", \"null\" ], \"default\" : 42 } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1428,7 +1428,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is 1st member and typeref-ed
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : { \"int\" : 42 } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1437,7 +1437,7 @@ public class TestSchemaTranslator
               // record field with union with typeref, with null last member, and optional, default is last member and null
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ ##T_START \"int\" ##T_END, \"null\" ], \"optional\" : true, \"default\" : null } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1446,7 +1446,7 @@ public class TestSchemaTranslator
               // array of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } } ] }",
               null,
               null,
               null
@@ -1455,7 +1455,7 @@ public class TestSchemaTranslator
               // array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"default\" : [ 42, 13 ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"default\" : [ 42, 13 ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1464,7 +1464,7 @@ public class TestSchemaTranslator
               // array of union with default, default value uses only 1st null member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"null\", \"string\" ] ##T_END }, \"default\" : [ null, null ] } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"null\", \"string\" ] }, \"default\" : [ null, null ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : [ \"null\", \"string\" ] }, \"default\" : [ null, null ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1473,7 +1473,7 @@ public class TestSchemaTranslator
               // optional array of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1482,7 +1482,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : [ 42, 13 ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : [ 42, 13 ] } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1491,7 +1491,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"int\" : 13 } ] } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1500,7 +1500,7 @@ public class TestSchemaTranslator
               // optional array of union with default, default value uses 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"array\", \"items\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true, \"default\" : [ { \"int\" : 42 }, { \"string\" : \"abc\" } ] } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1509,7 +1509,7 @@ public class TestSchemaTranslator
               // map of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } } ] }",
               null,
               null,
               null
@@ -1518,7 +1518,7 @@ public class TestSchemaTranslator
               // map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"default\" : { \"m1\" : 42 } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"default\" : { \"m1\" : 42 } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1527,7 +1527,7 @@ public class TestSchemaTranslator
               // map of union with default, default value uses only 1st null member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"null\", \"string\" ] ##T_END }, \"default\" : { \"m1\" : null } } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"null\", \"string\" ] }, \"default\" : { \"m1\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : [ \"null\", \"string\" ] }, \"default\" : { \"m1\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1536,7 +1536,7 @@ public class TestSchemaTranslator
               // optional map of union with no default
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true } ] }",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1545,7 +1545,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : { \"m1\" : 42 } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] }, \"null\" ], \"default\" : { \"m1\" : 42 } } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1554,7 +1554,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses only 1st member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : ##T_START { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ##T_END, \"optional\" : true, \"default\" : { \"m1\" : { \"int\" : 42 } } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1563,7 +1563,7 @@ public class TestSchemaTranslator
               // optional map of union with default, default value uses 2nd member type
               "{ \"type\" : \"record\", \"name\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"map\", \"values\" : ##T_START [ \"int\", \"string\" ] ##T_END }, \"optional\" : true, \"default\" : { \"m1\" : { \"string\" : \"abc\" } } } ] }",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"bar\", \"type\" : [ \"null\", { \"type\" : \"map\", \"values\" : [ \"int\", \"string\" ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               null
@@ -1591,7 +1591,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\",  \"fields\" : [ { \"name\" : \"f1\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" } ] } }, \"default\" : [  ] } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\",  \"fields\" : [ { \"name\" : \"f1\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" } ] } }, \"default\" : [  ] } ] }",
               null,
               null,
               null
@@ -1618,7 +1618,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" }, { \"name\" : \"f1\", \"type\" : \"double\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : \"int\" }, { \"name\" : \"f1\", \"type\" : \"double\" } ] }",
               null,
               null,
               null
@@ -1649,7 +1649,7 @@ public class TestSchemaTranslator
                   "  ] " +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null }, { \"name\" : \"f1\", \"type\" : { \"type\" : \"record\", \"name\" : \"f1\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } }, { \"name\" : \"f2\", \"type\" : { \"type\" : \"record\", \"name\" : \"f2\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null }, { \"name\" : \"f1\", \"type\" : { \"type\" : \"record\", \"name\" : \"f1\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } }, { \"name\" : \"f2\", \"type\" : { \"type\" : \"record\", \"name\" : \"f2\", \"fields\" : [ { \"name\" : \"b1\", \"type\" : [ \"null\", \"int\" ], \"default\" : null } ] } } ] }",
               null,
               null,
               null
@@ -1681,7 +1681,7 @@ public class TestSchemaTranslator
                   "  ]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"Bar\", \"li.data.translated.from\" : \"Bar\", \"fields\" : [ { \"name\" : \"barbara\", \"type\" : { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"frank\", \"type\" : [ \"null\", \"string\" ], \"default\" : null } ] }, \"default\" : { \"frank\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Bar\", \"schema.translated.from.src\" : \"Bar\", \"fields\" : [ { \"name\" : \"barbara\", \"type\" : { \"type\" : \"record\", \"name\" : \"Foo\", \"fields\" : [ { \"name\" : \"frank\", \"type\" : [ \"null\", \"string\" ], \"default\" : null } ] }, \"default\" : { \"frank\" : null } } ] }",
               null,
               null,
               null
@@ -1712,7 +1712,7 @@ public class TestSchemaTranslator
                   "  ]\n" +
                   "}\n",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"foo1\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"bar1\", \"type\" : [ \"string\", \"null\" ], \"default\" : \"abc\" } ] }, \"null\" ], \"default\" : { \"bar1\" : \"xyz\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"foo1\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"bar\", \"fields\" : [ { \"name\" : \"bar1\", \"type\" : [ \"string\", \"null\" ], \"default\" : \"abc\" } ] }, \"null\" ], \"default\" : { \"bar1\" : \"xyz\" } } ] }",
               emptyFooSchema,
               "{}",
               "{\"foo1\": {\"bar1\": \"xyz\"}}"
@@ -1733,7 +1733,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -1755,7 +1755,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -1777,7 +1777,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1800,7 +1800,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1822,7 +1822,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1845,7 +1845,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"string\", \"null\" ], \"doc\" : \"Success message\", \"default\" : \"Union with aliases.\" }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"success\", \"success\" : \"Union with aliases.\", \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": \"Union with aliases.\", \"failure\": null, \"fieldDiscriminator\": ##Q_STARTsuccess##Q_END}}"
@@ -1868,7 +1868,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1892,7 +1892,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateDefault,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"null\", \"success\" : null, \"failure\" : null } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] }, \"null\" ], \"default\" : { \"fieldDiscriminator\" : \"null\", \"success\" : null, \"failure\" : null } } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": {\"success\": null, \"failure\": null, \"fieldDiscriminator\": ##Q_STARTnull##Q_END}}"
@@ -1916,7 +1916,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               translateToNull,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"null\", \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } ], \"default\" : null } ] }",
               emptyFooSchema,
               emptyFooValue,
               "{\"result\": null}"
@@ -1957,7 +1957,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"Bar\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BarResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BarResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } }, { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"Baz\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BazResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BazResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"bar\", \"type\" : { \"type\" : \"record\", \"name\" : \"Bar\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BarResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BarResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } }, { \"name\" : \"baz\", \"type\" : { \"type\" : \"record\", \"name\" : \"Baz\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"BazResult\", \"fields\" : [ { \"name\" : \"resultUrn\", \"type\" : [ \"null\", \"string\" ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"BazResultDiscriminator\", \"symbols\" : [ \"resultUrn\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } } ] }",
               null,
               null,
               null
@@ -1992,7 +1992,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"message\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"MessageRecord\", \"fields\" : [ { \"name\" : \"message\", \"type\" : { \"type\" : \"record\", \"name\" : \"MessageRecordMessage\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"MessageRecordMessageDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"message\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"result\", \"type\" : { \"type\" : \"record\", \"name\" : \"fooResult\", \"fields\" : [ { \"name\" : \"message\", \"type\" : [ \"null\", { \"type\" : \"record\", \"name\" : \"MessageRecord\", \"fields\" : [ { \"name\" : \"message\", \"type\" : { \"type\" : \"record\", \"name\" : \"MessageRecordMessage\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"MessageRecordMessageDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] } ], \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultDiscriminator\", \"symbols\" : [ \"message\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ] }",
               null,
               null,
               null
@@ -2016,7 +2016,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2041,7 +2041,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2066,7 +2066,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -2092,7 +2092,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : [ \"null\", { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } ], \"default\" : null } ] }",
               null,
               null,
               null
@@ -2123,7 +2123,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2154,7 +2154,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2185,7 +2185,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2216,7 +2216,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"array\", \"items\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } } } ] }",
               null,
               null,
               null
@@ -2240,7 +2240,7 @@ public class TestSchemaTranslator
                   "]" +
                   "}",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"foo\", \"li.data.translated.from\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"foo\", \"schema.translated.from.src\" : \"foo\", \"fields\" : [ { \"name\" : \"results\", \"type\" : { \"type\" : \"map\", \"values\" : { \"type\" : \"record\", \"name\" : \"fooResults\", \"fields\" : [ { \"name\" : \"success\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Success message\", \"default\" : null }, { \"name\" : \"failure\", \"type\" : [ \"null\", \"string\" ], \"doc\" : \"Failure message\", \"default\" : null }, { \"name\" : \"fieldDiscriminator\", \"type\" : { \"type\" : \"enum\", \"name\" : \"fooResultsDiscriminator\", \"symbols\" : [ \"success\", \"failure\" ] }, \"doc\" : \"Contains the name of the field that has its value set.\" } ] } } } ] }",
               null,
               null,
               null
@@ -2258,7 +2258,7 @@ public class TestSchemaTranslator
               "   } ] " +
               " } ",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : \"f1\" } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : \"f1\" } ] }",
               null,
               null,
               null
@@ -2280,7 +2280,7 @@ public class TestSchemaTranslator
               "   } ] " +
               " } ",
               allModes,
-              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"li.data.translated.from\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
+              "{ \"type\" : \"record\", \"name\" : \"Foo\", \"schema.translated.from.src\" : \"Foo\", \"fields\" : [ { \"name\" : \"field1\", \"type\" : \"int\", \"a_customAnnotation\" : \"f1\", \"b_customAnnotation\" : \"f1\", \"c_customAnnotation\" : { \"a_nested\" : \"a\", \"b_nested\" : \"a\", \"c_nested\" : \"a\" } } ] }",
               null,
               null,
               null

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslatorBijectivity.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslatorBijectivity.java
@@ -61,8 +61,8 @@ public class TestSchemaTranslatorBijectivity {
     Assert.assertFalse(resultingAvroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION).isEmpty());
 
     Assert.assertTrue(ConfigurableSchemaComparator.equals(resultingAvroSchema, initialAvroSchema,
-            new SchemaComparisonConfiguration(true, true, true, false, true, true,
-                Collections.singleton((SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION)))),
+            SchemaComparisonConfiguration.STRICT.jsonPropNamesToIgnore(
+                Collections.singleton(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION))),
         initialAvroSchema + " ---------- " + resultingAvroSchema.toString());
   }
 

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslatorBijectivity.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestSchemaTranslatorBijectivity.java
@@ -16,6 +16,8 @@
 
 package com.linkedin.data.avro;
 
+import com.linkedin.avroutil1.compatibility.ConfigurableSchemaComparator;
+import com.linkedin.avroutil1.compatibility.SchemaComparisonConfiguration;
 import com.linkedin.data.schema.AbstractSchemaParser;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchemaResolver;
@@ -28,7 +30,10 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import org.apache.avro.Schema;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONParser;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -52,7 +57,12 @@ public class TestSchemaTranslatorBijectivity {
     DataSchema pdscSchema = SchemaTranslator.avroToDataSchema(initialAvroSchema, avroToDataSchemaTranslationOptions);
     Schema resultingAvroSchema = SchemaTranslator.dataToAvroSchema(pdscSchema, dataToAvroSchemaTranslationOptions);
 
-    Assert.assertTrue(AvroSchemaEquals.equals(resultingAvroSchema, initialAvroSchema, true, true, true),
+    Assert.assertNotNull(resultingAvroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION));
+    Assert.assertFalse(resultingAvroSchema.getProp(SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION).isEmpty());
+
+    Assert.assertTrue(ConfigurableSchemaComparator.equals(resultingAvroSchema, initialAvroSchema,
+            new SchemaComparisonConfiguration(true, true, true, false, true, true,
+                Collections.singleton((SchemaTranslator.TRANSLATED_FROM_SOURCE_OPTION)))),
         initialAvroSchema + " ---------- " + resultingAvroSchema.toString());
   }
 


### PR DESCRIPTION
### What
Adding an annotation in translated schemas, translated through SchemaTranslator

### Why
This will help in figuring out whether a schema is translated or source of truth.
This annotation can help in determining different behavior for SoT and translated schemas

### Test
Updated Unit tests


