### PR TITLE
Clarify dual read error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.7] - 2024-03-13
+- clarify dual read error messages
+
 ## [29.51.6] - 2024-03-04
 - shut down dualread executor properly and guard for rejected execution exceptions
 
@@ -5650,7 +5653,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.7...master
+[29.51.7]: https://github.com/linkedin/rest.li/compare/v29.51.6...v29.51.7
 [29.51.6]: https://github.com/linkedin/rest.li/compare/v29.51.5...v29.51.6
 [29.51.5]: https://github.com/linkedin/rest.li/compare/v29.51.4...v29.51.5
 [29.51.4]: https://github.com/linkedin/rest.li/compare/v29.51.3...v29.51.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancer.java
@@ -172,7 +172,9 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
             @Override
             public void onError(Throwable e)
             {
-              _rateLimitedLogger.error("Dual read failure. Unable to read service properties from: {}", serviceName, e);
+              _rateLimitedLogger.warn("Safe to ignore - dual read error. This is a side-way call to INDIS, "
+                  + "NOT being used for app's traffic. Unable to read from INDIS for service properties: {}",
+                  serviceName, e);
             }
 
             @Override
@@ -185,7 +187,9 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
                 @Override
                 public void onError(Throwable e)
                 {
-                  _rateLimitedLogger.error("Dual read failure. Unable to read cluster and uri properties " + "from: {}", clusterName, e);
+                  _rateLimitedLogger.warn("Safe to ignore - dual read error. This is a side-way call to INDIS, "
+                      + "NOT being used for app's traffic. Unable to read from INDIS for cluster and uri properties: "
+                      + "{}", clusterName, e);
                 }
 
                 @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.6
+version=29.51.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
As the title, made the messages clearer that dual read errors won't affect apps' traffic. Also changed the log level from error to warn.

## Test Done
build and test