### PR TITLE
Address the multiple onError calls in dual read and enhance unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.12] - 2024-03-22
+- Address the multiple onError calls in dual read and enhance unit test rigorously
+
 ## [29.51.11] - 2024-03-20
 - Glob collections support
 
@@ -5665,7 +5668,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.12...master
+[29.51.12]: https://github.com/linkedin/rest.li/compare/v29.51.11...v29.51.12
 [29.51.11]: https://github.com/linkedin/rest.li/compare/v29.51.10...v29.51.11
 [29.51.10]: https://github.com/linkedin/rest.li/compare/v29.51.9...v29.51.10
 [29.51.9]: https://github.com/linkedin/rest.li/compare/v29.51.8...v29.51.9

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancer.java
@@ -116,10 +116,6 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
       _rateLimitedLogger.debug("newLb executor rejected new task for start. "
           + "It is shut down or its queue size has reached max limit");
     }
-    catch (Exception e)
-    {
-      _rateLimitedLogger.debug("Failed to execute newLb task for start. ", e);
-    }
 
     _oldLb.start(getStartUpCallback(false,
         mode == DualReadModeProvider.DualReadMode.NEW_LB_ONLY ? null : callback
@@ -210,10 +206,6 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
           _rateLimitedLogger.debug("newLb executor rejected new task for getClient. "
               + "It is shut down or its queue size has reached max limit");
         }
-        catch (Exception e)
-        {
-          _rateLimitedLogger.debug("Failed to execute newLb task for getClient. ", e);
-        }
 
         _oldLb.getClient(request, requestContext, clientCallback);
         break;
@@ -241,10 +233,6 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
           _rateLimitedLogger.debug("newLb executor rejected new task for getLoadBalancedServiceProperties. "
               + "It is shut down or its queue size has reached max limit");
         }
-        catch (Exception e)
-        {
-          _rateLimitedLogger.debug("Failed to execute newLb task for getLoadBalancedServiceProperties. ", e);
-        }
         _oldLb.getLoadBalancedServiceProperties(serviceName, clientCallback);
         break;
       case OLD_LB_ONLY:
@@ -271,10 +259,6 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
         {
           _rateLimitedLogger.debug("newLb executor rejected new task for getLoadBalancedClusterAndUriProperties. "
               + "It is shut down or its queue size has reached max limit");
-        }
-        catch (Exception e)
-        {
-          _rateLimitedLogger.debug("Failed to execute newLb task for getLoadBalancedClusterAndUriProperties. ", e);
         }
         _oldLb.getLoadBalancedClusterAndUriProperties(clusterName, callback);
         break;

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancer.java
@@ -116,6 +116,10 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
       _rateLimitedLogger.debug("newLb executor rejected new task for start. "
           + "It is shut down or its queue size has reached max limit");
     }
+    catch (Exception e)
+    {
+      _rateLimitedLogger.debug("Failed to execute newLb task for start. ", e);
+    }
 
     _oldLb.start(getStartUpCallback(false,
         mode == DualReadModeProvider.DualReadMode.NEW_LB_ONLY ? null : callback
@@ -206,6 +210,10 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
           _rateLimitedLogger.debug("newLb executor rejected new task for getClient. "
               + "It is shut down or its queue size has reached max limit");
         }
+        catch (Exception e)
+        {
+          _rateLimitedLogger.debug("Failed to execute newLb task for getClient. ", e);
+        }
 
         _oldLb.getClient(request, requestContext, clientCallback);
         break;
@@ -233,6 +241,10 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
           _rateLimitedLogger.debug("newLb executor rejected new task for getLoadBalancedServiceProperties. "
               + "It is shut down or its queue size has reached max limit");
         }
+        catch (Exception e)
+        {
+          _rateLimitedLogger.debug("Failed to execute newLb task for getLoadBalancedServiceProperties. ", e);
+        }
         _oldLb.getLoadBalancedServiceProperties(serviceName, clientCallback);
         break;
       case OLD_LB_ONLY:
@@ -259,6 +271,10 @@ public class DualReadLoadBalancer implements LoadBalancerWithFacilities
         {
           _rateLimitedLogger.debug("newLb executor rejected new task for getLoadBalancedClusterAndUriProperties. "
               + "It is shut down or its queue size has reached max limit");
+        }
+        catch (Exception e)
+        {
+          _rateLimitedLogger.debug("Failed to execute newLb task for getLoadBalancedClusterAndUriProperties. ", e);
         }
         _oldLb.getLoadBalancedClusterAndUriProperties(clusterName, callback);
         break;

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -840,7 +840,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     }
     else
     {
-      _log.error("getServiceProperties for {} timed out, but no value in cache!", serviceName);
+      _log.warn("getServiceProperties for {} timed out, but no value in cache!", serviceName);
     }
   }
 
@@ -929,6 +929,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     }
   }
 
+  @VisibleForTesting
   public void handleTimeoutFromGetClusterAndUriProperties(String clusterName,
       Callback<Pair<ClusterProperties, UriProperties>> clusterAndUriPropertiesCallback)
   {
@@ -941,7 +942,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     }
     else
     {
-      _log.error("getClusterAndUriProperties for {} timed out, but no value in cache!", clusterName);
+      _log.warn("getClusterAndUriProperties for {} timed out, but no value in cache!", clusterName);
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -487,7 +487,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
             if (e instanceof TimeoutException)
             {
               // if timed out, should try to fetch the service properties from the cache
-              handleTimeoutFromGetServiceProperties(e, serviceName, finalCallback);
+              handleTimeoutFromGetServiceProperties(serviceName, finalCallback);
             }
             else
             {
@@ -782,7 +782,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
           {
             if (e instanceof TimeoutException)
             {
-              handleTimeoutFromGetServiceProperties(e, serviceName, finalCallback);
+              handleTimeoutFromGetServiceProperties(serviceName, finalCallback);
             }
             else
             {
@@ -829,7 +829,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     }
   }
 
-  public void handleTimeoutFromGetServiceProperties(Throwable e, String serviceName,
+  public void handleTimeoutFromGetServiceProperties(String serviceName,
       Callback<ServiceProperties> servicePropertiesCallback)
   {
     ServiceProperties properties = getServicePropertiesFromCache(serviceName, servicePropertiesCallback);
@@ -841,8 +841,6 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     else
     {
       _log.error("getServiceProperties for {} timed out, but no value in cache!", serviceName);
-      servicePropertiesCallback.onError(
-          new ServiceUnavailableException(serviceName, "PEGA_1011. " + e.getMessage(), e));
     }
   }
 
@@ -883,7 +881,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
               {
                 if (e instanceof TimeoutException)
                 {
-                  handleTimeoutFromGetClusterAndUriProperties(e, clusterName, finalCallback);
+                  handleTimeoutFromGetClusterAndUriProperties(clusterName, finalCallback);
                 }
                 else
                 {
@@ -931,7 +929,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     }
   }
 
-  private void handleTimeoutFromGetClusterAndUriProperties(Throwable e, String clusterName,
+  public void handleTimeoutFromGetClusterAndUriProperties(String clusterName,
       Callback<Pair<ClusterProperties, UriProperties>> clusterAndUriPropertiesCallback)
   {
     Pair<ClusterProperties, UriProperties> pair =
@@ -943,8 +941,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     }
     else
     {
-      clusterAndUriPropertiesCallback.onError(
-          new ServiceUnavailableException(clusterName, "PEGA_1011. " + e.getMessage(), e));
+      _log.error("getClusterAndUriProperties for {} timed out, but no value in cache!", clusterName);
     }
   }
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -486,9 +486,9 @@ public class SimpleLoadBalancerTest
     callback = spy(new FutureCallback<>());
     loadBalancer.listenToServiceAndCluster(SERVICE_NAME, callback);
     callback.get();
-    verify(callback).onSuccess(eq(SERVICE_PROPERTIES));
     // Make sure there is no timeout.
     verify(loadBalancer, never()).handleTimeoutFromGetServiceProperties(any(), any());
+    verify(callback).onSuccess(eq(SERVICE_PROPERTIES));
   }
 
   @Test
@@ -539,11 +539,12 @@ public class SimpleLoadBalancerTest
                                         new HashMap<>(), new HashMap<>()));
     loadBalancer = spy(new SimpleLoadBalancer(state, 5, TimeUnit.SECONDS, _d2Executor));
     clusterRegistry.put(CLUSTER1_NAME, CLUSTER_PROPERTIES);
-    uriRegistry.put(CLUSTER1_NAME, new UriProperties(CLUSTER1_NAME, new HashMap<>()));
+    uriRegistry.put(CLUSTER1_NAME, URI_PROPERTIES);
     callback = spy(new FutureCallback<>());
     loadBalancer.getLoadBalancedClusterAndUriProperties(CLUSTER1_NAME, callback);
     callback.get();
     verify(loadBalancer, never()).handleTimeoutFromGetClusterAndUriProperties(any(), any());
+    verify(callback).onSuccess(eq(Pair.of(CLUSTER_PROPERTIES, URI_PROPERTIES)));
   }
 
   @Test

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -454,7 +454,7 @@ public class SimpleLoadBalancerTest
              }).when(state).listenToService(any(), any());
     SimpleLoadBalancer loadBalancer = spy(new SimpleLoadBalancer(state, 1, TimeUnit.MILLISECONDS, _d2Executor));
     // case1: listenToService timeout, and simpleLoadBalancer not hit the cache value
-    FutureCallback<ServiceProperties> callback = spy(new FutureCallback<>());
+    FutureCallback<ServiceProperties> callback = mock(FutureCallback.class);
     loadBalancer.listenToServiceAndCluster(SERVICE_NAME, callback);
     try
     {
@@ -471,7 +471,7 @@ public class SimpleLoadBalancerTest
     // case2: listenToService timeout, and simpleLoadBalancer hit the cache value from state
     LoadBalancerStateItem<ServiceProperties> serviceItem = new LoadBalancerStateItem<>(SERVICE_PROPERTIES, 1, 1);
     when(state.getServiceProperties(SERVICE_NAME)).thenReturn(serviceItem);
-    callback = spy(new FutureCallback<>());
+    callback = mock(FutureCallback.class);
     loadBalancer.listenToServiceAndCluster(SERVICE_NAME, callback);
     // Make sure the onSuccess is called with SERVICE_PROPERTIES only once.
     callback.get();
@@ -483,7 +483,7 @@ public class SimpleLoadBalancerTest
         spy(new SimpleLoadBalancerState(new SynchronousExecutorService(), uriRegistry, clusterRegistry, serviceRegistry,
                                         new HashMap<>(), new HashMap<>()));
     loadBalancer = spy(new SimpleLoadBalancer(state, 5, TimeUnit.SECONDS, _d2Executor));
-    callback = spy(new FutureCallback<>());
+    callback = mock(FutureCallback.class);
     loadBalancer.listenToServiceAndCluster(SERVICE_NAME, callback);
     callback.get();
     // Make sure there is no timeout.
@@ -508,7 +508,7 @@ public class SimpleLoadBalancerTest
              }).when(state).listenToCluster(any(), any());
 
     SimpleLoadBalancer loadBalancer = spy(new SimpleLoadBalancer(state, 1, TimeUnit.MILLISECONDS, _d2Executor));
-    FutureCallback<Pair<ClusterProperties, UriProperties>> callback = spy(new FutureCallback<>());
+    FutureCallback<Pair<ClusterProperties, UriProperties>> callback = mock(FutureCallback.class);
     // case1: listenToCluster timeout, and simpleLoadBalancer not hit the cache value
     loadBalancer.getLoadBalancedClusterAndUriProperties(CLUSTER1_NAME, callback);
     try
@@ -527,7 +527,7 @@ public class SimpleLoadBalancerTest
     LoadBalancerStateItem<UriProperties> uriItem = new LoadBalancerStateItem<>(URI_PROPERTIES, 1, 1);
     when(state.getClusterProperties(CLUSTER1_NAME)).thenReturn(clusterItem);
     when(state.getUriProperties(CLUSTER1_NAME)).thenReturn(uriItem);
-    callback = spy(new FutureCallback<>());
+    callback = mock(FutureCallback.class);
     loadBalancer.getLoadBalancedClusterAndUriProperties(CLUSTER1_NAME, callback);
     callback.get();
     verify(callback).onSuccess(eq(Pair.of(CLUSTER_PROPERTIES, URI_PROPERTIES)));
@@ -540,7 +540,7 @@ public class SimpleLoadBalancerTest
     loadBalancer = spy(new SimpleLoadBalancer(state, 5, TimeUnit.SECONDS, _d2Executor));
     clusterRegistry.put(CLUSTER1_NAME, CLUSTER_PROPERTIES);
     uriRegistry.put(CLUSTER1_NAME, URI_PROPERTIES);
-    callback = spy(new FutureCallback<>());
+    callback = mock(FutureCallback.class);
     loadBalancer.getLoadBalancedClusterAndUriProperties(CLUSTER1_NAME, callback);
     callback.get();
     verify(loadBalancer, never()).handleTimeoutFromGetClusterAndUriProperties(any(), any());

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.11
+version=29.51.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestChannelPoolManagerFactorySharingConnection.java
+++ b/r2-netty/src/test/java/com/linkedin/r2/transport/http/client/TestChannelPoolManagerFactorySharingConnection.java
@@ -84,13 +84,13 @@ public class TestChannelPoolManagerFactorySharingConnection
         // standard
         HashMap<String, String> properties = new HashMap<>();
         properties.put(HttpClientFactory.HTTP_PROTOCOL_VERSION, protocolVersion);
-        properties.put(HttpClientFactory.HTTP_REQUEST_TIMEOUT, String.valueOf(10000));
+        properties.put(HttpClientFactory.HTTP_REQUEST_TIMEOUT, String.valueOf(20000));
         clients.add(new TransportClientAdapter(clientFactory.getClient(properties), restOverStream));
 
         // with parameter that should NOT create a new ChannelPoolManager
         properties = new HashMap<>();
         properties.put(HttpClientFactory.HTTP_PROTOCOL_VERSION, protocolVersion);
-        properties.put(HttpClientFactory.HTTP_REQUEST_TIMEOUT, String.valueOf(2000)); // property NOT of the ChannelPoolManager
+        properties.put(HttpClientFactory.HTTP_REQUEST_TIMEOUT, String.valueOf(10000)); // property NOT of the ChannelPoolManager
         clients.add(new TransportClientAdapter(clientFactory.getClient(properties), restOverStream));
       },
       // since the two clients have the same settings, with sharing, it should just open 1 connections


### PR DESCRIPTION
## Summary
As the title said
- Fix the multiple onError calls in dual-read null guard logic
- Fefactor and add more strict unit test to make each `onError` method and `onSuccess` method will only be called one time.
- Catch up more potential exception for dual-read
- Try to fix some legacy unit test flaky failed issue


## Test done (Unit test)
- [✅] Add more unit test condition to make sure each `onError` and `onSuccess` method will only be called one time.
-  [✅] Add more unit test condition to make sure handleTime... method will be called when timeout