### PR TITLE
Introduce new config to randomly pick the xDS server host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.49.9] - 2024-01-26
+- Introduce new config to randomly pick the xDS server host
 
 ## [29.49.8] - 2024-01-19
 - add WIRE_COMPATIBLE compatility checker mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.49.9] - 2024-01-26
+
 ## [29.49.8] - 2024-01-19
 - add WIRE_COMPATIBLE compatility checker mode.
 
@@ -5618,7 +5620,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.49.9...master
+[29.49.9]: https://github.com/linkedin/rest.li/compare/v29.49.8...v29.49.9
 [29.49.8]: https://github.com/linkedin/rest.li/compare/v29.49.7...v29.49.8
 [29.49.7]: https://github.com/linkedin/rest.li/compare/v29.49.6...v29.49.7
 [29.49.6]: https://github.com/linkedin/rest.li/compare/v29.49.5...v29.49.6

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
@@ -77,6 +77,7 @@ public class XdsChannelFactory
     NettyChannelBuilder builder = NettyChannelBuilder.forTarget(_xdsServerUri);
     if (_defaultLoadBalancingPolicy != null)
     {
+      _log.info("Applying custom load balancing policy for xDS channel: {}", _defaultLoadBalancingPolicy);
       builder = builder.defaultLoadBalancingPolicy(_defaultLoadBalancingPolicy);
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.49.8
+version=29.49.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Instead of using the default "pick_first" policy, which always picks the first IP address returned by DNS, "round_robin" will pick a random starting point in the list of IPs. This will fix the very lopsided load seen on the xDS servers.

Here is the current traffic distribution with using `pick_first`:
![image](https://github.com/linkedin/rest.li/assets/5124201/ed59a792-fd0a-4621-87e7-e31458d75d55)