### PR TITLE
Return RetriableRequestException for Netty Max Active Stream error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.55.0] - 2024-05-23
+- Allow HttpBridge to return RetriableRequestException for the Netty max active stream error 
+
 ## [29.54.0] - 2024-05-08
 - Dual read monitors cluster uris similarity
 
@@ -5689,7 +5692,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.54.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.55.0...master
+[29.55.0]: https://github.com/linkedin/rest.li/compare/v29.54.0...v29.55.0
 [29.54.0]: https://github.com/linkedin/rest.li/compare/v29.53.1...v29.54.0
 [29.53.1]: https://github.com/linkedin/rest.li/compare/v29.53.0...v29.53.1
 [29.53.0]: https://github.com/linkedin/rest.li/compare/v29.52.1...v29.53.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.55.0
+version=29.55.0-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.55.0-rc.1
+version=29.55.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.54.0
+version=29.55.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/build.gradle
+++ b/r2-core/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   compile externalDependency.servletApi
   compile externalDependency.mail
   compile externalDependency.javaxActivation
+  compile externalDependency.netty
   testCompile project(':r2-testutils')
   testCompile project(':test-util')
   testCompile externalDependency.testng

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/common/HttpBridge.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/common/HttpBridge.java
@@ -66,10 +66,6 @@ public class HttpBridge
       {
         if (response.hasError())
         {
-          Throwable responseError = response.getError();
-          // If the error is due to the netty max active stream error, wrap it with RetriableRequestException instead
-          RemoteInvocationException exception =
-              wrapResponseError("Failed to get response from server for URI " + uri, responseError);
           response =
               TransportResponseImpl.error(new RemoteInvocationException("Failed to get response from server for URI "
                       + uri,
@@ -161,19 +157,11 @@ public class HttpBridge
         if (response.hasError())
         {
           Throwable responseError = response.getError();
-          // If the error is due to the netty max active stream error, return a RetriableRequestException
-          if (shouldReturnRetriableRequestException(responseError))
-          {
-            response = TransportResponseImpl.error(
-                new RetriableRequestException("Failed to get response from server for URI " + uri, responseError),
-                response.getWireAttributes());
-          }
-          else
-          {
-            response = TransportResponseImpl.error(
-                new RemoteInvocationException("Failed to get response from server for URI " + uri, responseError),
-                response.getWireAttributes());
-          }
+          // If the error is due to the netty max active stream error, wrap it with RetriableRequestException instead
+          RemoteInvocationException exception =
+              wrapResponseError("Failed to get response from server for URI " + uri, responseError);
+          response =
+              TransportResponseImpl.error(exception, response.getWireAttributes());
         }
         else if (!RestStatus.isOK(response.getResponse().getStatus()))
         {


### PR DESCRIPTION
This change adds logic in `HttpBridge` to return `RetriableRequestException` rather than `RemoteInvocationException` when StreamException from Netty is returned with cause of `Maximum active streams violated for this endpoint`. This allows the downstream client - `RetryClient` to retry the request with different hosts when stream hits the maximum of a given host.

[wc-test passed](https://crt.prod.linkedin.com/#/testing/executions/b4c75c5a-b5c9-4a4d-93da-2ebae16484e6)