### PR TITLE
Bump setup-java to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           # Need to fetch 2 commits for the PR (base commit and head merge commit) so we can compute the diff
           fetch-depth: 2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
There are some known issues with v2 that are causing the builds to fail. See here for more details: https://github.com/actions/setup-java/issues/506