### PR TITLE
Allow subscribing to a single D2URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.63.2] - 2025-01-30
+- Allow subscribing to a single D2URI
+
 ## [29.63.1] - 2025-01-14
 - Add XdsDirectory to get d2 service and cluster names from INDIS
 
@@ -5764,7 +5767,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.63.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.63.2...master
+[29.63.2]: https://github.com/linkedin/rest.li/compare/v29.63.1...v29.63.2
 [29.63.1]: https://github.com/linkedin/rest.li/compare/v29.63.0...v29.63.1
 [29.63.0]: https://github.com/linkedin/rest.li/compare/v29.62.1...v29.63.0
 [29.62.1]: https://github.com/linkedin/rest.li/compare/v29.62.0...v29.62.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.63.3] - 2025-01-31
+## [29.64.0] - 2025-01-31
 - Allow subscribing to a single D2URI
 
 ## [29.63.2] - 2025-01-31
@@ -5770,8 +5770,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.63.3...master
-[29.63.3]: https://github.com/linkedin/rest.li/compare/v29.63.2...v29.63.3
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.64.0...master
+[29.64.0]: https://github.com/linkedin/rest.li/compare/v29.63.2...v29.64.0
 [29.63.2]: https://github.com/linkedin/rest.li/compare/v29.63.1...v29.63.2
 [29.63.1]: https://github.com/linkedin/rest.li/compare/v29.63.0...v29.63.1
 [29.63.0]: https://github.com/linkedin/rest.li/compare/v29.62.1...v29.63.0

--- a/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
@@ -1,14 +1,20 @@
 package com.linkedin.d2.xds;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GlobCollectionUtils
 {
   private static final String D2_URIS_PREFIX = "/d2/uris/";
   private static final String D2_URI_NODE_GLOB_COLLECTION_PREFIX = "xdstp:///indis.D2URI/";
   private static final String GLOB_COLLECTION_SUFFIX = "/*";
+  private static final String UTF_8 = StandardCharsets.UTF_8.name();
+  private static final Logger LOG = LoggerFactory.getLogger(GlobCollectionUtils.class);
 
   private GlobCollectionUtils()
   {
@@ -65,7 +71,25 @@ public class GlobCollectionUtils
 
       String clusterName = resourceName.substring(D2_URI_NODE_GLOB_COLLECTION_PREFIX.length(), lastIndex);
 
-      return new D2UriIdentifier(D2_URIS_PREFIX + clusterName, resourceName.substring(lastIndex + 1));
+      String uri;
+      try
+      {
+        uri = URLDecoder.decode(resourceName.substring(lastIndex + 1), UTF_8);
+      }
+      catch (UnsupportedEncodingException e)
+      {
+        // Note that this is impossible. It is only thrown if the charset isn't recognized, and UTF-8 is known to be
+        // supported.
+
+        throw new RuntimeException(e);
+      }
+      catch (Exception e)
+      {
+        LOG.warn("Ignoring D2URI URN with invalid URL encoding {}", resourceName, e);
+        return null;
+      }
+
+      return new D2UriIdentifier(D2_URIS_PREFIX + clusterName, uri);
     }
   }
 
@@ -88,7 +112,7 @@ public class GlobCollectionUtils
   {
     try
     {
-      return D2_URI_NODE_GLOB_COLLECTION_PREFIX + clusterName + "/" + URLEncoder.encode(uri, "UTF-8");
+      return D2_URI_NODE_GLOB_COLLECTION_PREFIX + clusterName + "/" + URLEncoder.encode(uri, UTF_8);
     }
     catch (UnsupportedEncodingException e)
     {

--- a/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
@@ -1,5 +1,7 @@
 package com.linkedin.d2.xds;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import javax.annotation.Nullable;
 
 public class GlobCollectionUtils
@@ -80,5 +82,20 @@ public class GlobCollectionUtils
     return D2_URI_NODE_GLOB_COLLECTION_PREFIX +
         clusterPath.substring(clusterPath.lastIndexOf('/') + 1) +
         GLOB_COLLECTION_SUFFIX;
+  }
+
+  public static String globCollectionUrn(String clusterName, String uri)
+  {
+    try
+    {
+      return D2_URI_NODE_GLOB_COLLECTION_PREFIX + clusterName + "/" + URLEncoder.encode(uri, "UTF-8");
+    }
+    catch (UnsupportedEncodingException e)
+    {
+      // Note that this is impossible. It is only thrown if the charset isn't recognized, and UTF-8 is known to be
+      // supported.
+      throw new RuntimeException(e);
+    }
+
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -406,6 +406,10 @@ public abstract class XdsClient
       _d2Uri = d2Uri;
     }
 
+    /**
+     * Returns the {@link XdsD2.D2URI} that was received, or {@code null} if the URI was deleted.
+     */
+    @Nullable
     public XdsD2.D2URI getD2Uri()
     {
       return _d2Uri;

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -414,7 +414,8 @@ public abstract class XdsClient
     @Override
     public boolean isValid()
     {
-      return _d2Uri != null;
+      // For this update type, the subscriber needs to be notified of deletions, so all D2URIUpdates are valid.
+      return true;
     }
 
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -95,6 +95,23 @@ public abstract class XdsClient
     }
   }
 
+  public static abstract class D2UriResourceWatcher
+  {
+    public abstract void onChanged(XdsD2.D2URI d2Uri);
+
+    public abstract void onDelete();
+
+    /**
+     * Called when the resource discovery RPC encounters some transient error.
+     */
+    public abstract void onError(Status error);
+
+    /**
+     * Called when the resource discovery RPC reestablishes connection.
+     */
+    public abstract void onReconnect();
+  }
+
   public static abstract class WildcardResourceWatcher
   {
     private final ResourceType _type;
@@ -354,6 +371,13 @@ public abstract class XdsClient
    * will always notify the given watcher of the current data.
    */
   public abstract void watchAllXdsResources(WildcardResourceWatcher watcher);
+
+  /**
+   * Subscribes the given {@link D2UriResourceWatcher} to a specific URI in a specific cluster. The watcher will be
+   * notified whenever the URI is added or removed. Repeated calls to this function with the same watcher will always
+   * notify the given watcher of the current data.
+   */
+  public abstract void watchD2Uri(String cluster, String uri, D2UriResourceWatcher watcher);
 
   /**
    * Initiates the RPC stream to the xDS server.

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -500,6 +500,7 @@ public class XdsClientImpl extends XdsClient
 
       if (clusterSubscriber == null && wildcardSubscriber == null)
       {
+        // Nothing left to do
         return;
       }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -492,15 +492,23 @@ public class XdsClientImpl extends XdsClient
         }
       }
 
-
       if (uriSubscriber != null)
       {
-        uriSubscriber.onData(new D2URIUpdate(uri), _serverMetricsProvider);
+        // Special case for the D2URI subscriber: the URI could not be deserialized. If a previous version of the data
+        // is present, do nothing and drop the update on the floor. If no previous version is present however, notify
+        // the subscriber that the URI is deleted/doesn't exist. This behavior is slightly different from the other
+        // types, which do not support deletions.
+        if (uri != null // The URI is being updated
+            || resource == null  // The URI is being deleted
+            || uriSubscriber.getData() == null // The URI was corrupted and there was no previous version of this URI
+        )
+        {
+          uriSubscriber.onData(new D2URIUpdate(uri), _serverMetricsProvider);
+        }
       }
 
       if (clusterSubscriber == null && wildcardSubscriber == null)
       {
-        // Nothing left to do
         return;
       }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -80,10 +80,9 @@ public class XdsClientImpl extends XdsClient
    * updates to subscribers.
    */
   private final Map<ResourceType, Map<String, ResourceSubscriber>> _resourceSubscribers = Maps.immutableEnumMap(
-      Stream.of(ResourceType.NODE, ResourceType.D2_URI_MAP)
+      Stream.of(ResourceType.values())
           .collect(Collectors.toMap(Function.identity(), e -> new HashMap<>())));
   private final Map<ResourceType, WildcardResourceSubscriber> _wildcardSubscribers = Maps.newEnumMap(ResourceType.class);
-  private final Map<String, D2UriSubscriber> _d2UriSubscribers = new HashMap<>();
   private final Node _node;
   private final ManagedChannel _managedChannel;
   private final ScheduledExecutorService _executorService;
@@ -200,34 +199,6 @@ public class XdsClientImpl extends XdsClient
         if (_adsStream != null)
         {
           _adsStream.sendDiscoveryRequest(adjustedType, Collections.singletonList("*"));
-        }
-      }
-
-      subscriber.addWatcher(watcher);
-    });
-  }
-
-  @Override
-  public void watchD2Uri(String cluster, String uri, D2UriResourceWatcher watcher)
-  {
-    _executorService.execute(() ->
-    {
-      String urn = GlobCollectionUtils.globCollectionUrn(cluster, uri);
-      D2UriSubscriber subscriber = getD2UriSubscribers().get(urn);
-      if (subscriber == null)
-      {
-        subscriber = new D2UriSubscriber(urn);
-        getD2UriSubscribers().put(urn, subscriber);
-
-        _log.info("Subscribing to D2URI: {}", urn);
-
-        if (_adsStream == null && !isInBackoff())
-        {
-          startRpcStreamLocal();
-        }
-        if (_adsStream != null)
-        {
-          _adsStream.sendDiscoveryRequest(ResourceType.D2_URI, Collections.singletonList(urn));
         }
       }
 
@@ -457,11 +428,11 @@ public class XdsClientImpl extends XdsClient
         return;
       }
 
-      ResourceSubscriber subscriber =
+      ResourceSubscriber clusterSubscriber =
           getResourceSubscriberMap(ResourceType.D2_URI_MAP).get(uriId.getClusterResourceName());
+      ResourceSubscriber uriSubscriber = getResourceSubscriberMap(ResourceType.D2_URI).get(resourceName);
       WildcardResourceSubscriber wildcardSubscriber = getWildcardResourceSubscriber(ResourceType.D2_URI_MAP);
-      D2UriSubscriber d2UriSubscriber = getD2UriSubscribers().get(resourceName);
-      if (subscriber == null && wildcardSubscriber == null && d2UriSubscriber == null)
+      if (clusterSubscriber == null && wildcardSubscriber == null && uriSubscriber == null)
       {
         String msg = String.format("Ignoring D2URI resource update for untracked cluster: %s", resourceName);
         _log.warn(msg);
@@ -469,7 +440,8 @@ public class XdsClientImpl extends XdsClient
         return;
       }
 
-      XdsD2.D2URI uri;
+      // uri will be null if the data was invalid, or if the resource is being deleted.
+      XdsD2.D2URI uri = null;
       if (resource != null)
       {
         try
@@ -480,21 +452,16 @@ public class XdsClientImpl extends XdsClient
         {
           _log.warn("Failed to unpack D2URI", e);
           errors.add("Failed to unpack D2URI");
-          return;
         }
       }
-      else
+
+
+      if (uriSubscriber != null)
       {
-        uri = null;
+        uriSubscriber.onData(new D2URIUpdate(uri), _serverMetricsProvider);
       }
 
-
-      if (d2UriSubscriber != null)
-      {
-        d2UriSubscriber.onData(uri, _serverMetricsProvider);
-      }
-
-      if (subscriber == null && wildcardSubscriber == null)
+      if (clusterSubscriber == null && wildcardSubscriber == null)
       {
         return;
       }
@@ -505,9 +472,9 @@ public class XdsClientImpl extends XdsClient
         D2URIMapUpdate currentData;
         // Use the existing data from whichever subscriber is present. If both are present, they will point to the same
         // D2URIMapUpdate.
-        if (subscriber != null)
+        if (clusterSubscriber != null)
         {
-          currentData = (D2URIMapUpdate) subscriber._data;
+          currentData = (D2URIMapUpdate) clusterSubscriber._data;
         }
         else
         {
@@ -523,8 +490,8 @@ public class XdsClientImpl extends XdsClient
         }
       });
 
-      // If the uri is null, it's being deleted
-      if (uri == null)
+      // If the resource is null, it's being deleted
+      if (resource == null)
       {
         // This is the special case where the entire collection is being deleted. This either means the client
         // subscribed to a cluster that does not exist, or all hosts stopped announcing to the cluster.
@@ -538,7 +505,9 @@ public class XdsClientImpl extends XdsClient
           update.removeUri(uriId.getUriName());
         }
       }
-      else
+      // Only put valid URIs in the map. Because the D2URIMapUpdate is still created by this loop, the subscriber will
+      // receive an update, unblocking any waiting futures, so there is no need to insert null/invalid URIs in the map.
+      else if (uri != null)
       {
         update.putUri(uriId.getUriName(), uri);
       }
@@ -618,10 +587,6 @@ public class XdsClientImpl extends XdsClient
     {
       wildcardResourceSubscriber.onError(error);
     }
-    for (D2UriSubscriber uriSubscriber : _d2UriSubscribers.values())
-    {
-      uriSubscriber.onError(error);
-    }
     _xdsClientJmx.setIsConnected(false);
   }
 
@@ -638,10 +603,6 @@ public class XdsClientImpl extends XdsClient
     {
       wildcardResourceSubscriber.onReconnect();
     }
-    for (D2UriSubscriber uriSubscriber : _d2UriSubscribers.values())
-    {
-      uriSubscriber.onReconnect();
-    }
     _xdsClientJmx.setIsConnected(true);
   }
 
@@ -655,12 +616,6 @@ public class XdsClientImpl extends XdsClient
   WildcardResourceSubscriber getWildcardResourceSubscriber(ResourceType type)
   {
     return _wildcardSubscribers.get(type);
-  }
-
-  @VisibleForTesting
-  Map<String, D2UriSubscriber> getD2UriSubscribers()
-  {
-    return _d2UriSubscribers;
   }
 
   static class ResourceSubscriber
@@ -770,6 +725,14 @@ public class XdsClientImpl extends XdsClient
             );
         trackServerLatencyForUris(updatedUris, metricsProvider, now);
         trackServerLatencyForUris(rawDiff.entriesOnlyOnLeft(), metricsProvider, now); // newly added uris
+      }
+      else if (resourceUpdate instanceof D2URIUpdate)
+      {
+        XdsD2.D2URI uri = ((D2URIUpdate) resourceUpdate).getD2Uri();
+        if (uri != null)
+        {
+          metricsProvider.trackLatency(now - uri.getModifiedTime().getSeconds() * 1000);
+        }
       }
     }
 
@@ -925,75 +888,6 @@ public class XdsClientImpl extends XdsClient
     }
   }
 
-  static class D2UriSubscriber
-  {
-    private final Set<D2UriResourceWatcher> _watchers = new HashSet<>();
-    private XdsD2.D2URI _d2Uri;
-    private final String _name;
-
-    D2UriSubscriber(String name)
-    {
-      _name = name;
-    }
-
-
-    @VisibleForTesting
-    public XdsD2.D2URI getData()
-    {
-      return _d2Uri;
-    }
-
-    @VisibleForTesting
-    public void setData(XdsD2.D2URI d2Uri)
-    {
-      _d2Uri = d2Uri;
-    }
-
-    void addWatcher(D2UriResourceWatcher watcher)
-    {
-      _watchers.add(watcher);
-      watcher.onChanged(_d2Uri);
-      _log.debug("Notifying watcher of current data for D2URI {}: {}", _name, _d2Uri);
-    }
-
-    private void onData(XdsD2.D2URI d2Uri, XdsServerMetricsProvider metricsProvider)
-    {
-      if (Objects.equals(_d2Uri, d2Uri))
-      {
-        _log.debug("Received resource update data equal to the current data for {}. Will not perform the update.",
-            _name);
-        return;
-      }
-      if (d2Uri == null)
-      {
-        for (D2UriResourceWatcher watcher : _watchers)
-        {
-          watcher.onDelete();
-        }
-      }
-      else
-      {
-        metricsProvider.trackLatency(System.currentTimeMillis() - d2Uri.getModifiedTime().getSeconds() * 1000);
-      }
-    }
-
-    private void onError(Status error)
-    {
-      for (D2UriResourceWatcher watcher : _watchers)
-      {
-        watcher.onError(error);
-      }
-    }
-
-    private void onReconnect()
-    {
-      for (D2UriResourceWatcher watcher : _watchers)
-      {
-        watcher.onReconnect();
-      }
-    }
-  }
-
   final class RpcRetryTask implements Runnable
   {
     @Override
@@ -1025,10 +919,6 @@ public class XdsClientImpl extends XdsClient
           resources.add("*");
         }
         _adsStream.sendDiscoveryRequest(rewrittenType, resources);
-      }
-      if (!_d2UriSubscribers.isEmpty())
-      {
-        _adsStream.sendDiscoveryRequest(ResourceType.D2_URI, _d2UriSubscribers.keySet());
       }
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.63.3
+version=29.64.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.63.1
+version=29.63.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This new endpoint on `XdsClient` allows one to watch a single URI using the glob collection interface. The watcher will be notified whenever the URI changes or is deleted, which allows for lightweight watches of a singular URI instead of needing to watch the entire cluster.

I was able to test this against a local Observer deployment, and validated that the URI updates and deletions are correctly propagated.