### PR TITLE
Update grpc version to 1.59.1 and protobuf to 3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5708,7 +5708,7 @@ patch operations can re-use these classes for generating patch messages.
 ## [0.14.1]
 
 [Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.2...master
-[29.57.1]: https://github.com/linkedin/rest.li/compare/v29.57.1...v29.57.2
+[29.57.2]: https://github.com/linkedin/rest.li/compare/v29.57.1...v29.57.2
 [29.57.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1
 [29.57.0]: https://github.com/linkedin/rest.li/compare/v29.56.1...v29.57.0
 [29.56.1]: https://github.com/linkedin/rest.li/compare/v29.56.0...v29.56.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.57.1-rc.1] - 2024-06-17
+## [29.57.1] - 2024-06-17
 - Update grpc version to 1.59.1 and protobuf to 3.24.0
 
 ## [29.57.0] - 2024-06-16
@@ -5704,8 +5704,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.1-rc.1...master
-[29.57.1-rc.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1-rc.1
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.1...master
+[29.57.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1
 [29.57.0]: https://github.com/linkedin/rest.li/compare/v29.56.1...v29.57.0
 [29.56.1]: https://github.com/linkedin/rest.li/compare/v29.56.0...v29.56.1
 [29.56.0]: https://github.com/linkedin/rest.li/compare/v29.55.0...v29.56.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.57.1-rc.1] - 2024-06-17
+- Update grpc version to 1.59.1 and protobuf to 3.24.0
+
 ## [29.57.0] - 2024-06-16
 - Add xds client metric for receiving invalid resource
 
@@ -5701,7 +5704,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.1-rc.1...master
+[29.57.1-rc.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1-rc.1
 [29.57.0]: https://github.com/linkedin/rest.li/compare/v29.56.1...v29.57.0
 [29.56.1]: https://github.com/linkedin/rest.li/compare/v29.56.0...v29.56.1
 [29.56.0]: https://github.com/linkedin/rest.li/compare/v29.55.0...v29.56.0

--- a/build.gradle
+++ b/build.gradle
@@ -124,12 +124,12 @@ project.ext.externalDependency = [
   "classgraph": "io.github.classgraph:classgraph:4.8.149",
 
   // for integrating with xDS service discovery
-  'grpcNettyShaded': 'io.grpc:grpc-netty-shaded:1.45.1',
-  'grpcProtobuf': 'io.grpc:grpc-protobuf:1.45.1',
-  'grpcStub': 'io.grpc:grpc-stub:1.45.1',
-  'protoc': 'com.google.protobuf:protoc:3.21.7',
-  'protobufJava': 'com.google.protobuf:protobuf-java:3.21.7',
-  'protobufJavaUtil': 'com.google.protobuf:protobuf-java-util:3.21.7',
+  'grpcNettyShaded': 'io.grpc:grpc-netty-shaded:1.59.1',
+  'grpcProtobuf': 'io.grpc:grpc-protobuf:1.59.1',
+  'grpcStub': 'io.grpc:grpc-stub:1.59.1',
+  'protoc': 'com.google.protobuf:protoc:3.24.0',
+  'protobufJava': 'com.google.protobuf:protobuf-java:3.24.0',
+  'protobufJavaUtil': 'com.google.protobuf:protobuf-java-util:3.24.0',
   'envoyApi': 'io.envoyproxy.controlplane:api:0.1.35',
 ];
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.57.0
+version=29.57.1-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.57.1-rc.1
+version=29.57.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.57.1
+version=29.57.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Update grpc version to 1.59.1 and protobuf to 3.24.0 
gRPC changes with 1.59.0 https://groups.google.com/g/grpc-io/c/HdrAVplyw7U/m/ki4QQkwOAQAJ
ProtoBuf changes with 3.24.0 https://groups.google.com/g/protobuf/c/mbfAytlUapY/m/n6Ex9uscDAAJ

Tests: tested RC version in dataformats/grpc-infra wc-test.