### PR TITLE
Increase verbosity of testExtensionSchemaValidation tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.58.1] - 2024-07-19
+- Increase verbosity of testExtensionSchemaValidation tests
+
 ## [29.58.0] - 2024-07-11
 - Allow both @extension and @grpcExtension extensions in schema validation
 
@@ -5710,7 +5713,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.1...master
+[29.58.1]: https://github.com/linkedin/rest.li/compare/v29.58.0...v29.58.1
 [29.58.0]: https://github.com/linkedin/rest.li/compare/v29.57.2...v29.58.0
 [29.57.2]: https://github.com/linkedin/rest.li/compare/v29.57.1...v29.57.2
 [29.57.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
@@ -40,6 +40,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecResult;
 
 import static com.linkedin.pegasus.gradle.SharedFileUtils.*;
 
@@ -154,7 +155,7 @@ public class ValidateExtensionSchemaTask extends DefaultTask
 
     ByteArrayOutputStream validationOutput = new ByteArrayOutputStream();
 
-    getProject().javaexec(javaExecSpec -> {
+    ExecResult result = getProject().javaexec(javaExecSpec -> {
       String resolverPathArg = resolverPathStr;
       if (isEnableArgFile())
       {

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
@@ -167,8 +167,15 @@ public class ValidateExtensionSchemaTask extends DefaultTask
       javaExecSpec.args(_inputDir.getAbsolutePath());
       javaExecSpec.setStandardOutput(validationOutput);
       javaExecSpec.setErrorOutput(validationOutput);
+
+      // Handle failure after exec to output errors to build log
+      javaExecSpec.setIgnoreExitValue(true);
     });
 
-    IOUtil.writeText(getOutputFile(), validationOutput.toString(StandardCharsets.UTF_8.name()));
+    String validationOutputString = validationOutput.toString(StandardCharsets.UTF_8.name());
+    IOUtil.writeText(getOutputFile(), validationOutputString);
+    if (result.getExitValue() != 0) {
+      throw new GradleException("Error occurred validating schema extensions:\n" + validationOutputString);
+    }
   }
 }

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/tasks/ValidateExtensionSchemaTask.java
@@ -169,14 +169,14 @@ public class ValidateExtensionSchemaTask extends DefaultTask
       javaExecSpec.setStandardOutput(validationOutput);
       javaExecSpec.setErrorOutput(validationOutput);
 
-      // Handle failure after exec to output errors to build log
+      // Handle failure after exec to output error to build log
       javaExecSpec.setIgnoreExitValue(true);
     });
 
     String validationOutputString = validationOutput.toString(StandardCharsets.UTF_8.name());
     IOUtil.writeText(getOutputFile(), validationOutputString);
     if (result.getExitValue() != 0) {
-      throw new GradleException("Error occurred validating schema extensions:\n" + validationOutputString);
+      throw new GradleException("Error occurred during schema extension validation:\n" + validationOutputString);
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.58.0
+version=29.58.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -86,20 +86,19 @@ public class TestExtensionSchemaValidationCmdLineApp
   {
       String resolverPath = testPegasusDir;
       String inputPath = testExtensionDir + File.separator + inputDir;
+
+      SoftAssert softAssert = new SoftAssert();
       try
       {
         ExtensionSchemaValidationCmdLineApp.parseAndValidateExtensionSchemas(resolverPath, new File(inputPath));
-        SoftAssert softAssert = new SoftAssert();
         softAssert.assertTrue(isValid);
         softAssert.assertEquals(null, errorMessage);
-        softAssert.assertAll();
       }
       catch (Exception e)
       {
-        SoftAssert softAssert = new SoftAssert();
         softAssert.assertTrue(!isValid);
         softAssert.assertEquals(e.getMessage(), errorMessage);
-        softAssert.assertAll();
       }
+      softAssert.assertAll();
   }
 }

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -91,7 +91,7 @@ public class TestExtensionSchemaValidationCmdLineApp
         ExtensionSchemaValidationCmdLineApp.parseAndValidateExtensionSchemas(resolverPath, new File(inputPath));
         SoftAssert softAssert = new SoftAssert();
         softAssert.assertTrue(isValid);
-        softAssert.assertEquals(null, errorMessage);
+        softAssert.assertEquals(errorMessage, null);
         softAssert.assertAll();
       }
       catch (Exception e)

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -17,7 +17,7 @@ package com.linkedin.restli.tools.data;
 
 import java.io.File;
 
-import org.testng.Assert;
+import org.testng.asserts.SoftAssert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -89,12 +89,17 @@ public class TestExtensionSchemaValidationCmdLineApp
       try
       {
         ExtensionSchemaValidationCmdLineApp.parseAndValidateExtensionSchemas(resolverPath, new File(inputPath));
-        Assert.assertTrue(isValid);
+        SoftAssert softAssert = new SoftAssert();
+        softAssert.assertTrue(isValid);
+        softAssert.assertEquals(null, errorMessage);
+        softAssert.assertAll();
       }
       catch (Exception e)
       {
-        Assert.assertTrue(!isValid);
-        Assert.assertEquals(e.getMessage(), errorMessage);
+        SoftAssert softAssert = new SoftAssert();
+        softAssert.assertTrue(!isValid);
+        softAssert.assertEquals(e.getMessage(), errorMessage);
+        softAssert.assertAll();
       }
   }
 }

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -97,7 +97,7 @@ public class TestExtensionSchemaValidationCmdLineApp
       catch (Exception e)
       {
         SoftAssert softAssert = new SoftAssert();
-        softAssert.assertTrue(!isValid);
+        softAssert.assertFalse(isValid);
         softAssert.assertEquals(errorMessage, e.getMessage());
         softAssert.assertAll();
       }

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -91,14 +91,14 @@ public class TestExtensionSchemaValidationCmdLineApp
         ExtensionSchemaValidationCmdLineApp.parseAndValidateExtensionSchemas(resolverPath, new File(inputPath));
         SoftAssert softAssert = new SoftAssert();
         softAssert.assertTrue(isValid);
-        softAssert.assertEquals(errorMessage, null);
+        softAssert.assertEquals(null, errorMessage);
         softAssert.assertAll();
       }
       catch (Exception e)
       {
         SoftAssert softAssert = new SoftAssert();
-        softAssert.assertFalse(isValid);
-        softAssert.assertEquals(errorMessage, e.getMessage());
+        softAssert.assertTrue(!isValid);
+        softAssert.assertEquals(e.getMessage(), errorMessage);
         softAssert.assertAll();
       }
   }

--- a/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
+++ b/restli-tools/src/test/java/com/linkedin/restli/tools/data/TestExtensionSchemaValidationCmdLineApp.java
@@ -98,7 +98,7 @@ public class TestExtensionSchemaValidationCmdLineApp
       {
         SoftAssert softAssert = new SoftAssert();
         softAssert.assertTrue(!isValid);
-        softAssert.assertEquals(e.getMessage(), errorMessage);
+        softAssert.assertEquals(errorMessage, e.getMessage());
         softAssert.assertAll();
       }
   }


### PR DESCRIPTION
### Summary

When testExtensionSchemaValidation tests fail, the reason behind those failures are not logged. This PR replaces `Assert` with `SoftAssert` to always output the reason for failure in the unit tests. Below are some example outputs:

Before change:
```
Failure message for com.linkedin.restli.tools.data.TestExtensionSchemaValidationCmdLineApp > testExtensionSchemaValidation[0](validCase, true, null):
    The following asserts failed:
        expected [true] but found [false]
```

After change:
```
Failure message for com.linkedin.restli.tools.data.TestExtensionSchemaValidationCmdLineApp > testExtensionSchemaValidation[0](validCase, true, null):
    The following asserts failed:
        expected [true] but found [false],
        expected [null] but found [versionSuffix value: 'V3' does not match the versionSuffix value which was defined in resourceKey/grpcService annotation]
```

In addition, this PR updates `ValidateExtensionSchemaTask` to output schema validation errors to the build log.

More information can be found at [SI-40347](https://jira01.corp.linkedin.com:8443/browse/SI-40347).

### Tests
I manually modified valid test cases to be invalid and invalid test cases to be valid to check for error message improvements.