### PR TITLE
Disable dark traffic dispatching during dark warmup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.61.0] - 2024-10-24
+- Disable dark traffic dispatching during dark warmup
+
 ## [29.60.0] - 2024-10-17
 - Restore the old constructor to avoid incompatible issue
 
@@ -5749,7 +5752,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.60.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.61.0...master
+[29.61.0]: https://github.com/linkedin/rest.li/compare/v29.60.0...v29.61.0
 [29.60.0]: https://github.com/linkedin/rest.li/compare/v29.59.0...v29.60.0
 [29.59.0]: https://github.com/linkedin/rest.li/compare/v29.58.11...v29.59.0
 [29.58.11]: https://github.com/linkedin/rest.li/compare/v29.58.10...v29.58.11

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -105,7 +105,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
 
   // Field to indicate if warm up was started. If it is true, it will try to end the warm up
   // by marking down on ZK if the connection goes down
-  private boolean _isWarmingUp;
+  private volatile boolean _isWarmingUp;
 
   // Field to indicate whether the mark up operation is being retried after a connection loss
   private boolean _isRetryWarmup;
@@ -825,5 +825,12 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
       _log.warn("Node path and data can't be found with unknown cluster: " + cluster + ". Ignored.");
     }
     return new ImmutablePair<>(nodePath, nodeData);
+  }
+
+  /**
+   * Indicates whether the announcement is currently made to the dark warmup cluster.
+   */
+  public boolean isWarmingUp() {
+    return _isWarmingUp;
   }
 }

--- a/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterManagerImpl.java
+++ b/darkcluster/src/main/java/com/linkedin/darkcluster/impl/DarkClusterManagerImpl.java
@@ -63,7 +63,6 @@ public class DarkClusterManagerImpl implements DarkClusterManager
   private final List<DarkRequestHeaderGenerator> _darkRequestHeaderGenerators;
   private Map<String, AtomicReference<URIRewriter>> _uriRewriterMap;
   private final List<ZooKeeperAnnouncer> _announcers;
-  private volatile boolean _isDarkWarmupComplete = false;
 
   public DarkClusterManagerImpl(@Nonnull String sourceClusterName, @Nonnull Facilities facilities,
                                 @Nonnull DarkClusterStrategyFactory strategyFactory, String whiteListRegEx,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.60.0
+version=29.61.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Description
----
Sending dark traffic during dark warmup is risky since it can result in the calls being sent back to the same hosts, resulting in a cycle.

Changes:
- Use `ZookeeperAnnouncer` in dark cluster utils to ensure that no dark requests are sent while any of the announcers is in warmup mode (and the app is receiving some dark traffic).

Testing
-------
Added UT.