### PR TITLE
Shut down dualread executor properly and guard for rejected execution exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.6] - 2024-03-04
+- shut down dualread executor properly and guard for rejected execution exceptions
+
 ## [29.51.5] - 2024-02-29
 - increase time between rate limited logging to 10 minutes
 
@@ -5647,7 +5650,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.6...master
+[29.51.6]: https://github.com/linkedin/rest.li/compare/v29.51.5...v29.51.6
 [29.51.5]: https://github.com/linkedin/rest.li/compare/v29.51.4...v29.51.5
 [29.51.4]: https://github.com/linkedin/rest.li/compare/v29.51.3...v29.51.4
 [29.51.3]: https://github.com/linkedin/rest.li/compare/v29.51.2...v29.51.3

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/QuarantineManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/QuarantineManager.java
@@ -54,6 +54,8 @@ public class QuarantineManager {
   private static final long MIN_QUARANTINE_LATENCY_MS = 300;
   private static final long MAX_QUARANTINE_LATENCY_MS = 1000;
 
+  private static final long ERROR_REPORT_PERIOD = 120 * 1000; // Limit error report logging to every 2 min
+
   private final String _serviceName;
   private final String _servicePath;
   private final HealthCheckOperations _healthCheckOperations;
@@ -83,7 +85,7 @@ public class QuarantineManager {
     _clock = clock;
     _updateIntervalMs = updateIntervalMs;
     _relativeLatencyLowThresholdFactor = relativeLatencyLowThresholdFactor;
-    _rateLimitedLogger = new RateLimitedLogger(LOG, RelativeLoadBalancerStrategyFactory.DEFAULT_UPDATE_INTERVAL_MS, clock);
+    _rateLimitedLogger = new RateLimitedLogger(LOG, ERROR_REPORT_PERIOD, clock);
 
     _quarantineEnabled = new AtomicBoolean(false);
     _quarantineRetries = new AtomicInteger(0);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.5
+version=29.51.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
For [SI-37856](https://jira01.corp.linkedin.com:8443/browse/SI-37856), dual read LB is submitting new tasks to new LB (xDS LB) during shutdown because the newLbExecutor was not shutdown aware (not created with standard scheduled executor factory, [code link](https://jarvis.corp.linkedin.com/codesearch/result/?name=D2ClientFactory.java&path=container%2Fpegasus%2Fpegasus-d2-client-factory%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fd2%2Fclient%2Ffactory&reponame=linkedin-multiproduct%2Fcontainer#1362)). The tasks (its timeout callbacks) are then submitted to the inner executor in simple LB, which is already shutdown, thus throws rejected execution exceptions, with stacktrace:
```
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@4ac6a905 rejected from com.linkedin.container.concurrent.InstrumentedScheduledThreadPoolExecutor@101ba415[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 13]
	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063) ~[?:1.8.0_282]
	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830) ~[?:1.8.0_282]
	at java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:326) ~[?:1.8.0_282]
	at java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:533) ~[?:1.8.0_282]
	at com.linkedin.container.concurrent.InstrumentedScheduledThreadPoolExecutor.schedule(InstrumentedScheduledThreadPoolExecutor.java:63) ~[com.linkedin.container-core-container-impl-1.3.171.jar:?]
	at com.linkedin.container.servicecall.ServiceCallScheduledExecutorService.schedule(ServiceCallScheduledExecutorService.java:39) ~[com.linkedin.container-core-container-servicecall-api-1.3.171.jar:?]
	at com.linkedin.r2.util.SingleTimeout.<init>(SingleTimeout.java:59) ~[com.linkedin.pegasus-r2-core-29.51.0.jar:?]
	at com.linkedin.r2.transport.http.client.TimeoutCallback.<init>(TimeoutCallback.java:90) ~[com.linkedin.pegasus-r2-core-29.51.0.jar:?]
	at com.linkedin.r2.transport.http.client.TimeoutCallback.<init>(TimeoutCallback.java:59) ~[com.linkedin.pegasus-r2-core-29.51.0.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.getLoadBalancedServiceProperties(SimpleLoadBalancer.java:758) ~[com.linkedin.pegasus-d2-29.51.0.jar:?]
	at com.linkedin.d2.balancer.util.TogglingLoadBalancer.getLoadBalancedServiceProperties(TogglingLoadBalancer.java:119) ~[com.linkedin.pegasus-d2-29.51.0.jar:?]
	at com.linkedin.d2.xds.balancer.XdsLoadBalancer.getLoadBalancedServiceProperties(XdsLoadBalancer.java:131) ~[com.linkedin.pegasus-d2-29.51.0.jar:?]
	at com.linkedin.d2.balancer.dualread.DualReadLoadBalancer.lambda$getLoadBalancedServiceProperties$2(DualReadLoadBalancer.java:201) ~[com.linkedin.pegasus-d2-29.51.0.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_282]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_282]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_282]
```

This change shut down the newLbExecutor properly in DualReadLoadBalancer, and also guard for any rejected execution exceptions (either due to shutdown or reaching max queue size) for both the newLbExecutor and the inner executor in SimpleLoadBalancer.

Note that this issue could also happen in ZK flow when new requests come in during shutdown, as shown in the log below. The new guard logic will catch them.

## Test Done
QEI deploy toki-war under dual read mode. 
In terminal, go to /System/Volumes/Data/export/content/lid/apps/toki/dev-i001, run "bin/control stop". During the shutdown, keep hitting toki endpoint:
```
curli -v "https://localhost:18792/Toki/resources/toki?action=tokiRestClient" -X POST --data '{"message": "Hello"}' --dv-auth SELF
```

Verified the log shows message "Executor rejected new tasks. It has shut down or its queue size has reached max limit". (I changed the log level to info for testing. In reality, it will be debug level, in case high QPS app generates tons of messages for reaching the queue limit under dual read), see:

[toki-war.log](https://github.com/linkedin/rest.li/files/14489230/toki-war.log)
