### PR TITLE
Add support for initial resource versions in xds client

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 
@@ -183,15 +184,19 @@ public abstract class XdsClient
   public interface ResourceUpdate
   {
     boolean isValid();
+    @Nonnull
+    Map<String, String> getVersions();
   }
 
   public static final class NodeUpdate implements ResourceUpdate
   {
     XdsD2.Node _nodeData;
+    Map<String, String> _versions;
 
-    NodeUpdate(XdsD2.Node nodeData)
+    NodeUpdate(XdsD2.Node nodeData, @Nonnull Map<String, String> versions)
     {
       _nodeData = nodeData;
+      _versions = versions;
     }
 
     public XdsD2.Node getNodeData()
@@ -211,13 +216,13 @@ public abstract class XdsClient
         return false;
       }
       NodeUpdate that = (NodeUpdate) object;
-      return Objects.equals(_nodeData, that._nodeData);
+      return Objects.equals(_versions, that._versions) && Objects.equals(_nodeData, that._nodeData);
     }
 
     @Override
     public int hashCode()
     {
-      return Objects.hash(_nodeData);
+      return Objects.hash(_versions, _nodeData);
     }
 
     @Override
@@ -226,20 +231,28 @@ public abstract class XdsClient
       return _nodeData != null && !_nodeData.getData().isEmpty();
     }
 
+    @Nonnull
+    @Override
+    public Map<String, String> getVersions() {
+      return _versions;
+    }
+
     @Override
     public String toString()
     {
-      return MoreObjects.toStringHelper(this).add("_nodeData", _nodeData).toString();
+      return MoreObjects.toStringHelper(this).add("_versions", _versions).add("_nodeData", _nodeData).toString();
     }
   }
 
   public static final class D2URIMapUpdate implements ResourceUpdate
   {
     Map<String, XdsD2.D2URI> _uriMap;
+    Map<String, String> _versions;
 
-    D2URIMapUpdate(Map<String, XdsD2.D2URI> uriMap)
+    D2URIMapUpdate(Map<String, XdsD2.D2URI> uriMap, @Nonnull Map<String, String> versions)
     {
       _uriMap = uriMap;
+      _versions = versions;
     }
 
     public Map<String, XdsD2.D2URI> getURIMap()
@@ -247,13 +260,14 @@ public abstract class XdsClient
       return _uriMap;
     }
 
-    D2URIMapUpdate putUri(String name, XdsD2.D2URI uri)
+    D2URIMapUpdate putUri(String name, XdsD2.D2URI uri, String version)
     {
       if (_uriMap == null)
       {
         _uriMap = new HashMap<>();
       }
       _uriMap.put(name, uri);
+      _versions.put(name, version);
       return this;
     }
 
@@ -263,6 +277,7 @@ public abstract class XdsClient
       {
         _uriMap.remove(name);
       }
+      _versions.remove(name);
       return this;
     }
 
@@ -278,13 +293,13 @@ public abstract class XdsClient
         return false;
       }
       D2URIMapUpdate that = (D2URIMapUpdate) object;
-      return Objects.equals(_uriMap, that._uriMap);
+      return Objects.equals(_versions, that._versions) && Objects.equals(_uriMap, that._uriMap);
     }
 
     @Override
     public int hashCode()
     {
-      return Objects.hash(_uriMap);
+      return Objects.hash(_versions, _uriMap);
     }
 
     @Override
@@ -293,15 +308,23 @@ public abstract class XdsClient
       return _uriMap != null;
     }
 
+    @Nonnull
+    @Override
+    public Map<String, String> getVersions() {
+      return _versions;
+    }
+
     @Override
     public String toString()
     {
-      return MoreObjects.toStringHelper(this).add("_uriMap", _uriMap).toString();
+      return MoreObjects.toStringHelper(this).add("_versions", _versions).add("_uriMap", _uriMap).toString();
     }
   }
 
-  public static final NodeUpdate EMPTY_NODE_UPDATE = new NodeUpdate(null);
-  public static final D2URIMapUpdate EMPTY_D2_URI_MAP_UPDATE = new D2URIMapUpdate(null);
+  // same as the default proto value for a string field
+  static final String UNKNOWN_RESOURCE_VERSION = "";
+  public static final NodeUpdate EMPTY_NODE_UPDATE = new NodeUpdate(null, new HashMap<>());
+  public static final D2URIMapUpdate EMPTY_D2_URI_MAP_UPDATE = new D2URIMapUpdate(null, new HashMap<>());
 
   enum ResourceType
   {

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -321,8 +321,6 @@ public abstract class XdsClient
     }
   }
 
-  // same as the default proto value for a string field
-  static final String UNKNOWN_RESOURCE_VERSION = "";
   public static final NodeUpdate EMPTY_NODE_UPDATE = new NodeUpdate(null, new HashMap<>());
   public static final D2URIMapUpdate EMPTY_D2_URI_MAP_UPDATE = new D2URIMapUpdate(null, new HashMap<>());
 

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -48,8 +48,8 @@ public class TestXdsClientImpl
   private static final Any PACKED_NODE_WITH_DATA = Any.pack(NODE_WITH_DATA);
   private static final Any PACKED_NODE_WITH_DATA2 = Any.pack(NODE_WITH_DATA2);
   private static final Any PACKED_NODE_WITH_EMPTY_DATA = Any.pack(NODE_WITH_EMPTY_DATA);
-  private static final XdsClient.NodeUpdate NODE_UPDATE1 = new XdsClient.NodeUpdate(NODE_WITH_DATA);
-  private static final XdsClient.NodeUpdate NODE_UPDATE2 = new XdsClient.NodeUpdate(NODE_WITH_DATA2);
+  private static final XdsClient.NodeUpdate NODE_UPDATE1 = new XdsClient.NodeUpdate(NODE_WITH_DATA, new HashMap<>());
+  private static final XdsClient.NodeUpdate NODE_UPDATE2 = new XdsClient.NodeUpdate(NODE_WITH_DATA2, new HashMap<>());
   private static final List<Resource> NODE_RESOURCES_WITH_DATA1 = Collections.singletonList(
       Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME).setResource(PACKED_NODE_WITH_DATA).build());
   private static final List<Resource> NODE_RESOURCES_WITH_DATA2 = Collections.singletonList(
@@ -72,9 +72,9 @@ public class TestXdsClientImpl
       .putUris(URI1, D2URI_1_1) // updated uri1
       .putUris(URI2, D2URI_2).build(); // added ur2
   private static final D2URIMapUpdate D2_URI_MAP_UPDATE_WITH_DATA1 =
-      new D2URIMapUpdate(D2_URI_MAP_WITH_DATA1.getUrisMap());
+      new D2URIMapUpdate(D2_URI_MAP_WITH_DATA1.getUrisMap(), new HashMap<>());
   private static final D2URIMapUpdate D2_URI_MAP_UPDATE_WITH_DATA2 =
-      new D2URIMapUpdate(D2_URI_MAP_WITH_DATA2.getUrisMap());
+      new D2URIMapUpdate(D2_URI_MAP_WITH_DATA2.getUrisMap(), new HashMap<>());
   private static final Any PACKED_D2_URI_MAP_WITH_DATA1 = Any.pack(D2_URI_MAP_WITH_DATA1);
   private static final Any PACKED_D2_URI_MAP_WITH_DATA2 = Any.pack(D2_URI_MAP_WITH_DATA2);
   private static final Any PACKED_D2_URI_MAP_WITH_EMPTY_DATA = Any.pack(D2_URI_MAP_WITH_EMPTY_DATA);
@@ -170,8 +170,8 @@ public class TestXdsClientImpl
     Assert.assertEquals(Objects.requireNonNull(actualData).getNodeData(), NODE_UPDATE1.getNodeData());
 
     // subscriber original data is invalid, xds server latency won't be tracked
-    fixture._nodeSubscriber.setData(new XdsClient.NodeUpdate(null));
-    fixture._nodeWildcardSubscriber.setData(SERVICE_RESOURCE_NAME, new XdsClient.NodeUpdate(null));
+    fixture._nodeSubscriber.setData(new XdsClient.NodeUpdate(null, new HashMap<>()));
+    fixture._nodeWildcardSubscriber.setData(SERVICE_RESOURCE_NAME, new XdsClient.NodeUpdate(null, new HashMap<>()));
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA1);
     fixture.verifyAckSent(2);
     verify(fixture._resourceWatcher, times(2)).onChanged(eq(NODE_UPDATE1));
@@ -264,8 +264,8 @@ public class TestXdsClientImpl
     Assert.assertEquals(Objects.requireNonNull(actualData).getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
 
     // subscriber original data is invalid, xds server latency won't be tracked
-    fixture._clusterSubscriber.setData(new XdsClient.D2URIMapUpdate(null));
-    fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, new XdsClient.D2URIMapUpdate(null));
+    fixture._clusterSubscriber.setData(new XdsClient.D2URIMapUpdate(null, new HashMap<>()));
+    fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, new XdsClient.D2URIMapUpdate(null, new HashMap<>()));
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA1);
     verify(fixture._resourceWatcher, times(2)).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
     verify(fixture._wildcardResourceWatcher, times(2)).onChanged(eq(CLUSTER_RESOURCE_NAME), eq(D2_URI_MAP_UPDATE_WITH_DATA1));
@@ -312,7 +312,7 @@ public class TestXdsClientImpl
     D2URIMapUpdate expectedUpdate =
         invalidData
             ? (D2URIMapUpdate) D2_URI_MAP.emptyData()
-            : new D2URIMapUpdate(Collections.emptyMap());
+            : new D2URIMapUpdate(Collections.emptyMap(), new HashMap<>());
     verify(fixture._resourceWatcher).onChanged(eq(expectedUpdate));
     if (!invalidData)
     {
@@ -392,8 +392,8 @@ public class TestXdsClientImpl
     Assert.assertEquals(Objects.requireNonNull(actualData).getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
 
     // subscriber original data is invalid, xds server latency won't be tracked
-    fixture._clusterSubscriber.setData(new D2URIMapUpdate(null));
-    fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, new D2URIMapUpdate(null));
+    fixture._clusterSubscriber.setData(new D2URIMapUpdate(null, new HashMap<>()));
+    fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, new D2URIMapUpdate(null, new HashMap<>()));
     fixture._xdsClientImpl.handleResponse(createUri1);
     fixture.verifyAckSent(2);
     verify(fixture._resourceWatcher, times(2)).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
@@ -410,7 +410,7 @@ public class TestXdsClientImpl
     fixture._xdsClientImpl.handleResponse(createUri2Delete1);
     actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
     // subscriber data should be updated to D2_URI_MAP_UPDATE_WITH_DATA2
-    D2URIMapUpdate expectedUpdate = new D2URIMapUpdate(Collections.singletonMap(URI2, D2URI_2));
+    D2URIMapUpdate expectedUpdate = new D2URIMapUpdate(Collections.singletonMap(URI2, D2URI_2), new HashMap<>());
     verify(fixture._resourceWatcher).onChanged(eq(expectedUpdate));
     verify(fixture._wildcardResourceWatcher).onChanged(eq(CLUSTER_RESOURCE_NAME), eq(expectedUpdate));
     // track latency only for updated/new uri (not for deletion)
@@ -426,7 +426,7 @@ public class TestXdsClientImpl
     fixture._xdsClientImpl.handleResponse(deleteUri2);
     actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
     // subscriber data should be updated to empty map
-    expectedUpdate = new D2URIMapUpdate(Collections.emptyMap());
+    expectedUpdate = new D2URIMapUpdate(Collections.emptyMap(), new HashMap<>());
     verify(fixture._resourceWatcher).onChanged(eq(expectedUpdate));
     verify(fixture._wildcardResourceWatcher).onChanged(eq(CLUSTER_RESOURCE_NAME), eq(expectedUpdate));
     verifyNoMoreInteractions(fixture._serverMetricsProvider);
@@ -543,7 +543,7 @@ public class TestXdsClientImpl
     subscriber.addWatcher(watcher);
     verify(watcher, times(0)).onChanged(any());
 
-    D2URIMapUpdate update = new D2URIMapUpdate(Collections.emptyMap());
+    D2URIMapUpdate update = new D2URIMapUpdate(Collections.emptyMap(), new HashMap<>());
     subscriber.setData(update);
     for (int i = 0; i < 10; i++)
     {


### PR DESCRIPTION
Setting the `initial_resource_versions` property in a delta resource request allows the xDS server to avoid re-sending data the client may already have from a previous successful connection to another server.

See https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#service-discovery-v3-deltadiscoveryrequest 

Changes:
- Track the incoming resource versions and send the version map to the server in the event of a re-connection.