### PR TITLE
Respect `startPublishing` call by always re-notifying watcher in XdsClientImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.58.4] - 2024-09-03
+
 ## [29.58.3] - 2024-08-12
 - Disable the warmUp flaky unit test
 
@@ -5719,7 +5721,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.4...master
+[29.58.4]: https://github.com/linkedin/rest.li/compare/v29.58.3...v29.58.4
 [29.58.3]: https://github.com/linkedin/rest.li/compare/v29.58.2...v29.58.3
 [29.58.2]: https://github.com/linkedin/rest.li/compare/v29.58.1...v29.58.2
 [29.58.1]: https://github.com/linkedin/rest.li/compare/v29.58.0...v29.58.1

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -255,6 +255,12 @@ public abstract class XdsClient
     }
   }
 
+  /**
+   * Subscribes the given {@link ResourceWatcher} to the resource of the given name. The watcher will be notified when
+   * the resource is received from the backend. Repeated calls to this function with the same resource name and watcher
+   * will always notify the given watcher of the current data if it is already present, even if the given watcher was
+   * already subscribed to said resource. However, the subscription will only be added once.
+   */
   abstract void watchXdsResource(String resourceName, ResourceWatcher watcher);
 
   abstract void startRpcStream();

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -554,11 +554,6 @@ public class XdsClientImpl extends XdsClient
 
     void addWatcher(ResourceWatcher watcher)
     {
-      if (_watchers.contains(watcher))
-      {
-        _log.warn("Watcher {} already registered", watcher);
-        return;
-      }
       _watchers.add(watcher);
       if (_data != null)
       {

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -558,6 +558,7 @@ public class XdsClientImpl extends XdsClient
       if (_data != null)
       {
         watcher.onChanged(_data);
+        _log.debug("Notifying watcher of current data for resource {} of type {}: {}", _resource, _type, _data);
       }
     }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -150,12 +150,9 @@ public class XdsToD2PropertiesAdaptor
     }
     else
     {
-      _watchedClusterResources.computeIfAbsent(clusterName, k ->
-      {
-        XdsClient.NodeResourceWatcher watcher = getClusterResourceWatcher(clusterName);
-        _xdsClient.watchXdsResource(resourceName, watcher);
-        return watcher;
-      });
+      XdsClient.ResourceWatcher watcher =
+          _watchedClusterResources.computeIfAbsent(clusterName, this::getClusterResourceWatcher);
+      _xdsClient.watchXdsResource(resourceName, watcher);
     }
   }
 
@@ -169,36 +166,27 @@ public class XdsToD2PropertiesAdaptor
     }
     else
     {
-      _watchedUriResources.computeIfAbsent(clusterName, k ->
-      {
-        XdsClient.D2URIMapResourceWatcher watcher = getUriResourceWatcher(clusterName);
-        _xdsClient.watchXdsResource(resourceName, watcher);
-        return watcher;
-      });
+      XdsClient.ResourceWatcher watcher =
+          _watchedUriResources.computeIfAbsent(clusterName, this::getUriResourceWatcher);
+      _xdsClient.watchXdsResource(resourceName, watcher);
     }
   }
 
   public void listenToService(String serviceName)
   {
-    _watchedServiceResources.computeIfAbsent(serviceName, k ->
-    {
-      XdsClient.NodeResourceWatcher watcher = getServiceResourceWatcher(serviceName);
-      _xdsClient.watchXdsResource(D2_SERVICE_NODE_PREFIX + serviceName, watcher);
-      return watcher;
-    });
+    XdsClient.ResourceWatcher watcher =
+        _watchedServiceResources.computeIfAbsent(serviceName, this::getServiceResourceWatcher);
+    _xdsClient.watchXdsResource(D2_SERVICE_NODE_PREFIX + serviceName, watcher);
   }
 
   private void listenToSymlink(String name, String fullResourceName)
   {
     // use full resource name ("/d2/clusters/$FooClusterMater", "/d2/uris/$FooClusterMaster") as the key
     // instead of just the symlink name ("$FooClusterMaster") to differentiate clusters and uris symlink resources.
-    _watchedSymlinkResources.computeIfAbsent(fullResourceName, k ->
-    {
-      // use symlink name "$FooClusterMaster" to create the watcher
-      XdsClient.NodeResourceWatcher watcher = getSymlinkResourceWatcher(fullResourceName, name);
-      _xdsClient.watchXdsResource(k, watcher);
-      return watcher;
-    });
+    XdsClient.ResourceWatcher watcher =
+        _watchedSymlinkResources.computeIfAbsent(fullResourceName, k -> getSymlinkResourceWatcher(k, name));
+    // use symlink name "$FooClusterMaster" to create the watcher
+    _xdsClient.watchXdsResource(fullResourceName, watcher);
   }
 
   XdsClient.NodeResourceWatcher getServiceResourceWatcher(String serviceName)

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -440,6 +441,23 @@ public class TestXdsClientImpl
     D2URIMapUpdate actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
     // removed resource will not overwrite the original valid data
     Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
+  }
+
+  @Test
+  public void testResourceSubscriberAddWatcher()
+  {
+    ResourceSubscriber subscriber = new ResourceSubscriber(NODE, "foo", null);
+    XdsClient.ResourceWatcher watcher = Mockito.mock(XdsClient.ResourceWatcher.class);
+    subscriber.addWatcher(watcher);
+    verify(watcher, times(0)).onChanged(any());
+
+    D2URIMapUpdate update = new D2URIMapUpdate(Collections.emptyMap());
+    subscriber.setData(update);
+    for (int i = 0; i < 10; i++)
+    {
+      subscriber.addWatcher(watcher);
+    }
+    verify(watcher, times(10)).onChanged(eq(update));
   }
 
   private static class XdsClientImplFixture

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.58.3
+version=29.58.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
When switching from the backup to the primary store (implemented in the XdsClientImpl), the data in the primary store is never replayed. This is different from the backup store behavior which respects the invocation of startPublishing and replays the contents of the store. This means that if the contents of the backup store are different from the contents of the primary store, and the client switches from the backup to the primary, the client will only see the backup values and not the primary values.