### PR TITLE
upgrade io.envoyproxy.controlplane module to 0.1.35 to fix compatibility issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.13] - 2024-03-26
+Upgrade the io.envoyproxy.controlplane module to 0.1.35
+
 ## [29.51.12] - 2024-03-22
 - Address the multiple onError calls in dual read and enhance unit test rigorously
 
@@ -5668,7 +5671,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.13...master
+[29.51.13]: https://github.com/linkedin/rest.li/compare/v29.51.12...v29.51.13
 [29.51.12]: https://github.com/linkedin/rest.li/compare/v29.51.11...v29.51.12
 [29.51.11]: https://github.com/linkedin/rest.li/compare/v29.51.10...v29.51.11
 [29.51.10]: https://github.com/linkedin/rest.li/compare/v29.51.9...v29.51.10

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ project.ext.externalDependency = [
   'protoc': 'com.google.protobuf:protoc:3.21.7',
   'protobufJava': 'com.google.protobuf:protobuf-java:3.21.7',
   'protobufJavaUtil': 'com.google.protobuf:protobuf-java-util:3.21.7',
-  'envoyApi': 'io.envoyproxy.controlplane:api:0.1.31',
+  'envoyApi': 'io.envoyproxy.controlplane:api:0.1.35',
 ];
 
 if (!project.ext.isDefaultEnvironment)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.12
+version=29.51.13
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Context

We found that for some samza mps([sitespeed-samza-beam](https://github.com/linkedin-multiproduct/sitespeed-samza-beam)  and [samza-pem](https://github.com/linkedin-multiproduct/samza-pem)), they are excluding the io.envoy module which will casued the INDIS xds stream initialization to fail.

`exclude group: 'io.envoyproxy.controlplane', module: 'api'`


## Analysis

The problem is the low version  io.envoyproxy.controlplane is shading instead of depending on an old version of opentelemetry-proto that’s not compatible with the lib that the team is using now. The compatability issue will cause the build failed, showing that  there is no ScopeMetrics class.

```java
> Task :samza-yarn-jobs:samza-pem-degradation-tracking:compileJava
/Users/sying/products/samza-pem/samza-yarn-jobs/samza-pem-degradation-tracking/src/main/java/com/linkedin/pem/functions/map/ProductAvailabilityPartialSessionScoreEventToOTelMetricsFn.java:226: error: cannot find symbol
        .addScopeMetrics(scopeMetrics)
        ^
  symbol:   method addScopeMetrics(io.opentelemetry.proto.metrics.v1.ScopeMetrics)
  location: class io.opentelemetry.proto.metrics.v1.ResourceMetrics.Builder
```



So after investigation, we found, now pegasus is using verion 0.1.31 for io.envoyproxy.controlplane. And the ScopeMetrics is added after 0.1.35.([java doc is here](https://javadoc.io/doc/io.envoyproxy.controlplane/api/0.1.35/index.html))
![image](https://github.com/linkedin/rest.li/assets/150380879/398a5ec6-9be7-47ef-9e41-8b42e78e9adf)



## Solution

As the above samza mp is not using pegasus directly, the best practice is to upgrade the  io.envoyproxy.controlplane version in pegasus, then bump up the pegasus version in container.
![image](https://github.com/linkedin/rest.li/assets/150380879/d03e0a6f-e9da-4e1f-9cf4-7ba6019df1bd)



## Local Test

https://lva1-app63607.corp.linkedin.com/s/x6fhh6h6o4amu/dependencies?dependencies=io.envoy&expandAll -> build successfully.

Find the INDIS successfully log
```
2024-03-26 13:51:05.954 [Indis xDS client executor-4-1] []  XdsClientImpl [INFO] ADS stream started, connected to server: main.indis-registry-observer.ei-ltx1.atd.disco.linkedin.com:32123
2024-03-26 13:51:06.659 [Indis xDS client executor-4-1] []  XdsClientImpl [INFO] ADS stream ready, cancelled timeout task: true
2024-03-26 13:51:08.428 [Indis xDS client executor-13-1] []  XdsClientImpl [INFO] ADS stream started, connected to server: main.indis-registry-observer.ei-ltx1.atd.disco.linkedin.com:32123
2024-03-26 13:51:08.709 [Indis xDS client executor-13-1] []  XdsClientImpl [INFO] ADS stream ready, cancelled timeout task: true
2024-03-26 13:51:54.335 [Indis xDS client executor-22-1] []  XdsClientImpl [INFO] ADS stream started, connected to server: main.indis-registry-observer.ei-ltx1.atd.disco.linkedin.com:32123
2024-03-26 13:51:54.665 [Indis xDS client executor-22-1] []  XdsClientImpl [INFO] ADS stream ready, cancelled timeout task: true
2024-03-26 13:51:55.803 [Indis xDS client executor-31-1] []  XdsClientImpl [INFO] ADS stream started, connected to server: main.indis-registry-observer.ei-ltx1.atd.disco.linkedin.com:32123
2024-03-26 13:51:56.031 [Indis xDS client executor-31-1] []  XdsClientImpl [INFO] ADS stream ready, cancelled timeout task: true
2024-03-26 13:51:06.712 [Indis xDS client executor-4-1] []  XdsClientImpl [INFO] Successfully established stream with ADS server: ltx1-app6591.stg.linkedin.com
```

Find the `samza job` successfully log
```
2024-03-26 14:01:32.524 [Samza StreamProcessor Container Thread-0] []  SubmitMetricsToAmfFn [INFO] Emit metrics to AMF
```
