### PR TITLE
Fix the concurrent configuration resolution error in Gradle 8 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.52.1] - 2024-04-03
+- fix concurrent configuration resolution issue in the Gradle plugin in Gradle 8 and above
+
 ## [29.52.0] - 2024-04-01
 - fix applying client side service config override in INDIS flow
 
@@ -5677,7 +5680,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.52.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.52.1...master
+[29.52.1]: https://github.com/linkedin/rest.li/compare/v29.52.0...v29.52.1
 [29.52.0]: https://github.com/linkedin/rest.li/compare/v29.51.14...v29.52.0
 [29.51.14]: https://github.com/linkedin/rest.li/compare/v29.51.13...v29.51.14
 [29.51.13]: https://github.com/linkedin/rest.li/compare/v29.51.12...v29.51.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.52.0
+version=29.52.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
In Gradle 8, the build might sometimes fail if two or more projects attempt to resolve the same configuration of the third project simultaneously. In fact, reading from the configuration of other projects is considered a bad practice and will be prohibited starting from Gradle 9. To fix the products that fail with this issue in Gradle 8 and make plugin compatible with Gradle 9, this PR introduces a local proxy configuration that serves as a medium for accessing the configuration of the other projects.

## Testing Done

- local build ok
- confirmed that this change fixes the projects that were failing before