### PR TITLE
Fix applying client side service config override in INDIS flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.51.15] - 2024-03-30
+## [29.52.0] - 2024-04-01
 - fix applying client side service config override in INDIS flow
 
 ## [29.51.14] - 2024-03-27
@@ -5677,8 +5677,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.15...master
-[29.51.15]: https://github.com/linkedin/rest.li/compare/v29.51.14...v29.51.15
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.52.0...master
+[29.52.0]: https://github.com/linkedin/rest.li/compare/v29.51.14...v29.52.0
 [29.51.14]: https://github.com/linkedin/rest.li/compare/v29.51.13...v29.51.14
 [29.51.13]: https://github.com/linkedin/rest.li/compare/v29.51.12...v29.51.13
 [29.51.12]: https://github.com/linkedin/rest.li/compare/v29.51.11...v29.51.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.51.15] - 2024-03-30
+- fix applying client side service config override in INDIS flow
+
 ## [29.51.14] - 2024-03-27
 - Support translating default values for optional non-record/union fields to Avro (when TRANSLATE_DEFAULT is enabled). 
 
@@ -5674,7 +5677,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.14...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.51.15...master
+[29.51.15]: https://github.com/linkedin/rest.li/compare/v29.51.14...v29.51.15
 [29.51.14]: https://github.com/linkedin/rest.li/compare/v29.51.13...v29.51.14
 [29.51.13]: https://github.com/linkedin/rest.li/compare/v29.51.12...v29.51.13
 [29.51.12]: https://github.com/linkedin/rest.li/compare/v29.51.11...v29.51.12

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
@@ -70,6 +70,10 @@ public class ServicePropertiesJsonSerializer implements
 
   public ServicePropertiesJsonSerializer(Map<String, Map<String, Object>> clientServicesConfig)
   {
+    if (clientServicesConfig == null)
+    {
+      clientServicesConfig = Collections.emptyMap();
+    }
     _clientServicesConfig = validateClientServicesConfig(clientServicesConfig);
   }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -61,7 +61,7 @@ public class XdsToD2PropertiesAdaptor
   private final XdsClient _xdsClient;
   private final List<XdsConnectionListener> _xdsConnectionListeners = Collections.synchronizedList(new ArrayList<>());
 
-  private final ServicePropertiesJsonSerializer _servicePropertiesJsonSerializer = new ServicePropertiesJsonSerializer();
+  private final ServicePropertiesJsonSerializer _servicePropertiesJsonSerializer;
   private final ClusterPropertiesJsonSerializer _clusterPropertiesJsonSerializer = new ClusterPropertiesJsonSerializer();
   private final UriPropertiesJsonSerializer _uriPropertiesJsonSerializer = new UriPropertiesJsonSerializer();
   private final UriPropertiesMerger _uriPropertiesMerger = new UriPropertiesMerger();
@@ -95,9 +95,16 @@ public class XdsToD2PropertiesAdaptor
   public XdsToD2PropertiesAdaptor(XdsClient xdsClient, DualReadStateManager dualReadStateManager,
       ServiceDiscoveryEventEmitter eventEmitter)
   {
+    this(xdsClient, dualReadStateManager, eventEmitter, Collections.emptyMap());
+  }
+
+  public XdsToD2PropertiesAdaptor(XdsClient xdsClient, DualReadStateManager dualReadStateManager,
+      ServiceDiscoveryEventEmitter eventEmitter, Map<String, Map<String, Object>> clientServicesConfig)
+  {
     _xdsClient = xdsClient;
     _dualReadStateManager = dualReadStateManager;
     _eventEmitter = eventEmitter;
+    _servicePropertiesJsonSerializer = new ServicePropertiesJsonSerializer(clientServicesConfig);
   }
 
   public void start()

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -62,7 +62,7 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
     d2ClientJmxManager.registerXdsClientJmx(xdsClient.getXdsClientJmx());
 
     XdsToD2PropertiesAdaptor adaptor = new XdsToD2PropertiesAdaptor(xdsClient, config.dualReadStateManager,
-        config.serviceDiscoveryEventEmitter);
+        config.serviceDiscoveryEventEmitter, config.clientServicesConfig);
 
     XdsLoadBalancer xdsLoadBalancer = new XdsLoadBalancer(adaptor, executorService,
         new XdsFsTogglingLoadBalancerFactory(config.lbWaitTimeout, config.lbWaitUnit, config.indisFsBasePath,

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -131,7 +131,7 @@ public class SimpleLoadBalancerTest
   private static final String NONEXISTENT_CLUSTER = "nonexistent_cluster";
   private static final String SERVICE_NAME = "foo";
   private static final ServiceProperties SERVICE_PROPERTIES =
-      new ServiceProperties(SERVICE_NAME, CLUSTER1_NAME, "/" + SERVICE_NAME, Arrays.asList("degrader"),
+      new ServiceProperties(SERVICE_NAME, CLUSTER1_NAME, "/" + SERVICE_NAME, Collections.singletonList("degrader"),
           Collections.emptyMap(), null, null, Collections.emptyList(), null);
 
   private static final ClusterProperties CLUSTER_PROPERTIES =
@@ -182,25 +182,22 @@ public class SimpleLoadBalancerTest
     }
   }
 
-  private SimpleLoadBalancer setupLoadBalancer(LoadBalancerState state, MockStore<ServiceProperties> serviceRegistry,
+  private SimpleLoadBalancer setupLoadBalancer(MockStore<ServiceProperties> serviceRegistry,
       MockStore<ClusterProperties> clusterRegistry, MockStore<UriProperties> uriRegistry)
       throws ExecutionException, InterruptedException
   {
     Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories =
         new HashMap<>();
     Map<String, TransportClientFactory> clientFactories = new HashMap<>();
-    LoadBalancerState loadBalancerState = state;
+    LoadBalancerState loadBalancerState = null;
 
     loadBalancerStrategyFactories.put("degrader", new DegraderLoadBalancerStrategyFactoryV3());
     clientFactories.put(PropertyKeys.HTTP_SCHEME, new DoNothingClientFactory());
     clientFactories.put(PropertyKeys.HTTPS_SCHEME, new DoNothingClientFactory());
 
-    if (loadBalancerState == null)
-    {
-      loadBalancerState =
-          new SimpleLoadBalancerState(new SynchronousExecutorService(), uriRegistry, clusterRegistry, serviceRegistry,
-              clientFactories, loadBalancerStrategyFactories);
-    }
+    loadBalancerState =
+        new SimpleLoadBalancerState(new SynchronousExecutorService(), uriRegistry, clusterRegistry, serviceRegistry,
+            clientFactories, loadBalancerStrategyFactories);
     SimpleLoadBalancer loadBalancer =
         new SimpleLoadBalancer(loadBalancerState, 5, TimeUnit.SECONDS, _d2Executor);
 
@@ -240,7 +237,7 @@ public class SimpleLoadBalancerTest
     MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
     MockStore<ClusterProperties> clusterRegistry = new MockStore<>();
     MockStore<UriProperties> uriRegistry = new MockStore<>();
-    SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
+    SimpleLoadBalancer loadBalancer = setupLoadBalancer(serviceRegistry, clusterRegistry, uriRegistry);
 
     populateUriRegistry(numHttp, numHttps, partitionIdForAdd, uriRegistry);
     clusterRegistry.put(CLUSTER1_NAME, new ClusterProperties(CLUSTER1_NAME));
@@ -277,7 +274,7 @@ public class SimpleLoadBalancerTest
     MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
     MockStore<ClusterProperties> clusterRegistry = new MockStore<>();
     MockStore<UriProperties> uriRegistry = new MockStore<>();
-    SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
+    SimpleLoadBalancer loadBalancer = setupLoadBalancer(serviceRegistry, clusterRegistry, uriRegistry);
 
     DarkClusterConfig darkClusterConfig = new DarkClusterConfig()
         .setMultiplier(1.0f)
@@ -318,7 +315,7 @@ public class SimpleLoadBalancerTest
     MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
     MockStore<ClusterProperties> clusterRegistry = new MockStore<>();
     MockStore<UriProperties> uriRegistry = new MockStore<>();
-    SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
+    SimpleLoadBalancer loadBalancer = setupLoadBalancer(serviceRegistry, clusterRegistry, uriRegistry);
 
     DarkClusterConfig darkClusterConfig = new DarkClusterConfig()
         .setMultiplier(1.0f)
@@ -356,7 +353,7 @@ public class SimpleLoadBalancerTest
     MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
     MockStore<ClusterProperties> clusterRegistry = new MockStore<>();
     MockStore<UriProperties> uriRegistry = new MockStore<>();
-    SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
+    SimpleLoadBalancer loadBalancer = setupLoadBalancer(serviceRegistry, clusterRegistry, uriRegistry);
 
     loadBalancer.getDarkClusterConfigMap(NONEXISTENT_CLUSTER, new Callback<DarkClusterConfigMap>()
     {
@@ -385,7 +382,7 @@ public class SimpleLoadBalancerTest
     MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
     MockStore<ClusterProperties> clusterRegistry = new MockStore<>();
     MockStore<UriProperties> uriRegistry = new MockStore<>();
-    SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
+    SimpleLoadBalancer loadBalancer = setupLoadBalancer(serviceRegistry, clusterRegistry, uriRegistry);
     FutureCallback<None> balancerCallback = new FutureCallback<>();
     loadBalancer.start(balancerCallback);
     balancerCallback.get();
@@ -416,7 +413,7 @@ public class SimpleLoadBalancerTest
     MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
     MockStore<ClusterProperties> clusterRegistry = new MockStore<>();
     MockStore<UriProperties> uriRegistry = new MockStore<>();
-    SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
+    SimpleLoadBalancer loadBalancer = setupLoadBalancer(serviceRegistry, clusterRegistry, uriRegistry);
     FutureCallback<None> balancerCallback = new FutureCallback<>();
     loadBalancer.start(balancerCallback);
     balancerCallback.get();
@@ -439,6 +436,7 @@ public class SimpleLoadBalancerTest
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testListenToServiceAndClusterTimeout() throws ExecutionException, InterruptedException
   {
     MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
@@ -492,6 +490,7 @@ public class SimpleLoadBalancerTest
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetLoadBalancedClusterAndUriProperties() throws InterruptedException, ExecutionException
   {
     MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
@@ -659,8 +658,7 @@ public class SimpleLoadBalancerTest
 
       serviceRegistry.put("foo", new ServiceProperties("foo",
                                                         "cluster-1",
-                                                        "/foo",
-                                                        Arrays.asList("degrader"),
+                                                        "/foo", Collections.singletonList("degrader"),
                                                         Collections.<String,Object>emptyMap(),
                                                         null,
                                                         null,
@@ -733,7 +731,7 @@ public class SimpleLoadBalancerTest
     MockStore<UriProperties> uriRegistry = new MockStore<>();
     List<String> prioritizedSchemes = new ArrayList<>();
 
-    SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
+    SimpleLoadBalancer loadBalancer = setupLoadBalancer(serviceRegistry, clusterRegistry, uriRegistry);
 
     //URI uri = URI.create("http://test.qd.com:5678");
     Map<Integer, PartitionData> partitionData = new HashMap<>(1);
@@ -753,8 +751,7 @@ public class SimpleLoadBalancerTest
 
     serviceRegistry.put("foo", new ServiceProperties("foo",
         CLUSTER1_NAME,
-        "/foo",
-        Arrays.asList("degrader"),
+        "/foo", Collections.singletonList("degrader"),
         Collections.<String,Object>emptyMap(),
         null,
         null,
@@ -825,7 +822,7 @@ public class SimpleLoadBalancerTest
     MockStore<UriProperties> uriRegistry = new MockStore<>();
     List<String> prioritizedSchemes = new ArrayList<>();
 
-    SimpleLoadBalancer loadBalancer = setupLoadBalancer(null, serviceRegistry, clusterRegistry, uriRegistry);
+    SimpleLoadBalancer loadBalancer = setupLoadBalancer(serviceRegistry, clusterRegistry, uriRegistry);
 
     URI uri1 = URI.create("http://test.qd.com:1234");
 
@@ -850,8 +847,7 @@ public class SimpleLoadBalancerTest
 
     serviceRegistry.put("foo", new ServiceProperties("foo",
         CLUSTER1_NAME,
-        "/foo",
-        Arrays.asList("degrader"),
+        "/foo", Collections.singletonList("degrader"),
         Collections.<String,Object>emptyMap(),
         null,
         null,
@@ -938,8 +934,7 @@ public class SimpleLoadBalancerTest
 
     serviceRegistry.put("foo", new ServiceProperties("foo",
         "cluster-1",
-        "/foo",
-        Arrays.asList("degrader"),
+        "/foo", Collections.singletonList("degrader"),
         Collections.<String,Object>emptyMap(),
         null,
         null,
@@ -959,7 +954,6 @@ public class SimpleLoadBalancerTest
 
   /**
    * This tests getClient(). When TargetHints and scheme does not match, throw ServiceUnavailableException
-   * @throws Exception
    */
   @Test (expectedExceptions = ServiceUnavailableException.class)
   @SuppressWarnings("deprecation")
@@ -998,8 +992,6 @@ public class SimpleLoadBalancerTest
     loadBalancer.start(balancerCallback);
     balancerCallback.get(5, TimeUnit.SECONDS);
 
-    Map<Integer, PartitionData> partitionData = new HashMap<>(1);
-    partitionData.put(DEFAULT_PARTITION_ID, new PartitionData(1d));
     Map<URI, Map<Integer, PartitionData>> uriData = new HashMap<>(3);
 
     prioritizedSchemes.add(PropertyKeys.HTTPS_SCHEME);
@@ -1008,8 +1000,7 @@ public class SimpleLoadBalancerTest
 
     serviceRegistry.put("foo", new ServiceProperties("foo",
         "cluster-1",
-        "/foo",
-        Arrays.asList("degrader"),
+        "/foo", Collections.singletonList("degrader"),
         Collections.<String,Object>emptyMap(),
         null,
         null,
@@ -1030,7 +1021,6 @@ public class SimpleLoadBalancerTest
 
   /**
    * Tests getClient() when with host override list specified in the request context.
-   * @throws Exception
    */
   @Test
   public void testGetClientHostOverrideList() throws Exception
@@ -1080,8 +1070,7 @@ public class SimpleLoadBalancerTest
 
     serviceRegistry.put(service1, new ServiceProperties(service1,
         cluster1,
-        "/service1Path",
-        Arrays.asList("degrader"),
+        "/service1Path", Collections.singletonList("degrader"),
         Collections.<String,Object>emptyMap(),
         null,
         null,
@@ -1090,7 +1079,6 @@ public class SimpleLoadBalancerTest
     uriRegistry.put(cluster1, new UriProperties(cluster1, uriData));
 
     URI override = URI.create("http://override/path");
-    URI expected = URI.create("http://override/path/service1Path");
     URIRequest uriRequest = new URIRequest("d2://service1");
 
     HostOverrideList clusterOverrides = new HostOverrideList();
@@ -1200,22 +1188,22 @@ public class SimpleLoadBalancerTest
     Assert.assertNull(result.getPartitionInfoMap().get(0));
     // results for partition 1 should contain server1, server2 and server3
     KeysAndHosts<Integer> keysAndHosts1 = result.getPartitionInfoMap().get(1);
-    Assert.assertTrue(keysAndHosts1.getKeys().size() == 1);
-    Assert.assertTrue(keysAndHosts1.getKeys().iterator().next() == 1);
+    assertEquals(keysAndHosts1.getKeys().size(), 1);
+    assertEquals((int) keysAndHosts1.getKeys().iterator().next(), 1);
     List<URI> ordering1 = keysAndHosts1.getHosts();
     // results for partition 2 should be the same as partition1.
     KeysAndHosts<Integer> keysAndHosts2 = result.getPartitionInfoMap().get(2);
-    Assert.assertTrue(keysAndHosts2.getKeys().size() == 1);
-    Assert.assertTrue(keysAndHosts2.getKeys().iterator().next() == 2);
+    assertEquals(keysAndHosts2.getKeys().size(), 1);
+    assertEquals((int) keysAndHosts2.getKeys().iterator().next(), 2);
     List<URI> ordering2 = keysAndHosts2.getHosts();
     //for partition 3
     KeysAndHosts<Integer> keysAndHosts3 = result.getPartitionInfoMap().get(3);
-    Assert.assertTrue(keysAndHosts3.getKeys().size() == 1);
-    Assert.assertTrue(keysAndHosts3.getKeys().iterator().next() == 3);
+    assertEquals(keysAndHosts3.getKeys().size(), 1);
+    assertEquals((int) keysAndHosts3.getKeys().iterator().next(), 3);
     List<URI> ordering3 = keysAndHosts3.getHosts();
 
     // Just compare the size and contents of the list, not the ordering.
-    Assert.assertTrue(ordering1.size() == 3);
+    assertEquals(ordering1.size(), 3);
     List<URI> allServers = new ArrayList<>();
     allServers.add(server1);
     allServers.add(server2);
@@ -1388,7 +1376,7 @@ public class SimpleLoadBalancerTest
     allServers.add(server2);
     allServers.add(server3);
 
-    Assert.assertTrue(ordering1.size() == 3);
+    assertEquals(ordering1.size(), 3);
     Assert.assertTrue(ordering1.containsAll(allServers));
 
     // partition 2 should be the same as partition 1
@@ -1446,12 +1434,6 @@ public class SimpleLoadBalancerTest
       URI uri2 = URI.create("http://test.qa2.com:2345");
       URI uri3 = URI.create("http://test.qa3.com:6789");
 
-      Map<URI, Double> uris = new HashMap<>();
-
-      uris.put(uri1, 1d);
-      uris.put(uri2, 1d);
-      uris.put(uri3, 1d);
-
       Map<URI,Map<Integer, PartitionData>> partitionDesc =
           new HashMap<>();
 
@@ -1498,8 +1480,7 @@ public class SimpleLoadBalancerTest
 
       serviceRegistry.put("foo", new ServiceProperties("foo",
                                                         "cluster-1",
-                                                        "/foo",
-                                                        Arrays.asList("degrader"),
+                                                        "/foo", Collections.singletonList("degrader"),
                                                         Collections.singletonMap(PropertyKeys.HTTP_LB_CONSISTENT_HASH_ALGORITHM, "pointBased"),
                                                         null,
                                                         null,
@@ -1564,12 +1545,12 @@ public class SimpleLoadBalancerTest
               }
               else if (partitionMethod == 1)
               {
-                assertTrue(ii % 2 == 0);
+                assertEquals(ii % 2, 0);
               }
               else
               {
                 str[0] = ii + "";
-                assertTrue(hashFunction.hash(str) % 2 == 0);
+                assertEquals(hashFunction.hash(str) % 2, 0);
               }
             }
             // check if only key belonging to partition 1 gets uri3
@@ -1581,12 +1562,12 @@ public class SimpleLoadBalancerTest
               }
               else if (partitionMethod == 1)
               {
-                assertTrue(ii % 2 == 1);
+                assertEquals(ii % 2, 1);
               }
               else
               {
                 str[0] = ii + "";
-                assertTrue(hashFunction.hash(str) % 2 == 1);
+                assertEquals(hashFunction.hash(str) % 2, 1);
               }
             }
           }
@@ -1657,7 +1638,8 @@ public class SimpleLoadBalancerTest
         assertTrue(client.getDecoratedClient() instanceof RewriteClient);
         RewriteClient rewriteClient = (RewriteClient) client.getDecoratedClient();
         assertTrue(rewriteClient.getDecoratedClient() instanceof TrackerClient);
-        assertTrue(((TrackerClient) rewriteClient.getDecoratedClient()).getPartitionWeight(DEFAULT_PARTITION_ID) == 1.0d);
+        assertEquals(((TrackerClient) rewriteClient.getDecoratedClient()).getPartitionWeight(DEFAULT_PARTITION_ID),
+            1.0d);
       }
 
       final CountDownLatch latch = new CountDownLatch(1);
@@ -1698,7 +1680,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 1");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1709,7 +1691,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 2");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1720,7 +1702,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 3");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1731,7 +1713,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 4");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1742,7 +1724,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 5");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1753,7 +1735,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 6");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1764,7 +1746,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 7");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1775,7 +1757,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 8");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1784,11 +1766,9 @@ public class SimpleLoadBalancerTest
     try
     {
       balancer.getClient(uriRequest, new RequestContext());
-      fail("should have received a service unavailable exception, case 9" +
-        "" +
-        "");
+      fail("should have received a service unavailable exception, case 9");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1799,7 +1779,7 @@ public class SimpleLoadBalancerTest
       balancer.getClient(uriRequest, new RequestContext());
       fail("should have received a service unavailable exception, case 10");
     }
-    catch (ServiceUnavailableException e)
+    catch (ServiceUnavailableException ignored)
     {
     }
 
@@ -1977,9 +1957,8 @@ public class SimpleLoadBalancerTest
   {
     private final AtomicLong _count = new AtomicLong();
 
-    @SuppressWarnings("unchecked")
     @Override
-    public TransportClient getClient(Map<String, ? extends Object> properties)
+    public TransportClient getClient(Map<String, ?> properties)
     {
       _count.incrementAndGet();
       if (properties.containsKey("foobar"))
@@ -2098,7 +2077,7 @@ public class SimpleLoadBalancerTest
     public int getPartitionId(String key)
         throws PartitionAccessException
     {
-      Integer i = Integer.parseInt(key);
+      int i = Integer.parseInt(key);
       if (i == 1)
       {
         return 1;
@@ -2182,8 +2161,7 @@ public class SimpleLoadBalancerTest
 
       serviceRegistry.put("foo", new ServiceProperties("foo",
               "cluster-1",
-              "/foo",
-              Arrays.asList("degrader"),
+              "/foo", Collections.singletonList("degrader"),
               Collections.<String,Object>emptyMap(),
               null,
               null,

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -452,7 +452,7 @@ public class SimpleLoadBalancerTest
              }).when(state).listenToService(any(), any());
     SimpleLoadBalancer loadBalancer = spy(new SimpleLoadBalancer(state, 1, TimeUnit.MILLISECONDS, _d2Executor));
     // case1: listenToService timeout, and simpleLoadBalancer not hit the cache value
-    FutureCallback<ServiceProperties> callback = mock(FutureCallback.class);
+    FutureCallback<ServiceProperties> callback = spy(new FutureCallback<>());
     loadBalancer.listenToServiceAndCluster(SERVICE_NAME, callback);
     try
     {
@@ -469,7 +469,7 @@ public class SimpleLoadBalancerTest
     // case2: listenToService timeout, and simpleLoadBalancer hit the cache value from state
     LoadBalancerStateItem<ServiceProperties> serviceItem = new LoadBalancerStateItem<>(SERVICE_PROPERTIES, 1, 1);
     when(state.getServiceProperties(SERVICE_NAME)).thenReturn(serviceItem);
-    callback = mock(FutureCallback.class);
+    callback = spy(new FutureCallback<>());
     loadBalancer.listenToServiceAndCluster(SERVICE_NAME, callback);
     // Make sure the onSuccess is called with SERVICE_PROPERTIES only once.
     callback.get();
@@ -481,7 +481,7 @@ public class SimpleLoadBalancerTest
         spy(new SimpleLoadBalancerState(new SynchronousExecutorService(), uriRegistry, clusterRegistry, serviceRegistry,
                                         new HashMap<>(), new HashMap<>()));
     loadBalancer = spy(new SimpleLoadBalancer(state, 5, TimeUnit.SECONDS, _d2Executor));
-    callback = mock(FutureCallback.class);
+    callback = spy(new FutureCallback<>());
     loadBalancer.listenToServiceAndCluster(SERVICE_NAME, callback);
     callback.get();
     // Make sure there is no timeout.
@@ -507,7 +507,7 @@ public class SimpleLoadBalancerTest
              }).when(state).listenToCluster(any(), any());
 
     SimpleLoadBalancer loadBalancer = spy(new SimpleLoadBalancer(state, 1, TimeUnit.MILLISECONDS, _d2Executor));
-    FutureCallback<Pair<ClusterProperties, UriProperties>> callback = mock(FutureCallback.class);
+    FutureCallback<Pair<ClusterProperties, UriProperties>> callback = spy(new FutureCallback<>());
     // case1: listenToCluster timeout, and simpleLoadBalancer not hit the cache value
     loadBalancer.getLoadBalancedClusterAndUriProperties(CLUSTER1_NAME, callback);
     try
@@ -526,7 +526,7 @@ public class SimpleLoadBalancerTest
     LoadBalancerStateItem<UriProperties> uriItem = new LoadBalancerStateItem<>(URI_PROPERTIES, 1, 1);
     when(state.getClusterProperties(CLUSTER1_NAME)).thenReturn(clusterItem);
     when(state.getUriProperties(CLUSTER1_NAME)).thenReturn(uriItem);
-    callback = mock(FutureCallback.class);
+    callback = spy(new FutureCallback<>());
     loadBalancer.getLoadBalancedClusterAndUriProperties(CLUSTER1_NAME, callback);
     callback.get();
     verify(callback).onSuccess(eq(Pair.of(CLUSTER_PROPERTIES, URI_PROPERTIES)));
@@ -539,7 +539,7 @@ public class SimpleLoadBalancerTest
     loadBalancer = spy(new SimpleLoadBalancer(state, 5, TimeUnit.SECONDS, _d2Executor));
     clusterRegistry.put(CLUSTER1_NAME, CLUSTER_PROPERTIES);
     uriRegistry.put(CLUSTER1_NAME, URI_PROPERTIES);
-    callback = mock(FutureCallback.class);
+    callback = spy(new FutureCallback<>());
     loadBalancer.getLoadBalancedClusterAndUriProperties(CLUSTER1_NAME, callback);
     callback.get();
     verify(loadBalancer, never()).handleTimeoutFromGetClusterAndUriProperties(any(), any());

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerTest.java
@@ -189,13 +189,12 @@ public class SimpleLoadBalancerTest
     Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories =
         new HashMap<>();
     Map<String, TransportClientFactory> clientFactories = new HashMap<>();
-    LoadBalancerState loadBalancerState = null;
 
     loadBalancerStrategyFactories.put("degrader", new DegraderLoadBalancerStrategyFactoryV3());
     clientFactories.put(PropertyKeys.HTTP_SCHEME, new DoNothingClientFactory());
     clientFactories.put(PropertyKeys.HTTPS_SCHEME, new DoNothingClientFactory());
 
-    loadBalancerState =
+    LoadBalancerState loadBalancerState =
         new SimpleLoadBalancerState(new SynchronousExecutorService(), uriRegistry, clusterRegistry, serviceRegistry,
             clientFactories, loadBalancerStrategyFactories);
     SimpleLoadBalancer loadBalancer =

--- a/d2/src/test/java/com/linkedin/d2/xds/XdsToD2SampleClient.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/XdsToD2SampleClient.java
@@ -89,7 +89,7 @@ public class XdsToD2SampleClient
 
     XdsChannelFactory xdsChannelFactory = new XdsChannelFactory(sslContext, xdsServer);
     XdsClient xdsClient = new XdsClientImpl(node, xdsChannelFactory.createChannel(),
-        Executors.newSingleThreadScheduledExecutor(), XdsClientImpl.DEFAULT_READY_TIMEOUT_MILLIS);
+        Executors.newSingleThreadScheduledExecutor(), XdsClientImpl.DEFAULT_READY_TIMEOUT_MILLIS, false);
 
     DualReadStateManager dualReadStateManager = new DualReadStateManager(
         () -> DualReadModeProvider.DualReadMode.DUAL_READ,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.14
+version=29.51.15
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.51.15
+version=29.52.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
Client app could define [client side service config override](https://jarvis.corp.linkedin.com/codesearch/result/?name=prod.src&path=learning-api%2Fconfig%2Fapp%2Flearning-api-chat%2Fgroups&reponame=linkedin-multiproduct%2Flearning-api#22) to override transport client properties set in server side d2 config (if listed in allowedClientOverrideKeys). This functionality was implemented in ZK flow by applying the client side override to the d2 service properties when deserializing it after received from ZK. INDIS flow currently is broken since the client side override is not set to the d2 service (de-)serializer in INDIS flow.  

This change:
1. Fix applying client side service config override in INDIS flow
2. Clean up build time warning in SimpleLoadBalancer and XdsToD2SampleClient. 

(Note that once this change is merged, [gRPC client code](https://github.com/linkedin-multiproduct/grpc-infra/blob/014d03a61fe5ef4fc407281206c4e97c5fffd0f9/si-grpc/si-grpc-factory/src/main/java/com/linkedin/grpc/client/factory/XdsFsSdServiceFactory.java#L110) needs to be updated to fix the same issue) 

## Test Done
In d2-proxy, set read mode to observer-only:
```
<property name="indisConfigProvider.dualReadMode" value="NEW_LB_ONLY"/>
```
Set client side override for tokiBackend (which server side request timeout is the default 10s and allows all keys to be overridden):
```
<property name="__r2d2DefaultClient__.r2d2Client.clientServicesConfig">
     <map>
          <entry key="tokiBackend">
               <map>
                     <entry key="http.maxResponseSize" value="31457280"/>
                     <entry key="http.requestTimeout" value="20000"/>
               </map>
         </entry>
    </map>
</property>
```
QEI deploy d2-proxy.
curli tokiBackend with 12s delay:
```
curli -v "d2://tokiBackend?action=tokiServer" -X POST --data '{"message": "Hello", "delay": "12000"}' --d2-proxy-url "http://localhost:21360/d2/" --force-insecure-d2
```
Without the fix, the request timed out. With the fix, the request succeeds, and checking the log could see the service properties is overridden by the client side override:


2024/03/30 12:11:50.452 INFO [SimpleLoadBalancerState] [Indis xDS client executor-4-1] [d2-proxy] [AAYU5YdPDTRHZvFiJcO0lw==] refreshing service strategies for service: ServiceProperties [_clusterName=TokiBackend, _path=/tokiBackend, _serviceName=tokiBackend, _loadBalancerStrategyList=[relative], _loadBalancerStrategyProperties={}, _transportClientProperties={http.idleTimeout=25000, allowedClientOverrideKeys=http.poolSize,http.requestTimeout,http.idleTimeout,http.maxResponseSize,http.shutdownTimeout,http.responseCompressionOperations,http.poolWaiterSize,http.poolMinSize,http.protocolVersion, http.poolSize=100, http.protocolVersion=HTTP_2, **http.maxResponseSize=31457280**, http.sslIdleTimeout=10500000, **http.requestTimeout=20000**}, _relativeStrategyProperties={highErrorRate=0.1, lowErrorRate=0.02, downStep=0.2, enableFastRecovery=true, relativeLatencyLowThresholdFactor=4.0, relativeLatencyHighThresholdFactor=5.0, slowStartThreshold=0.16, quarantineProperties={quarantineMaxPercent=0.0}, initialHealthScore=0.01, ringProperties={consistentHashAlgorithm=multiProbe}, upStep=0.05, emittingIntervalMs=0}, _degraderProperties={}, prioritizedSchemes=[https], bannedUris=[], serviceMetadata={isDefaultService=true}, backupRequests=[], enableClusterSubsetting=false, minimumClusterSubsetSize=-1]


[d2-proxy.log](https://github.com/linkedin/rest.li/files/14813086/d2-proxy.log)
