### PR TITLE
Respect glob collection subscriptions on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.58.5] - 2024-09-04
+- Respect glob collection subscriptions on reconnect
+
 ## [29.58.4] - 2024-09-03
+- Respect `startPublishing` call by always re-notifying watcher in XdsClientImpl
 
 ## [29.58.3] - 2024-08-12
 - Disable the warmUp flaky unit test
@@ -5721,7 +5725,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.5...master
+[29.58.5]: https://github.com/linkedin/rest.li/compare/v29.58.4...v29.58.5
 [29.58.4]: https://github.com/linkedin/rest.li/compare/v29.58.3...v29.58.4
 [29.58.3]: https://github.com/linkedin/rest.li/compare/v29.58.2...v29.58.3
 [29.58.2]: https://github.com/linkedin/rest.li/compare/v29.58.1...v29.58.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,19 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.57.3] - 2024-07-18
-- Respect glob collection subscriptions on reconnect
+## [29.58.4] - 2024-09-03
+
+## [29.58.3] - 2024-08-12
+- Disable the warmUp flaky unit test
+
+## [29.58.2] - 2024-08-06
+- Add try/catch logic for INDIS xds stream initialization
+
+## [29.58.1] - 2024-07-19
+- Increase verbosity of testExtensionSchemaValidation tests
+
+## [29.58.0] - 2024-07-11
+- Allow both @extension and @grpcExtension extensions in schema validation
 
 ## [29.57.2] - 2024-06-17
 - Update grpc version to 1.59.1 and protobuf to 3.24.0
@@ -5710,8 +5721,12 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.3...master
-[29.57.3]: https://github.com/linkedin/rest.li/compare/v29.57.2...v29.57.3
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.4...master
+[29.58.4]: https://github.com/linkedin/rest.li/compare/v29.58.3...v29.58.4
+[29.58.3]: https://github.com/linkedin/rest.li/compare/v29.58.2...v29.58.3
+[29.58.2]: https://github.com/linkedin/rest.li/compare/v29.58.1...v29.58.2
+[29.58.1]: https://github.com/linkedin/rest.li/compare/v29.58.0...v29.58.1
+[29.58.0]: https://github.com/linkedin/rest.li/compare/v29.57.2...v29.58.0
 [29.57.2]: https://github.com/linkedin/rest.li/compare/v29.57.1...v29.57.2
 [29.57.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1
 [29.57.0]: https://github.com/linkedin/rest.li/compare/v29.56.1...v29.57.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.57.3] - 2024-07-18
+- Respect glob collection subscriptions on reconnect
+
 ## [29.57.2] - 2024-06-17
 - Update grpc version to 1.59.1 and protobuf to 3.24.0
 
@@ -5707,7 +5710,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.57.3...master
+[29.57.3]: https://github.com/linkedin/rest.li/compare/v29.57.2...v29.57.3
 [29.57.2]: https://github.com/linkedin/rest.li/compare/v29.57.1...v29.57.2
 [29.57.1]: https://github.com/linkedin/rest.li/compare/v29.57.0...v29.57.1
 [29.57.0]: https://github.com/linkedin/rest.li/compare/v29.56.1...v29.57.0

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -705,6 +705,7 @@ public class XdsClientImpl extends XdsClient
           resources = resources.stream()
               .map(GlobCollectionUtils::globCollectionUrlForClusterResource)
               .collect(Collectors.toSet());
+          type = ResourceType.D2_URI;
         }
         _adsStream.sendDiscoveryRequest(type, resources);
       }
@@ -943,8 +944,8 @@ public class XdsClientImpl extends XdsClient
     private void sendDiscoveryRequest(ResourceType type, Collection<String> resources)
     {
       _log.info("Sending {} request for resources: {}", type, resources);
-      DiscoveryRequestData request = new DiscoveryRequestData(_node, type, resources);
-      _requestWriter.onNext(request.toEnvoyProto());
+      DeltaDiscoveryRequest request = new DiscoveryRequestData(_node, type, resources).toEnvoyProto();
+      _requestWriter.onNext(request);
       _log.debug("Sent DiscoveryRequest\n{}", request);
     }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -692,11 +692,18 @@ public class XdsClientImpl extends XdsClient
     public void run() {
       startRpcStreamLocal();
       for (ResourceType type : ResourceType.values()) {
-        Map<String, ResourceSubscriber> subscriberMap = getResourceSubscriberMap(type);
-        Collection<String> resources = subscriberMap.isEmpty() ? null : subscriberMap.keySet();
-        if (resources != null) {
-          _adsStream.sendDiscoveryRequest(type, resources);
+        Collection<String> resources = getResourceSubscriberMap(type).keySet();
+        if (resources.isEmpty())
+        {
+          continue;
         }
+        if (_subscribeToUriGlobCollection && type == ResourceType.D2_URI_MAP)
+        {
+          resources = resources.stream()
+              .map(GlobCollectionUtils::globCollectionUrlForClusterResource)
+              .collect(Collectors.toSet());
+        }
+        _adsStream.sendDiscoveryRequest(type, resources);
       }
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.58.4
+version=29.58.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.57.2
+version=29.57.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.57.3
+version=29.58.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The RetryTask did not resubscribe to glob collections after a reconnect. Instead it goes back to map subscriptions. This change honors the glob collection config in the retry task.
