### PR TITLE
[INDIS]-check whether new load balancer executor is shutdown before using in dual-read mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.3] - 2024-02-28
+- fix newLb executor in dual-read mode shutdown issue
+
 ## [29.51.3] - 2024-02-23
 - fix excessive logs in uri data/version mismatch and dual read failure
 
@@ -5641,7 +5644,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.4...master
+[29.51.4]: https://github.com/linkedin/rest.li/compare/v29.51.3...v29.51.4
 [29.51.3]: https://github.com/linkedin/rest.li/compare/v29.51.2...v29.51.3
 [29.51.2]: https://github.com/linkedin/rest.li/compare/v29.51.1...v29.51.2
 [29.51.1]: https://github.com/linkedin/rest.li/compare/v29.51.0...v29.51.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancer.java
@@ -156,6 +156,12 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
         _newLb.getClient(request, requestContext, clientCallback);
         break;
       case DUAL_READ:
+        if (_newLbExecutor.isShutdown())
+        {
+          _rateLimitedLogger.error("Dual read failure. New load balancer executor is shutdown.");
+          _oldLb.getClient(request, requestContext, clientCallback);
+          return;
+        }
         _newLbExecutor.execute(
             () -> _newLb.getLoadBalancedServiceProperties(serviceName, new Callback<ServiceProperties>()
             {


### PR DESCRIPTION
# Background
For `samza job`, the LoadBalancer will be shutdown during running.
2024-02-28 22:28:49.469 [main] DynamicClient [INFO] shutting down dynamic client
2024-02-28 22:28:49.469 [main] DualReadLoadBalancer [INFO] New load balancer successfully shut down
2024-02-28 22:28:49.470 [main] ZKFSLoadBalancer [INFO] Shutting down
2024-02-28 22:28:49.470 [Indis xDS client executor-4-1] XdsClientImpl [INFO] Shutting down

More context could check from :
https://linkedin-randd.slack.com/archives/C033U0SJFEX/p1709165894672129?thread_ts=1709075763.043899&cid=C033U0SJFEX

[SI-37856](https://jira01.corp.linkedin.com:8443/browse/SI-37856)

As the `newLb executor` in `DualReadLoadBalancer` is shut down, so DualReadLoadBalancer throws exceptions when it’s already shutdown but gets new tasks submitted to it.  Then [Samza code](https://jarvis.corp.linkedin.com/codesearch/result/?name=ClusterBasedJobCoordinatorRunner.java&path=samza-li%2Fsamza%2Fsamza-core%2Fsrc%2Fmain%2Fjava%2Forg%2Fapache%2Fsamza%2Fclustermanager&reponame=linkedin-multiproduct%2Fsamza-li#51) force-exits when uncaught exception is found.

# Solution
So for `_newLbExecutor` in `dual-read` mode. We need to check whether is it `shutdown` before using to avoid new tasks process.

# Test done
Regression test in local on `toki-restli-backend` for dual-read mode

Here is the full log: https://paste.corp.linkedin.com/show/68939493/


```
curli -v "https://localhost:18793/TokiRestliBackend/resources/tokiBackend?action=tokiServer" -X POST --data '{"message": "Hello", "delay": "100"}' --dv-auth SELF
```
![Xnip2024-02-28_20-14-55](https://github.com/linkedin/rest.li/assets/150380879/2dd0f519-476d-47bf-82b7-5f3e60cef2b1)
<img width="722" alt="Untitled" src="https://github.com/linkedin/rest.li/assets/150380879/1029e019-9799-445e-b587-6c0219fbc00f">



# Follow up
As it’s hard to catch the timing for when the dual read LB is not shutdown yet, but the newLbExecutor is shut down. So we could not get the `newLb executor is shutdown already. Skipping getClient on newLb executor.` log using `mint undeploy` method.
Will double check with samza team to check their deployment is no problem.
