### PR TITLE
check and warn for invalid partition weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.62.0] - 2024-10-28
+- Check and take configurable action for invalid partition weight
+
 ## [29.61.0] - 2024-10-24
 - Disable dark traffic dispatching during dark warmup
 
@@ -5752,7 +5755,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.61.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.62.0...master
+[29.62.0]: https://github.com/linkedin/rest.li/compare/v29.61.0...v29.62.0
 [29.61.0]: https://github.com/linkedin/rest.li/compare/v29.60.0...v29.61.0
 [29.60.0]: https://github.com/linkedin/rest.li/compare/v29.59.0...v29.60.0
 [29.59.0]: https://github.com/linkedin/rest.li/compare/v29.58.11...v29.59.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -102,6 +102,9 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
    * For example, 100.00 means the max weight allowed is 100 and the max number of decimal places is 2.
    */
   private final BigDecimal _maxWeight;
+  /**
+   * The action to take when d2 weight breaches validation rules.
+   */
   private ActOnWeightBreach _actOnWeightBreach = ActOnWeightBreach.IGNORE;
   private volatile Map<String, Object> _uriSpecificProperties;
 
@@ -151,15 +154,14 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
   // Field to store the dark warm-up time duration in seconds, defaults to zero
   private final int _warmupDuration;
 
-  /**
-   * The action to take when d2 weight breaches validation rules.
-   */
   public enum ActOnWeightBreach {
     // Ignore and no op.
     IGNORE,
-    //
+    // only log warnings
     WARN,
+    // throw exceptions
     THROW,
+    // rectify the invalid weight (e.g: cap to the max, round to the nearest valid decimal places)
     RECTIFY
   }
 
@@ -245,7 +247,11 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     _executorService = executorService;
     _eventEmitter = eventEmitter;
     _maxWeight = maxWeight;
-    _actOnWeightBreach = actOnWeightBreach;
+    
+    if (actOnWeightBreach != null)
+    {
+      _actOnWeightBreach = actOnWeightBreach;
+    }
 
     if (server instanceof ZooKeeperServer)
     {

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -246,6 +246,8 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     _warmupDuration = warmupDuration;
     _executorService = executorService;
     _eventEmitter = eventEmitter;
+
+    // take in max weight as a string to be precise at decimal places when creating a BigDecimal.
     _maxWeight = maxWeight == null ? null : new BigDecimal(maxWeight);
     if (actOnWeightBreach != null)
     {
@@ -873,6 +875,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
             throw getMaxWeightBreachException(weight, entry.getKey());
           case RECTIFY:
             entry.setValue(new PartitionData(_maxWeight.intValue()));
+            weight = _maxWeight;
             _log.warn("Capped weight {} in Partition {} to the max weight allowed: {}.", weight.doubleValue(),
                 entry.getKey(), _maxWeight.intValue());
             break;

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -110,7 +110,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
   /**
    * The action to take when d2 weight breaches validation rules.
    */
-  private ActionOnWeightBreach _actionOnWeightBreach = ActionOnWeightBreach.IGNORE;
+  private final ActionOnWeightBreach _actionOnWeightBreach;
 
   private final AtomicInteger _maxWeightBreachedCount = new AtomicInteger(0);
   private final AtomicInteger _weightDecimalPlacesBreachedCount = new AtomicInteger(0);
@@ -267,10 +267,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     _eventEmitter = eventEmitter;
 
     _maxWeight = maxWeight;
-    if (actionOnWeightBreach != null)
-    {
-      _actionOnWeightBreach = actionOnWeightBreach;
-    }
+    _actionOnWeightBreach = actionOnWeightBreach != null ? actionOnWeightBreach : ActionOnWeightBreach.IGNORE;
 
     if (server instanceof ZooKeeperServer)
     {

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -848,6 +848,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
    */
   public boolean isWarmingUp() {
     return _isWarmingUp;
+  }
 
   private Map<Integer, PartitionData> validatePartitionData(Map<Integer, PartitionData> partitionData) {
     if (_maxWeight == null || _actOnWeightBreach == ActOnWeightBreach.IGNORE) {

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -230,7 +230,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
 
   public ZooKeeperAnnouncer(LoadBalancerServer server, boolean initialIsUp,
       boolean isDarkWarmupEnabled, String warmupClusterName, int warmupDuration, ScheduledExecutorService executorService,
-      ServiceDiscoveryEventEmitter eventEmitter, BigDecimal maxWeight, ActOnWeightBreach actOnWeightBreach)
+      ServiceDiscoveryEventEmitter eventEmitter, String maxWeight, ActOnWeightBreach actOnWeightBreach)
   {
     _server = server;
     // initialIsUp is used for delay mark up. If it's false, there won't be markup when the announcer is started.
@@ -246,8 +246,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     _warmupDuration = warmupDuration;
     _executorService = executorService;
     _eventEmitter = eventEmitter;
-    _maxWeight = maxWeight;
-    
+    _maxWeight = maxWeight == null ? null : new BigDecimal(maxWeight);
     if (actOnWeightBreach != null)
     {
       _actOnWeightBreach = actOnWeightBreach;

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -158,7 +158,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
   /**
    * Whether the announcer has completed sending a dark warmup cluster markup intent.
    */
-  private final AtomicBoolean _isDarkWarmupMarkedUp = new AtomicBoolean(false);
+  private final AtomicBoolean _isDarkWarmupMarkUpIntentSent = new AtomicBoolean(false);
 
   // String to store the name of the dark warm-up cluster, defaults to null
   private final String _warmupClusterName;
@@ -455,7 +455,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
       @Override
       public void onSuccess(None result)
       {
-        _isDarkWarmupMarkedUp.set(false);
+        _isDarkWarmupMarkUpIntentSent.set(false);
         emitSDStatusActiveUpdateIntentAndWriteEvents(_warmupClusterName, false, true, _warmupClusterMarkDownStartAtRef.get());
         // Mark _isWarmingUp to false to indicate warm up has completed
         _isWarmingUp = false;
@@ -506,7 +506,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
       @Override
       public void onSuccess(None result)
       {
-        _isDarkWarmupMarkedUp.set(true);
+        _isDarkWarmupMarkUpIntentSent.set(true);
         emitSDStatusActiveUpdateIntentAndWriteEvents(_warmupClusterName, true, true, _warmupClusterMarkUpStartAtRef.get());
         _log.info("markUp for uri {} on warm-up cluster {} succeeded", _uri, _warmupClusterName);
         // Mark _isWarmingUp to true to indicate warm up is in progress
@@ -819,14 +819,14 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     return _markUpFailed;
   }
 
-  public boolean isMarkedUp()
+  public boolean isMarkUpIntentSent()
   {
     return _isMarkUpIntentSent.get();
   }
 
-  public boolean isDarkWarmupMarkedUp()
+  public boolean isDarkWarmupMarkUpIntentSent()
   {
-    return _isDarkWarmupMarkedUp.get();
+    return _isDarkWarmupMarkUpIntentSent.get();
   }
 
   public int getMaxWeightBreachedCount()

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmx.java
@@ -185,14 +185,14 @@ public class ZooKeeperAnnouncerJmx implements ZooKeeperAnnouncerJmxMXBean
   }
 
   @Override
-  public boolean isMarkedUp()
+  public boolean isMarkUpIntentSent()
   {
-    return _announcer.isMarkedUp();
+    return _announcer.isMarkUpIntentSent();
   }
 
   @Override
-  public boolean isDarkWarmupMarkedUp() {
-    return _announcer.isDarkWarmupMarkedUp();
+  public boolean isDarkWarmupMarkUpIntentSent() {
+    return _announcer.isDarkWarmupMarkUpIntentSent();
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmx.java
@@ -183,4 +183,27 @@ public class ZooKeeperAnnouncerJmx implements ZooKeeperAnnouncerJmxMXBean
   public boolean isMarkUpFailed() {
     return _announcer.isMarkUpFailed();
   }
+
+  @Override
+  public boolean isMarkedUp()
+  {
+    return _announcer.isMarkedUp();
+  }
+
+  @Override
+  public boolean isDarkWarmupMarkedUp() {
+    return _announcer.isDarkWarmupMarkedUp();
+  }
+
+  @Override
+  public int getMaxWeightBreachedCount()
+  {
+    return _announcer.getMaxWeightBreachedCount();
+  }
+
+  @Override
+  public int getWeightDecimalPlacesBreachedCount()
+  {
+    return _announcer.getWeightDecimalPlacesBreachedCount();
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmxMXBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmxMXBean.java
@@ -72,4 +72,25 @@ public interface ZooKeeperAnnouncerJmxMXBean
   void setPartitionData(Map<Integer, PartitionData> partitionData);
 
   boolean isMarkUpFailed();
+
+  /**
+   * @return true if the announcer is marked up.
+   */
+  boolean isMarkedUp();
+
+  /**
+   * @return true if the announcer marked up the dark warmup cluster.
+   */
+  boolean isDarkWarmupMarkedUp();
+
+  /**
+   * @return the times that the max weight has been breached.
+   */
+  int getMaxWeightBreachedCount();
+
+  /**
+   *
+   * @return the times that the max number of decimal places on weight have been breached.
+   */
+  int getWeightDecimalPlacesBreachedCount();
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmxMXBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmxMXBean.java
@@ -74,14 +74,16 @@ public interface ZooKeeperAnnouncerJmxMXBean
   boolean isMarkUpFailed();
 
   /**
-   * @return true if the announcer is marked up.
+   * @return true if the announcer has completed sending a markup intent. NOTE THAT a mark-up intent sent does NOT mean the
+   * announcement status on service discovery registry is up. Service discovery registry may further process the host
+   * and determine its status. Check on service discovery registry for the final status.
    */
-  boolean isMarkedUp();
+  boolean isMarkUpIntentSent();
 
   /**
-   * @return true if the announcer marked up the dark warmup cluster.
+   * @return true if the announcer has completed sending a dark warmup cluster markup intent.
    */
-  boolean isDarkWarmupMarkedUp();
+  boolean isDarkWarmupMarkUpIntentSent();
 
   /**
    * @return the times that the max weight has been breached.
@@ -90,7 +92,7 @@ public interface ZooKeeperAnnouncerJmxMXBean
 
   /**
    *
-   * @return the times that the max number of decimal places on weight have been breached.
+   * @return the times that the max number of decimal places on weight has been breached.
    */
   int getWeightDecimalPlacesBreachedCount();
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/servers/TestZooKeeperAnnouncer.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/servers/TestZooKeeperAnnouncer.java
@@ -2,13 +2,20 @@ package com.linkedin.d2.balancer.servers;
 
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.util.None;
+import com.linkedin.d2.balancer.properties.PartitionData;
 import com.linkedin.d2.balancer.properties.PropertyKeys;
 
+import com.linkedin.d2.discovery.event.LogOnlyServiceDiscoveryEventEmitter;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Map;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 
@@ -23,6 +30,13 @@ public class TestZooKeeperAnnouncer
   private ZooKeeperServer _server;
   @Mock
   private Callback<None> _callback;
+
+  private static final Map<Integer, PartitionData> MAX_WEIGHT_BREACH_PARTITION_DATA =
+      Collections.singletonMap(0, new PartitionData(1000));
+  private static final Map<Integer, PartitionData> DECIMAL_PLACES_BREACH_PARTITION_DATA =
+      Collections.singletonMap(0, new PartitionData(5.345));
+  private static final Map<Integer, PartitionData> MAX_WEIGHT_AND_DECIMAL_PLACES_BREACH_PARTITION_DATA =
+      Collections.singletonMap(0, new PartitionData(10.89));
 
   @BeforeMethod
   public void setUp()
@@ -42,5 +56,81 @@ public class TestZooKeeperAnnouncer
     _announcer.setDoNotLoadBalance(_callback, false);
 
     verify(_server).addUriSpecificProperty(any(), any(), any(), any(), eq(PropertyKeys.DO_NOT_LOAD_BALANCE), eq(false), any());
+  }
+
+  @DataProvider(name = "validatePartitionDataDataProvider")
+  public Object[][] getValidatePartitionDataDataProvider()
+  {
+    return new Object[][] {
+        {
+          // no weight rules
+          null, null, MAX_WEIGHT_BREACH_PARTITION_DATA, MAX_WEIGHT_BREACH_PARTITION_DATA, null, 0, 0
+        },
+        {
+          // no action default to IGNORE, which won't correct the value BUT will increment the counts
+          "10.0", null, MAX_WEIGHT_BREACH_PARTITION_DATA, MAX_WEIGHT_BREACH_PARTITION_DATA, null, 1, 0
+        },
+        {
+          // warn action won't correct the value
+          "10.0", ZooKeeperAnnouncer.ActionOnWeightBreach.WARN, MAX_WEIGHT_BREACH_PARTITION_DATA,
+            MAX_WEIGHT_BREACH_PARTITION_DATA, null, 1, 0
+        },
+        {
+          // max weight breach, correct the value
+          "10.0", ZooKeeperAnnouncer.ActionOnWeightBreach.RECTIFY, MAX_WEIGHT_BREACH_PARTITION_DATA,
+            Collections.singletonMap(0, new PartitionData(10)), null, 1, 0
+        },
+        {
+          // decimal places breach, correct the value
+          "10.0", ZooKeeperAnnouncer.ActionOnWeightBreach.RECTIFY, DECIMAL_PLACES_BREACH_PARTITION_DATA,
+            Collections.singletonMap(0, new PartitionData(5.3)), null, 0, 1
+        },
+        {
+          // max weight and decimal places breach, correct the value
+          "10.0", ZooKeeperAnnouncer.ActionOnWeightBreach.RECTIFY, MAX_WEIGHT_AND_DECIMAL_PLACES_BREACH_PARTITION_DATA,
+            Collections.singletonMap(0, new PartitionData(10)), null, 1, 0
+        },
+        {
+          // throw action throws for max weight breach
+          "10.0", ZooKeeperAnnouncer.ActionOnWeightBreach.THROW, MAX_WEIGHT_BREACH_PARTITION_DATA, null,
+            new IllegalArgumentException("[ACTION NEEDED] Weight 1000.0 in Partition 0 is greater than the max weight "
+                + "allowed: 10.0. Please correct the weight. It will be force-capped to the max weight in the future."),
+            1, 0
+        },
+        {
+          // throw action doesn not throw for decimal places breach
+          "10.0", ZooKeeperAnnouncer.ActionOnWeightBreach.THROW, DECIMAL_PLACES_BREACH_PARTITION_DATA,
+            DECIMAL_PLACES_BREACH_PARTITION_DATA, null, 0, 1
+        }
+    };
+  }
+  @Test(dataProvider = "validatePartitionDataDataProvider")
+  public void testValidatePartitionData(String maxWeight, ZooKeeperAnnouncer.ActionOnWeightBreach action,
+      Map<Integer, PartitionData> input, Map<Integer, PartitionData> expected, Exception expectedException,
+      int expectedMaxWeightBreachedCount, int expectedWeightDecimalPlacesBreachedCount)
+  {
+    ZooKeeperAnnouncer announcer = new ZooKeeperAnnouncer(_server, true, false, null, 0,
+        null, new LogOnlyServiceDiscoveryEventEmitter(),
+        maxWeight == null ? null : new BigDecimal(maxWeight), action);
+
+    if (expectedException != null)
+    {
+      try
+      {
+        announcer.validatePartitionData(input);
+        fail("Expected exception not thrown");
+      }
+      catch (Exception ex)
+      {
+        assertTrue(ex instanceof IllegalArgumentException);
+        assertEquals(expectedException.getMessage(), ex.getMessage());
+      }
+    }
+    else
+    {
+      assertEquals(expected, announcer.validatePartitionData(input));
+    }
+    assertEquals(expectedMaxWeightBreachedCount, announcer.getMaxWeightBreachedCount());
+    assertEquals(expectedWeightDecimalPlacesBreachedCount, announcer.getWeightDecimalPlacesBreachedCount());
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/servers/TestZooKeeperAnnouncer.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/servers/TestZooKeeperAnnouncer.java
@@ -37,6 +37,8 @@ public class TestZooKeeperAnnouncer
       Collections.singletonMap(0, new PartitionData(5.345));
   private static final Map<Integer, PartitionData> MAX_WEIGHT_AND_DECIMAL_PLACES_BREACH_PARTITION_DATA =
       Collections.singletonMap(0, new PartitionData(10.89));
+  private static final Map<Integer, PartitionData> VALID_PARTITION_DATA =
+      Collections.singletonMap(0, new PartitionData(2.3));
 
   @BeforeMethod
   public void setUp()
@@ -70,6 +72,10 @@ public class TestZooKeeperAnnouncer
           // negative weight throws
           null, null, Collections.singletonMap(0, new PartitionData(-1.0)), null,
             new IllegalArgumentException("Weight -1.0 in Partition 0 is negative. Please correct it."), 0, 0
+        },
+        {
+          // valid weight
+          "3.0", null, VALID_PARTITION_DATA, VALID_PARTITION_DATA, null, 0, 0
         },
         {
           // no action default to IGNORE, which won't correct the value BUT will increment the counts

--- a/d2/src/test/java/com/linkedin/d2/balancer/servers/TestZooKeeperAnnouncer.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/servers/TestZooKeeperAnnouncer.java
@@ -67,6 +67,11 @@ public class TestZooKeeperAnnouncer
           null, null, MAX_WEIGHT_BREACH_PARTITION_DATA, MAX_WEIGHT_BREACH_PARTITION_DATA, null, 0, 0
         },
         {
+          // negative weight throws
+          null, null, Collections.singletonMap(0, new PartitionData(-1.0)), null,
+            new IllegalArgumentException("Weight -1.0 in Partition 0 is negative. Please correct it."), 0, 0
+        },
+        {
           // no action default to IGNORE, which won't correct the value BUT will increment the counts
           "10.0", null, MAX_WEIGHT_BREACH_PARTITION_DATA, MAX_WEIGHT_BREACH_PARTITION_DATA, null, 1, 0
         },
@@ -98,7 +103,7 @@ public class TestZooKeeperAnnouncer
             1, 0
         },
         {
-          // throw action doesn not throw for decimal places breach
+          // throw action does not throw for decimal places breach
           "10.0", ZooKeeperAnnouncer.ActionOnWeightBreach.THROW, DECIMAL_PLACES_BREACH_PARTITION_DATA,
             DECIMAL_PLACES_BREACH_PARTITION_DATA, null, 0, 1
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.61.0
+version=29.62.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
Announcer weight has been a double with no limit rules. Technically, a maximum of 100, and at most 2 digits after the decimal point should be sufficient to serve all load distribution needs in reality. With INDIS observer serving Envoy clients which require an integer uri weight, unlimited double number will cause conversion complexity that should never be encountered in real use case. In this PR, we add a max weight config which defines the max value and the number of decimal places allowed. We also added another config for the action to take when the weight rule is breached. It can be configured to ignore, log warn msg, throw exception, or rectify the value.

Note that this change will warn invalid weights set dynamically thru ZookeeperAnnouncerJmx as well.

Also added jmx methods to return the count of weight breaches for max value and decimal places, and the current markUp status of the announcer for regular cluster and dark warmup cluster respectively

See [container PR](https://github.com/linkedin-multiproduct/container/pull/1195) for LI-specific use case and tests. 

## Test Done
See container PR.