### PR TITLE
Fix invalid handling of glob collections for wildcard subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.58.9] - 2024-09-20
+## [29.58.9] - 2024-09-24
 - Fix invalid handling of glob collections for wildcard subscribers
 
 ## [29.58.8] - 2024-09-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.58.9] - 2024-09-20
+- Fix invalid handling of glob collections for wildcard subscribers
+
 ## [29.58.8] - 2024-09-23
 - Revert Add WildcardResourceSubscriber which could subscribe to all resources, like NODE and URIMap resources.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5737,7 +5737,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.58.9...master
+[29.58.9]: https://github.com/linkedin/rest.li/compare/v29.58.8...v29.58.9
 [29.58.8]: https://github.com/linkedin/rest.li/compare/v29.58.7...v29.58.8
 [29.58.7]: https://github.com/linkedin/rest.li/compare/v29.58.6...v29.58.7
 [29.58.6]: https://github.com/linkedin/rest.li/compare/v29.58.5...v29.58.6

--- a/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/TestDynamicClient.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/TestDynamicClient.java
@@ -19,7 +19,7 @@ import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestRequestBuilder;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.util.NamedThreadFactory;
-import com.linkedin.test.util.retry.ThreeRetries;
+import com.linkedin.test.util.retry.TenRetries;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.net.URI;
@@ -141,7 +141,7 @@ public class TestDynamicClient extends D2BaseTest {
    * the requests sending from the clients should result in an even distribution. The total call count
    * received by a single server should not deviate by more than 15% of the average.
    */
-  @Test(retryAnalyzer = ThreeRetries.class)
+  @Test(retryAnalyzer = TenRetries.class)
   public void testBalancedLoadDistribution()
   {
     SimpleLoadBalancerStateTest.TestListener listener = new SimpleLoadBalancerStateTest.TestListener();
@@ -198,7 +198,7 @@ public class TestDynamicClient extends D2BaseTest {
    * After the update event is received by the ZK event subscriber. One request is required to actually trigger the
    * load balancer state and hash ring changes.
    */
-  @Test(retryAnalyzer = ThreeRetries.class)
+  @Test(retryAnalyzer = TenRetries.class)
   public void testD2WeightLessThanOne()
   {
     SimpleLoadBalancerStateTest.TestListener listener = new SimpleLoadBalancerStateTest.TestListener();
@@ -218,11 +218,12 @@ public class TestDynamicClient extends D2BaseTest {
       throw new RuntimeException("Failed the test because thread was interrupted");
     }
 
-    try {
+    try
+    {
       // Change the D2 weight of server:2851 to 0.5
       invokeD2ChangeWeightJmx(new ObjectName("com.linkedin.d2:type=\"server:2851\""), 0.5);
-      // Wait 5ms for the change to propagate
-      Thread.sleep(5);
+      // Wait 50ms for the change to propagate
+      Thread.sleep(50);
     } catch (Exception e) {
       fail("Failed to invoke d2 weight change jmx", e);
     }
@@ -284,7 +285,7 @@ public class TestDynamicClient extends D2BaseTest {
    * And if we further increase the weight to 4.0. The host will receive 4x the traffic of the other hosts
    * (with a tolerance of 15%).
    */
-  @Test(retryAnalyzer = ThreeRetries.class)
+  @Test(retryAnalyzer = TenRetries.class)
   public void testD2WeightGreaterThanOne()
   {
     SimpleLoadBalancerStateTest.TestListener listener = new SimpleLoadBalancerStateTest.TestListener();
@@ -304,11 +305,12 @@ public class TestDynamicClient extends D2BaseTest {
       throw new RuntimeException("Failed the test because thread was interrupted");
     }
 
-    try {
+    try
+    {
       // Change the D2 weight of server:2851 to 2.0
       invokeD2ChangeWeightJmx(new ObjectName("com.linkedin.d2:type=\"server:2851\""), 2);
-      // Wait 5ms for the change to propagate
-      Thread.sleep(5);
+      // Wait 50ms for the change to propagate
+      Thread.sleep(50);
     } catch (Exception e) {
       fail("Failed to invoke d2 weight change jmx", e);
     }
@@ -363,11 +365,12 @@ public class TestDynamicClient extends D2BaseTest {
       }
     }
 
-    try {
+    try
+    {
       // Change the D2 weight of server:2851 to 4.0
       invokeD2ChangeWeightJmx(new ObjectName("com.linkedin.d2:type=\"server:2851\""), 4);
-      // Wait 5ms for the change to propagate
-      Thread.sleep(5);
+      // Wait 50ms for the change to propagate
+      Thread.sleep(50);
     } catch (Exception e) {
       fail("Failed to invoke d2 weight change jmx", e);
     }
@@ -405,7 +408,7 @@ public class TestDynamicClient extends D2BaseTest {
    *   2. The host start receiving traffic and has a health score > 0.5.
    * The host will then be kicked out of the recovery program and continue to recover/degrade using normal up/downStep.
    */
-  @Test(retryAnalyzer = ThreeRetries.class)
+  @Test(retryAnalyzer = TenRetries.class)
   public void testHostMarkDownAndMarkUp()
   {
     SimpleLoadBalancerStateTest.TestListener listener = new SimpleLoadBalancerStateTest.TestListener();
@@ -425,11 +428,12 @@ public class TestDynamicClient extends D2BaseTest {
       throw new RuntimeException("Failed the test because thread was interrupted");
     }
 
-    try {
+    try
+    {
       // Mark down server:2851
       invokeMarkDownJmx(new ObjectName("com.linkedin.d2:type=\"server:2851\""));
-      // Wait 5ms for the change to propagate
-      Thread.sleep(5);
+      // Wait 50ms for the change to propagate
+      Thread.sleep(50);
     } catch (Exception e) {
       fail("Failed to invoke d2 weight change jmx", e);
     }
@@ -459,11 +463,12 @@ public class TestDynamicClient extends D2BaseTest {
       throw new RuntimeException("Failed the test because thread was interrupted");
     }
 
-    try {
+    try
+    {
       // Mark up server:2851
       invokeMarkUpJmx(new ObjectName("com.linkedin.d2:type=\"server:2851\""));
-      // Wait 5ms for the change to propagate
-      Thread.sleep(5);
+      // Wait 50ms for the change to propagate
+      Thread.sleep(50);
     } catch (Exception e) {
       fail("Failed to invoke d2 weight change jmx", e);
     }

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -95,6 +95,91 @@ public abstract class XdsClient
     }
   }
 
+  public static abstract class WildcardResourceWatcher
+  {
+    private final ResourceType _type;
+
+    /**
+     * Defining a private constructor means only classes that are defined in this file can extend this class (see
+     * {@link ResourceWatcher}).
+     */
+    WildcardResourceWatcher(ResourceType type)
+    {
+      _type = type;
+    }
+
+    final ResourceType getType()
+    {
+      return _type;
+    }
+
+    /**
+     * Called when the resource discovery RPC encounters some transient error.
+     */
+    public abstract void onError(Status error);
+
+    /**
+     * Called when the resource discovery RPC reestablishes connection.
+     */
+    public abstract void onReconnect();
+
+    /**
+     * Called when a resource is added or updated.
+     * @param resourceName the name of the resource that was added or updated.
+     * @param update       the new data {@link ResourceUpdate} for the resource.
+     */
+    abstract void onChanged(String resourceName, ResourceUpdate update);
+
+    /**
+     * Called when a resource is removed.
+     * @param resourceName the name of the resource that was removed.
+     */
+    public abstract void onRemoval(String resourceName);
+  }
+
+  public static abstract class WildcardNodeResourceWatcher extends WildcardResourceWatcher
+  {
+    public WildcardNodeResourceWatcher()
+    {
+      super(ResourceType.NODE);
+    }
+
+    /**
+     * Called when a node resource is added or updated.
+     * @param resourceName the resource name of the {@link NodeUpdate} that was added or updated.
+     * @param update       the new data for the {@link NodeUpdate}, including D2 cluster and service information.
+     */
+    public abstract void onChanged(String resourceName, NodeUpdate update);
+
+    @Override
+    final void onChanged(String resourceName, ResourceUpdate update)
+    {
+      onChanged(resourceName, (NodeUpdate) update);
+    }
+  }
+
+  public static abstract class WildcardD2URIMapResourceWatcher extends WildcardResourceWatcher
+  {
+    public WildcardD2URIMapResourceWatcher()
+    {
+      super(ResourceType.D2_URI_MAP);
+    }
+
+    /**
+     * Called when a {@link D2URIMapUpdate} resource is added or updated.
+     * @param resourceName the resource name of the {@link D2URIMapUpdate} map resource that was added or updated.
+     *                     like the /d2/uris/clusterName
+     * @param update       the new data for the {@link D2URIMapUpdate} resource
+     */
+    public abstract void onChanged(String resourceName, D2URIMapUpdate update);
+
+    @Override
+    final void onChanged(String resourceName, ResourceUpdate update)
+    {
+      onChanged(resourceName, (D2URIMapUpdate) update);
+    }
+  }
+
   public interface ResourceUpdate
   {
     boolean isValid();
@@ -109,7 +194,7 @@ public abstract class XdsClient
       _nodeData = nodeData;
     }
 
-    XdsD2.Node getNodeData()
+    public XdsD2.Node getNodeData()
     {
       return _nodeData;
     }
@@ -261,13 +346,32 @@ public abstract class XdsClient
    * will always notify the given watcher of the current data if it is already present, even if the given watcher was
    * already subscribed to said resource. However, the subscription will only be added once.
    */
-  abstract void watchXdsResource(String resourceName, ResourceWatcher watcher);
+  public abstract void watchXdsResource(String resourceName, ResourceWatcher watcher);
 
-  abstract void startRpcStream();
+  /**
+   * Subscribes the given {@link WildcardResourceWatcher} to all the resources of the corresponding type. The watcher
+   * will be notified whenever a resource is added or removed. Repeated calls to this function with the same watcher
+   * will always notify the given watcher of the current data.
+   */
+  public abstract void watchAllXdsResources(WildcardResourceWatcher watcher);
 
-  abstract void shutdown();
+  /**
+   * Initiates the RPC stream to the xDS server.
+   */
+  public abstract void startRpcStream();
 
-  abstract String getXdsServerAuthority();
+  /**
+   * Shuts down the xDS client.
+   */
+  public abstract void shutdown();
 
-  abstract public XdsClientJmx getXdsClientJmx();
+  /**
+   * Returns the authority of the xDS server.
+   */
+  public abstract String getXdsServerAuthority();
+
+  /**
+   * Returns the JMX bean for the xDS client.
+   */
+  public abstract XdsClientJmx getXdsClientJmx();
 }

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -77,6 +77,7 @@ public class XdsClientImpl extends XdsClient
       Arrays.stream(ResourceType.values())
           .filter(e -> e.typeUrl() != null)
           .collect(Collectors.toMap(Function.identity(), e -> new HashMap<>())));
+  private final Map<ResourceType, WildcardResourceSubscriber> _wildcardSubscribers = Maps.newEnumMap(ResourceType.class);
   private final Node _node;
   private final ManagedChannel _managedChannel;
   private final ScheduledExecutorService _executorService;
@@ -131,7 +132,7 @@ public class XdsClientImpl extends XdsClient
   }
 
   @Override
-  void watchXdsResource(String resourceName, ResourceWatcher watcher)
+  public void watchXdsResource(String resourceName, ResourceWatcher watcher)
   {
     _executorService.execute(() ->
     {
@@ -164,6 +165,32 @@ public class XdsClientImpl extends XdsClient
           _adsStream.sendDiscoveryRequest(type, Collections.singletonList(adjustedResourceName));
         }
       }
+      subscriber.addWatcher(watcher);
+    });
+  }
+
+  @Override
+  public void watchAllXdsResources(WildcardResourceWatcher watcher)
+  {
+    _executorService.execute(() ->
+    {
+      _log.info("Subscribing to wildcard for resource type: {}", watcher.getType());
+      WildcardResourceSubscriber subscriber = getWildcardResourceSubscriber(watcher.getType());
+      if (subscriber == null)
+      {
+        subscriber = new WildcardResourceSubscriber(watcher.getType());
+        _wildcardSubscribers.put(watcher.getType(), subscriber);
+
+        if (_adsStream == null && !isInBackoff())
+        {
+          startRpcStreamLocal();
+        }
+        if (_adsStream != null)
+        {
+          _adsStream.sendDiscoveryRequest(watcher.getType(), Collections.singletonList("*"));
+        }
+      }
+
       subscriber.addWatcher(watcher);
     });
   }
@@ -225,7 +252,7 @@ public class XdsClientImpl extends XdsClient
   }
 
   @Override
-  void shutdown()
+  public void shutdown()
   {
     _executorService.execute(() ->
     {
@@ -238,7 +265,7 @@ public class XdsClientImpl extends XdsClient
   }
 
   @Override
-  String getXdsServerAuthority()
+  public String getXdsServerAuthority()
   {
     return _managedChannel.authority();
   }
@@ -471,6 +498,11 @@ public class XdsClientImpl extends XdsClient
       {
         subscriber.onData(entry.getValue(), _serverMetricsProvider);
       }
+      WildcardResourceSubscriber wildcardSubscriber = _wildcardSubscribers.get(type);
+      if (wildcardSubscriber != null)
+      {
+        wildcardSubscriber.onData(entry.getKey(), entry.getValue());
+      }
     }
   }
 
@@ -490,6 +522,11 @@ public class XdsClientImpl extends XdsClient
         subscriber.onRemoval();
       }
     }
+    WildcardResourceSubscriber wildcardSubscriber = _wildcardSubscribers.get(type);
+    if (wildcardSubscriber != null)
+    {
+      removedResources.forEach(wildcardSubscriber::onRemoval);
+    }
   }
 
 
@@ -501,6 +538,10 @@ public class XdsClientImpl extends XdsClient
       {
         subscriber.onError(error);
       }
+    }
+    for (WildcardResourceSubscriber wildcardResourceSubscriber : _wildcardSubscribers.values())
+    {
+      wildcardResourceSubscriber.onError(error);
     }
     _xdsClientJmx.setIsConnected(false);
   }
@@ -514,6 +555,10 @@ public class XdsClientImpl extends XdsClient
         subscriber.onReconnect();
       }
     }
+    for (WildcardResourceSubscriber wildcardResourceSubscriber : _wildcardSubscribers.values())
+    {
+      wildcardResourceSubscriber.onReconnect();
+    }
     _xdsClientJmx.setIsConnected(true);
   }
 
@@ -521,6 +566,12 @@ public class XdsClientImpl extends XdsClient
   Map<String, ResourceSubscriber> getResourceSubscriberMap(ResourceType type)
   {
     return _resourceSubscribers.get(type);
+  }
+
+  @VisibleForTesting
+  WildcardResourceSubscriber getWildcardResourceSubscriber(ResourceType type)
+  {
+    return _wildcardSubscribers.get(type);
   }
 
   static class ResourceSubscriber
@@ -690,24 +741,132 @@ public class XdsClientImpl extends XdsClient
     }
   }
 
-  final class RpcRetryTask implements Runnable {
+  static class WildcardResourceSubscriber
+  {
+    private final ResourceType _type;
+    private final Set<WildcardResourceWatcher> _watchers = new HashSet<>();
+    private Map<String, ResourceUpdate> _data = new HashMap<>();
+
+    @VisibleForTesting
+    public Map<String, ResourceUpdate> getData()
+    {
+      return _data;
+    }
+
+    @VisibleForTesting
+    public void setData(@Nullable Map<String, ResourceUpdate> data)
+    {
+      _data = data;
+    }
+
+    WildcardResourceSubscriber(ResourceType type)
+    {
+      _type = type;
+    }
+
+    void addWatcher(WildcardResourceWatcher watcher)
+    {
+      _watchers.add(watcher);
+      for (Map.Entry<String, ResourceUpdate> entry : _data.entrySet())
+      {
+        watcher.onChanged(entry.getKey(), entry.getValue());
+        _log.debug("Notifying watcher of current data for resource {} of type {}: {}",
+            entry.getKey(), _type, entry.getValue());
+      }
+    }
+
+    private void onData(String resourceName, ResourceUpdate data)
+    {
+      if (Objects.equals(_data.get(resourceName), data))
+      {
+        _log.debug("Received resource update data equal to the current data. Will not perform the update.");
+        return;
+      }
+      // null value guard to avoid overwriting the property with null
+      if (data != null && data.isValid())
+      {
+        _data.put(resourceName, data);
+        for (WildcardResourceWatcher watcher : _watchers)
+        {
+          watcher.onChanged(resourceName, data);
+        }
+      }
+      else
+      {
+        if (_type == ResourceType.D2_URI_MAP || _type == ResourceType.D2_URI)
+        {
+          RATE_LIMITED_LOGGER.warn("Received invalid data for {} {}, data: {}", _type, resourceName, data);
+        }
+        else
+        {
+          _log.warn("Received invalid data for {} {}, data: {}", _type, resourceName, data);
+        }
+      }
+    }
+
+    public ResourceType getType()
+    {
+      return _type;
+    }
+
+    private void onError(Status error)
+    {
+      for (WildcardResourceWatcher watcher : _watchers)
+      {
+        watcher.onError(error);
+      }
+    }
+
+    private void onReconnect()
+    {
+      for (WildcardResourceWatcher watcher : _watchers)
+      {
+        watcher.onReconnect();
+      }
+    }
+
+    @VisibleForTesting
+    void onRemoval(String resourceName)
+    {
+      _data.remove(resourceName);
+      for (WildcardResourceWatcher watcher : _watchers)
+      {
+        watcher.onRemoval(resourceName);
+      }
+    }
+  }
+
+  final class RpcRetryTask implements Runnable
+  {
     @Override
-    public void run() {
+    public void run()
+    {
       startRpcStreamLocal();
-      for (ResourceType type : ResourceType.values()) {
-        Collection<String> resources = getResourceSubscriberMap(type).keySet();
-        if (resources.isEmpty())
+      for (ResourceType type : ResourceType.values())
+      {
+        Set<String> resources = new HashSet<>(getResourceSubscriberMap(type).keySet());
+        if (resources.isEmpty() && getWildcardResourceSubscriber(type) == null)
         {
           continue;
         }
+        ResourceType rewrittenType;
         if (_subscribeToUriGlobCollection && type == ResourceType.D2_URI_MAP)
         {
           resources = resources.stream()
               .map(GlobCollectionUtils::globCollectionUrlForClusterResource)
-              .collect(Collectors.toSet());
-          type = ResourceType.D2_URI;
+              .collect(Collectors.toCollection(HashSet::new));
+          rewrittenType = ResourceType.D2_URI;
         }
-        _adsStream.sendDiscoveryRequest(type, resources);
+        else
+        {
+          rewrittenType = type;
+        }
+        // If there is a wildcard subscriber, we should always send a wildcard request to the server.
+        if (getWildcardResourceSubscriber(type) != null)
+        {
+          resources.add("*");
+        }
+        _adsStream.sendDiscoveryRequest(rewrittenType, resources);
       }
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.58.8
+version=29.58.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/test-util/src/main/java/com/linkedin/test/util/retry/TenRetries.java
+++ b/test-util/src/main/java/com/linkedin/test/util/retry/TenRetries.java
@@ -1,0 +1,29 @@
+/*
+   Copyright (c) 2020 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.test.util.retry;
+
+
+/**
+ * Allows ten retries for a given test method. This is useful for tests that are especially flaky.
+ */
+public class TenRetries extends Retries
+{
+  public TenRetries()
+  {
+    super(10);
+  }
+}


### PR DESCRIPTION
As the title says, things weren't wired through correctly for glob collections, namely they were being ignored because they were triggering the check for whtehre the cluster is being watched at all. This fixes that (and the fact that the initial subscription did not respect the `useGlobCollections` flag). This change has been unit tested and tested through in restli-resource-explorer, and it works for both glob and non-glob.