### PR TITLE
Fix excessive logs in uri data/version mismatch and dual read failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.3] - 2024-02-23
+- fix excessive logs in uri data/version mismatch and dual read failure
+
 ## [29.51.2] - 2024-02-15
 - use tracingId in xDS flow for SD tracking events
 
@@ -5638,7 +5641,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.3...master
+[29.51.3]: https://github.com/linkedin/rest.li/compare/v29.51.2...v29.51.3
 [29.51.2]: https://github.com/linkedin/rest.li/compare/v29.51.1...v29.51.2
 [29.51.1]: https://github.com/linkedin/rest.li/compare/v29.51.0...v29.51.1
 [29.51.0]: https://github.com/linkedin/rest.li/compare/v29.50.1...v29.51.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitor.java
@@ -92,12 +92,19 @@ public abstract class DualReadLoadBalancerMonitor<T>
         // different.
         if (!isReadFromFS(existingEntry._version, propertyVersion))
         {
-          warnByPropType(isUriProp,
-              String.format("Received same data of different versions in %s LB for %s: %s."
+          String msg = String.format("Received same data of different versions in %s LB for %s: %s."
                       + " Old version: %s, New version: %s, Data: %s",
                   fromNewLb ? "New" : "Old", propertyClassName, propertyName, existingEntry._version,
-                  propertyVersion, property)
-          );
+                  propertyVersion, property);
+
+          if (isUriProp)
+          {
+            LOG.debug(msg);
+          }
+          else
+          {
+            warnByPropType(isUriProp, msg);
+          }
         }
         // still need to put in the cache, don't skip
       }
@@ -136,10 +143,16 @@ public abstract class DualReadLoadBalancerMonitor<T>
     else {
       if (isDataEqual)
       {
-        warnByPropType(isUriProp,
-            String.format("Received same data of %s for %s but with different versions: %s",
-                propertyClassName, propertyName, entriesLogMsg)
-        );
+        String msg = String.format("Received same data of %s for %s but with different versions: %s",
+            propertyClassName, propertyName, entriesLogMsg);
+        if (isUriProp)
+        {
+          LOG.debug(msg);
+        }
+        else
+        {
+          warnByPropType(isUriProp, msg);
+        }
       }
       cacheToAdd.put(propertyName, newEntry);
       incrementEntryOutOfSyncCount();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.2
+version=29.51.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary 
1. fix [SI-37741](https://jira01.corp.linkedin.com:8443/browse/SI-37741) - set this log to debug level instead of warn: the log that reports uri data being the same but the version is different. 
2. fix [SI-37667](https://jira01.corp.linkedin.com:8443/browse/SI-37667) - rate limit dual read failure logs, since its volume can be huge on high QPS apps.

## Test Done
existing tests