### PR TITLE
Implement new DualReadMonitor for UriProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.54.0] - 2024-05-08
+- Dual read monitors cluster uris similarity
+
 ## [29.53.1] - 2024-04-24
 - Remove emitting SD event for receiving URI data update
 
@@ -5686,7 +5689,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.53.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.54.0...master
+[29.54.0]: https://github.com/linkedin/rest.li/compare/v29.53.1...v29.54.0
 [29.53.1]: https://github.com/linkedin/rest.li/compare/v29.53.0...v29.53.1
 [29.53.0]: https://github.com/linkedin/rest.li/compare/v29.52.1...v29.53.0
 [29.52.1]: https://github.com/linkedin/rest.li/compare/v29.52.0...v29.52.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmx.java
@@ -16,8 +16,11 @@
 
 package com.linkedin.d2.balancer.dualread;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 
 public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
@@ -32,6 +35,8 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
   private final AtomicInteger _clusterPropertiesOutOfSyncCount = new AtomicInteger();
 
   private final AtomicReference<Double> _uriPropertiesSimilarity = new AtomicReference<>(0d);
+
+  private final Map<String, UriPropertiesDualReadMonitor.ClusterMatchRecord> _clusters = new HashMap<>();
 
 
   @Override
@@ -97,6 +102,11 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
     return _uriPropertiesSimilarity.get();
   }
 
+  @Override
+  public @Nullable UriPropertiesDualReadMonitor.ClusterMatchRecord getClusterMatchRecord(String clusterName) {
+    return _clusters.get(clusterName);
+  }
+
   public void incrementServicePropertiesErrorCount()
   {
     _servicePropertiesErrorCount.incrementAndGet();
@@ -140,5 +150,11 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
   public void setUriPropertiesSimilarity(double similarity)
   {
     _uriPropertiesSimilarity.set(similarity);
+  }
+
+  public void setClusterMatchRecord(String clusterName,
+      UriPropertiesDualReadMonitor.ClusterMatchRecord clusterMatchRecord)
+  {
+    _clusters.put(clusterName, clusterMatchRecord);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmx.java
@@ -17,21 +17,21 @@
 package com.linkedin.d2.balancer.dualread;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 
 public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
 {
   private final AtomicInteger _servicePropertiesErrorCount = new AtomicInteger();
   private final AtomicInteger _clusterPropertiesErrorCount = new AtomicInteger();
-  private final AtomicInteger _uriPropertiesErrorCount = new AtomicInteger();
 
   private final AtomicInteger _servicePropertiesEvictCount = new AtomicInteger();
   private final AtomicInteger _clusterPropertiesEvictCount = new AtomicInteger();
-  private final AtomicInteger _uriPropertiesEvictCount = new AtomicInteger();
 
   private final AtomicInteger _servicePropertiesOutOfSyncCount = new AtomicInteger();
   private final AtomicInteger _clusterPropertiesOutOfSyncCount = new AtomicInteger();
-  private final AtomicInteger _uriPropertiesOutOfSyncCount = new AtomicInteger();
+
+  private final AtomicReference<Double> _uriPropertiesSimilarity = new AtomicReference<>(0d);
 
 
   @Override
@@ -46,10 +46,11 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
     return _clusterPropertiesErrorCount.get();
   }
 
+  @Deprecated
   @Override
   public int getUriPropertiesErrorCount()
   {
-    return _uriPropertiesErrorCount.get();
+    return 0;
   }
 
   @Override
@@ -64,25 +65,36 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
     return _clusterPropertiesEvictCount.get();
   }
 
+  @Deprecated
   @Override
   public int getUriPropertiesEvictCount()
   {
-    return _uriPropertiesEvictCount.get();
+    return 0;
   }
 
   @Override
-  public int getServicePropertiesOutOfSyncCount() {
+  public int getServicePropertiesOutOfSyncCount()
+  {
     return _servicePropertiesOutOfSyncCount.get();
   }
 
   @Override
-  public int getClusterPropertiesOutOfSyncCount() {
+  public int getClusterPropertiesOutOfSyncCount()
+  {
     return _clusterPropertiesOutOfSyncCount.get();
   }
 
+  @Deprecated
   @Override
-  public int getUriPropertiesOutOfSyncCount() {
-    return _uriPropertiesOutOfSyncCount.get();
+  public int getUriPropertiesOutOfSyncCount()
+  {
+    return 0;
+  }
+
+  @Override
+  public double getUriPropertiesSimilarity()
+  {
+    return _uriPropertiesSimilarity.get();
   }
 
   public void incrementServicePropertiesErrorCount()
@@ -95,11 +107,6 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
     _clusterPropertiesErrorCount.incrementAndGet();
   }
 
-  public void incrementUriPropertiesErrorCount()
-  {
-    _uriPropertiesErrorCount.incrementAndGet();
-  }
-
   public void incrementServicePropertiesEvictCount()
   {
     _servicePropertiesEvictCount.incrementAndGet();
@@ -108,11 +115,6 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
   public void incrementClusterPropertiesEvictCount()
   {
     _clusterPropertiesEvictCount.incrementAndGet();
-  }
-
-  public void incrementUriPropertiesEvictCount()
-  {
-    _uriPropertiesEvictCount.incrementAndGet();
   }
 
   public void incrementServicePropertiesOutOfSyncCount()
@@ -125,11 +127,6 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
     _clusterPropertiesOutOfSyncCount.incrementAndGet();
   }
 
-  public void incrementUriPropertiesOutOfSyncCount()
-  {
-    _uriPropertiesOutOfSyncCount.incrementAndGet();
-  }
-
   public void decrementServicePropertiesOutOfSyncCount()
   {
     _servicePropertiesOutOfSyncCount.decrementAndGet();
@@ -140,8 +137,8 @@ public class DualReadLoadBalancerJmx implements DualReadLoadBalancerJmxMBean
     _clusterPropertiesOutOfSyncCount.decrementAndGet();
   }
 
-  public void decrementUriPropertiesOutOfSyncCount()
+  public void setUriPropertiesSimilarity(double similarity)
   {
-    _uriPropertiesOutOfSyncCount.decrementAndGet();
+    _uriPropertiesSimilarity.set(similarity);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmxMBean.java
@@ -46,5 +46,10 @@ public interface DualReadLoadBalancerJmxMBean
   @Deprecated
   int getUriPropertiesOutOfSyncCount();
 
+  // Similarity is calculated as the ratio of the number of URIs that are common between the two LBs to the total
+  // number of URIs in both LBs.
   double getUriPropertiesSimilarity();
+
+  // Returns the ClusterMatchRecord for the given clusterName.
+  UriPropertiesDualReadMonitor.ClusterMatchRecord getClusterMatchRecord(String clusterName);
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadLoadBalancerJmxMBean.java
@@ -23,6 +23,7 @@ public interface DualReadLoadBalancerJmxMBean
 
   int getClusterPropertiesErrorCount();
 
+  @Deprecated
   int getUriPropertiesErrorCount();
 
   // Evict count is incremented when cache grows to the max size and entries get evicted.
@@ -30,6 +31,7 @@ public interface DualReadLoadBalancerJmxMBean
 
   int getClusterPropertiesEvictCount();
 
+  @Deprecated
   int getUriPropertiesEvictCount();
 
   // Entries become out of sync when:
@@ -41,5 +43,8 @@ public interface DualReadLoadBalancerJmxMBean
 
   int getClusterPropertiesOutOfSyncCount();
 
+  @Deprecated
   int getUriPropertiesOutOfSyncCount();
+
+  double getUriPropertiesSimilarity();
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
@@ -60,15 +60,23 @@ public class DualReadStateManager
 
   private final DualReadLoadBalancerJmx _dualReadLoadBalancerJmx;
 
-  private final UriPropertiesDualReadMonitor _uriPropertiesDualReadMonitor;
   private final DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor _servicePropertiesDualReadMonitor;
   private final DualReadLoadBalancerMonitor.ClusterPropertiesDualReadMonitor _clusterPropertiesDualReadMonitor;
+  private final UriPropertiesDualReadMonitor _uriPropertiesDualReadMonitor;
+  private final boolean _monitorUriProperties;
 
-
+  @Deprecated
   public DualReadStateManager(DualReadModeProvider dualReadModeProvider, ScheduledExecutorService executorService)
+  {
+    this(dualReadModeProvider, executorService, false);
+  }
+
+  public DualReadStateManager(DualReadModeProvider dualReadModeProvider, ScheduledExecutorService executorService,
+      boolean monitorUriProperties)
   {
     _dualReadLoadBalancerJmx = new DualReadLoadBalancerJmx();
     Clock clock = SystemClock.instance();
+    _monitorUriProperties = monitorUriProperties;
     _uriPropertiesDualReadMonitor = new UriPropertiesDualReadMonitor(_dualReadLoadBalancerJmx);
     _servicePropertiesDualReadMonitor = new DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor(
         _dualReadLoadBalancerJmx, clock);
@@ -171,7 +179,8 @@ public class DualReadStateManager
 
   private void reportUriPropertiesData(String propertyName, UriProperties property, boolean fromNewLb)
   {
-    if (_clusterDualReadModes.getOrDefault(propertyName, _dualReadMode) == DualReadModeProvider.DualReadMode.DUAL_READ)
+    if (_monitorUriProperties &&
+        _clusterDualReadModes.getOrDefault(propertyName, _dualReadMode) == DualReadModeProvider.DualReadMode.DUAL_READ)
     {
       _uriPropertiesDualReadMonitor.reportData(propertyName, property, fromNewLb);
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/DualReadStateManager.java
@@ -60,7 +60,7 @@ public class DualReadStateManager
 
   private final DualReadLoadBalancerJmx _dualReadLoadBalancerJmx;
 
-  private final DualReadLoadBalancerMonitor.UriPropertiesDualReadMonitor _uriPropertiesDualReadMonitor;
+  private final UriPropertiesDualReadMonitor _uriPropertiesDualReadMonitor;
   private final DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor _servicePropertiesDualReadMonitor;
   private final DualReadLoadBalancerMonitor.ClusterPropertiesDualReadMonitor _clusterPropertiesDualReadMonitor;
 
@@ -69,8 +69,7 @@ public class DualReadStateManager
   {
     _dualReadLoadBalancerJmx = new DualReadLoadBalancerJmx();
     Clock clock = SystemClock.instance();
-    _uriPropertiesDualReadMonitor = new DualReadLoadBalancerMonitor.UriPropertiesDualReadMonitor(
-        _dualReadLoadBalancerJmx, clock);
+    _uriPropertiesDualReadMonitor = new UriPropertiesDualReadMonitor(_dualReadLoadBalancerJmx);
     _servicePropertiesDualReadMonitor = new DualReadLoadBalancerMonitor.ServicePropertiesDualReadMonitor(
         _dualReadLoadBalancerJmx, clock);
     _clusterPropertiesDualReadMonitor = new DualReadLoadBalancerMonitor.ClusterPropertiesDualReadMonitor(
@@ -174,8 +173,7 @@ public class DualReadStateManager
   {
     if (_clusterDualReadModes.getOrDefault(propertyName, _dualReadMode) == DualReadModeProvider.DualReadMode.DUAL_READ)
     {
-      String version = property.getVersion() + "|" + property.Uris().size();
-      _uriPropertiesDualReadMonitor.reportData(propertyName, property, version, fromNewLb);
+      _uriPropertiesDualReadMonitor.reportData(propertyName, property, fromNewLb);
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
@@ -5,11 +5,11 @@ import com.linkedin.d2.balancer.properties.UriProperties;
 import com.linkedin.util.RateLimitedLogger;
 import com.linkedin.util.clock.SystemClock;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -17,10 +17,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class UriPropertiesDualReadMonitor {
+public class UriPropertiesDualReadMonitor
+{
   private static final Logger LOG = LoggerFactory.getLogger(UriPropertiesDualReadMonitor.class);
 
-  private final ConcurrentHashMap<String, ClusterMatchRecord> _clusters = new ConcurrentHashMap<>();
+  private final HashMap<String, ClusterMatchRecord> _clusters = new HashMap<>();
   // Limit error report logging to every 10 minutes
   private final RateLimitedLogger RATE_LIMITED_LOGGER =
       new RateLimitedLogger(LOG, TimeUnit.MINUTES.toMillis(10), SystemClock.instance());
@@ -28,86 +29,96 @@ public class UriPropertiesDualReadMonitor {
   private int _matchedUris = 0;
   private final DualReadLoadBalancerJmx _dualReadLoadBalancerJmx;
 
-  public UriPropertiesDualReadMonitor(DualReadLoadBalancerJmx dualReadLoadBalancerJmx) {
+  public UriPropertiesDualReadMonitor(DualReadLoadBalancerJmx dualReadLoadBalancerJmx)
+  {
     _dualReadLoadBalancerJmx = dualReadLoadBalancerJmx;
   }
 
-  public void reportData(String clusterName, UriProperties property, boolean fromNewLb) {
+  public synchronized void reportData(String clusterName, UriProperties property, boolean fromNewLb)
+  {
     ClusterMatchRecord cluster = _clusters.computeIfAbsent(clusterName, k -> new ClusterMatchRecord());
 
-    // Both zk and indis threads can race to report their data to the same cluster and perform operations on the total
-    // uris and matched uris counts at the same time, which can lead to incorrect results and unexpected behaviors.
-    // We need to lock per cluster when editing its ClusterMatchRecord, and release the lock after all operations done.
-    synchronized (cluster) {
-      if (fromNewLb) {
-        cluster._newLb = property;
-      } else {
-        cluster._oldLb = property;
-      }
+    if (fromNewLb)
+    {
+      cluster._newLb = property;
+    }
+    else
+    {
+      cluster._oldLb = property;
+    }
 
-      _totalUris -= cluster._uris;
-      _matchedUris -= cluster._matched;
+    _totalUris -= cluster._uris;
+    _matchedUris -= cluster._matched;
 
-      LOG.debug("Updated URI properties for cluster {}:\nOld LB: {}\nNew LB: {}",
-          clusterName, cluster._oldLb, cluster._newLb);
+    LOG.debug("Updated URI properties for cluster {}:\nOld LB: {}\nNew LB: {}",
+        clusterName, cluster._oldLb, cluster._newLb);
 
-      if (cluster._oldLb == null && cluster._newLb == null) {
-        _clusters.remove(clusterName);
-        updateJmxMetrics(clusterName, null);
-        return;
-      }
+    if (cluster._oldLb == null && cluster._newLb == null)
+    {
+      _clusters.remove(clusterName);
+      updateJmxMetrics(clusterName, null);
+      return;
+    }
 
-      cluster._matched = 0;
+    cluster._matched = 0;
 
-      if (cluster._oldLb == null || cluster._newLb == null) {
-        LOG.debug("Added new URI properties for {} for {} LB.", clusterName, fromNewLb ? "New" : "Old");
+    if (cluster._oldLb == null || cluster._newLb == null)
+    {
+      LOG.debug("Added new URI properties for {} for {} LB.", clusterName, fromNewLb ? "New" : "Old");
 
-        cluster._uris = (cluster._oldLb == null) ? cluster._newLb.Uris().size() : cluster._oldLb.Uris().size();
-        _totalUris += cluster._uris;
-
-        updateJmxMetrics(clusterName, cluster);
-        return;
-      }
-
-      cluster._uris = cluster._oldLb.Uris().size();
-      Set<URI> newLbUris = new HashSet<>(cluster._newLb.Uris());
-
-      for (URI uri : cluster._oldLb.Uris()) {
-        if (!newLbUris.remove(uri)) {
-          continue;
-        }
-
-        if (compareURI(uri, cluster._oldLb, cluster._newLb)) {
-          cluster._matched++;
-        }
-      }
-      // add the remaining unmatched URIs in newLbUris to the uri count
-      cluster._uris += newLbUris.size();
-
-      if (cluster._matched != cluster._uris) {
-        infoOrDebugIfLimited(
-            "Mismatched uri properties for cluster {} (match score: {}, total uris: {}):\nOld LB: {}\nNew LB: {}",
-            clusterName, (double) cluster._matched / (double) cluster._uris, cluster._uris, cluster._oldLb,
-            cluster._newLb);
-      } else {
-        LOG.debug("Matched uri properties for cluster {} (matched {} out of {} URIs)", clusterName,
-            cluster._matched, cluster._uris);
-      }
-
+      cluster._uris = (cluster._oldLb == null) ? cluster._newLb.Uris().size() : cluster._oldLb.Uris().size();
       _totalUris += cluster._uris;
-      _matchedUris += cluster._matched;
 
       updateJmxMetrics(clusterName, cluster);
+      return;
     }
+
+    cluster._uris = cluster._oldLb.Uris().size();
+    Set<URI> newLbUris = new HashSet<>(cluster._newLb.Uris());
+
+    for (URI uri : cluster._oldLb.Uris())
+    {
+      if (!newLbUris.remove(uri))
+      {
+        continue;
+      }
+
+      if (compareURI(uri, cluster._oldLb, cluster._newLb))
+      {
+        cluster._matched++;
+      }
+    }
+    // add the remaining unmatched URIs in newLbUris to the uri count
+    cluster._uris += newLbUris.size();
+
+    if (cluster._matched != cluster._uris)
+    {
+      infoOrDebugIfLimited(
+          "Mismatched uri properties for cluster {} (match score: {}, total uris: {}):\nOld LB: {}\nNew LB: {}",
+          clusterName, (double) cluster._matched / (double) cluster._uris, cluster._uris, cluster._oldLb,
+          cluster._newLb);
+    }
+    else
+    {
+      LOG.debug("Matched uri properties for cluster {} (matched {} out of {} URIs)", clusterName,
+          cluster._matched, cluster._uris);
+    }
+
+    _totalUris += cluster._uris;
+    _matchedUris += cluster._matched;
+
+    updateJmxMetrics(clusterName, cluster);
   }
 
-  private void updateJmxMetrics(String clusterName, ClusterMatchRecord cluster) {
+  private void updateJmxMetrics(String clusterName, ClusterMatchRecord cluster)
+  {
     // set a copy of cluster match record to jmx to avoid jmx reading the record in the middle of an update
     _dualReadLoadBalancerJmx.setClusterMatchRecord(clusterName, cluster == null ? null : cluster.copy());
     _dualReadLoadBalancerJmx.setUriPropertiesSimilarity((double) _matchedUris / (double) _totalUris);
   }
 
-  private static boolean compareURI(URI uri, UriProperties oldLb, UriProperties newLb) {
+  private static boolean compareURI(URI uri, UriProperties oldLb, UriProperties newLb)
+  {
     String clusterName = oldLb.getClusterName();
     return compareMaps("partition desc", clusterName, uri, UriProperties::getPartitionDesc, oldLb, newLb) &&
         compareMaps("specific properties", clusterName, uri, UriProperties::getUriSpecificProperties, oldLb, newLb);
@@ -116,10 +127,12 @@ public class UriPropertiesDualReadMonitor {
   private static <K, V> boolean compareMaps(
       String type, String cluster, URI uri, Function<UriProperties, Map<URI, Map<K, V>>> extractor,
       UriProperties oldLb, UriProperties newLb
-  ) {
+  )
+  {
     Map<K, V> oldData = extractor.apply(oldLb).get(uri);
     Map<K, V> newData = extractor.apply(newLb).get(uri);
-    if (Objects.equals(oldData, newData)) {
+    if (Objects.equals(oldData, newData))
+    {
       return true;
     }
 
@@ -128,30 +141,38 @@ public class UriPropertiesDualReadMonitor {
     return false;
   }
 
-  private void infoOrDebugIfLimited(String msg, Object... args) {
-    if (RATE_LIMITED_LOGGER.logAllowed()) {
+  private void infoOrDebugIfLimited(String msg, Object... args)
+  {
+    if (RATE_LIMITED_LOGGER.logAllowed())
+    {
       LOG.info(msg, args);
-    } else {
+    }
+    else
+    {
       LOG.debug(msg, args);
     }
   }
 
   @VisibleForTesting
-  int getTotalUris() {
+  synchronized int getTotalUris()
+  {
     return _totalUris;
   }
 
   @VisibleForTesting
-  int getMatchedUris() {
+  synchronized int getMatchedUris()
+  {
     return _matchedUris;
   }
 
   @VisibleForTesting
-  ClusterMatchRecord getMatchRecord(String cluster) {
-    return _clusters.get(cluster);
+  synchronized ClusterMatchRecord getMatchRecord(String cluster)
+  {
+    return _clusters.get(cluster).copy();
   }
 
-  public static class ClusterMatchRecord {
+  public static class ClusterMatchRecord
+  {
     @Nullable
     @VisibleForTesting
     UriProperties _oldLb;
@@ -166,23 +187,27 @@ public class UriPropertiesDualReadMonitor {
     @VisibleForTesting
     int _matched;
 
-    private ClusterMatchRecord() {
+    private ClusterMatchRecord()
+    {
     }
 
     @VisibleForTesting
-    ClusterMatchRecord(@Nullable UriProperties oldLb, @Nullable UriProperties newLb, int uris, int matched) {
+    ClusterMatchRecord(@Nullable UriProperties oldLb, @Nullable UriProperties newLb, int uris, int matched)
+    {
       _oldLb = oldLb;
       _newLb = newLb;
       _uris = uris;
       _matched = matched;
     }
 
-    public synchronized ClusterMatchRecord copy() {
+    ClusterMatchRecord copy()
+    {
       return new ClusterMatchRecord(_oldLb, _newLb, _uris, _matched);
     }
 
     @Override
-    public synchronized String toString() {
+    public String toString()
+    {
       return "ClusterMatchRecord{ " +
           "\nTotal Uris: " + _uris + ", Matched: " + _matched +
           "\nOld LB: " + _oldLb +
@@ -191,14 +216,18 @@ public class UriPropertiesDualReadMonitor {
     }
 
     @Override
-    public synchronized boolean equals(Object obj) {
-      if (this == obj) {
+    public boolean equals(Object obj)
+    {
+      if (this == obj)
+      {
         return true;
       }
-      if (obj == null) {
+      if (obj == null)
+      {
         return false;
       }
-      if (getClass() != obj.getClass()) {
+      if (getClass() != obj.getClass())
+      {
         return false;
       }
 
@@ -211,7 +240,8 @@ public class UriPropertiesDualReadMonitor {
     }
 
     @Override
-    public synchronized int hashCode() {
+    public int hashCode()
+    {
       return Objects.hash(_oldLb, _newLb, _uris, _matched);
     }
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
@@ -137,6 +137,11 @@ public class UriPropertiesDualReadMonitor {
     return _matchedUris;
   }
 
+  @VisibleForTesting
+  ClusterMatchRecord getMatchRecord(String cluster) {
+    return _clusters.get(cluster);
+  }
+
   public static class ClusterMatchRecord {
     @Nullable
     @VisibleForTesting

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
@@ -85,9 +85,12 @@ public class UriPropertiesDualReadMonitor {
       cluster._uris += newLbUris.size();
 
       if (cluster._matched != cluster._uris) {
-        RATE_LIMITED_LOGGER.info("Mismatched cluster properties for {} (match score: {}, total uris: {}):"
-                + "\nOld LB: {}\nNew LB: {}",
-            clusterName, cluster._matched / cluster._uris, cluster._uris, cluster._oldLb, cluster._newLb);
+        String msg = String.format("Mismatched cluster properties for %s (match score: %f, total uris: %d):"
+                + "\nOld LB: %s\nNew LB: %s",
+            clusterName, (double) cluster._matched / (double) cluster._uris, cluster._uris, cluster._oldLb,
+            cluster._newLb);
+        RATE_LIMITED_LOGGER.info(msg);
+        LOG.debug(msg);
       }
 
       _totalUris += cluster._uris;

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
@@ -85,12 +85,10 @@ public class UriPropertiesDualReadMonitor {
       cluster._uris += newLbUris.size();
 
       if (cluster._matched != cluster._uris) {
-        String msg = String.format("Mismatched cluster properties for %s (match score: %f, total uris: %d):"
-                + "\nOld LB: %s\nNew LB: %s",
+        infoOrDebugIfLimited(
+            "Mismatched cluster properties for {} (match score: {}, total uris: {}):\nOld LB: {}\nNew LB: {}",
             clusterName, (double) cluster._matched / (double) cluster._uris, cluster._uris, cluster._oldLb,
             cluster._newLb);
-        RATE_LIMITED_LOGGER.info(msg);
-        LOG.debug(msg);
       }
 
       _totalUris += cluster._uris;
@@ -127,6 +125,14 @@ public class UriPropertiesDualReadMonitor {
     return false;
   }
 
+  private void infoOrDebugIfLimited(String msg, Object... args) {
+    if (RATE_LIMITED_LOGGER.logAllowed()) {
+      LOG.info(msg, args);
+    } else {
+      LOG.debug(msg, args);
+    }
+  }
+
   @VisibleForTesting
   int getTotalUris() {
     return _totalUris;
@@ -157,10 +163,11 @@ public class UriPropertiesDualReadMonitor {
     @VisibleForTesting
     int _matched;
 
-    public ClusterMatchRecord() {
+    private ClusterMatchRecord() {
     }
 
-    public ClusterMatchRecord(@Nullable UriProperties oldLb, @Nullable UriProperties newLb, int uris, int matched) {
+    @VisibleForTesting
+    ClusterMatchRecord(@Nullable UriProperties oldLb, @Nullable UriProperties newLb, int uris, int matched) {
       _oldLb = oldLb;
       _newLb = newLb;
       _uris = uris;

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
@@ -1,0 +1,122 @@
+package com.linkedin.d2.balancer.dualread;
+
+import com.linkedin.d2.balancer.properties.UriProperties;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UriPropertiesDualReadMonitor
+{
+  private static final Logger LOG = LoggerFactory.getLogger(UriPropertiesDualReadMonitor.class);
+
+  private final Map<String, Cluster> _clusters = new HashMap<>();
+  private double _totalUris = 0;
+  private double _matchedUris = 0;
+  private final DualReadLoadBalancerJmx _dualReadLoadBalancerJmx;
+
+  public UriPropertiesDualReadMonitor(DualReadLoadBalancerJmx dualReadLoadBalancerJmx)
+  {
+    _dualReadLoadBalancerJmx = dualReadLoadBalancerJmx;
+  }
+
+  public void reportData(String clusterName, UriProperties property, boolean fromNewLb)
+  {
+    Cluster cluster = _clusters.computeIfAbsent(clusterName, k -> new Cluster());
+
+    if (fromNewLb)
+    {
+      cluster._newLb = property;
+    }
+    else
+    {
+      cluster._oldLb = property;
+    }
+
+
+    _totalUris -= cluster._uris;
+    _matchedUris -= cluster._matched;
+
+    if (cluster._oldLb == null && cluster._newLb == null)
+    {
+      _clusters.remove(clusterName);
+      return;
+    }
+
+    cluster._matched = 0;
+
+    if (cluster._oldLb == null || cluster._newLb == null)
+    {
+      cluster._uris = (cluster._oldLb == null) ? cluster._oldLb.Uris().size() : cluster._newLb.Uris().size();
+      _totalUris += cluster._uris;
+      return;
+    }
+
+    cluster._uris = cluster._oldLb.Uris().size();
+    Set<URI> newLbUris = new HashSet<>(cluster._newLb.Uris());
+
+    for (URI uri : cluster._oldLb.Uris())
+    {
+      if (!newLbUris.remove(uri))
+      {
+        continue;
+      }
+
+      if (compareURI(uri, cluster._oldLb, cluster._newLb))
+      {
+        cluster._matched++;
+      }
+    }
+
+    cluster._uris += newLbUris.size();
+
+    _totalUris += cluster._uris;
+    _matchedUris += cluster._matched;
+    _dualReadLoadBalancerJmx.setUriPropertiesSimilarity(_matchedUris / _totalUris);
+  }
+
+  private static class Cluster
+  {
+    @Nullable
+    private UriProperties _oldLb;
+    @Nullable
+    private UriProperties _newLb;
+    private double _uris;
+    private double _matched;
+  }
+
+  private static boolean compareURI(URI uri, UriProperties oldLb, UriProperties newLb)
+  {
+    String clusterName = oldLb.getClusterName();
+    return compareMaps("partition desc", clusterName, uri, UriProperties::getPartitionDesc, oldLb, newLb) &&
+        compareMaps("specific properties", clusterName, uri, UriProperties::getUriSpecificProperties, oldLb, newLb);
+  }
+
+  private static <K, V> boolean compareMaps(
+      String type, String cluster, URI uri, Function<UriProperties, Map<URI, Map<K, V>>> extractor,
+      UriProperties oldLb, UriProperties newLb
+  )
+  {
+    Map<K, V> oldData = extractor.apply(oldLb).get(uri);
+    Map<K, V> newData = extractor.apply(newLb).get(uri);
+    if (Objects.equals(oldData, newData) || isEmptyMap(oldData) == isEmptyMap(newData))
+    {
+      return true;
+    }
+
+    LOG.debug("URI {} for {}/{} mismatched between old and new LB.\nOld LB: {}\nNew LB: {}",
+        type, cluster, uri, oldData, newData);
+    return false;
+  }
+
+  private static <K, V> boolean isEmptyMap(Map<K, V> map)
+  {
+    return map == null || map.isEmpty();
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitor.java
@@ -86,9 +86,12 @@ public class UriPropertiesDualReadMonitor {
 
       if (cluster._matched != cluster._uris) {
         infoOrDebugIfLimited(
-            "Mismatched cluster properties for {} (match score: {}, total uris: {}):\nOld LB: {}\nNew LB: {}",
+            "Mismatched uri properties for cluster {} (match score: {}, total uris: {}):\nOld LB: {}\nNew LB: {}",
             clusterName, (double) cluster._matched / (double) cluster._uris, cluster._uris, cluster._oldLb,
             cluster._newLb);
+      } else {
+        LOG.debug("Matched uri properties for cluster {} (matched {} out of {} URIs)", clusterName,
+            cluster._matched, cluster._uris);
       }
 
       _totalUris += cluster._uris;

--- a/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
@@ -127,7 +127,7 @@ public class UriPropertiesDualReadMonitorTest {
   @DataProvider
   public Object[][] reportDataInMultiThreadsDataProvider() {
     // simulate different orders that the data is reported between the old and new Lbs.
-    return new Object[][] {
+    return new Object[][]{
         {
             Arrays.asList(
                 new ImmutablePair<>(URI_PROPERTIES_1, false),
@@ -137,11 +137,11 @@ public class UriPropertiesDualReadMonitorTest {
             )
         },
         {
-          Arrays.asList(
-            new ImmutablePair<>(URI_PROPERTIES_1, false),
-            new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, false),
-            new ImmutablePair<>(URI_PROPERTIES_1, true),
-            new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, true)
+            Arrays.asList(
+                new ImmutablePair<>(URI_PROPERTIES_1, false),
+                new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, false),
+                new ImmutablePair<>(URI_PROPERTIES_1, true),
+                new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, true)
             )
         },
         {
@@ -149,7 +149,7 @@ public class UriPropertiesDualReadMonitorTest {
                 new ImmutablePair<>(URI_PROPERTIES_1, false),
                 new ImmutablePair<>(URI_PROPERTIES_1, true),
                 new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, true),
-            new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, false)
+                new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, false)
             )
         },
         {
@@ -164,8 +164,9 @@ public class UriPropertiesDualReadMonitorTest {
         }
     };
   }
+
   @SuppressWarnings("ResultOfMethodCallIgnored")
-  @Test(dataProvider = "reportDataInMultiThreadsDataProvider")
+  @Test(dataProvider = "reportDataInMultiThreadsDataProvider", invocationCount = 10)
   public void testReportDataInMultiThreads(List<Pair<UriProperties, Boolean>> properties) {
     UriPropertiesDualReadMonitorTestFixture fixture = new UriPropertiesDualReadMonitorTestFixture();
     UriPropertiesDualReadMonitor monitor = fixture.getMonitor();
@@ -173,9 +174,10 @@ public class UriPropertiesDualReadMonitorTest {
     ExecutorService executor = Executors.newFixedThreadPool(2,
         new NamedThreadFactory("UriPropertiesDualReadMonitorTest"));
     properties.forEach(p -> executor.execute(() -> reportAndVerifyState(monitor, p.getLeft(), p.getRight())));
+    
     try {
       executor.shutdown();
-      executor.awaitTermination(500, TimeUnit.MILLISECONDS);
+      executor.awaitTermination(5000, TimeUnit.MILLISECONDS);
       // similarity eventually converge to 1
       assertEquals((double) monitor.getMatchedUris() / (double) monitor.getTotalUris(), 1.0);
     } catch (InterruptedException e) {
@@ -189,8 +191,8 @@ public class UriPropertiesDualReadMonitorTest {
     // e.g: when total uris = 1, matched uris = 1, if reporting URI_PROPERTIES_URI_1_AND_2 for new and old Lbs are
     // executed concurrently, total uris will decrement by 1 twice and become -1.
     // We verify that doesn't happen no matter what order the data is reported between the old and new Lbs.
-    assertTrue(monitor.getTotalUris() >= 0);
-    assertTrue(monitor.getMatchedUris() >= 0);
+    assertTrue(monitor.getTotalUris() >= 0 && monitor.getTotalUris() <= 2);
+    assertTrue(monitor.getMatchedUris() >= 0 && monitor.getMatchedUris() <= 2);
   }
 
   private ClusterMatchRecord createMatchRecord(UriProperties oldLb, UriProperties newLb, int uris, int matched) {

--- a/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
@@ -1,0 +1,153 @@
+package com.linkedin.d2.balancer.dualread;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.UriProperties;
+import java.util.Collections;
+import java.util.Map;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.Test;
+
+import static com.linkedin.d2.balancer.dualread.UriPropertiesDualReadMonitor.*;
+import static com.linkedin.d2.util.TestDataHelper.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class UriPropertiesDualReadMonitorTest {
+  private static final String CLUSTER_1 = "cluster1";
+  private static final String CLUSTER_2 = "cluster2";
+  private static final Map<Integer, PartitionData> WEIGHT_1_PARTITION_DATA = ImmutableMap.of(0, new PartitionData(1));
+  private static final Map<Integer, PartitionData> WEIGHT_2_PARTITION_DATA = ImmutableMap.of(0, new PartitionData(2));
+  private static final Map<String, Object> SIZE_ONE_URI_SPECIFIC_PROPERTIES = ImmutableMap.of("foo", "foo-value");
+  private static final Map<String, Object> SIZE_TWO_URI_SPECIFIC_PROPERTIES = ImmutableMap.of(
+      "foo", "foo-value",
+      "bar", 1);
+  private static final UriProperties URI_PROPERTIES_1 = new UriProperties(CLUSTER_1,
+      ImmutableMap.of(URI_1, WEIGHT_1_PARTITION_DATA),
+      ImmutableMap.of(URI_1, Collections.emptyMap()));
+
+  private static final UriProperties URI_PROPERTIES_2 = new UriProperties(CLUSTER_1,
+      ImmutableMap.of(URI_2, WEIGHT_1_PARTITION_DATA),
+      ImmutableMap.of(URI_2, Collections.emptyMap()));
+
+  private static final UriProperties URI_PROPERTIES_URI_1_AND_2 = new UriProperties(CLUSTER_1,
+      ImmutableMap.of(URI_1, WEIGHT_1_PARTITION_DATA, URI_2, WEIGHT_1_PARTITION_DATA),
+      ImmutableMap.of(URI_1, Collections.emptyMap(), URI_2, Collections.emptyMap()));
+
+  private static final UriProperties URI_PROPERTIES_URI_3_AND_4 = new UriProperties(CLUSTER_2,
+      ImmutableMap.of(URI_3, WEIGHT_1_PARTITION_DATA, URI_4, WEIGHT_1_PARTITION_DATA),
+      ImmutableMap.of(URI_3, Collections.emptyMap(), URI_4, SIZE_ONE_URI_SPECIFIC_PROPERTIES));
+
+  private static final UriProperties URI_PROPERTIES_URI_3_DIFF_SPECIFIC_PROPERTIES_AND_4_DIFF_WEIGHT =
+      new UriProperties(CLUSTER_2,
+          ImmutableMap.of(URI_3, WEIGHT_1_PARTITION_DATA, URI_4, WEIGHT_2_PARTITION_DATA),
+          ImmutableMap.of(URI_3, SIZE_ONE_URI_SPECIFIC_PROPERTIES, URI_4, SIZE_ONE_URI_SPECIFIC_PROPERTIES));
+
+  private static final UriProperties URI_PROPERTIES_URI_3_ANOTHER_DIFF_SPECIFIC_PROPERTIES_AND_4_DIFF_WEIGHT =
+      new UriProperties(CLUSTER_2,
+          ImmutableMap.of(URI_3, WEIGHT_1_PARTITION_DATA, URI_4, WEIGHT_2_PARTITION_DATA),
+          ImmutableMap.of(URI_3, SIZE_TWO_URI_SPECIFIC_PROPERTIES, URI_4, SIZE_ONE_URI_SPECIFIC_PROPERTIES));
+
+  @Test
+  public void testReportData() {
+    UriPropertiesDualReadMonitorTestFixture fixture = new UriPropertiesDualReadMonitorTestFixture();
+    UriPropertiesDualReadMonitor monitor = fixture.getMonitor();
+
+    // new lb has uri 1
+    monitor.reportData(CLUSTER_1, URI_PROPERTIES_1, true);
+    verifyJmxMetricParams(fixture, CLUSTER_1,
+        createMatchRecord(null, URI_PROPERTIES_1, 1, 0),
+        0.0);
+
+    // old lb has uri 2
+    monitor.reportData(CLUSTER_1, URI_PROPERTIES_2, false);
+    verifyJmxMetricParams(fixture, CLUSTER_1,
+        createMatchRecord(URI_PROPERTIES_2, URI_PROPERTIES_1, 2, 0),
+        0.0);
+
+    // old lb updated with both uri 1 and 2
+    monitor.reportData(CLUSTER_1, URI_PROPERTIES_URI_1_AND_2, false);
+    verifyJmxMetricParams(fixture, CLUSTER_1,
+        createMatchRecord(URI_PROPERTIES_URI_1_AND_2, URI_PROPERTIES_1, 2, 1),
+        0.5);
+
+    // new lb updated with both uri 1 and 2
+    monitor.reportData(CLUSTER_1, URI_PROPERTIES_URI_1_AND_2, true);
+    verifyJmxMetricParams(fixture, CLUSTER_1,
+        createMatchRecord(URI_PROPERTIES_URI_1_AND_2, URI_PROPERTIES_URI_1_AND_2, 2, 2),
+        1.0);
+
+    // add data for cluster 2, old lb with uri 3 and 4
+    monitor.reportData(CLUSTER_2, URI_PROPERTIES_URI_3_AND_4, false);
+    assertEquals(monitor.getTotalUris(), 4);
+    assertEquals(monitor.getMatchedUris(), 2);
+    verifyJmxMetricParams(fixture, CLUSTER_2,
+        createMatchRecord(URI_PROPERTIES_URI_3_AND_4, null, 2, 0),
+        0.5);
+
+    // new lb updated with uri 3 with different uri specific properties and uri 4 with different weight
+    monitor.reportData(CLUSTER_2, URI_PROPERTIES_URI_3_DIFF_SPECIFIC_PROPERTIES_AND_4_DIFF_WEIGHT, true);
+    assertEquals(monitor.getTotalUris(), 4);
+    assertEquals(monitor.getMatchedUris(), 2);
+    verifyJmxMetricParams(fixture, CLUSTER_2,
+        createMatchRecord(URI_PROPERTIES_URI_3_AND_4, URI_PROPERTIES_URI_3_DIFF_SPECIFIC_PROPERTIES_AND_4_DIFF_WEIGHT,
+            2, 0),
+        0.5);
+
+    // old lb updated with uri 3 with still different uri specific properties and uri 4 with same weight as new lb
+    monitor.reportData(CLUSTER_2, URI_PROPERTIES_URI_3_ANOTHER_DIFF_SPECIFIC_PROPERTIES_AND_4_DIFF_WEIGHT, false);
+    assertEquals(monitor.getTotalUris(), 4);
+    assertEquals(monitor.getMatchedUris(), 3);
+    verifyJmxMetricParams(fixture, CLUSTER_2,
+        createMatchRecord(URI_PROPERTIES_URI_3_ANOTHER_DIFF_SPECIFIC_PROPERTIES_AND_4_DIFF_WEIGHT,
+            URI_PROPERTIES_URI_3_DIFF_SPECIFIC_PROPERTIES_AND_4_DIFF_WEIGHT,
+            2, 1),
+        0.75);
+
+    // delete both lbs data for cluster 2
+    monitor.reportData(CLUSTER_2, null, true);
+    monitor.reportData(CLUSTER_2, null, false);
+    verifyJmxMetricParams(fixture, CLUSTER_2, null, 1.0);
+  }
+
+  private ClusterMatchRecord createMatchRecord(UriProperties oldLb, UriProperties newLb, int uris, int matched) {
+    ClusterMatchRecord cluster = new ClusterMatchRecord();
+    cluster._oldLb = oldLb;
+    cluster._newLb = newLb;
+    cluster._uris = uris;
+    cluster._matched = matched;
+    return cluster;
+  }
+
+  private void verifyJmxMetricParams(UriPropertiesDualReadMonitorTestFixture fixture, String clusterName,
+      ClusterMatchRecord clusterMatchRecord, double totalSimilarity) {
+    assertEquals(fixture._clusterNameCaptor.getValue(), clusterName);
+    assertEquals(fixture._clusterMatchCaptor.getValue(), clusterMatchRecord);
+    assertEquals(fixture._similarityCaptor.getValue(), totalSimilarity);
+  }
+
+  private static class UriPropertiesDualReadMonitorTestFixture {
+    @Mock
+    DualReadLoadBalancerJmx _mockJmx;
+    @Captor
+    ArgumentCaptor<String> _clusterNameCaptor;
+    @Captor
+    ArgumentCaptor<ClusterMatchRecord> _clusterMatchCaptor;
+    @Captor
+    ArgumentCaptor<Double> _similarityCaptor;
+
+    UriPropertiesDualReadMonitorTestFixture() {
+      MockitoAnnotations.initMocks(this);
+      doNothing().when(_mockJmx).setUriPropertiesSimilarity(_similarityCaptor.capture());
+      doNothing().when(_mockJmx).setClusterMatchRecord(_clusterNameCaptor.capture(), _clusterMatchCaptor.capture());
+    }
+
+    UriPropertiesDualReadMonitor getMonitor() {
+      return new UriPropertiesDualReadMonitor(_mockJmx);
+    }
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
@@ -131,6 +131,7 @@ public class UriPropertiesDualReadMonitorTest {
     // simulate different orders that the data is reported between the old and new Lbs.
     return new Object[][]{
         {
+            // typical case where each lb gets an update alternative
             new ConcurrentLinkedDeque<>(Arrays.asList(
                 new ImmutablePair<>(URI_PROPERTIES_1, false),
                 new ImmutablePair<>(URI_PROPERTIES_1, true),
@@ -139,6 +140,7 @@ public class UriPropertiesDualReadMonitorTest {
             ))
         },
         {
+            // old lb gets all updates first
             new ConcurrentLinkedDeque<>(Arrays.asList(
                 new ImmutablePair<>(URI_PROPERTIES_1, false),
                 new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, false),
@@ -147,6 +149,7 @@ public class UriPropertiesDualReadMonitorTest {
             ))
         },
         {
+           // old lb gets the last update finally
             new ConcurrentLinkedDeque<>(Arrays.asList(
                 new ImmutablePair<>(URI_PROPERTIES_1, false),
                 new ImmutablePair<>(URI_PROPERTIES_1, true),
@@ -154,6 +157,7 @@ public class UriPropertiesDualReadMonitorTest {
                 new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, false)
             ))
         },
+        // more cases with 3 updates for each lb
         {
             new ConcurrentLinkedDeque<>(Arrays.asList(
                 new ImmutablePair<>(URI_PROPERTIES_1, false),
@@ -161,6 +165,26 @@ public class UriPropertiesDualReadMonitorTest {
                 new ImmutablePair<>(URI_PROPERTIES_1, true),
                 new ImmutablePair<>(URI_PROPERTIES_1, false),
                 new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, true),
+                new ImmutablePair<>(URI_PROPERTIES_1, true)
+            ))
+        },
+        {
+            new ConcurrentLinkedDeque<>(Arrays.asList(
+                new ImmutablePair<>(URI_PROPERTIES_1, false),
+                new ImmutablePair<>(URI_PROPERTIES_1, true),
+                new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, false),
+                new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, true),
+                new ImmutablePair<>(URI_PROPERTIES_1, true),
+                new ImmutablePair<>(URI_PROPERTIES_1, false)
+            ))
+        },
+        {
+            new ConcurrentLinkedDeque<>(Arrays.asList(
+                new ImmutablePair<>(URI_PROPERTIES_1, false),
+                new ImmutablePair<>(URI_PROPERTIES_1, true),
+                new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, true),
+                new ImmutablePair<>(URI_PROPERTIES_URI_1_AND_2, false),
+                new ImmutablePair<>(URI_PROPERTIES_1, false),
                 new ImmutablePair<>(URI_PROPERTIES_1, true)
             ))
         }

--- a/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
@@ -232,8 +232,8 @@ public class UriPropertiesDualReadMonitorTest {
     // if reportData on the same cluster are NOT synchronized, the total uris and matched uris counts could become < 0
     // or > 2.
     // e.g: when total uris = 1, matched uris = 1, if reporting URI_PROPERTIES_URI_1_AND_2 for new and old Lbs are
-    // executed concurrently, total uris will decrement by 1 twice and become -1, and matched uris will increment by 2
-    // twice and become 4.
+    // executed concurrently, both counts will decrement by 1 twice and become -1 first, and total uris will increment
+    // by 2 twice and become 4.
     // We verify that doesn't happen no matter what order the data is reported between the old and new Lbs.
     assertTrue(monitor.getTotalUris() >= 0 && monitor.getTotalUris() <= 2);
     assertTrue(monitor.getMatchedUris() >= 0 && monitor.getMatchedUris() <= 2);

--- a/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/dualread/UriPropertiesDualReadMonitorTest.java
@@ -174,12 +174,14 @@ public class UriPropertiesDualReadMonitorTest {
     ExecutorService executor = Executors.newFixedThreadPool(2,
         new NamedThreadFactory("UriPropertiesDualReadMonitorTest"));
     properties.forEach(p -> executor.execute(() -> reportAndVerifyState(monitor, p.getLeft(), p.getRight())));
-    
+
     try {
       executor.shutdown();
-      executor.awaitTermination(5000, TimeUnit.MILLISECONDS);
-      // similarity eventually converge to 1
-      assertEquals((double) monitor.getMatchedUris() / (double) monitor.getTotalUris(), 1.0);
+      boolean completed = executor.awaitTermination(5000, TimeUnit.MILLISECONDS);
+      if (completed) {
+        // similarity eventually converge to 1
+        assertEquals((double) monitor.getMatchedUris() / (double) monitor.getTotalUris(), 1.0);
+      }
     } catch (InterruptedException e) {
       Assert.fail("Tasks were interrupted");
     }

--- a/d2/src/test/java/com/linkedin/d2/jmx/D2ClientJmxManagerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/D2ClientJmxManagerTest.java
@@ -143,7 +143,7 @@ public class D2ClientJmxManagerTest {
           _servicePropertiesArgumentCaptor.capture());
       Mockito.doNothing().when(_simpleLoadBalancerState).register(_simpleLoadBalancerStateListenerCaptor.capture());
 
-      _dualReadStateManager = spy(new DualReadStateManager(_dualReadModeProvider, _executorService));
+      _dualReadStateManager = spy(new DualReadStateManager(_dualReadModeProvider, _executorService, true));
 
       doCallRealMethod().when(_dualReadStateManager).addGlobalWatcher(any());
       doCallRealMethod().when(_dualReadStateManager).addServiceWatcher(any(), any());

--- a/d2/src/test/java/com/linkedin/d2/xds/XdsToD2SampleClient.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/XdsToD2SampleClient.java
@@ -95,7 +95,7 @@ public class XdsToD2SampleClient
 
     DualReadStateManager dualReadStateManager = new DualReadStateManager(
         () -> DualReadModeProvider.DualReadMode.DUAL_READ,
-        Executors.newSingleThreadScheduledExecutor());
+        Executors.newSingleThreadScheduledExecutor(), true);
 
     XdsToD2PropertiesAdaptor adaptor = new XdsToD2PropertiesAdaptor(xdsClient, dualReadStateManager, null);
     adaptor.listenToService(serviceName);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.53.1
+version=29.54.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/pegasus-common/src/main/java/com/linkedin/util/RateLimitedLogger.java
+++ b/pegasus-common/src/main/java/com/linkedin/util/RateLimitedLogger.java
@@ -551,7 +551,7 @@ public class RateLimitedLogger implements Logger
     }
   }
 
-  private boolean logAllowed()
+  public boolean logAllowed()
   {
     final long now = _clock.currentTimeMillis();
     final long lastLog = _lastLog.get();


### PR DESCRIPTION
## Summary
Previous dual read matches URI properties only when the versions are the same (same ZK data served from ZK vs Observer), but with Kafka data served, the version will never be the same. And the OutOfSync metric was never useful since only one version of uri properties is cached for each cluster, when uri data changes frequently, the OutOfSync increases and never comes down.
This new URI matching now produces a similarity metric which represents the fraction of matching uris present in the ZK response and the observer response, just the same as how observer is monitoring the cluster uri similarity. The similarity metric may go up during downstream deployment/updates, but eventually it should be 1. The goal is to verify that client side response processing logic in INDIS is not causing uri data to drift (given that Kafka data matches ZK data on observer already). 

The Cluster and Service monitors remain unchanged.  
(This new monitor should be as expensive as the previous one since the previous one called the `.equals` method on `UriProperties`, which compares every single URI). 

## Test Done
Added unit tests. Will do manual qei testing with d2-proxy in the counterpart container PR for adding the config.