### PR TITLE
Make restli plugin compatible with Gradle 8 and create a new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5632,7 +5632,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.50.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.0...master
+[29.51.0]: https://github.com/linkedin/rest.li/compare/v29.50.1...v29.51.0
 [29.50.1]: https://github.com/linkedin/rest.li/compare/v29.50.0...v29.50.1
 [29.50.0]: https://github.com/linkedin/rest.li/compare/v29.49.9...v29.50.0
 [29.49.9]: https://github.com/linkedin/rest.li/compare/v29.49.8...v29.49.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [30.0.0] - 2024-02-06
-- Major version bump due to dropping support to Gradle versions below 6.9.4.
+## [29.51.0] - 2024-02-06
+- Minor version bump due to dropping support to Gradle versions below 6.9.4.
 - Make rest.li codebase use Gradle 6.9.4 to build itself
 - Make PegasusPlugin compatible with all Gradle version from 6.9.4 to 8.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [30.0.0] - 2024-02-06
+- Major version bump due to dropping support to Gradle versions below 6.9.4.
+- Make rest.li codebase use Gradle 6.9.4 to build itself
+- Make PegasusPlugin compatible with all Gradle version from 6.9.4 to 8.5
+
 ## [29.50.1] - 2024-01-31
 - Fix r2-netty illegal state exception due to premature channel recycling.
 

--- a/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/IntegTestingUtil.groovy
+++ b/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/IntegTestingUtil.groovy
@@ -1,7 +1,7 @@
 package com.linkedin.pegasus.gradle
 
 final class IntegTestingUtil {
-  public static final List<String> ALL_SUPPORTED_GRADLE_VERSIONS = ['6.9.4', '7.0.2', '7.5.1']
+  public static final List<String> ALL_SUPPORTED_GRADLE_VERSIONS = ['6.9.4', '7.0.2', '7.5.1', '8.5']
   public static final List<String> OLD_PUBLISHING_SUPPORTED_GRADLE_VERSIONS = ['6.9.4']
-  public static final List<String> NEW_PUBLISHING_SUPPORTED_GRADLE_VERSIONS = ['6.9.4', '7.0.2', '7.6.3']
+  public static final List<String> NEW_PUBLISHING_SUPPORTED_GRADLE_VERSIONS = ['6.9.4', '7.0.2', '7.6.3', '8.5']
 }

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -74,7 +74,6 @@ import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.Sync;
-import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -942,9 +941,6 @@ public class PegasusPlugin implements Plugin<Project>
     project.getTasks().getByName("check").dependsOn(validateSchemaAnnotationTask);
   }
 
-
-
-  @SuppressWarnings("deprecation")
   protected void configureGeneratedSourcesAndJavadoc(Project project)
   {
     _generateJavadocTask = project.getTasks().create("generateJavadoc", Javadoc.class);
@@ -963,8 +959,7 @@ public class PegasusPlugin implements Plugin<Project>
       _generateSourcesJarTask = project.getTasks().create("generateSourcesJar", Jar.class, jarTask -> {
         jarTask.setGroup(JavaBasePlugin.DOCUMENTATION_GROUP);
         jarTask.setDescription("Generates a jar file containing the sources for the generated Java classes.");
-        // FIXME change to #getArchiveClassifier().set("sources"); breaks backwards-compatibility before 5.1
-        jarTask.setClassifier("sources");
+        jarTask.getArchiveClassifier().set("sources");
       });
 
       project.getArtifacts().add("generatedSources", _generateSourcesJarTask);
@@ -985,8 +980,7 @@ public class PegasusPlugin implements Plugin<Project>
         jarTask.dependsOn(_generateJavadocTask);
         jarTask.setGroup(JavaBasePlugin.DOCUMENTATION_GROUP);
         jarTask.setDescription("Generates a jar file containing the Javadoc for the generated Java classes.");
-        // FIXME change to #getArchiveClassifier().set("sources"); breaks backwards-compatibility before 5.1
-        jarTask.setClassifier("javadoc");
+        jarTask.getArchiveClassifier().set("javadoc");
         jarTask.from(_generateJavadocTask.getDestinationDir());
       });
 
@@ -1443,8 +1437,8 @@ public class PegasusPlugin implements Plugin<Project>
 
       // Use the files from apiDir for generating the changed files report as we need to notify user only when
       // source system files are modified.
-      changedFileReportTask.setIdlFiles(SharedFileUtils.getSuffixedFiles(project, apiIdlDir, IDL_FILE_SUFFIX));
-      changedFileReportTask.setSnapshotFiles(SharedFileUtils.getSuffixedFiles(project, apiSnapshotDir,
+      changedFileReportTask.getIdlFiles().from(SharedFileUtils.getSuffixedFiles(project, apiIdlDir, IDL_FILE_SUFFIX));
+      changedFileReportTask.getSnapshotFiles().from(SharedFileUtils.getSuffixedFiles(project, apiSnapshotDir,
           SNAPSHOT_FILE_SUFFIX));
       changedFileReportTask.mustRunAfter(publishRestliSnapshotTask, publishRestliIdlTask);
       changedFileReportTask.doLast(new CacheableAction<>(t ->
@@ -1516,7 +1510,6 @@ public class PegasusPlugin implements Plugin<Project>
     project.getTasks().getByName(LifecycleBasePlugin.ASSEMBLE_TASK_NAME).dependsOn(publishPegasusSchemaSnapshot);
   }
 
-  @SuppressWarnings("deprecation")
   protected void configureAvroSchemaGeneration(Project project, SourceSet sourceSet)
   {
     File dataSchemaDir = project.file(getDataSchemaPath(project, sourceSet));
@@ -1566,8 +1559,7 @@ public class PegasusPlugin implements Plugin<Project>
         copySpec.eachFile(fileCopyDetails ->
             fileCopyDetails.setPath("avro" + File.separatorChar + fileCopyDetails.getPath())));
 
-      // FIXME change to #getArchiveAppendix().set(...); breaks backwards-compatibility before 5.1
-      task.setAppendix(getAppendix(sourceSet, "avro-schema"));
+      task.getArchiveAppendix().set(getAppendix(sourceSet, "avro-schema"));
       task.setDescription("Generate an avro schema jar");
     });
 
@@ -1644,7 +1636,6 @@ public class PegasusPlugin implements Plugin<Project>
     });
   }
 
-  @SuppressWarnings("deprecation")
   protected GenerateDataTemplateTask configureDataTemplateGeneration(Project project, SourceSet sourceSet)
   {
     File dataSchemaDir = project.file(getDataSchemaPath(project, sourceSet));
@@ -1835,8 +1826,7 @@ public class PegasusPlugin implements Plugin<Project>
           task.dependsOn(dataTemplateJarDepends);
           task.from(targetSourceSet.getOutput());
 
-          // FIXME change to #getArchiveAppendix().set(...); breaks backwards-compatibility before 5.1
-          task.setAppendix(getAppendix(sourceSet, "data-template"));
+          task.getArchiveAppendix().set(getAppendix(sourceSet, "data-template"));
           task.setDescription("Generate a data template jar");
         });
 
@@ -1987,7 +1977,6 @@ public class PegasusPlugin implements Plugin<Project>
   // It also compiles the rest client source files into classes, and creates both the
   // rest model and rest client jar files.
   //
-  @SuppressWarnings("deprecation")
   protected void configureRestClientGeneration(Project project, SourceSet sourceSet)
   {
     // idl directory for api project
@@ -2108,8 +2097,7 @@ public class PegasusPlugin implements Plugin<Project>
             .info("Add idl file: {}", fileCopyDetails));
         copySpec.setIncludes(Collections.singletonList('*' + IDL_FILE_SUFFIX));
       });
-      // FIXME change to #getArchiveAppendix().set(...); breaks backwards-compatibility before 5.1
-      task.setAppendix(getAppendix(sourceSet, "rest-model"));
+      task.getArchiveAppendix().set(getAppendix(sourceSet, "rest-model"));
       task.setDescription("Generate rest model jar");
     });
 
@@ -2126,8 +2114,7 @@ public class PegasusPlugin implements Plugin<Project>
             copySpec.setIncludes(Collections.singletonList('*' + IDL_FILE_SUFFIX));
           });
           task.from(targetSourceSet.getOutput());
-          // FIXME change to #getArchiveAppendix().set(...); breaks backwards-compatibility before 5.1
-          task.setAppendix(getAppendix(sourceSet, "rest-client"));
+          task.getArchiveAppendix().set(getAppendix(sourceSet, "rest-client"));
           task.setDescription("Generate rest client jar");
         });
 
@@ -2231,7 +2218,7 @@ public class PegasusPlugin implements Plugin<Project>
    */
   public static boolean isPropertyTrue(Project project, String propertyName)
   {
-    return project.hasProperty(propertyName) && Boolean.valueOf(project.property(propertyName).toString());
+    return project.hasProperty(propertyName) && Boolean.parseBoolean(project.property(propertyName).toString());
   }
 
   private static String createModifiedFilesMessage(Collection<String> nonEquivExpectedFiles,

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ChangedFileReportTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ChangedFileReportTask.java
@@ -1,26 +1,28 @@
 package com.linkedin.pegasus.gradle.tasks;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
+import org.gradle.work.ChangeType;
+import org.gradle.work.Incremental;
+import org.gradle.work.InputChanges;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
-public class ChangedFileReportTask extends DefaultTask
+public abstract class ChangedFileReportTask extends DefaultTask
 {
   private final Collection<String> _needCheckinFiles = new ArrayList<>();
-
-  private FileCollection _idlFiles = getProject().files();
-  private FileCollection _snapshotFiles = getProject().files();
 
   public ChangedFileReportTask()
   {
@@ -29,11 +31,11 @@ public class ChangedFileReportTask extends DefaultTask
   }
 
   @TaskAction
-  public void checkFilesForChanges(IncrementalTaskInputs inputs)
+  public void checkFilesForChanges(InputChanges inputs)
   {
     getLogger().lifecycle("Checking idl and snapshot files for changes...");
-    getLogger().info("idlFiles: " + _idlFiles.getAsPath());
-    getLogger().info("snapshotFiles: " + _snapshotFiles.getAsPath());
+    getLogger().info("idlFiles: " + getIdlFiles().getAsPath());
+    getLogger().info("snapshotFiles: " + getSnapshotFiles().getAsPath());
 
     Set<String> filesRemoved = new HashSet<>();
     Set<String> filesAdded = new HashSet<>();
@@ -41,24 +43,24 @@ public class ChangedFileReportTask extends DefaultTask
 
     if (inputs.isIncremental())
     {
-      inputs.outOfDate(inputFileDetails -> {
-        if (inputFileDetails.isAdded())
-        {
-          filesAdded.add(inputFileDetails.getFile().getAbsolutePath());
-        }
+      for (FileCollection fileCollection : Arrays.asList(getIdlFiles(), getSnapshotFiles())) {
+        inputs.getFileChanges(fileCollection).forEach(inputFileDetails -> {
+          if (inputFileDetails.getChangeType().equals(ChangeType.ADDED))
+          {
+            filesAdded.add(inputFileDetails.getFile().getAbsolutePath());
+          }
 
-        if (inputFileDetails.isRemoved())
-        {
-          filesRemoved.add(inputFileDetails.getFile().getAbsolutePath());
-        }
+          if (inputFileDetails.getChangeType().equals(ChangeType.REMOVED))
+          {
+            filesRemoved.add(inputFileDetails.getFile().getAbsolutePath());
+          }
 
-        if (inputFileDetails.isModified())
-        {
-          filesChanged.add(inputFileDetails.getFile().getAbsolutePath());
-        }
-      });
-
-      inputs.removed(inputFileDetails -> filesRemoved.add(inputFileDetails.getFile().getAbsolutePath()));
+          if (inputFileDetails.getChangeType().equals(ChangeType.MODIFIED))
+          {
+            filesChanged.add(inputFileDetails.getFile().getAbsolutePath());
+          }
+        });
+      }
 
       if (!filesRemoved.isEmpty())
       {
@@ -91,28 +93,12 @@ public class ChangedFileReportTask extends DefaultTask
   }
 
   @InputFiles
-  @SkipWhenEmpty
-  public FileCollection getSnapshotFiles()
-  {
-    return _snapshotFiles;
-  }
-
-  public void setSnapshotFiles(FileCollection snapshotFiles)
-  {
-    _snapshotFiles = snapshotFiles;
-  }
+  @Incremental
+  public abstract ConfigurableFileCollection getSnapshotFiles();
 
   @InputFiles
-  @SkipWhenEmpty
-  public FileCollection getIdlFiles()
-  {
-    return _idlFiles;
-  }
-
-  public void setIdlFiles(FileCollection idlFiles)
-  {
-    _idlFiles = idlFiles;
-  }
+  @Incremental
+  public abstract ConfigurableFileCollection getIdlFiles();
 
   @Internal
   public Collection<String> getNeedCheckinFiles()

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ChangedFileReportTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ChangedFileReportTask.java
@@ -6,7 +6,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.ChangeType;
 import org.gradle.work.Incremental;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=30.0.0
+version=29.51.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.50.1
+version=30.0.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This PR makes restli plugin compatible with Gradle 8. To do it, the following changes are introduced:

- all deprecated API usages are replaced with non-deprecated analogs

This PR also bumps the major version to make a new release. The major version bump is necessary because the previous PR dropped support of some Gradle versions which breaks backward compatiblity.

## Testing Done

local build ok