### PR TITLE
Allow both @extension and @grpcExtension extensions in schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.58.0] - 2024-07-11
+- Allow both @extension and @grpcExtension extensions in schema validation
 
 ## [29.57.2] - 2024-06-17
 - Update grpc version to 1.59.1 and protobuf to 3.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.58.0] - 2024-07-11
+
 ## [29.57.2] - 2024-06-17
 - Update grpc version to 1.59.1 and protobuf to 3.24.0
 
@@ -5707,7 +5709,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.0...master
+[29.58.0]: https://github.com/linkedin/rest.li/compare/v29.57.2...v29.58.0
 [29.57.2]: https://github.com/linkedin/rest.li/compare/v29.57.1...v29.57.2
 [29.57.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1
 [29.57.0]: https://github.com/linkedin/rest.li/compare/v29.56.1...v29.57.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.57.2
+version=29.58.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/data/ExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/data/ExtensionSchemaValidationCmdLineApp.java
@@ -63,8 +63,8 @@ import static com.linkedin.data.schema.annotation.GrpcExtensionAnnotationHandler
  * 1. The extension schema is a valid schema.
  * 2. The extension schema name has to follow the naming convention: <baseSchemaName> + "Extensions"
  * 3. The extension schema can only include the base schema.
- * 4. The extension schema's field annotation keys must be in the "extension" or "grpcExtension" namespaces (but not both).
- * 5. The extension schema's field annotations must conform to {@link ExtensionSchemaAnnotation} or {@link GrpcExtensionAnnotation}.
+ * 4. The extension schema's field annotation keys must be in the "extension" and/or "grpcExtension" namespaces
+ * 5. The extension schema's field annotations must conform to {@link ExtensionSchemaAnnotation} and/or {@link GrpcExtensionAnnotation}.
  * 6. The extension schema's fields can only be Typeref or array of Typeref.
  * 7. The extension schema's field schema's annotation keys must be in the "resourceKey" and/or "grpcService" namespaces.
  * 8. The extension schema's field annotation versionSuffix value has to match the versionSuffix value in "resourceKey"/"grpcService" annotation on the field schema.
@@ -232,7 +232,7 @@ public class ExtensionSchemaValidationCmdLineApp
       {
         validateRestLiExtensionField(field);
       }
-      else if (properties.containsKey(GRPC_EXTENSION_ANNOTATION_NAMESPACE))
+      if (properties.containsKey(GRPC_EXTENSION_ANNOTATION_NAMESPACE))
       {
         validateGrpcExtensionField(field);
       }
@@ -242,12 +242,6 @@ public class ExtensionSchemaValidationCmdLineApp
   private static void validateRestLiExtensionField(RecordDataSchema.Field field)
       throws InvalidExtensionSchemaException {
     Map<String, Object> properties = field.getProperties();
-    // Validate that it doesn't also contain gRPC downstream info
-    if (properties.containsKey(GRPC_EXTENSION_ANNOTATION_NAMESPACE))
-    {
-      throw new InvalidExtensionSchemaException("The extension schema field '"
-          + field.getName() + "' cannot be annotated with both 'extension' and 'grpcExtension'");
-    }
 
     // Validate the actual content/structure of the annotation value
     validateFieldAnnotation(properties.get(EXTENSION_ANNOTATION_NAMESPACE), new ExtensionSchemaAnnotation().schema());
@@ -262,12 +256,6 @@ public class ExtensionSchemaValidationCmdLineApp
   private static void validateGrpcExtensionField(RecordDataSchema.Field field)
       throws InvalidExtensionSchemaException {
     Map<String, Object> properties = field.getProperties();
-    // Validate that it doesn't also contain Rest.li downstream info
-    if (properties.containsKey(EXTENSION_ANNOTATION_NAMESPACE))
-    {
-      throw new InvalidExtensionSchemaException("The extension schema field '"
-          + field.getName() + "' cannot be annotated with both 'extension' and 'grpcExtension'");
-    }
 
     // Validate the actual content/structure of the annotation value
     validateFieldAnnotation(properties.get(GRPC_EXTENSION_ANNOTATION_NAMESPACE), new GrpcExtensionAnnotation().schema());

--- a/restli-tools/src/test/extensions/validCase/BazExtensions.pdl
+++ b/restli-tools/src/test/extensions/validCase/BazExtensions.pdl
@@ -1,0 +1,10 @@
+/**
+ * Valid extension schema:
+ * The co-existence of @extension and @grpcExtension is allowed
+ */
+record BazExtensions includes Baz {
+  @extension.using = "finder: test"
+  @grpcExtension.rpc = "get"
+  @grpcExtension.versionSuffix = "V2"
+  testField: array[DummyKeyWithGrpc]
+}

--- a/restli-tools/src/test/pegasus/DummyKeyWithGrpc.pdl
+++ b/restli-tools/src/test/pegasus/DummyKeyWithGrpc.pdl
@@ -1,0 +1,42 @@
+/**
+ * A test schema which is used as a field type in extension schema.
+ */
+@resourceKey = [ {
+  "keyConfig" : {
+    "keys" : {
+      "profilesId" : {
+        "assocKey" : {
+          "authorId" : "fabricName",
+          "objectId" : "sessionId"
+        }
+      }
+    }
+  },
+  "entity" : "Profile",
+  "resourcePath" : "/profiles/{profilesId}"
+}, {
+  "keyConfig" : {
+    "keys" : {
+      "profilesId" : {
+        "assocKey" : {
+          "authorId" : "fabricName",
+          "objectId" : "sessionId"
+        }
+      }
+    }
+  },
+  "entity" : "ProfileV2",
+  "resourcePath" : "/profilesV2/{profilesId}",
+  "versionSuffix" : "V2"
+} ]
+@grpcService = [ {
+  "entity" : "proto.com.linkedin.Profile"
+  "rpc" : "get",
+  "service" : "proto.com.linkedin.ProfileService"
+}, {
+  "entity" : "proto.com.linkedin.ProfileV2"
+  "rpc" : "get",
+  "service" : "proto.com.linkedin.ProfileServiceV2"
+  "versionSuffix": "V2"
+} ]
+typeref DummyKeyWithGrpc = string


### PR DESCRIPTION
### Summary

To help bridge rest.li with gRpc as part of the gRpc migration, this PR allows @extension and @grpcExtension extensions to co-exist in the same schema. More information can be found in [SI-39662](https://jira01.corp.linkedin.com:8443/browse/SI-39662).

### Tests

I added a unit test to check if @extension and @grpcExtension extensions can co-exist in the same schema. I depend on the previous existing tests to check for backwards compatibility.
