### PR TITLE
Prevent duplicate uri property update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.56.1] - 2024-06-06
+- prevent duplicate uri property update
+
 ## [29.56.0] - 2024-05-30
 - degrade hosts for HTTP/2 stream errors in Degrader and Relative LB.
 
@@ -5695,7 +5698,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.56.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.56.1...master
+[29.56.1]: https://github.com/linkedin/rest.li/compare/v29.56.0...v29.56.1
 [29.56.0]: https://github.com/linkedin/rest.li/compare/v29.55.0...v29.56.0
 [29.55.0]: https://github.com/linkedin/rest.li/compare/v29.54.0...v29.55.0
 [29.54.0]: https://github.com/linkedin/rest.li/compare/v29.53.1...v29.54.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/UriLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/UriLoadBalancerSubscriber.java
@@ -59,6 +59,17 @@ class UriLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<UriProper
     {
       String clusterName = uriProperties.getClusterName();
 
+      Optional<UriProperties> currentUriProperties = Optional.ofNullable(
+          _simpleLoadBalancerState.getUriProperties(clusterName)).map(LoadBalancerStateItem::getProperty);
+      if (currentUriProperties.isPresent() && currentUriProperties.get().equals(uriProperties))
+      {
+        _log.debug("For cluster: {}, received duplicate uri properties: {}", clusterName, uriProperties);
+        return;
+      }
+
+      _log.debug("For cluster: {}, received new uri properties: {}\nOld properties: {}", clusterName, uriProperties,
+          currentUriProperties);
+
       Set<String> serviceNames = _simpleLoadBalancerState.getServicesPerCluster().get(clusterName);
       //updates all the services that these uris provide
       if (serviceNames != null)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.56.0
+version=29.56.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
Uri subscriber can receive duplicate uri properties during INDIS migration as both ZK data and Kafka data are input on INDIS Observer (using ZK data to cover server apps that don't emit or partially emit kafka data). Since Kafka data has higher precedence, when Kafka data arrives later than ZK data, it will be sent to the client although the uri properties inside is effectively the same as ZK data, which is still needed, since the metadata is different, like tracing ID, modified time, etc, the client will send tracking events of receipt to track the end-to-end propagation latency for Kafka announcements.

This change only prevents uri subscriber from processing the inner duplicate uri properties as an update, which will prevent all subsequent actions taken by the uri property listeners. (note: there are other edge cases of receiving duplicate uri properties, such as when the version in the uri properties is incremented but the data is unchanged. This change generally protect against all of them and can help us investigate such case in the future)

## Testing Done
QEI deployed indis-canary, restart indis-canary backend (which will trigger uri property update with markdowns then back up. When uri is back up, the client will receive it twice), look for logs "received duplicate uri properties" by UriLoadBalancerSubscriber (set log level INFO)


[indis-canary.log](https://github.com/user-attachments/files/15665091/indis-canary.log)
