### PR TITLE
Remove emitting SD event for receiving URI data update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.53.1] - 2024-04-24
+- Remove emitting SD event for receiving URI data update
+
 ## [29.53.0] - 2024-04-09
 - add xDS server latency metric provider
 
@@ -5683,7 +5686,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.53.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.53.1...master
+[29.53.1]: https://github.com/linkedin/rest.li/compare/v29.53.0...v29.53.1
 [29.53.0]: https://github.com/linkedin/rest.li/compare/v29.52.1...v29.53.0
 [29.52.1]: https://github.com/linkedin/rest.li/compare/v29.52.0...v29.52.1
 [29.52.0]: https://github.com/linkedin/rest.li/compare/v29.51.14...v29.52.0

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -598,14 +598,8 @@ public class XdsToD2PropertiesAdaptor
       MapDifference<String, XdsAndD2Uris> mapDifference = Maps.difference(_currentData, updates);
       Map<String, XdsAndD2Uris> markedDownUris = mapDifference.entriesOnlyOnLeft();
       Map<String, XdsAndD2Uris> markedUpUris = mapDifference.entriesOnlyOnRight();
-      Map<String, XdsAndD2Uris> updatedUris  = mapDifference.entriesDiffering().entrySet().stream()
-          .collect(Collectors.toMap(
-              Map.Entry::getKey,
-              e -> e.getValue().rightValue() // new data in updated uris
-          ));
 
       emitSDStatusUpdateReceiptEvents(markedUpUris, true, timestamp);
-      emitSDStatusUpdateReceiptEvents(updatedUris, true, timestamp);
       emitSDStatusUpdateReceiptEvents(markedDownUris, false, timestamp);
     }
 

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -231,7 +231,8 @@ public class TestXdsToD2PropertiesAdaptor {
     uriMap.put(URI_NAME, getD2URI(PRIMARY_CLUSTER_NAME, URI_NAME, VERSION_2));
     uriMap.put(URI_NAME_3, getD2URI(PRIMARY_CLUSTER_NAME, URI_NAME_3, VERSION));
     fixture._uriMapWatcher.onChanged(new XdsClient.D2URIMapUpdate(uriMap));
-    verify(fixture._eventEmitter).emitSDStatusUpdateReceiptEvent(
+    // events should be emitted only for remove/add, but not update
+    verify(fixture._eventEmitter, never()).emitSDStatusUpdateReceiptEvent(
         any(), eq(HOST_1), anyInt(), eq(ServiceDiscoveryEventEmitter.StatusUpdateActionType.MARK_READY), anyBoolean(),
         any(), any(), any(), eq((int) VERSION_2), any(), anyLong());
     verify(fixture._eventEmitter).emitSDStatusUpdateReceiptEvent(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.53.0
+version=29.53.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
We recently added emitting SD status update receipt event for receiving URI data updates (previously only add/remove URI will emit the event). Turns out that increased the event volume a lot ---- apps like seas do URI data updates very frequently (weight, uri specific properties, etc.) and have both large fleet size and large audience group (hence huge fanout). Considering that having the events for add/remove URI is good enough for analyzing SD end-to-end propagation latency, and including the URI data updates could cause unmanageable pressure on the data analysis pipeline, such as Kusto query, inlogs, etc, we could exclude the URI data updates from emitting events. 

## Testing Done
Updated existing tests.