### PR TITLE
Add announcer status delegate interface and support getting server announce mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.63.0] - 2024-11-06
+- Add announcer status delegate interface
+
 ## [29.62.1] - 2024-11-05
 - Enhancements in ByteString and its ByteIterator to reduce object allocation
 
@@ -5758,7 +5761,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.62.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.63.0...master
+[29.63.0]: https://github.com/linkedin/rest.li/compare/v29.62.1...v29.63.0
 [29.62.1]: https://github.com/linkedin/rest.li/compare/v29.62.0...v29.62.1
 [29.62.0]: https://github.com/linkedin/rest.li/compare/v29.61.0...v29.62.0
 [29.61.0]: https://github.com/linkedin/rest.li/compare/v29.60.0...v29.61.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerServer.java
@@ -71,4 +71,21 @@ public interface LoadBalancerServer
   void shutdown(Callback<None> callback);
 
   String getConnectString();
+
+  /**
+   * Get announce mode of the server. Some server may have different announce mode, e.g. dual write mode, force announce
+   * mode.
+   */
+  AnnounceMode getAnnounceMode();
+
+  enum AnnounceMode
+  {
+    STATIC_OLD_SR_ONLY,                // statically only announce to old service registry
+    DYNAMIC_OLD_SR_ONLY,               // dynamically only announce to old service registry
+    DYNAMIC_DUAL_WRITE,                // dynamically announce to both service registries
+    DYNAMIC_NEW_SR_ONLY,               // dynamically only announce to new service registry
+    DYNAMIC_FORCE_DUAL_WRITE,          // Using dynamic server yet forced to announce to both service registries
+    STATIC_NEW_SR_ONLY,                // statically only announce to new service registry
+    STATIC_NEW_SR_ONLY_NO_WRITE_BACK   // statically only announce to new service registry without writing back to old service registry
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerServer.java
@@ -74,11 +74,15 @@ public interface LoadBalancerServer
 
   /**
    * Get announce mode of the server. Some server may have different announce mode, e.g. dual write mode, force announce
-   * mode. NOTE the order of the enum shows the migration progress. The ordinal is used in JMX --- each number higher
-   * means one more step completed in the migration --- which can ease devs to know the status.
+   * mode.
    */
   AnnounceMode getAnnounceMode();
 
+  /**
+   * NOTE the order in this enum shows the migration progress from an old service registry to a new one.
+   * The ordinal is used in JMX --- each number higher means one more step completed in the migration --- which can
+   * ease devs to know the status.
+   */
   enum AnnounceMode
   {
     STATIC_OLD_SR_ONLY,                // statically only announce to old service registry

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerServer.java
@@ -74,18 +74,19 @@ public interface LoadBalancerServer
 
   /**
    * Get announce mode of the server. Some server may have different announce mode, e.g. dual write mode, force announce
-   * mode.
+   * mode. NOTE the order of the enum shows the migration progress. The ordinal is used in JMX --- each number higher
+   * means one more step completed in the migration --- which can ease devs to know the status.
    */
   AnnounceMode getAnnounceMode();
 
   enum AnnounceMode
   {
     STATIC_OLD_SR_ONLY,                // statically only announce to old service registry
-    STATIC_NEW_SR_ONLY,                // statically only announce to new service registry
-    STATIC_NEW_SR_ONLY_NO_WRITE_BACK,   // statically only announce to new service registry without writing back to old service registry
     DYNAMIC_OLD_SR_ONLY,               // dynamically only announce to old service registry
     DYNAMIC_DUAL_WRITE,                // dynamically announce to both service registries
     DYNAMIC_NEW_SR_ONLY,               // dynamically only announce to new service registry
-    DYNAMIC_FORCE_DUAL_WRITE          // Using dynamic server yet forced to announce to both service registries
+    DYNAMIC_FORCE_DUAL_WRITE,          // Using dynamic server yet forced to announce to both service registries
+    STATIC_NEW_SR_ONLY,                // statically only announce to new service registry
+    STATIC_NEW_SR_ONLY_NO_WRITE_BACK   // statically only announce to new service registry without writing back to old service registry
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerServer.java
@@ -81,11 +81,11 @@ public interface LoadBalancerServer
   enum AnnounceMode
   {
     STATIC_OLD_SR_ONLY,                // statically only announce to old service registry
+    STATIC_NEW_SR_ONLY,                // statically only announce to new service registry
+    STATIC_NEW_SR_ONLY_NO_WRITE_BACK,   // statically only announce to new service registry without writing back to old service registry
     DYNAMIC_OLD_SR_ONLY,               // dynamically only announce to old service registry
     DYNAMIC_DUAL_WRITE,                // dynamically announce to both service registries
     DYNAMIC_NEW_SR_ONLY,               // dynamically only announce to new service registry
-    DYNAMIC_FORCE_DUAL_WRITE,          // Using dynamic server yet forced to announce to both service registries
-    STATIC_NEW_SR_ONLY,                // statically only announce to new service registry
-    STATIC_NEW_SR_ONLY_NO_WRITE_BACK   // statically only announce to new service registry without writing back to old service registry
+    DYNAMIC_FORCE_DUAL_WRITE          // Using dynamic server yet forced to announce to both service registries
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/AnnouncerStatusDelegate.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/AnnouncerStatusDelegate.java
@@ -1,0 +1,32 @@
+package com.linkedin.d2.balancer.servers;
+
+import java.net.URI;
+
+
+public interface AnnouncerStatusDelegate
+{
+  /**
+   * @return true if the markup intent has been sent.
+   */
+  boolean isMarkUpIntentSent();
+
+  /**
+   * @return true if the dark warmup mark up intent has been sent.
+   */
+  boolean isDarkWarmupMarkUpIntentSent();
+
+  /**
+   * @return the name of the regular cluster that the announcer manages.
+   */
+  String getCluster();
+
+  /**
+   * @return the name of the warmup cluster that the announcer manages.
+   */
+  String getWarmupCluster();
+
+  /**
+   * @return the uri that the announcer manages.
+   */
+  URI getURI();
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -862,10 +862,11 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper, Announ
 
   @Override
   public void emitSDStatusActiveUpdateIntentAndWriteEvents(String cluster, boolean isMarkUp, boolean succeeded, long startAt) {
-    // since SD event is sent in IndisAnnouncer for INDIS-write-only, inside ZookeeperAnnouncer, any calls to
-    // "emitSDStatusActiveUpdateIntentAndWriteEvents" should only happen when _server is an instance of
-    // ZooKeeperServer (which means it only emits the event when it's doing zk-only or dual write).
-    if (!(_server instanceof ZooKeeperServer))
+    // In this class, SD event should be sent only when the announcing mode is to old service registry or dual write,
+    // so we can directly return when _server is NOT an instance of ZooKeeperServer or the announcement mode is dynamic
+    // new SR only.
+    if (!(_server instanceof ZooKeeperServer)
+        || _server.getAnnounceMode() == LoadBalancerServer.AnnounceMode.DYNAMIC_NEW_SR_ONLY)
     {
       return;
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
  * @author Francesco Capponi (fcapponi@linkedin.com)
  */
 
-public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
+public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper, AnnouncerStatusDelegate
 {
   public static final boolean DEFAULT_DARK_WARMUP_ENABLED = false;
   public static final int DEFAULT_DARK_WARMUP_DURATION = 0;
@@ -705,6 +705,13 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     };
   }
 
+  @Override
+  public String getWarmupCluster()
+  {
+    return _warmupClusterName;
+  }
+
+  @Override
   public String getCluster()
   {
     return _cluster;
@@ -718,6 +725,12 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
   public String getUri()
   {
     return _uri.toString();
+  }
+
+  @Override
+  public URI getURI()
+  {
+    return _uri;
   }
 
   public void setUri(String uri)
@@ -816,11 +829,13 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
     return _markUpFailed;
   }
 
+  @Override
   public boolean isMarkUpIntentSent()
   {
     return _isMarkUpIntentSent.get();
   }
 
+  @Override
   public boolean isDarkWarmupMarkUpIntentSent()
   {
     return _isDarkWarmupMarkUpIntentSent.get();
@@ -834,6 +849,11 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper
   public int getWeightDecimalPlacesBreachedCount()
   {
     return _weightDecimalPlacesBreachedCount.get();
+  }
+
+  public LoadBalancerServer.AnnounceMode getServerAnnounceMode()
+  {
+    return _server.getAnnounceMode();
   }
 
   public void setEventEmitter(ServiceDiscoveryEventEmitter emitter) {

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -194,7 +194,7 @@ public class
         }
         else
         {
-          warn(_log, _store, " marked down for cluster ", clusterName, "with uri: ", uri);
+          warn(_log, _store, " marked down for cluster ", clusterName, " with uri: ", uri);
           Map<URI, Map<Integer, PartitionData>> partitionData = new HashMap<>(2);
           partitionData.put(uri, Collections.emptyMap());
           _store.removePartial(clusterName, new UriProperties(clusterName, partitionData), callback);

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperServer.java
@@ -61,6 +61,11 @@ public class
   }
 
   @Override
+  public AnnounceMode getAnnounceMode() {
+    return AnnounceMode.STATIC_OLD_SR_ONLY;
+  }
+
+  @Override
   public void start(Callback<None> callback)
   {
     _store.start(callback);
@@ -367,7 +372,7 @@ public class
     return new UriProperties(clusterName, partitionDesc, uriToUriSpecificProperties);
   }
 
-  private void storeGet(final String clusterName, final Callback<UriProperties> callback)
+  protected void storeGet(final String clusterName, final Callback<UriProperties> callback)
   {
     if (_store == null)
     {

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmx.java
@@ -206,4 +206,9 @@ public class ZooKeeperAnnouncerJmx implements ZooKeeperAnnouncerJmxMXBean
   {
     return _announcer.getWeightDecimalPlacesBreachedCount();
   }
+
+  @Override
+  public int getServerAnnounceMode() {
+    return _announcer.getServerAnnounceMode().ordinal();
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmxMXBean.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ZooKeeperAnnouncerJmxMXBean.java
@@ -20,6 +20,7 @@
 
 package com.linkedin.d2.jmx;
 
+import com.linkedin.d2.balancer.LoadBalancerServer;
 import com.linkedin.d2.balancer.properties.PartitionData;
 import com.linkedin.d2.discovery.stores.PropertyStoreException;
 
@@ -95,4 +96,9 @@ public interface ZooKeeperAnnouncerJmxMXBean
    * @return the times that the max number of decimal places on weight has been breached.
    */
   int getWeightDecimalPlacesBreachedCount();
+
+  /**
+   * @return the server announce mode corresponding to {@link LoadBalancerServer#getAnnounceMode()}
+   */
+  int getServerAnnounceMode();
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.62.1
+version=29.63.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
1. Added announcer status delegate interface and implemented it in ZooKeeperAnnouncer to reflect its status.
2. Made LoadBalancerServer reports its announcing mode: statically announcing or dynamically announcing (could change at runtime) to the old or new service registry, or both. 
3. Added ZooKeeperAnnouncer's JMX method to report its server's announcing mode.

All changes are to support the container [PR](https://github.com/linkedin-multiproduct/container/pull/1253).

## Test Done
See container [PR](https://github.com/linkedin-multiproduct/container/pull/1253) for UT and qei deploy test.