### PR TITLE
Add xds client metric for receiving invalid resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.57.0] - 2024-06-16
+- Add xds client metric for receiving invalid resource
+
 ## [29.56.1] - 2024-06-06
 - prevent duplicate uri property update
 
@@ -5698,7 +5701,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.56.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.0...master
+[29.57.0]: https://github.com/linkedin/rest.li/compare/v29.56.1...v29.57.0
 [29.56.1]: https://github.com/linkedin/rest.li/compare/v29.56.0...v29.56.1
 [29.56.0]: https://github.com/linkedin/rest.li/compare/v29.55.0...v29.56.0
 [29.55.0]: https://github.com/linkedin/rest.li/compare/v29.54.0...v29.55.0

--- a/d2/src/main/java/com/linkedin/d2/jmx/XdsClientJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/XdsClientJmx.java
@@ -29,6 +29,7 @@ public class XdsClientJmx implements XdsClientJmxMBean
 
   private final AtomicBoolean _isConnected = new AtomicBoolean();
   private final AtomicInteger _resourceNotFoundCount = new AtomicInteger();
+  private final AtomicInteger _resourceInvalidCount = new AtomicInteger();
   private final XdsServerMetricsProvider _xdsServerMetricsProvider;
 
   @Deprecated
@@ -65,6 +66,12 @@ public class XdsClientJmx implements XdsClientJmxMBean
   public int getResourceNotFoundCount()
   {
     return _resourceNotFoundCount.get();
+  }
+
+  @Override
+  public int getResourceInvalidCount()
+  {
+    return _resourceInvalidCount.get();
   }
 
   @Override
@@ -129,5 +136,10 @@ public class XdsClientJmx implements XdsClientJmxMBean
   public void incrementResourceNotFoundCount()
   {
     _resourceNotFoundCount.incrementAndGet();
+  }
+
+  public void incrementResourceInvalidCount()
+  {
+    _resourceInvalidCount.incrementAndGet();
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/XdsClientJmxMBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/XdsClientJmxMBean.java
@@ -35,6 +35,9 @@ public interface XdsClientJmxMBean {
   // when the resource is not found.
   int getResourceNotFoundCount();
 
+  // when the resource is invalid.
+  int getResourceInvalidCount();
+
   /**
    * Get minimum of Xds server latency, which is from when the resource is updated on the Xds server to when the
    * client receives it.

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -447,8 +447,8 @@ public class TestXdsClientImpl
     XdsClientImpl _xdsClientImpl;
     @Mock
     XdsClientJmx _xdsClientJmx;
-    ResourceSubscriber _nodeSubscriber = spy(new ResourceSubscriber(NODE, SERVICE_RESOURCE_NAME));
-    ResourceSubscriber _clusterSubscriber = spy(new ResourceSubscriber(D2_URI_MAP, CLUSTER_RESOURCE_NAME));
+    ResourceSubscriber _nodeSubscriber;
+    ResourceSubscriber _clusterSubscriber;
     Map<ResourceType, Map<String, ResourceSubscriber>> _subscribers = new HashMap<>();
     @Mock
     XdsClient.ResourceWatcher _resourceWatcher;
@@ -463,6 +463,8 @@ public class TestXdsClientImpl
     XdsClientImplFixture(boolean useGlobCollections)
     {
       MockitoAnnotations.initMocks(this);
+      _nodeSubscriber = spy(new ResourceSubscriber(NODE, SERVICE_RESOURCE_NAME, _xdsClientJmx));
+      _clusterSubscriber = spy(new ResourceSubscriber(D2_URI_MAP, CLUSTER_RESOURCE_NAME, _xdsClientJmx));
 
       doNothing().when(_resourceWatcher).onChanged(any());
       for (ResourceSubscriber subscriber : Lists.newArrayList(_nodeSubscriber, _clusterSubscriber))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.56.1
+version=29.57.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
As the title, add a metric when the xds resource received is invalid.

## Test
Existing tests. QEI deploy d2-proxy, the metrics showed up on jmx console. 