### PR TITLE
Use tracingId in xDS flow for SD tracking events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.2] - 2024-02-15
+- use tracingId in xDS flow for SD tracking events
+
 ## [29.51.1] - 2024-02-13
 - Default back to pick_first policy
 
@@ -5635,7 +5638,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.2...master
+[29.51.2]: https://github.com/linkedin/rest.li/compare/v29.51.1...v29.51.2
 [29.51.1]: https://github.com/linkedin/rest.li/compare/v29.51.0...v29.51.1
 [29.51.0]: https://github.com/linkedin/rest.li/compare/v29.50.1...v29.51.0
 [29.50.1]: https://github.com/linkedin/rest.li/compare/v29.50.0...v29.50.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/UriPropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/UriPropertiesJsonSerializer.java
@@ -125,7 +125,9 @@ public class UriPropertiesJsonSerializer implements PropertySerializer<UriProper
       return new UriProperties(
           protoUri.getClusterName(),
           Collections.singletonMap(uri, partitionDesc),
-          Collections.singletonMap(uri, applicationProperties),
+          applicationProperties.isEmpty() ?
+              Collections.emptyMap() :
+              Collections.singletonMap(uri, applicationProperties),
           protoUri.getVersion()
       );
     }

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -476,7 +476,8 @@ public class XdsToD2PropertiesAdaptor
         uriProperties = _uriPropertiesJsonSerializer.fromProto(xdsUri);
         if (uriProperties.getVersion() < 0)
         {
-          LOG.warn("xDS data: {} for uri: {} has invalid version: {}", xdsUri, uriName, uriProperties.getVersion());
+          LOG.warn("xDS data: {} for uri: {} in cluster: {} has invalid version: {}",
+              xdsUri, uriName, _clusterName, uriProperties.getVersion());
         }
       }
       catch (PropertySerializationException e)

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -62,6 +62,8 @@ message Node {
 // ZooKeeperServer and ZooKeeperAnnouncer that there cannot ever be more than one URI in one ZK announcement, therefore
 // this new proto representation does not need to share the same shortcomings and can, instead, represent things more
 // linearly.
+// linearly. Note that since a URI can announce to multiple partitions, this is still represented as a map to capture
+// the weights for each partition.
 //
 // Here is a sample ZK announcement in JSON serialized from a UriProperties for additional clarity on the fields that
 // are represented as maps when they do not need to be:
@@ -74,6 +76,9 @@ message Node {
 //				"0": {
 //					"weight": 1.0
 //				}
+//				"1": {
+//					"weight": 2.0
+//				}
 //			}
 //		},
 //		"uriSpecificProperties": {
@@ -82,6 +87,19 @@ message Node {
 //			}
 //		},
 //		"clusterName": "Toki"
+//	}
+//
+// And here is what the corresponding D2URI would look like for this announcement:
+//	{
+//		"cluster_name": "Toki",
+//		"uri": "https://foo.stg.linkedin.com:18792/Toki/resources",
+//		"partition_desc": {
+//			"0": 1.0,
+//			"1": 2.0
+//		},
+//		"uri_specific_properties": {
+//			"com.linkedin.app.version": "0.1.76"
+//		}
 //	}
 message D2URI {
   // The version of this announcement. When coming from ZK, this will be the node's mzxid.
@@ -103,6 +121,11 @@ message D2URI {
 
   // Additional metadata for this announcement. This is inferred from the original "uriSpecificProperties" field.
   google.protobuf.Struct uri_specific_properties = 6;
+
+  // The tracing ID for this announcement, which should be unique to this announcement. For Kafka announcements, this
+  // comes from the announcing server (which sets a UUID for each announcement) and for Zookeeper,
+  // this will be the full path to the d2URI. eg: /d2/uris/FooCluster/lor1-app000-xxxxx
+  string tracing_id = 7;
 }
 
 message D2URIMap {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.1
+version=29.51.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
1. Use the new tracingId field in xDS d2 proto for SD tracking events (previously, we were hard-coding the tracing id to zookeeper node path, which is invalid for Kafka data). 
2. Correct the version field in the tracking event (previously hard-coding to 0 for ZK data).
3. fix uri specific properties formatting in xds data. Before this fix, xDS uri properties put an empty map inside merged uriSpecificProperties for uris that don't have such property, leading to uri mismatches as described [here](https://docs.google.com/document/d/1phtGwYaQ6yuuqumS8lMZ8_Y5EkY11_R9bXZHzp0BX9E/edit#bookmark=id.i8523geqptmk).

## Test Done
1. Existing tests cover the uri publish logic, updated to cover the tracking events.
2. Manual tested with d2-proxy. Was able to make calls to downstream apps for both symlink and non-symlink clusters. And verified the merged uri properties are exactly the same now:

- ZK uri data to compare against:
[$EntitlementsBackendMaster.txt](https://github.com/linkedin/rest.li/files/14348799/EntitlementsBackendMaster.txt)

- xDS uri data before the fix:
[$EntitlementsBackendMaster_before.txt](https://github.com/linkedin/rest.li/files/14348804/EntitlementsBackendMaster_before.txt)

- xDS uri data after the fix:
[$EntitlementsBackendMaster_after.txt](https://github.com/linkedin/rest.li/files/14348809/EntitlementsBackendMaster_after.txt)
