### PR TITLE
Glob collections implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.11] - 2024-03-20
+- Glob collections support
+
 ## [29.51.10] - 2024-03-20
 - Fix null guard log issue
 
@@ -5662,7 +5665,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.11...master
+[29.51.11]: https://github.com/linkedin/rest.li/compare/v29.51.10...v29.51.11
 [29.51.10]: https://github.com/linkedin/rest.li/compare/v29.51.9...v29.51.10
 [29.51.9]: https://github.com/linkedin/rest.li/compare/v29.51.8...v29.51.9
 [29.51.8]: https://github.com/linkedin/rest.li/compare/v29.51.7...v29.51.8

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -215,7 +215,7 @@ public class D2ClientBuilder
                   _config.dualReadNewLbExecutor,
                   _config.xdsChannelLoadBalancingPolicy,
                   _config.xdsChannelLoadBalancingPolicyConfig,
-                  _config.useGlobCollectionsForUriSubscriptions
+                  _config.subscribeToUriGlobCollection
     );
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
@@ -712,8 +712,8 @@ public class D2ClientBuilder
     return this;
   }
 
-  public D2ClientBuilder setUseGlobCollectionsForUriSubscriptions(boolean useGlobCollectionsForUriSubscriptions) {
-    _config.useGlobCollectionsForUriSubscriptions = useGlobCollectionsForUriSubscriptions;
+  public D2ClientBuilder setSubscribeToUriGlobCollection(boolean subscribeToUriGlobCollection) {
+    _config.subscribeToUriGlobCollection = subscribeToUriGlobCollection;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -214,7 +214,8 @@ public class D2ClientBuilder
                   _config.xdsStreamReadyTimeout,
                   _config.dualReadNewLbExecutor,
                   _config.xdsChannelLoadBalancingPolicy,
-                  _config.xdsChannelLoadBalancingPolicyConfig
+                  _config.xdsChannelLoadBalancingPolicyConfig,
+                  _config.useGlobCollectionsForUriSubscriptions
     );
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
@@ -708,6 +709,11 @@ public class D2ClientBuilder
 
   public D2ClientBuilder xdsChannelLoadBalancingPolicyConfig(Map<String, ?> xdsChannelLoadBalancingPolicyConfig) {
     _config.xdsChannelLoadBalancingPolicyConfig = xdsChannelLoadBalancingPolicyConfig;
+    return this;
+  }
+
+  public D2ClientBuilder setUseGlobCollectionsForUriSubscriptions(boolean useGlobCollectionsForUriSubscriptions) {
+    _config.useGlobCollectionsForUriSubscriptions = useGlobCollectionsForUriSubscriptions;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -134,6 +134,7 @@ public class D2ClientConfig
   public ExecutorService dualReadNewLbExecutor = null;
   public String xdsChannelLoadBalancingPolicy = null;
   public Map<String, ?> xdsChannelLoadBalancingPolicyConfig = null;
+  public boolean useGlobCollectionsForUriSubscriptions = false;
 
   public D2ClientConfig()
   {
@@ -208,7 +209,9 @@ public class D2ClientConfig
                  Long xdsStreamReadyTimeout,
                  ExecutorService dualReadNewLbExecutor,
                  String xdsChannelLoadBalancingPolicy,
-                 Map<String, ?> xdsChannelLoadBalancingPolicyConfig)
+                 Map<String, ?> xdsChannelLoadBalancingPolicyConfig,
+                 boolean useGlobCollectionsForUriSubscriptions
+      )
   {
     this.zkHosts = zkHosts;
     this.xdsServer = xdsServer;
@@ -280,5 +283,6 @@ public class D2ClientConfig
     this.dualReadNewLbExecutor = dualReadNewLbExecutor;
     this.xdsChannelLoadBalancingPolicy = xdsChannelLoadBalancingPolicy;
     this.xdsChannelLoadBalancingPolicyConfig = xdsChannelLoadBalancingPolicyConfig;
+    this.useGlobCollectionsForUriSubscriptions = useGlobCollectionsForUriSubscriptions;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -134,7 +134,7 @@ public class D2ClientConfig
   public ExecutorService dualReadNewLbExecutor = null;
   public String xdsChannelLoadBalancingPolicy = null;
   public Map<String, ?> xdsChannelLoadBalancingPolicyConfig = null;
-  public boolean useGlobCollectionsForUriSubscriptions = false;
+  public boolean subscribeToUriGlobCollection = false;
 
   public D2ClientConfig()
   {
@@ -210,7 +210,7 @@ public class D2ClientConfig
                  ExecutorService dualReadNewLbExecutor,
                  String xdsChannelLoadBalancingPolicy,
                  Map<String, ?> xdsChannelLoadBalancingPolicyConfig,
-                 boolean useGlobCollectionsForUriSubscriptions
+                 boolean subscribeToUriGlobCollection
       )
   {
     this.zkHosts = zkHosts;
@@ -283,6 +283,6 @@ public class D2ClientConfig
     this.dualReadNewLbExecutor = dualReadNewLbExecutor;
     this.xdsChannelLoadBalancingPolicy = xdsChannelLoadBalancingPolicy;
     this.xdsChannelLoadBalancingPolicyConfig = xdsChannelLoadBalancingPolicyConfig;
-    this.useGlobCollectionsForUriSubscriptions = useGlobCollectionsForUriSubscriptions;
+    this.subscribeToUriGlobCollection = subscribeToUriGlobCollection;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
@@ -1,41 +1,77 @@
 package com.linkedin.d2.xds;
 
+import javax.annotation.Nullable;
+
 public class GlobCollectionUtils
 {
-  private static final String D2_URI_NODE_GLOB_COLLECTION_PREFIX = "xdstp:///indis.D2URI/";
+  private static final String D2_URIS_PREFIX = "/d2/uris/";
+  private static final String D2_URI_NODE_GLOB_COLLECTION_PREFIX = "xdstp:///indis.D2URI/d2/uris/";
   private static final String GLOB_COLLECTION_SUFFIX = "/*";
 
   private GlobCollectionUtils()
   {
   }
 
-  /**
-   * Extracts the glob collection URL (e.g. xdstp:///indis.D2URI/FooCluster/*) from the given resource URN.
-   */
-  public static String globCollectionUrlFromResourceUrn(String resourceUrn)
+  public static class D2UriIdentifier
   {
-    return resourceUrn.substring(0, resourceUrn.lastIndexOf('/')) + GLOB_COLLECTION_SUFFIX;
-  }
+    private final String _clusterPath;
+    private final String _uriName;
 
-  /**
-   * Extracts the URI from the resource URN. Resource URNs for indis.D2URIs have the format of:<pre>
-   *   xdstp:///indis.D2URI/{CLUSTER}/{URL_ESCAPED_ANNOUNCER}
-   * </pre>
-   */
-  public static String uriFromResourceUrn(String resourceUrn)
-  {
-    return resourceUrn.substring(resourceUrn.lastIndexOf('/'));
+    private D2UriIdentifier(String clusterPath, String name)
+    {
+      _clusterPath = clusterPath;
+      _uriName = name;
+    }
+
+    public String getClusterPath()
+    {
+      return _clusterPath;
+    }
+
+    public String getUriName()
+    {
+      return _uriName;
+    }
+
+    /**
+     * Parses the given resource name into a {@link D2UriIdentifier}. URNs for {@code indis.D2URIs} have the format of:
+     * <pre>
+     *   xdstp:///indis.D2URI/{CLUSTER}/{NAME}
+     * </pre>
+     *
+     * @return The parse {@link D2UriIdentifier} if the given resource name is a valid URN, otherwise {@code null}.
+     */
+    @Nullable
+    public static D2UriIdentifier parse(String resourceName)
+    {
+      if (!resourceName.startsWith(D2_URI_NODE_GLOB_COLLECTION_PREFIX))
+      {
+        return null;
+      }
+      int lastIndex = resourceName.lastIndexOf('/');
+      if (lastIndex == 1)
+      {
+        return null;
+      }
+      return new D2UriIdentifier(
+          D2_URIS_PREFIX + resourceName.substring(0, lastIndex) + GLOB_COLLECTION_SUFFIX,
+          resourceName.substring(lastIndex + 1)
+      );
+    }
   }
 
   /**
    * Returns the glob collection URL for the cluster, which has the format:<pre>
-   *   xdstp:///indis.D2URI/{CLUSTER}/*
+   *   xdstp:///indis.D2URI/{CLUSTER_NAME}/*
    * </pre>
-   * Note that CLUSTER in this case does not include the /d2/uris/ prefix, it is only the cluster name.
+   *
+   * @param clusterPath The full path to the cluster, including the "/d2/uris/" prefix. This matches the resource name
+   *                    for the D2URIMap type.
    */
-  public static String globCollectionUrlForCluster(String cluster)
+  public static String globCollectionUrlForClusterResource(String clusterPath)
   {
-    return D2_URI_NODE_GLOB_COLLECTION_PREFIX + cluster + GLOB_COLLECTION_SUFFIX;
+    return D2_URI_NODE_GLOB_COLLECTION_PREFIX +
+        clusterPath.substring(clusterPath.lastIndexOf('/') + 1) +
+        GLOB_COLLECTION_SUFFIX;
   }
-
 }

--- a/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
@@ -14,20 +14,26 @@ public class GlobCollectionUtils
 
   public static class D2UriIdentifier
   {
-    private final String _clusterPath;
+    private final String _clusterResourceName;
     private final String _uriName;
 
-    private D2UriIdentifier(String clusterPath, String name)
+    private D2UriIdentifier(String clusterResourceName, String name)
     {
-      _clusterPath = clusterPath;
+      _clusterResourceName = clusterResourceName;
       _uriName = name;
     }
 
-    public String getClusterPath()
+    /**
+     * Returns the cluster resource's name, i.e. {@code /d2/uris/{CLUSTER_NAME}}.
+     */
+    public String getClusterResourceName()
     {
-      return _clusterPath;
+      return _clusterResourceName;
     }
 
+    /**
+     * Returns the name of the URI within that cluster.
+     */
     public String getUriName()
     {
       return _uriName;

--- a/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
@@ -5,7 +5,7 @@ import javax.annotation.Nullable;
 public class GlobCollectionUtils
 {
   private static final String D2_URIS_PREFIX = "/d2/uris/";
-  private static final String D2_URI_NODE_GLOB_COLLECTION_PREFIX = "xdstp:///indis.D2URI/d2/uris/";
+  private static final String D2_URI_NODE_GLOB_COLLECTION_PREFIX = "xdstp:///indis.D2URI/";
   private static final String GLOB_COLLECTION_SUFFIX = "/*";
 
   private GlobCollectionUtils()
@@ -48,15 +48,16 @@ public class GlobCollectionUtils
       {
         return null;
       }
+
       int lastIndex = resourceName.lastIndexOf('/');
-      if (lastIndex == 1)
+      if (lastIndex == -1)
       {
         return null;
       }
-      return new D2UriIdentifier(
-          D2_URIS_PREFIX + resourceName.substring(0, lastIndex) + GLOB_COLLECTION_SUFFIX,
-          resourceName.substring(lastIndex + 1)
-      );
+
+      String clusterName = resourceName.substring(D2_URI_NODE_GLOB_COLLECTION_PREFIX.length(), lastIndex);
+
+      return new D2UriIdentifier(D2_URIS_PREFIX + clusterName, resourceName.substring(lastIndex + 1));
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
@@ -1,0 +1,41 @@
+package com.linkedin.d2.xds;
+
+public class GlobCollectionUtils
+{
+  private static final String D2_URI_NODE_GLOB_COLLECTION_PREFIX = "xdstp:///indis.D2URI/";
+  private static final String GLOB_COLLECTION_SUFFIX = "/*";
+
+  private GlobCollectionUtils()
+  {
+  }
+
+  /**
+   * Extracts the glob collection URL (e.g. xdstp:///indis.D2URI/FooCluster/*) from the given resource URN.
+   */
+  public static String globCollectionUrlFromResourceUrn(String resourceUrn)
+  {
+    return resourceUrn.substring(0, resourceUrn.lastIndexOf('/')) + GLOB_COLLECTION_SUFFIX;
+  }
+
+  /**
+   * Extracts the URI from the resource URN. Resource URNs for indis.D2URIs have the format of:<pre>
+   *   xdstp:///indis.D2URI/{CLUSTER}/{URL_ESCAPED_ANNOUNCER}
+   * </pre>
+   */
+  public static String uriFromResourceUrn(String resourceUrn)
+  {
+    return resourceUrn.substring(resourceUrn.lastIndexOf('/'));
+  }
+
+  /**
+   * Returns the glob collection URL for the cluster, which has the format:<pre>
+   *   xdstp:///indis.D2URI/{CLUSTER}/*
+   * </pre>
+   * Note that CLUSTER in this case does not include the /d2/uris/ prefix, it is only the cluster name.
+   */
+  public static String globCollectionUrlForCluster(String cluster)
+  {
+    return D2_URI_NODE_GLOB_COLLECTION_PREFIX + cluster + GLOB_COLLECTION_SUFFIX;
+  }
+
+}

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -70,7 +70,7 @@ public class XdsClientImpl extends XdsClient
   private final Node _node;
   private final ManagedChannel _managedChannel;
   private final ScheduledExecutorService _executorService;
-  private final boolean _useUriGlobCollections;
+  private final boolean _subscribeToUriGlobCollection;
   private final BackoffPolicy.Provider _backoffPolicyProvider = new ExponentialBackoffPolicy.Provider();
   private BackoffPolicy _retryBackoffPolicy;
   private AdsStream _adsStream;
@@ -95,14 +95,14 @@ public class XdsClientImpl extends XdsClient
   }
 
   public XdsClientImpl(Node node, ManagedChannel managedChannel, ScheduledExecutorService executorService,
-      long readyTimeoutMillis, boolean useUriGlobCollections)
+      long readyTimeoutMillis, boolean subscribeToUriGlobCollection)
   {
     _readyTimeoutMillis = readyTimeoutMillis;
     _node = node;
     _managedChannel = managedChannel;
     _executorService = executorService;
-    _useUriGlobCollections = true;
-    if (_useUriGlobCollections)
+    _subscribeToUriGlobCollection = subscribeToUriGlobCollection;
+    if (_subscribeToUriGlobCollection)
     {
       _log.info("Glob collection support enabled");
     }
@@ -122,7 +122,7 @@ public class XdsClientImpl extends XdsClient
         resourceSubscriberMap.put(resourceName, subscriber);
         ResourceType type;
         String adjustedResourceName;
-        if (watcher.getType() == ResourceType.D2_URI_MAP && _useUriGlobCollections)
+        if (watcher.getType() == ResourceType.D2_URI_MAP && _subscribeToUriGlobCollection)
         {
           type = ResourceType.D2_URI;
           adjustedResourceName = GlobCollectionUtils.globCollectionUrlForClusterResource(resourceName);

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -101,7 +101,7 @@ public class XdsClientImpl extends XdsClient
     _node = node;
     _managedChannel = managedChannel;
     _executorService = executorService;
-    _useUriGlobCollections = useUriGlobCollections;
+    _useUriGlobCollections = true;
     if (_useUriGlobCollections)
     {
       _log.info("Glob collection support enabled");
@@ -339,7 +339,7 @@ public class XdsClientImpl extends XdsClient
 
     Set<String> removedClusters = new HashSet<>();
 
-    data.foreach((resourceName, resource) ->
+    data.forEach((resourceName, resource) ->
     {
       D2UriIdentifier uriId = D2UriIdentifier.parse(resourceName);
       if (uriId == null)
@@ -354,8 +354,7 @@ public class XdsClientImpl extends XdsClient
           getResourceSubscriberMap(ResourceType.D2_URI_MAP).get(uriId.getClusterResourceName());
       if (subscriber == null)
       {
-        String msg =
-            String.format("Ignoring D2URI resource update for untracked cluster: %s", uriId.getClusterResourceName());
+        String msg = String.format("Ignoring D2URI resource update for untracked cluster: %s", resourceName);
         _log.warn(msg);
         errors.add(msg);
         return;
@@ -399,8 +398,8 @@ public class XdsClientImpl extends XdsClient
         }
         catch (InvalidProtocolBufferException e)
         {
-          _log.warn("Failed to unpack D2URI glob collection response", e);
-          errors.add("Failed to unpack D2URI glob collection response");
+          _log.warn("Failed to unpack D2URI", e);
+          errors.add("Failed to unpack D2URI");
         }
       }
     });
@@ -705,7 +704,7 @@ public class XdsClientImpl extends XdsClient
      * Invokes the given consumer for each resource in this response. If the {@link Resource} is not null, it is being
      * created/modified and if it is null, it is being removed.
      */
-    void foreach(BiConsumer<String, Resource> consumer)
+    void forEach(BiConsumer<String, Resource> consumer)
     {
       for (Resource resource : _resources)
       {

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -57,7 +57,7 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
         new XdsChannelFactory(config.grpcSslContext, config.xdsServer).createChannel(),
         executorService,
         xdsStreamReadyTimeout,
-        config.useGlobCollectionsForUriSubscriptions
+        config.subscribeToUriGlobCollection
     );
     d2ClientJmxManager.registerXdsClientJmx(xdsClient.getXdsClientJmx());
 

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -58,7 +58,7 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
     d2ClientJmxManager.registerXdsClientJmx(xdsClient.getXdsClientJmx());
 
     XdsToD2PropertiesAdaptor adaptor = new XdsToD2PropertiesAdaptor(xdsClient, config.dualReadStateManager,
-        config.serviceDiscoveryEventEmitter);
+        config.serviceDiscoveryEventEmitter, config.useGlobCollectionsForUriSubscriptions);
 
     XdsLoadBalancer xdsLoadBalancer = new XdsLoadBalancer(adaptor, executorService,
         new XdsFsTogglingLoadBalancerFactory(config.lbWaitTimeout, config.lbWaitUnit, config.indisFsBasePath,

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -52,13 +52,17 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
         Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("D2 xDS PropertyEventExecutor")));
     long xdsStreamReadyTimeout = ObjectUtils.defaultIfNull(config.xdsStreamReadyTimeout,
         XdsClientImpl.DEFAULT_READY_TIMEOUT_MILLIS);
-    XdsClient xdsClient = new XdsClientImpl(new Node(config.hostName),
-        new XdsChannelFactory(config.grpcSslContext, config.xdsServer).createChannel(), executorService,
-        xdsStreamReadyTimeout);
+    XdsClient xdsClient = new XdsClientImpl(
+        new Node(config.hostName),
+        new XdsChannelFactory(config.grpcSslContext, config.xdsServer).createChannel(),
+        executorService,
+        xdsStreamReadyTimeout,
+        config.useGlobCollectionsForUriSubscriptions
+    );
     d2ClientJmxManager.registerXdsClientJmx(xdsClient.getXdsClientJmx());
 
     XdsToD2PropertiesAdaptor adaptor = new XdsToD2PropertiesAdaptor(xdsClient, config.dualReadStateManager,
-        config.serviceDiscoveryEventEmitter, config.useGlobCollectionsForUriSubscriptions);
+        config.serviceDiscoveryEventEmitter);
 
     XdsLoadBalancer xdsLoadBalancer = new XdsLoadBalancer(adaptor, executorService,
         new XdsFsTogglingLoadBalancerFactory(config.lbWaitTimeout, config.lbWaitUnit, config.indisFsBasePath,

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -337,7 +337,7 @@ public class TestXdsClientImpl
         new DiscoveryResponseData(D2_URI, null, Collections.singletonList(URI_URN2), NONCE, null);
     fixture._xdsClientImpl.handleResponse(deleteUri2);
     actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
-    // subscriber data should be updated to D2_URI_MAP_UPDATE_WITH_DATA2
+    // subscriber data should be updated to empty map
     expectedUpdate = new D2URIMapUpdate(Collections.emptyMap());
     verify(fixture._resourceWatcher).onChanged(eq(expectedUpdate));
     Assert.assertEquals(actualData.getURIMap(), expectedUpdate.getURIMap());

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -28,8 +28,9 @@ import static org.mockito.Mockito.*;
 public class TestXdsClientImpl
 {
   private static final byte[] DATA = "data".getBytes();
-  private static final String RESOURCE_NAME = "FooService";
+  private static final String SERVICE_RESOURCE_NAME = "/d2/services/FooService";
   private static final String CLUSTER_NAME = "FooClusterMaster-prod-ltx1";
+  private static final String CLUSTER_RESOURCE_NAME = "/d2/uris/" + CLUSTER_NAME;
   private static final String URI1 = "TestURI";
   private static final String URI2 = "TestURI2";
   private static final String VERSION1 = "1";
@@ -42,16 +43,12 @@ public class TestXdsClientImpl
   private static final XdsClient.NodeUpdate NODE_UPDATE1 = new XdsClient.NodeUpdate(NODE_WITH_DATA);
   private static final XdsClient.NodeUpdate NODE_UPDATE2 = new XdsClient.NodeUpdate(NODE_WITH_DATA);
   private static final List<Resource> NODE_RESOURCES_WITH_DATA1 = Collections.singletonList(
-      Resource.newBuilder().setVersion(VERSION1).setName(RESOURCE_NAME).setResource(PACKED_NODE_WITH_DATA).build());
+      Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME).setResource(PACKED_NODE_WITH_DATA).build());
   private static final List<Resource> NODE_RESOURCES_WITH_DATA2 = Collections.singletonList(
-      Resource.newBuilder().setVersion(VERSION2).setName(RESOURCE_NAME).setResource(PACKED_NODE_WITH_DATA).build());
+      Resource.newBuilder().setVersion(VERSION2).setName(SERVICE_RESOURCE_NAME).setResource(PACKED_NODE_WITH_DATA).build());
 
-  private static final List<Resource> RESOURCES_WITH_RESOURCE_IS_NULL =
-      Collections.singletonList(Resource.newBuilder().setVersion(VERSION1).setName(RESOURCE_NAME)
-          // not set resource field
-          .build());
   private static final List<Resource> NODE_RESOURCES_WITH_NULL_RESOURCE_FILED = Collections.singletonList(
-      Resource.newBuilder().setVersion(VERSION1).setName(RESOURCE_NAME).setResource(PACKED_NODE_WITH_EMPTY_DATA).build());
+      Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME).setResource(PACKED_NODE_WITH_EMPTY_DATA).build());
 
   private static final XdsD2.D2URI.Builder URI_BUILDER1 =
       XdsD2.D2URI.newBuilder().setVersion(Long.parseLong(VERSION1)).setClusterName(CLUSTER_NAME).setUri(URI1);
@@ -60,9 +57,9 @@ public class TestXdsClientImpl
   private static final XdsD2.D2URIMap.Builder D2_URI_MAP_BUILDER = XdsD2.D2URIMap.newBuilder();
   private static final XdsD2.D2URIMap D2_URI_MAP_WITH_EMPTY_DATA = XdsD2.D2URIMap.newBuilder().build();
   private static final XdsD2.D2URIMap D2_URI_MAP_WITH_DATA1 =
-      D2_URI_MAP_BUILDER.putUris(RESOURCE_NAME, URI_BUILDER1.build()).build();
+      D2_URI_MAP_BUILDER.putUris(URI1, URI_BUILDER1.build()).build();
   private static final XdsD2.D2URIMap D2_URI_MAP_WITH_DATA2 =
-      D2_URI_MAP_BUILDER.putUris(RESOURCE_NAME, URI_BUILDER2.build()).build();
+      D2_URI_MAP_BUILDER.putUris(URI2, URI_BUILDER2.build()).build();
   private static final XdsClient.D2URIMapUpdate D2_URI_MAP_UPDATE_WITH_DATA1 =
       new XdsClient.D2URIMapUpdate(D2_URI_MAP_WITH_DATA1.getUrisMap());
   private static final XdsClient.D2URIMapUpdate D2_URI_MAP_UPDATE_WITH_DATA2 =
@@ -72,22 +69,22 @@ public class TestXdsClientImpl
   private static final Any PACKED_D2_URI_MAP_WITH_EMPTY_DATA = Any.pack(D2_URI_MAP_WITH_EMPTY_DATA);
   private static final List<Resource> URI_MAP_RESOURCE_WITH_DATA1 = Collections.singletonList(Resource.newBuilder()
       .setVersion(VERSION1)
-      .setName(RESOURCE_NAME)
+      .setName(CLUSTER_RESOURCE_NAME)
       .setResource(PACKED_D2_URI_MAP_WITH_DATA1)
       .build());
 
   private static final List<Resource> URI_MAP_RESOURCE_WITH_DATA2 = Collections.singletonList(Resource.newBuilder()
       .setVersion(VERSION1)
-      .setName(RESOURCE_NAME)
+      .setName(CLUSTER_RESOURCE_NAME)
       .setResource(PACKED_D2_URI_MAP_WITH_DATA2)
       .build());
   private static final List<Resource> URI_MAP_RESOURCE_WITH_NULL_RESOURCE_FILED = Collections.singletonList(
       Resource.newBuilder()
           .setVersion(VERSION2)
-          .setName(RESOURCE_NAME)
+          .setName(CLUSTER_RESOURCE_NAME)
           .setResource(PACKED_D2_URI_MAP_WITH_EMPTY_DATA)
           .build());
-  private static final List<String> REMOVED_RESOURCE = Collections.singletonList(RESOURCE_NAME);
+  //  private static final List<String> REMOVED_RESOURCE = ;
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_DATA1 =
       new DiscoveryResponseData(NODE, NODE_RESOURCES_WITH_DATA1, null, NONCE, null);
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_DATA2 =
@@ -95,7 +92,14 @@ public class TestXdsClientImpl
 
   // case 1: Resource in ResourceUpdate is null, failed to parse which causes InvalidProtocolBufferException
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_RESOURCE_IS_NULL =
-      new DiscoveryResponseData(NODE, RESOURCES_WITH_RESOURCE_IS_NULL, null, NONCE, null);
+      new DiscoveryResponseData(
+          NODE,
+          Collections.singletonList(Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME)
+              // not set resource field
+              .build()),
+          null,
+          NONCE,
+          null);
 
   // case 2: Resource field in Resource is null
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_NULL_DATA_IN_RESOURCE_FILED =
@@ -111,7 +115,14 @@ public class TestXdsClientImpl
 
   // case1: Resource in ResourceUpdate is null, failed to parse response.resource
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_RESOURCE_IS_NULL =
-      new DiscoveryResponseData(D2_URI_MAP, RESOURCES_WITH_RESOURCE_IS_NULL, null, NONCE, null);
+      new DiscoveryResponseData(
+          D2_URI_MAP,
+          Collections.singletonList(Resource.newBuilder().setVersion(VERSION1).setName(CLUSTER_RESOURCE_NAME)
+              // not set resource field
+              .build()),
+          null,
+          NONCE,
+          null);
 
   // case2 : Resource field in Resource is null
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_NULL_DATA_IN_RESOURCE_FILED =
@@ -121,9 +132,9 @@ public class TestXdsClientImpl
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_WITH_EMPTY_URI_MAP_RESPONSE =
       new DiscoveryResponseData(D2_URI_MAP, null, null, NONCE, null);
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_DATA_WITH_REMOVAL =
-      new DiscoveryResponseData(NODE, Collections.emptyList(), REMOVED_RESOURCE, NONCE, null);
+      new DiscoveryResponseData(NODE, Collections.emptyList(), Collections.singletonList(SERVICE_RESOURCE_NAME), NONCE, null);
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_DATA_WITH_REMOVAL =
-      new DiscoveryResponseData(D2_URI_MAP, Collections.emptyList(), REMOVED_RESOURCE, NONCE, null);
+      new DiscoveryResponseData(D2_URI_MAP, Collections.emptyList(), Collections.singletonList(CLUSTER_RESOURCE_NAME), NONCE, null);
 
   private static final String CLUSTER_GLOB_COLLECTION = "xdstp:///indis.D2URI/" + CLUSTER_NAME + "/*";
   private static final String URI_URN1 = "xdstp:///indis.D2URI/" + CLUSTER_NAME + "/" + URI1;
@@ -134,17 +145,17 @@ public class TestXdsClientImpl
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
     // subscriber original data is null
-    fixture._nodeResourceSubscriber.setData(null);
+    fixture._nodeSubscriber.setData(null);
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA1);
     fixture.verifyAckSent(1);
     verify(fixture._resourceWatcher).onChanged(eq(NODE_UPDATE1));
-    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeResourceSubscriber.getData();
+    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
     // subscriber data should be updated to NODE_UPDATE1
     Assert.assertEquals(actualData.getNodeData(), NODE_UPDATE1.getNodeData());
 
     // subscriber data should be updated to NODE_UPDATE2
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA2);
-    actualData = (XdsClient.NodeUpdate) fixture._nodeResourceSubscriber.getData();
+    actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
     verify(fixture._resourceWatcher).onChanged(eq(NODE_UPDATE2));
     Assert.assertEquals(actualData.getNodeData(), NODE_UPDATE2.getNodeData());
   }
@@ -170,18 +181,18 @@ public class TestXdsClientImpl
   public void testHandleD2NodeUpdateWithBadData(DiscoveryResponseData badData, boolean nackExpected)
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
-    fixture._nodeResourceSubscriber.setData(null);
+    fixture._nodeSubscriber.setData(null);
     fixture._xdsClientImpl.handleResponse(badData);
     fixture.verifyAckOrNack(nackExpected, 1);
     verify(fixture._resourceWatcher).onChanged(eq(NODE.emptyData()));
-    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeResourceSubscriber.getData();
+    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
     Assert.assertEquals(actualData.getNodeData(), null);
 
-    fixture._nodeResourceSubscriber.setData(NODE_UPDATE1);
+    fixture._nodeSubscriber.setData(NODE_UPDATE1);
     fixture._xdsClientImpl.handleResponse(badData);
     fixture.verifyAckOrNack(nackExpected, 2);
     verify(fixture._resourceWatcher).onChanged(eq(NODE_UPDATE1));
-    actualData = (XdsClient.NodeUpdate) fixture._nodeResourceSubscriber.getData();
+    actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
     // bad data will not overwrite the original valid data
     Assert.assertEquals(actualData.getNodeData(), NODE_UPDATE1.getNodeData());
   }
@@ -190,12 +201,12 @@ public class TestXdsClientImpl
   public void testHandleD2NodeResponseWithRemoval()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
-    fixture._nodeResourceSubscriber.setData(NODE_UPDATE1);
+    fixture._nodeSubscriber.setData(NODE_UPDATE1);
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA_WITH_REMOVAL);
     fixture.verifyAckSent(1);
     verify(fixture._resourceWatcher).onChanged(eq(NODE_UPDATE1));
-    verify(fixture._nodeResourceSubscriber).onRemoval();
-    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeResourceSubscriber.getData();
+    verify(fixture._nodeSubscriber).onRemoval();
+    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
     //  removed resource will not overwrite the original valid data
     Assert.assertEquals(actualData.getNodeData(), NODE_UPDATE1.getNodeData());
   }
@@ -205,16 +216,16 @@ public class TestXdsClientImpl
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
     // subscriber original data is null
-    fixture._nodeResourceSubscriber.setData(null);
+    fixture._nodeSubscriber.setData(null);
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA1);
     fixture.verifyAckSent(1);
     verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._uriMapResourceSubscriber.getData();
+    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
     // subscriber data should be updated to D2_URI_MAP_UPDATE_WITH_DATA1
     Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
 
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA2);
-    actualData = (XdsClient.D2URIMapUpdate) fixture._uriMapResourceSubscriber.getData();
+    actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
     // subscriber data should be updated to D2_URI_MAP_UPDATE_WITH_DATA2
     verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA2));
     Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA2.getURIMap());
@@ -243,19 +254,18 @@ public class TestXdsClientImpl
   public void testHandleD2URIMapUpdateWithBadData(DiscoveryResponseData badData, boolean nackExpected)
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
-    fixture._uriMapResourceSubscriber.setData(null);
+    fixture._clusterSubscriber.setData(null);
     fixture._xdsClientImpl.handleResponse(badData);
     fixture.verifyAckOrNack(nackExpected, 1);
-    verify(fixture._xdsClientImpl).sendAckOrNack(any(), any(), any());
     verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP.emptyData()));
-    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._uriMapResourceSubscriber.getData();
+    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
     Assert.assertEquals(actualData.getURIMap(), null);
 
-    fixture._uriMapResourceSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
+    fixture._clusterSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._xdsClientImpl.handleResponse(badData);
     fixture.verifyAckOrNack(nackExpected, 2);
     verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-    actualData = (XdsClient.D2URIMapUpdate) fixture._uriMapResourceSubscriber.getData();
+    actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
     // bad data will not overwrite the original valid data
     Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
   }
@@ -264,12 +274,101 @@ public class TestXdsClientImpl
   public void testHandleD2URIMapResponseWithRemoval()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
-    fixture._uriMapResourceSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
+    fixture._clusterSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA_WITH_REMOVAL);
     fixture.verifyAckSent(1);
     verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-    verify(fixture._uriMapResourceSubscriber).onRemoval();
-    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._uriMapResourceSubscriber.getData();
+    verify(fixture._clusterSubscriber).onRemoval();
+    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
+    // removed resource will not overwrite the original valid data
+    Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
+  }
+
+  @Test
+  public void testHandleD2URICollectionResponseWithData()
+  {
+    DiscoveryResponseData createUri1 = new DiscoveryResponseData(D2_URI, Collections.singletonList(
+        Resource.newBuilder()
+            .setVersion(VERSION1)
+            .setName(URI_URN1)
+            .setResource(Any.pack(URI_BUILDER1.build()))
+            .build()
+    ), null, NONCE, null);
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    // subscriber original data is null
+    fixture._nodeSubscriber.setData(null);
+    fixture._xdsClientImpl.handleResponse(createUri1);
+    fixture.verifyAckSent(1);
+    verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
+    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
+    // subscriber data should be updated to D2_URI_MAP_UPDATE_WITH_DATA1
+    Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
+
+    DiscoveryResponseData createUri2Delete1 = new DiscoveryResponseData(D2_URI, Collections.singletonList(
+        Resource.newBuilder()
+            .setVersion(VERSION1)
+            .setName(URI_URN2)
+            .setResource(Any.pack(URI_BUILDER2.build()))
+            .build()
+    ), Collections.singletonList(URI_URN1), NONCE, null);
+    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA2);
+    actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
+    // subscriber data should be updated to D2_URI_MAP_UPDATE_WITH_DATA2
+    verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA2));
+    Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA2.getURIMap());
+    fixture.verifyAckSent(2);
+  }
+
+  @Test
+  public void testHandleD2URICollectionUpdateWithEmptyResponse()
+  {
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    // Sanity check that the code handles empty responses
+    fixture._xdsClientImpl.handleResponse(new DiscoveryResponseData(D2_URI, null, null, NONCE, null));
+    fixture.verifyAckSent(1);
+  }
+
+  @Test
+  public void testHandleD2URICollectionUpdateWithBadData()
+  {
+    DiscoveryResponseData badData = new DiscoveryResponseData(
+        D2_URI,
+        Collections.singletonList(Resource.newBuilder().setVersion(VERSION1).setName(URI_URN1)
+            // not set resource field
+            .build()),
+        null,
+        NONCE,
+        null);
+
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture._clusterSubscriber.setData(null);
+    fixture._xdsClientImpl.handleResponse(badData);
+    fixture.verifyNackSent(1);
+    verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP.emptyData()));
+    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
+    Assert.assertEquals(actualData.getURIMap(), null);
+
+    fixture._clusterSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
+    fixture._xdsClientImpl.handleResponse(badData);
+    fixture.verifyNackSent(2);
+    // Due to teh way glob collection updates are handled, bad data is dropped rather than showing any visible side
+    // effects other than NACKing the response.
+    verify(fixture._resourceWatcher, times(0)).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
+  }
+
+  @Test
+  public void testHandleD2URICollectionResponseWithRemoval()
+  {
+    DiscoveryResponseData removeClusterResponse =
+        new DiscoveryResponseData(D2_URI, null, Collections.singletonList(CLUSTER_GLOB_COLLECTION), NONCE, null);
+
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture._clusterSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
+    fixture._xdsClientImpl.handleResponse(removeClusterResponse);
+    fixture.verifyAckSent(1);
+    verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
+    verify(fixture._clusterSubscriber).onRemoval();
+    XdsClient.D2URIMapUpdate actualData = (XdsClient.D2URIMapUpdate) fixture._clusterSubscriber.getData();
     // removed resource will not overwrite the original valid data
     Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
   }
@@ -279,9 +378,8 @@ public class TestXdsClientImpl
     XdsClientImpl _xdsClientImpl;
     @Mock
     XdsClientJmx _xdsClientJmx;
-    ResourceSubscriber _nodeResourceSubscriber = spy(new ResourceSubscriber(NODE, RESOURCE_NAME));
-    ResourceSubscriber _uriMapResourceSubscriber = spy(new ResourceSubscriber(D2_URI_MAP, RESOURCE_NAME));
-    ResourceSubscriber _uriCollectionResourceSubscriber = spy(new ResourceSubscriber(D2_URI, CLUSTER_GLOB_COLLECTION));
+    ResourceSubscriber _nodeSubscriber = spy(new ResourceSubscriber(NODE, SERVICE_RESOURCE_NAME));
+    ResourceSubscriber _clusterSubscriber = spy(new ResourceSubscriber(D2_URI_MAP, CLUSTER_RESOURCE_NAME));
     Map<ResourceType, Map<String, ResourceSubscriber>> _subscribers = new HashMap<>();
     @Mock
     XdsClient.ResourceWatcher _resourceWatcher;
@@ -296,8 +394,7 @@ public class TestXdsClientImpl
       MockitoAnnotations.initMocks(this);
 
       doNothing().when(_resourceWatcher).onChanged(any());
-      for (ResourceSubscriber subscriber : Lists.newArrayList(
-          _nodeResourceSubscriber, _uriMapResourceSubscriber, _uriCollectionResourceSubscriber))
+      for (ResourceSubscriber subscriber : Lists.newArrayList(_nodeSubscriber, _clusterSubscriber))
       {
         subscriber.addWatcher(_resourceWatcher);
         _subscribers.put(subscriber.getType(), Collections.singletonMap(subscriber.getResource(), subscriber));

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -67,8 +67,8 @@ public class TestXdsToD2PropertiesAdaptor {
   private static final String SERVICE_NAME = "FooService";
   private final UriPropertiesJsonSerializer uriSerializer = new UriPropertiesJsonSerializer();
 
-  private static final XdsClient.NodeUpdate EMPTY_NODE_DATA = new XdsClient.NodeUpdate("", null);
-  private static final XdsClient.D2URIMapUpdate EMPTY_DATA_URI_MAP = new XdsClient.D2URIMapUpdate("", null);
+  private static final XdsClient.NodeUpdate EMPTY_NODE_DATA = new XdsClient.NodeUpdate(null);
+  private static final XdsClient.D2URIMapUpdate EMPTY_DATA_URI_MAP = new XdsClient.D2URIMapUpdate(null);
 
   @Test
   public void testListenToService()
@@ -81,7 +81,7 @@ public class TestXdsToD2PropertiesAdaptor {
 
     XdsClient.NodeResourceWatcher symlinkNodeWatcher =
         (XdsClient.NodeResourceWatcher) fixture._clusterWatcherArgumentCaptor.getValue();
-    symlinkNodeWatcher.onChanged(new XdsClient.NodeUpdate("", XdsD2.Node.newBuilder()
+    symlinkNodeWatcher.onChanged(new XdsClient.NodeUpdate(XdsD2.Node.newBuilder()
         .setData(
             ByteString.copyFrom(
                 new ServicePropertiesJsonSerializer().toBytes(
@@ -190,7 +190,7 @@ public class TestXdsToD2PropertiesAdaptor {
     // update uri data
     XdsClient.D2URIMapResourceWatcher watcher =
         (XdsClient.D2URIMapResourceWatcher) fixture._uriWatcherArgumentCaptor.getValue();
-    watcher.onChanged(new XdsClient.D2URIMapUpdate("", Collections.emptyMap()));
+    watcher.onChanged(new XdsClient.D2URIMapUpdate(Collections.emptyMap()));
 
     // verify uri data is merged and published under symlink name and the actual cluster name
     verify(fixture._uriEventBus).publishInitialize(SYMLINK_NAME, getDefaultUriProperties(SYMLINK_NAME));
@@ -209,7 +209,7 @@ public class TestXdsToD2PropertiesAdaptor {
     XdsD2.D2URI protoUri = getD2URI(PRIMARY_CLUSTER_NAME);
     UriProperties uriProps = new UriPropertiesJsonSerializer().fromProto(protoUri);
 
-    watcher.onChanged(new XdsClient.D2URIMapUpdate("", Collections.singletonMap(URI_NAME, protoUri)));
+    watcher.onChanged(new XdsClient.D2URIMapUpdate(Collections.singletonMap(URI_NAME, protoUri)));
 
     verify(fixture._uriEventBus).publishInitialize(PRIMARY_CLUSTER_NAME, uriProps);
     verify(fixture._eventEmitter).emitSDStatusUpdateReceiptEvent(
@@ -288,7 +288,7 @@ public class TestXdsToD2PropertiesAdaptor {
 
   private static XdsClient.NodeUpdate getSymlinkNodeUpdate(String primaryClusterResourceName)
   {
-    return new XdsClient.NodeUpdate("",
+    return new XdsClient.NodeUpdate(
         XdsD2.Node.newBuilder()
             .setData(ByteString.copyFromUtf8(primaryClusterResourceName))
             .build()
@@ -297,7 +297,7 @@ public class TestXdsToD2PropertiesAdaptor {
 
   private static XdsClient.NodeUpdate getClusterNodeUpdate(String clusterName)
   {
-    return new XdsClient.NodeUpdate("", XdsD2.Node.newBuilder()
+    return new XdsClient.NodeUpdate(XdsD2.Node.newBuilder()
         .setData(
             ByteString.copyFrom(
                 new ClusterPropertiesJsonSerializer().toBytes(
@@ -329,7 +329,7 @@ public class TestXdsToD2PropertiesAdaptor {
     XdsClient.D2URIMapResourceWatcher watcher = (XdsClient.D2URIMapResourceWatcher)
         fixture._uriWatcherArgumentCaptor.getValue();
     XdsD2.D2URI protoUri = getD2URI(clusterName);
-    watcher.onChanged(new XdsClient.D2URIMapUpdate("", Collections.singletonMap(URI_NAME, protoUri)));
+    watcher.onChanged(new XdsClient.D2URIMapUpdate(Collections.singletonMap(URI_NAME, protoUri)));
     verify(fixture._uriEventBus).publishInitialize(clusterName, uriSerializer.fromProto(protoUri));
     if (symlinkName != null)
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.10
+version=29.51.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Implement efficient URI updates by leveraging glob collections. Instead of receiving the entire URI map from the observer every time, this allows receiving only the added/removed URIs in teh cluster. Each cluster is represented as a glob collection named:
```
xdstp:///indis.D2URI/{clusterName}/*
```
And the URI resource names (AKA resource URN) look like this:
```
xdstp:///indis.D2URI/{clusterName}/{query-escaped URI}
```

For testing, I reproduced the same testing steps listed in https://github.com/linkedin/rest.li/pull/975. Here is the attached log for d2-proxy: https://paste.corp.linkedin.com/show/68966295/

The requests are routed correctly, and both symlink and non-symlink clusters seem to be working just fine!

Here are the results of the curli requests: https://paste.corp.linkedin.com/show/68966305/