### PR TITLE
Cancel xds stream ready timeout when the stream is closed. Correct xds connection status metric.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.57.1] - 2024-06-24
+- Cancel xds stream ready timeout when the stream is closed. Correct xds connection status metric.
+
 ## [29.57.0] - 2024-06-16
 - Add xds client metric for receiving invalid resource
 
@@ -5701,7 +5704,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.1...master
+[29.57.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1
 [29.57.0]: https://github.com/linkedin/rest.li/compare/v29.56.1...v29.57.0
 [29.56.1]: https://github.com/linkedin/rest.li/compare/v29.56.0...v29.56.1
 [29.56.0]: https://github.com/linkedin/rest.li/compare/v29.55.0...v29.56.0

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -214,7 +214,7 @@ public class XdsClientImpl extends XdsClient
       // to one of the sub-channels (unless an error or complete callback is called).
     }, _readyTimeoutMillis, TimeUnit.MILLISECONDS);
     _adsStream.start();
-    _log.info("Staring ADS stream, connecting to server: {}", _managedChannel.authority());
+    _log.info("Starting ADS stream, connecting to server: {}", _managedChannel.authority());
   }
 
   @Override
@@ -270,8 +270,6 @@ public class XdsClientImpl extends XdsClient
     _readyTimeoutFuture = null; // set it to null to avoid repeat notifications to subscribers.
     if (_retryRpcStreamFuture != null)
     {
-      _log.info("ADS stream reconnected after {} milliseconds",
-          _retryRpcStreamFuture.getDelay(TimeUnit.MILLISECONDS));
       _retryRpcStreamFuture = null;
       _xdsClientJmx.incrementReconnectionCount();
     }

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -228,6 +228,12 @@ public class XdsToD2PropertiesAdaptor
             _serviceEventBus.publishInitialize(serviceName, null);
           }
         }
+        else
+        {
+          // Received xds resource update while service event bus is not set. Notify that the xds source becomes
+          // available instead.
+          onReconnect();
+        }
       }
 
       @Override
@@ -283,6 +289,12 @@ public class XdsToD2PropertiesAdaptor
                 clusterName);
             _clusterEventBus.publishInitialize(clusterName, null);
           }
+        }
+        else
+        {
+          // Received xds resource update while service event bus is not set. Notify that the xds source becomes
+          // available instead.
+          onReconnect();
         }
       }
 
@@ -541,6 +553,12 @@ public class XdsToD2PropertiesAdaptor
       if (_uriEventBus != null)
       {
         _uriEventBus.publishInitialize(clusterName, mergedUriProperties);
+      }
+      else
+      {
+        // Received xds resource update while service event bus is not set. Notify that the xds source becomes
+        // available instead.
+        onReconnect();
       }
 
       if (_dualReadStateManager != null)

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -292,7 +292,7 @@ public class XdsToD2PropertiesAdaptor
         }
         else
         {
-          // Received xds resource update while service event bus is not set. Notify that the xds source becomes
+          // Received xds resource update while cluster event bus is not set. Notify that the xds source becomes
           // available instead.
           onReconnect();
         }
@@ -556,7 +556,7 @@ public class XdsToD2PropertiesAdaptor
       }
       else
       {
-        // Received xds resource update while service event bus is not set. Notify that the xds source becomes
+        // Received xds resource update while uri event bus is not set. Notify that the xds source becomes
         // available instead.
         onReconnect();
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.57.0
+version=29.57.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
See context at [slack discussion](https://linkedin-randd.slack.com/archives/C02LGUWBLU8/p1718914811474299?thread_ts=1718903018.359899&cid=C02LGUWBLU8). 

This change:
1. cleans up xds stream ready timeout future when that stream is closed (instead of being ready). 
2. align xds connection status metric with what the connection listeners receive (in the previous edge case, the connected is indeed good, but the listeners are mis-notified that it's not connected).  
3. cleans up connection retry future when that reconnection stream is ready.
4. After all, if similar issues happen in future where xds stream is actually ready and taking in updates but the event bus is incorrectly enabled with backup store, updated XdsToD2PropertiesAdaptor will notify that xds is reconnected when it receives an update.

## Tests
N/A