### PR TITLE
Handle HTTP/2 stream errors in tracker client and LB state updator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Handle HTTP/2 stream errors in tracker client and LB state updator.
 
 ## [29.55.0] - 2024-05-23
 - Allow HttpBridge to return RetriableRequestException for the Netty max active stream error 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.55.0] - 2024-05-14
-- Handle HTTP/2 stream errors in tracker client and LB state updator.
+- degrade hosts for HTTP/2 stream errors in Degrader and Relative LB.
 
 ## [29.55.0] - 2024-05-23
 - Allow HttpBridge to return RetriableRequestException for the Netty max active stream error 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.55.0] - 2024-05-14
 - Handle HTTP/2 stream errors in tracker client and LB state updator.
 
 ## [29.55.0] - 2024-05-23

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -762,6 +762,7 @@ public class D2ClientBuilder
 
     if (_config.enableRelativeLoadBalancer)
     {
+      // TODO: create StateUpdater.LoadBalanceConfig and pass it to the RelativeLoadBalancerStrategyFactory
       final RelativeLoadBalancerStrategyFactory relativeLoadBalancerStrategyFactory = new RelativeLoadBalancerStrategyFactory(
           _config._executorService, _config.healthCheckOperations, Collections.emptyList(), _config.eventEmitter,
           SystemClock.instance(), _config.loadBalanceStreamException);

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -217,7 +217,8 @@ public class D2ClientBuilder
                   _config.xdsChannelLoadBalancingPolicy,
                   _config.xdsChannelLoadBalancingPolicyConfig,
                   _config.subscribeToUriGlobCollection,
-                  _config._xdsServerMetricsProvider
+                  _config._xdsServerMetricsProvider,
+                  _config.loadBalanceStreamException
     );
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
@@ -724,6 +725,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  public D2ClientBuilder setLoadBalanceStreamException(boolean loadBalanceStreamException) {
+    _config.loadBalanceStreamException = loadBalanceStreamException;
+    return this;
+  }
+
   private Map<String, TransportClientFactory> createDefaultTransportClientFactories()
   {
     final Map<String, TransportClientFactory> clientFactories = new HashMap<>();
@@ -758,7 +764,7 @@ public class D2ClientBuilder
     {
       final RelativeLoadBalancerStrategyFactory relativeLoadBalancerStrategyFactory = new RelativeLoadBalancerStrategyFactory(
           _config._executorService, _config.healthCheckOperations, Collections.emptyList(), _config.eventEmitter,
-          SystemClock.instance());
+          SystemClock.instance(), _config.loadBalanceStreamException);
       loadBalancerStrategyFactories.putIfAbsent(RelativeLoadBalancerStrategy.RELATIVE_LOAD_BALANCER_STRATEGY_NAME,
           relativeLoadBalancerStrategyFactory);
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -138,6 +138,7 @@ public class D2ClientConfig
   public Map<String, ?> xdsChannelLoadBalancingPolicyConfig = null;
   public boolean subscribeToUriGlobCollection = false;
   public XdsServerMetricsProvider _xdsServerMetricsProvider = new NoOpXdsServerMetricsProvider();
+  public boolean loadBalanceStreamException = false;
 
   public D2ClientConfig()
   {
@@ -214,7 +215,8 @@ public class D2ClientConfig
                  String xdsChannelLoadBalancingPolicy,
                  Map<String, ?> xdsChannelLoadBalancingPolicyConfig,
                  boolean subscribeToUriGlobCollection,
-                 XdsServerMetricsProvider xdsServerMetricsProvider
+                 XdsServerMetricsProvider xdsServerMetricsProvider,
+                 boolean loadBalanceStreamException
       )
   {
     this.zkHosts = zkHosts;
@@ -289,5 +291,6 @@ public class D2ClientConfig
     this.xdsChannelLoadBalancingPolicyConfig = xdsChannelLoadBalancingPolicyConfig;
     this.subscribeToUriGlobCollection = subscribeToUriGlobCollection;
     this._xdsServerMetricsProvider = xdsServerMetricsProvider;
+    this.loadBalanceStreamException = loadBalanceStreamException;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -100,7 +100,8 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
     SimpleLoadBalancerState state = new SimpleLoadBalancerState(
       config._executorService, uriBus, clusterBus, serviceBus, config.clientFactories, config.loadBalancerStrategyFactories,
       config.sslContext, config.sslParameters, config.isSSLEnabled, config.partitionAccessorRegistry,
-      config.sslSessionValidatorFactory, config.deterministicSubsettingMetadataProvider, config.canaryDistributionProvider);
+      config.sslSessionValidatorFactory, config.deterministicSubsettingMetadataProvider, config.canaryDistributionProvider,
+      config.loadBalanceStreamException);
     d2ClientJmxManager.setSimpleLoadBalancerState(state);
 
     SimpleLoadBalancer simpleLoadBalancer = new SimpleLoadBalancer(state, config.lbWaitTimeout, config.lbWaitUnit, config._executorService,

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -98,7 +98,8 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    config.failoutConfigProviderFactory,
                                                    config.canaryDistributionProvider,
                                                    config.serviceDiscoveryEventEmitter,
-                                                   config.dualReadStateManager
+                                                   config.dualReadStateManager,
+                                                   config.loadBalanceStreamException
     );
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/DegraderTrackerClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/DegraderTrackerClientImpl.java
@@ -39,6 +39,7 @@ public class DegraderTrackerClientImpl extends TrackerClientImpl implements Degr
 
   private final Map<Integer, PartitionState> _partitionStates;
 
+  @Deprecated
   public DegraderTrackerClientImpl(URI uri, Map<Integer, PartitionData> partitionDataMap, TransportClient wrappedClient)
   {
     this(uri, partitionDataMap, wrappedClient, SystemClock.instance(), null,
@@ -62,6 +63,13 @@ public class DegraderTrackerClientImpl extends TrackerClientImpl implements Degr
                                Clock clock, DegraderImpl.Config config, long interval, Pattern errorStatusPattern,
                                boolean doNotSlowStart)
   {
+    this(uri, partitionDataMap, wrappedClient, clock, config, interval, errorStatusPattern, doNotSlowStart, false);
+  }
+
+  public DegraderTrackerClientImpl(URI uri, Map<Integer, PartitionData> partitionDataMap, TransportClient wrappedClient,
+      Clock clock, DegraderImpl.Config config, long interval, Pattern errorStatusPattern,
+      boolean doNotSlowStart, boolean loadBalanceStreamException)
+  {
     super(uri, partitionDataMap, wrappedClient, clock, interval,
         (status) -> errorStatusPattern.matcher(Integer.toString(status)).matches(), true, doNotSlowStart, false);
 
@@ -79,6 +87,7 @@ public class DegraderTrackerClientImpl extends TrackerClientImpl implements Degr
     {
       config.setInitialDropRate(DegraderImpl.DEFAULT_DO_NOT_SLOW_START_INITIAL_DROP_RATE);
     }
+    config.setLoadBalanceStreamException(loadBalanceStreamException);
 
     /* TrackerClient contains state for each partition, but they actually share the same DegraderImpl
      *

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientFactory.java
@@ -54,9 +54,7 @@ public class TrackerClientFactory
 
   private static final int LOG_RATE_MS = 20000;
 
-  /**
-   * @see #createTrackerClient(URI, UriProperties, ServiceProperties, String, TransportClient, Clock)
-   */
+  @Deprecated
   public static TrackerClient createTrackerClient(URI uri,
                                            UriProperties uriProperties,
                                            ServiceProperties serviceProperties,
@@ -64,6 +62,17 @@ public class TrackerClientFactory
                                            TransportClient transportClient)
   {
     return createTrackerClient(uri, uriProperties, serviceProperties, loadBalancerStrategyName, transportClient, SystemClock.instance());
+  }
+
+  public static TrackerClient createTrackerClient(URI uri,
+      UriProperties uriProperties,
+      ServiceProperties serviceProperties,
+      String loadBalancerStrategyName,
+      TransportClient transportClient,
+      boolean loadBalanceStreamException)
+  {
+    return createTrackerClient(uri, uriProperties, serviceProperties, loadBalancerStrategyName, transportClient,
+        SystemClock.instance(), loadBalanceStreamException);
   }
 
   /**
@@ -77,12 +86,25 @@ public class TrackerClientFactory
    * @param clock Clock used for internal call tracking.
    * @return TrackerClient
    */
+  @Deprecated
   public static TrackerClient createTrackerClient(URI uri,
                                                   UriProperties uriProperties,
                                                   ServiceProperties serviceProperties,
                                                   String loadBalancerStrategyName,
                                                   TransportClient transportClient,
                                                   Clock clock)
+  {
+    return createTrackerClient(uri, uriProperties, serviceProperties, loadBalancerStrategyName, transportClient, clock,
+        false);
+  }
+
+  public static TrackerClient createTrackerClient(URI uri,
+      UriProperties uriProperties,
+      ServiceProperties serviceProperties,
+      String loadBalancerStrategyName,
+      TransportClient transportClient,
+      Clock clock,
+      boolean loadBalanceStreamException)
   {
     TrackerClient trackerClient;
 
@@ -104,7 +126,8 @@ public class TrackerClientFactory
     switch (loadBalancerStrategyName)
     {
       case (DegraderLoadBalancerStrategyV3.DEGRADER_STRATEGY_NAME):
-        trackerClient = createDegraderTrackerClient(uri, uriProperties, serviceProperties,  loadBalancerStrategyName, transportClient, clock, doNotSlowStart);
+        trackerClient = createDegraderTrackerClient(uri, uriProperties, serviceProperties,  loadBalancerStrategyName,
+            transportClient, clock, doNotSlowStart, loadBalanceStreamException);
         break;
       case (RelativeLoadBalancerStrategy.RELATIVE_LOAD_BALANCER_STRATEGY_NAME):
         trackerClient = createTrackerClientImpl(uri, uriProperties, serviceProperties, loadBalancerStrategyName,
@@ -124,7 +147,8 @@ public class TrackerClientFactory
                                                                    String loadBalancerStrategyName,
                                                                    TransportClient transportClient,
                                                                    Clock clock,
-                                                                   boolean doNotSlowStart)
+                                                                   boolean doNotSlowStart,
+                                                                   boolean loadBalanceStreamException)
   {
     DegraderImpl.Config config = null;
 
@@ -151,7 +175,8 @@ public class TrackerClientFactory
                                      config,
                                      trackerClientInterval,
                                      errorStatusPattern,
-                                     doNotSlowStart);
+                                     doNotSlowStart,
+                                     loadBalanceStreamException);
   }
 
   private static long getInterval(String loadBalancerStrategyName, ServiceProperties serviceProperties)

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
@@ -42,6 +42,7 @@ import com.linkedin.util.degrader.CallTracker;
 import com.linkedin.util.degrader.CallTrackerImpl;
 import com.linkedin.util.degrader.ErrorType;
 
+import io.netty.handler.codec.http2.Http2Exception;
 import java.net.ConnectException;
 import java.net.URI;
 import java.nio.channels.ClosedChannelException;
@@ -310,6 +311,9 @@ public class TrackerClientImpl implements TrackerClient
       else if (originalThrowable instanceof TimeoutException)
       {
         callCompletion.endCallWithError(ErrorType.TIMEOUT_EXCEPTION);
+      }
+      else if (originalThrowable instanceof Http2Exception.StreamException) {
+        callCompletion.endCallWithError(ErrorType.STREAM_ERROR);
       }
       else
       {

--- a/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/clients/TrackerClientImpl.java
@@ -312,7 +312,8 @@ public class TrackerClientImpl implements TrackerClient
       {
         callCompletion.endCallWithError(ErrorType.TIMEOUT_EXCEPTION);
       }
-      else if (originalThrowable instanceof Http2Exception.StreamException) {
+      else if (originalThrowable instanceof Http2Exception.StreamException)
+      {
         callCompletion.endCallWithError(ErrorType.STREAM_ERROR);
       }
       else

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -974,6 +974,7 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
       return null;
     }
 
+    //TODO: create TrackerClient.LoadBalanceConfig and pass it into createTrackerClient method
     return serviceProperties == null ? null : TrackerClientFactory.createTrackerClient(uri, uriProperties,
         serviceProperties, loadBalancerStrategy.getName(), transportClient, _loadBalanceStreamException);
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancerState.java
@@ -146,6 +146,7 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
   private final SslSessionValidatorFactory _sslSessionValidatorFactory;
   private final SubsettingState _subsettingState;
   private final CanaryDistributionProvider _canaryDistributionProvider;
+  private final boolean _loadBalanceStreamException;
 
   /*
    * Concurrency considerations:
@@ -315,6 +316,26 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
                                  DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider,
                                  CanaryDistributionProvider canaryDistributionProvider)
   {
+    this(executorService, uriBus, clusterBus, serviceBus, clientFactories, loadBalancerStrategyFactories, sslContext,
+        sslParameters, isSSLEnabled, partitionAccessorRegistry, sessionValidatorFactory,
+        deterministicSubsettingMetadataProvider, canaryDistributionProvider, false);
+  }
+
+  public SimpleLoadBalancerState(ScheduledExecutorService executorService,
+      PropertyEventBus<UriProperties> uriBus,
+      PropertyEventBus<ClusterProperties> clusterBus,
+      PropertyEventBus<ServiceProperties> serviceBus,
+      Map<String, TransportClientFactory> clientFactories,
+      Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories,
+      SSLContext sslContext,
+      SSLParameters sslParameters,
+      boolean isSSLEnabled,
+      PartitionAccessorRegistry partitionAccessorRegistry,
+      SslSessionValidatorFactory sessionValidatorFactory,
+      DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider,
+      CanaryDistributionProvider canaryDistributionProvider,
+      boolean loadBalanceStreamException)
+  {
     _executor = executorService;
     _uriProperties = new ConcurrentHashMap<>();
     _clusterInfo = new ConcurrentHashMap<>();
@@ -349,6 +370,7 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
       _subsettingState = null;
     }
     _canaryDistributionProvider = canaryDistributionProvider;
+    _loadBalanceStreamException = loadBalanceStreamException;
   }
 
   public void register(final SimpleLoadBalancerStateListener listener)
@@ -952,11 +974,8 @@ public class SimpleLoadBalancerState implements LoadBalancerState, ClientFactory
       return null;
     }
 
-    return serviceProperties == null ? null : TrackerClientFactory.createTrackerClient(uri,
-                                                                                       uriProperties,
-                                                                                       serviceProperties,
-                                                                                       loadBalancerStrategy.getName(),
-                                                                                       transportClient);
+    return serviceProperties == null ? null : TrackerClientFactory.createTrackerClient(uri, uriProperties,
+        serviceProperties, loadBalancerStrategy.getName(), transportClient, _loadBalanceStreamException);
   }
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategyFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategyFactory.java
@@ -76,15 +76,24 @@ public class RelativeLoadBalancerStrategyFactory implements LoadBalancerStrategy
   private final List<PartitionStateUpdateListener.Factory<PartitionState>> _stateListenerFactories;
   private final EventEmitter _eventEmitter;
   private final Clock _clock;
+  private final boolean _loadBalanceStreamException;
 
   public RelativeLoadBalancerStrategyFactory(ScheduledExecutorService executorService, HealthCheckOperations healthCheckOperations,
       List<PartitionStateUpdateListener.Factory<PartitionState>> stateListenerFactories, EventEmitter eventEmitter, Clock clock)
+  {
+    this(executorService, healthCheckOperations, stateListenerFactories, eventEmitter, clock, false);
+  }
+
+  public RelativeLoadBalancerStrategyFactory(ScheduledExecutorService executorService, HealthCheckOperations healthCheckOperations,
+      List<PartitionStateUpdateListener.Factory<PartitionState>> stateListenerFactories, EventEmitter eventEmitter, Clock clock,
+      boolean loadBalanceStreamException)
   {
     _executorService = executorService;
     _healthCheckOperations = healthCheckOperations;
     _stateListenerFactories = stateListenerFactories;
     _eventEmitter = (eventEmitter == null) ? new NoopEventEmitter() : eventEmitter;
     _clock = clock;
+    _loadBalanceStreamException = loadBalanceStreamException;
   }
 
 
@@ -112,7 +121,8 @@ public class RelativeLoadBalancerStrategyFactory implements LoadBalancerStrategy
     {
       listenerFactories.addAll(_stateListenerFactories);
     }
-    return new StateUpdater(relativeStrategyProperties, quarantineManager, _executorService, listenerFactories, serviceName);
+    return new StateUpdater(relativeStrategyProperties, quarantineManager, _executorService, listenerFactories,
+        serviceName, _loadBalanceStreamException);
   }
 
   private ClientSelector getClientSelector(D2RelativeStrategyProperties relativeStrategyProperties)

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -440,9 +440,11 @@ public class StateUpdater
     Integer closedChannelExceptionCount = errorTypeCounts.getOrDefault(ErrorType.CLOSED_CHANNEL_EXCEPTION, 0);
     Integer serverErrorCount = errorTypeCounts.getOrDefault(ErrorType.SERVER_ERROR, 0);
     Integer timeoutExceptionCount = errorTypeCounts.getOrDefault(ErrorType.TIMEOUT_EXCEPTION, 0);
+    Integer streamErrorCount = errorTypeCounts.getOrDefault(ErrorType.STREAM_ERROR, 0);
     return callCount == 0
         ? 0
-        : (double) (connectExceptionCount + closedChannelExceptionCount + serverErrorCount + timeoutExceptionCount) / callCount;
+        : (double) (connectExceptionCount + closedChannelExceptionCount + serverErrorCount + timeoutExceptionCount +
+            streamErrorCount) / callCount;
   }
 
   private void initializePartition(Set<TrackerClient> trackerClients, int partitionId, long clusterGenerationId)

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.d2.balancer.strategies.relative;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.d2.D2RelativeStrategyProperties;
 import com.linkedin.d2.balancer.clients.TrackerClient;
 import com.linkedin.d2.balancer.strategies.PartitionStateUpdateListener;
@@ -65,14 +66,27 @@ public class StateUpdater
   private final ScheduledFuture<?> scheduledFuture;
   private ConcurrentMap<Integer, PartitionState> _partitionLoadBalancerStateMap;
   private int _firstPartitionId = -1;
+  private final boolean _loadBalanceStreamException;
 
+  @Deprecated
   StateUpdater(D2RelativeStrategyProperties relativeStrategyProperties,
                        QuarantineManager quarantineManager,
                        ScheduledExecutorService executorService,
                        List<PartitionStateUpdateListener.Factory<PartitionState>> listenerFactories,
                        String serviceName)
   {
-    this(relativeStrategyProperties, quarantineManager, executorService, new ConcurrentHashMap<>(), listenerFactories, serviceName);
+    this(relativeStrategyProperties, quarantineManager, executorService, new ConcurrentHashMap<>(), listenerFactories,
+        serviceName, false);
+  }
+
+  StateUpdater(D2RelativeStrategyProperties relativeStrategyProperties,
+      QuarantineManager quarantineManager,
+      ScheduledExecutorService executorService,
+      List<PartitionStateUpdateListener.Factory<PartitionState>> listenerFactories,
+      String serviceName, boolean loadBalanceStreamException)
+  {
+    this(relativeStrategyProperties, quarantineManager, executorService, new ConcurrentHashMap<>(), listenerFactories,
+        serviceName, loadBalanceStreamException);
   }
 
   StateUpdater(D2RelativeStrategyProperties relativeStrategyProperties,
@@ -81,6 +95,17 @@ public class StateUpdater
       ConcurrentMap<Integer, PartitionState> partitionLoadBalancerStateMap,
       List<PartitionStateUpdateListener.Factory<PartitionState>> listenerFactories,
       String serviceName)
+  {
+    this(relativeStrategyProperties, quarantineManager, executorService, partitionLoadBalancerStateMap,
+        listenerFactories, serviceName, false);
+  }
+
+  StateUpdater(D2RelativeStrategyProperties relativeStrategyProperties,
+      QuarantineManager quarantineManager,
+      ScheduledExecutorService executorService,
+      ConcurrentMap<Integer, PartitionState> partitionLoadBalancerStateMap,
+      List<PartitionStateUpdateListener.Factory<PartitionState>> listenerFactories,
+      String serviceName, boolean loadBalanceStreamException)
   {
     _relativeStrategyProperties = relativeStrategyProperties;
     _quarantineManager = quarantineManager;
@@ -91,8 +116,9 @@ public class StateUpdater
     _serviceName = serviceName;
 
     scheduledFuture = executorService.scheduleWithFixedDelay(this::updateState, EXECUTOR_INITIAL_DELAY,
-                                                             _relativeStrategyProperties.getUpdateIntervalMs(),
-                                                             TimeUnit.MILLISECONDS);
+        _relativeStrategyProperties.getUpdateIntervalMs(),
+        TimeUnit.MILLISECONDS);
+    _loadBalanceStreamException = loadBalanceStreamException;
   }
 
   /**
@@ -434,17 +460,22 @@ public class StateUpdater
     state.getListeners().forEach(listener -> listener.onUpdate(state));
   }
 
-  private static double getErrorRate(Map<ErrorType, Integer> errorTypeCounts, int callCount)
+  @VisibleForTesting
+  double getErrorRate(Map<ErrorType, Integer> errorTypeCounts, int callCount)
   {
     Integer connectExceptionCount = errorTypeCounts.getOrDefault(ErrorType.CONNECT_EXCEPTION, 0);
     Integer closedChannelExceptionCount = errorTypeCounts.getOrDefault(ErrorType.CLOSED_CHANNEL_EXCEPTION, 0);
     Integer serverErrorCount = errorTypeCounts.getOrDefault(ErrorType.SERVER_ERROR, 0);
     Integer timeoutExceptionCount = errorTypeCounts.getOrDefault(ErrorType.TIMEOUT_EXCEPTION, 0);
     Integer streamErrorCount = errorTypeCounts.getOrDefault(ErrorType.STREAM_ERROR, 0);
-    return callCount == 0
-        ? 0
-        : (double) (connectExceptionCount + closedChannelExceptionCount + serverErrorCount + timeoutExceptionCount +
-            streamErrorCount) / callCount;
+
+    double validExceptionCount = connectExceptionCount + closedChannelExceptionCount + serverErrorCount
+        + timeoutExceptionCount;
+    if (_loadBalanceStreamException)
+    {
+      validExceptionCount += streamErrorCount;
+    }
+    return callCount == 0 ? 0 : validExceptionCount / callCount;
   }
 
   private void initializePartition(Set<TrackerClient> trackerClients, int partitionId, long clusterGenerationId)

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsFsTogglingLoadBalancerFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsFsTogglingLoadBalancerFactory.java
@@ -80,7 +80,9 @@ public class XdsFsTogglingLoadBalancerFactory
   private final DeterministicSubsettingMetadataProvider _deterministicSubsettingMetadataProvider;
   private final CanaryDistributionProvider _canaryDistributionProvider;
   private final FailoutConfigProviderFactory _failoutConfigProviderFactory;
+  private final boolean _loadBalanceStreamException;
 
+  @Deprecated
   public XdsFsTogglingLoadBalancerFactory(long timeout, TimeUnit timeoutUnit, String fsBasePath,
       Map<String, TransportClientFactory> clientFactories,
       Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories,
@@ -89,6 +91,22 @@ public class XdsFsTogglingLoadBalancerFactory
       SslSessionValidatorFactory sslSessionValidatorFactory, D2ClientJmxManager d2ClientJmxManager,
       DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider,
       FailoutConfigProviderFactory failoutConfigProviderFactory, CanaryDistributionProvider canaryDistributionProvider)
+  {
+    this(timeout, timeoutUnit, fsBasePath, clientFactories, loadBalancerStrategyFactories, d2ServicePath, sslContext,
+        sslParameters, isSSLEnabled, clientServicesConfig, partitionAccessorRegistry, sslSessionValidatorFactory,
+        d2ClientJmxManager, deterministicSubsettingMetadataProvider, failoutConfigProviderFactory,
+        canaryDistributionProvider, false);
+  }
+
+  public XdsFsTogglingLoadBalancerFactory(long timeout, TimeUnit timeoutUnit, String fsBasePath,
+      Map<String, TransportClientFactory> clientFactories,
+      Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories,
+      String d2ServicePath, SSLContext sslContext, SSLParameters sslParameters, boolean isSSLEnabled,
+      Map<String, Map<String, Object>> clientServicesConfig, PartitionAccessorRegistry partitionAccessorRegistry,
+      SslSessionValidatorFactory sslSessionValidatorFactory, D2ClientJmxManager d2ClientJmxManager,
+      DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider,
+      FailoutConfigProviderFactory failoutConfigProviderFactory, CanaryDistributionProvider canaryDistributionProvider,
+      boolean loadBalanceStreamException)
   {
     _lbTimeout = timeout;
     _lbTimeoutUnit = timeoutUnit;
@@ -106,6 +124,7 @@ public class XdsFsTogglingLoadBalancerFactory
     _deterministicSubsettingMetadataProvider = deterministicSubsettingMetadataProvider;
     _failoutConfigProviderFactory = failoutConfigProviderFactory;
     _canaryDistributionProvider = canaryDistributionProvider;
+    _loadBalanceStreamException = loadBalanceStreamException;
   }
 
   public TogglingLoadBalancer create(ScheduledExecutorService executorService, XdsToD2PropertiesAdaptor xdsAdaptor)
@@ -146,7 +165,8 @@ public class XdsFsTogglingLoadBalancerFactory
     SimpleLoadBalancerState state =
         new SimpleLoadBalancerState(executorService, uriBus, clusterBus, serviceBus, _clientFactories,
             _loadBalancerStrategyFactories, _sslContext, _sslParameters, _isSSLEnabled, _partitionAccessorRegistry,
-            _sslSessionValidatorFactory, _deterministicSubsettingMetadataProvider, _canaryDistributionProvider);
+            _sslSessionValidatorFactory, _deterministicSubsettingMetadataProvider, _canaryDistributionProvider,
+            _loadBalanceStreamException);
     _d2ClientJmxManager.setSimpleLoadBalancerState(state);
 
     SimpleLoadBalancer balancer =

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -65,12 +65,15 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
     XdsToD2PropertiesAdaptor adaptor = new XdsToD2PropertiesAdaptor(xdsClient, config.dualReadStateManager,
         config.serviceDiscoveryEventEmitter, config.clientServicesConfig);
 
-    XdsLoadBalancer xdsLoadBalancer = new XdsLoadBalancer(adaptor, executorService,
+    XdsLoadBalancer xdsLoadBalancer = new XdsLoadBalancer(
+        adaptor,
+        executorService,
         new XdsFsTogglingLoadBalancerFactory(config.lbWaitTimeout, config.lbWaitUnit, config.indisFsBasePath,
             config.clientFactories, config.loadBalancerStrategyFactories, config.d2ServicePath, config.sslContext,
             config.sslParameters, config.isSSLEnabled, config.clientServicesConfig, config.partitionAccessorRegistry,
             config.sslSessionValidatorFactory, d2ClientJmxManager, config.deterministicSubsettingMetadataProvider,
-            config.failoutConfigProviderFactory, config.canaryDistributionProvider));
+            config.failoutConfigProviderFactory, config.canaryDistributionProvider, config.loadBalanceStreamException)
+    );
 
     LoadBalancerWithFacilities balancer = xdsLoadBalancer;
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/clients/RetryClientTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/clients/RetryClientTest.java
@@ -330,7 +330,7 @@ public class RetryClientTest
     }
   }
 
-  @Test(retryAnalyzer = SingleRetry.class) // Known to be flaky in CI
+  @Test(retryAnalyzer = ThreeRetries.class) // Known to be flaky in CI
   public void testRestRetryExceedsClientRetryRatio() throws Exception
   {
     SimpleLoadBalancer balancer = prepareLoadBalancer(Arrays.asList("http://test.linkedin.com/retry1", "http://test.linkedin.com/good"),

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/TrackerClientMockHelper.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/TrackerClientMockHelper.java
@@ -80,7 +80,8 @@ public class TrackerClientMockHelper
 
   public static List<TrackerClient> mockTrackerClients(int numTrackerClients, List<Integer> callCountList,
       List<Integer> outstandingCallCountList, List<Long> latencyList, List<Long> outstandingLatencyList,
-      List<Integer> errorCountList, boolean doNotSlowStart, List<Boolean> doNotLoadBalance) {
+      List<Integer> errorCountList, boolean doNotSlowStart, List<Boolean> doNotLoadBalance)
+  {
     List<Map<ErrorType, Integer>> errorTypeCountsList = errorCountList.stream().map(count -> {
       Map<ErrorType, Integer> errorTypeCounts = new HashMap<>();
       errorTypeCounts.put(ErrorType.SERVER_ERROR, count);

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/TrackerClientMockHelper.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/TrackerClientMockHelper.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 
 import static org.mockito.Matchers.anyInt;
@@ -77,6 +78,18 @@ public class TrackerClientMockHelper
     return mockTrackerClients(numTrackerClients, callCountList, outstandingCallCountList, latencyList, outstandingLatencyList, errorCountList, false, doNotLoadBalance);
   }
 
+  public static List<TrackerClient> mockTrackerClients(int numTrackerClients, List<Integer> callCountList,
+      List<Integer> outstandingCallCountList, List<Long> latencyList, List<Long> outstandingLatencyList,
+      List<Integer> errorCountList, boolean doNotSlowStart, List<Boolean> doNotLoadBalance) {
+    List<Map<ErrorType, Integer>> errorTypeCountsList = errorCountList.stream().map(count -> {
+      Map<ErrorType, Integer> errorTypeCounts = new HashMap<>();
+      errorTypeCounts.put(ErrorType.SERVER_ERROR, count);
+      return errorTypeCounts;
+    }).collect(Collectors.toList());
+    return mockTrackerClients(numTrackerClients, callCountList, outstandingCallCountList, latencyList,
+        outstandingLatencyList, errorCountList, doNotSlowStart, doNotLoadBalance, errorTypeCountsList);
+  }
+
   /**
    * Mock a list of {@link TrackerClient} for testing
    *
@@ -86,11 +99,13 @@ public class TrackerClientMockHelper
    * @param latencyList The latency of each host
    * @param outstandingLatencyList The outstanding latency of each host
    * @param errorCountList The error count of each host
+   * @param errorTypeCounts The error count by type of each host
    * @return A list of mocked {@link TrackerClient}
    */
   public static List<TrackerClient> mockTrackerClients(int numTrackerClients, List<Integer> callCountList,
       List<Integer> outstandingCallCountList, List<Long> latencyList, List<Long> outstandingLatencyList,
-      List<Integer> errorCountList, boolean doNotSlowStart, List<Boolean> doNotLoadBalance)
+      List<Integer> errorCountList, boolean doNotSlowStart, List<Boolean> doNotLoadBalance,
+      List<Map<ErrorType, Integer>> errorTypeCounts)
   {
     List<TrackerClient> trackerClients = new ArrayList<>();
     for (int index = 0; index < numTrackerClients; index ++)
@@ -99,8 +114,6 @@ public class TrackerClientMockHelper
       TrackerClient trackerClient = Mockito.mock(TrackerClient.class);
       CallTracker callTracker = Mockito.mock(CallTracker.class);
       LongStats longStats = new LongStats(callCountList.get(index), latencyList.get(index), 0, 0, 0, 0, 0, 0, 0);
-      Map<ErrorType, Integer> errorTypeCounts = new HashMap<>();
-      errorTypeCounts.put(ErrorType.SERVER_ERROR, errorCountList.get(index));
 
       CallTrackerImpl.CallTrackerStats callStats = new CallTrackerImpl.CallTrackerStats(
           RelativeLoadBalancerStrategyFactory.DEFAULT_UPDATE_INTERVAL_MS,
@@ -115,8 +128,8 @@ public class TrackerClientMockHelper
           RelativeLoadBalancerStrategyFactory.DEFAULT_UPDATE_INTERVAL_MS - outstandingLatencyList.get(index),
       outstandingCallCountList.get(index),
       longStats,
-      errorTypeCounts,
-      errorTypeCounts);
+      errorTypeCounts.get(index),
+      errorTypeCounts.get(index));
 
       Mockito.when(trackerClient.getCallTracker()).thenReturn(callTracker);
       Mockito.when(callTracker.getCallStats()).thenReturn(callStats);

--- a/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenDelayedWatcherTest.java
+++ b/d2/src/test/java/com/linkedin/d2/discovery/stores/zk/ZooKeeperEphemeralStoreChildrenDelayedWatcherTest.java
@@ -27,6 +27,7 @@ import com.linkedin.d2.discovery.stores.PropertySetStringSerializer;
 import com.linkedin.test.util.AssertionMethods;
 import com.linkedin.test.util.ClockedExecutor;
 
+import com.linkedin.test.util.retry.ThreeRetries;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -235,7 +236,7 @@ public class ZooKeeperEphemeralStoreChildrenDelayedWatcherTest
     client.shutdown();
   }
 
-  @Test(dataProvider = "dataNumOfchildrenToAddToRemoveReadWindow")
+  @Test(dataProvider = "dataNumOfchildrenToAddToRemoveReadWindow", retryAnalyzer = ThreeRetries.class)
   public void testChildNodeRemoved(int numberOfAdditionalChildren, int numberOfRemove, int zookeeperReadWindowMs)
     throws Exception
   {

--- a/degrader/build.gradle
+++ b/degrader/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
   compile project(':pegasus-common')
   testCompile externalDependency.testng
+
+  testImplementation externalDependency.mockito
+  testImplementation externalDependency.guava
 }

--- a/degrader/src/main/java/com/linkedin/util/degrader/ErrorType.java
+++ b/degrader/src/main/java/com/linkedin/util/degrader/ErrorType.java
@@ -35,5 +35,10 @@ public enum ErrorType
   /**
    * represents a server side error condition
    */
-  SERVER_ERROR
+  SERVER_ERROR,
+
+  /**
+   * represents an http2 stream error
+   */
+  STREAM_ERROR
 }

--- a/degrader/src/test/java/com/linkedin/util/degrader/DegraderImplTest.java
+++ b/degrader/src/test/java/com/linkedin/util/degrader/DegraderImplTest.java
@@ -1,0 +1,72 @@
+package com.linkedin.util.degrader;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.util.clock.SystemClock;
+import java.util.Map;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class DegraderImplTest
+{
+  @DataProvider
+  public Object[][] loadBalanceStreamExceptionDataProvider()
+  {
+    return new Object[][] {
+        { false },
+        { true }
+    };
+  }
+
+  @Test(dataProvider = "loadBalanceStreamExceptionDataProvider")
+  public void testGetErrorRateToDegrade(Boolean loadBalancerStreamException)
+  {
+    Map<ErrorType, Integer> errorTypeCounts = ImmutableMap.of(
+        ErrorType.CONNECT_EXCEPTION, 1,
+        ErrorType.CLOSED_CHANNEL_EXCEPTION, 1,
+        ErrorType.SERVER_ERROR, 1,
+        ErrorType.TIMEOUT_EXCEPTION, 1,
+        ErrorType.STREAM_ERROR, 1
+    );
+    DegraderImpl degrader = new DegraderImplTestFixture().getDegraderImpl(loadBalancerStreamException, errorTypeCounts,
+        10);
+    assertEquals(degrader.getErrorRateToDegrade(), loadBalancerStreamException ? 0.5 : 0.4);
+  }
+
+  private static final class DegraderImplTestFixture
+  {
+    @Mock
+    CallTracker _callTracker;
+    @Mock
+    CallTracker.CallStats _callStats;
+
+    DegraderImplTestFixture()
+    {
+      MockitoAnnotations.initMocks(this);
+      doReturn(_callStats).when(_callTracker).getCallStats();
+      doNothing().when(_callTracker).addStatsRolloverEventListener(any());
+    }
+
+    DegraderImpl getDegraderImpl(boolean loadBalancerStreamException, Map<ErrorType, Integer> errorTypeCounts, int callCount)
+    {
+      when(_callStats.getErrorTypeCounts()).thenReturn(errorTypeCounts);
+      when(_callStats.getCallCount()).thenReturn(callCount);
+
+      DegraderImpl.Config config = new DegraderImpl.Config();
+      config.setName("DegraderImplTest");
+      config.setClock(SystemClock.instance());
+      config.setCallTracker(_callTracker);
+      config.setMaxDropDuration(1);
+      config.setInitialDropRate(0.01);
+      config.setLogger(LoggerFactory.getLogger(DegraderImplTest.class));
+      config.setLoadBalanceStreamException(loadBalancerStreamException);
+      return new DegraderImpl(config);
+    }
+  }
+}


### PR DESCRIPTION
# Summary
H/2 stream errors were seen in recent incidents and they aren't handled by the Tracker client currently. Handle `Http2Exception.StreamException` to fix this.

# Testing Done
Added UTs