### PR TITLE
Allow for null paging inside Collection response envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.58.6] - 2024-09-08
+
 ## [29.58.5] - 2024-09-04
 - Respect glob collection subscriptions on reconnect
 
@@ -5725,7 +5727,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.6...master
+[29.58.6]: https://github.com/linkedin/rest.li/compare/v29.58.5...v29.58.6
 [29.58.5]: https://github.com/linkedin/rest.li/compare/v29.58.4...v29.58.5
 [29.58.4]: https://github.com/linkedin/rest.li/compare/v29.58.3...v29.58.4
 [29.58.3]: https://github.com/linkedin/rest.li/compare/v29.58.2...v29.58.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.58.5
+version=29.58.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Allow for null paging inside Collection response envelopes. Some use cases don't want to use index based pagination and instead want a custom pagination mechanism using custom metadata. 

In such cases, the framework injected default index based pagination is confusing for their clients. Supporting this natively within the framework is risky and fragile, since it involves changes to many places to undo the assumption that index based pagination always exists.

However, it is possible to put in a workaround by asking the services interested to author a custom rest.li filter to strip out index based pagination in such cases from the response. However, for such a filter to work this particular change is needed since the code that converts collection response envelopes to `CollectionResponse` objects needs to be aware of cases where pagination can be null.