### PR TITLE
Increase time between rate-limited logging from DualReadLoadBalancingMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.5] - 2024-02-29
+- increase time between rate limited logging to 10 minutes
+
 ## [29.51.4] - 2024-02-29
 - fix newLb executor in dual-read mode shutdown issue
 
@@ -5644,7 +5647,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.5...master
+[29.51.5]: https://github.com/linkedin/rest.li/compare/v29.51.4...v29.51.5
 [29.51.4]: https://github.com/linkedin/rest.li/compare/v29.51.3...v29.51.4
 [29.51.3]: https://github.com/linkedin/rest.li/compare/v29.51.2...v29.51.3
 [29.51.2]: https://github.com/linkedin/rest.li/compare/v29.51.1...v29.51.2

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerMonitor.java
@@ -97,14 +97,7 @@ public abstract class DualReadLoadBalancerMonitor<T>
                   fromNewLb ? "New" : "Old", propertyClassName, propertyName, existingEntry._version,
                   propertyVersion, property);
 
-          if (isUriProp)
-          {
-            LOG.debug(msg);
-          }
-          else
-          {
-            warnByPropType(isUriProp, msg);
-          }
+          logByPropType(isUriProp, msg);
         }
         // still need to put in the cache, don't skip
       }
@@ -136,7 +129,7 @@ public abstract class DualReadLoadBalancerMonitor<T>
     { // data is not the same but version is the same, a mismatch!
       incrementPropertiesErrorCount();
       incrementEntryOutOfSyncCount(); // increment the out-of-sync count for the entry received later
-      warnByPropType(isUriProp,
+      logByPropType(isUriProp,
           String.format("Received mismatched %s for %s. %s", propertyClassName, propertyName, entriesLogMsg));
       cacheToCompare.invalidate(propertyName);
     }
@@ -145,14 +138,7 @@ public abstract class DualReadLoadBalancerMonitor<T>
       {
         String msg = String.format("Received same data of %s for %s but with different versions: %s",
             propertyClassName, propertyName, entriesLogMsg);
-        if (isUriProp)
-        {
-          LOG.debug(msg);
-        }
-        else
-        {
-          warnByPropType(isUriProp, msg);
-        }
+        logByPropType(isUriProp, msg);
       }
       cacheToAdd.put(propertyName, newEntry);
       incrementEntryOutOfSyncCount();
@@ -209,11 +195,11 @@ public abstract class DualReadLoadBalancerMonitor<T>
     return v1.startsWith(VERSION_FROM_FS) || v2.startsWith(VERSION_FROM_FS);
   }
 
-  private void warnByPropType(boolean isUriProp, String msg)
+  private void logByPropType(boolean isUriProp, String msg)
   {
     if (isUriProp)
     {
-      _rateLimitedLogger.warn(msg);
+      _rateLimitedLogger.debug(msg);
     }
     else
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.4
+version=29.51.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Logging UriProperties diffs can cause frequent and very large log lines at the warn level due to large entries.

Since these logs are still valuable at warn level, increasing time for rate-limited logger