### PR TITLE
Add XdsDirectory to get d2 service and cluster names from INDIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.63.1] - 2025-01-14
+- Add XdsDirectory to get d2 service and cluster names from INDIS
+
 ## [29.63.0] - 2024-11-06
 - Add announcer status delegate interface
 
@@ -5761,7 +5764,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.63.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.63.1...master
+[29.63.1]: https://github.com/linkedin/rest.li/compare/v29.63.0...v29.63.1
 [29.63.0]: https://github.com/linkedin/rest.li/compare/v29.62.1...v29.63.0
 [29.62.1]: https://github.com/linkedin/rest.li/compare/v29.62.0...v29.62.1
 [29.62.0]: https://github.com/linkedin/rest.li/compare/v29.61.0...v29.62.0

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -138,7 +138,8 @@ public abstract class XdsClient
     public abstract void onRemoval(String resourceName);
 
     /**
-     * Just a signal to notify that all resources (including both changed and removed ones) have been processed.
+     * Just a signal to notify that all resources (including both changed and removed ones) in all response chunks (if
+     * any) have been processed.
      * Default implementation does nothing.
      */
     public void onAllResourcesProcessed()

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -17,6 +17,7 @@
 package com.linkedin.d2.xds;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
 import com.linkedin.d2.jmx.XdsClientJmx;
 import indis.XdsD2;
 import io.grpc.Status;
@@ -301,7 +302,8 @@ public abstract class XdsClient
     @Override
     public boolean isValid()
     {
-      return _nameData != null && (!_nameData.getClusterName().isEmpty() || !_nameData.getServiceName().isEmpty());
+      return _nameData != null
+          && (!Strings.isNullOrEmpty(_nameData.getClusterName()) || !Strings.isNullOrEmpty(_nameData.getServiceName()));
     }
 
     @Override

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -206,7 +206,7 @@ public abstract class XdsClient
     @Override
     final void onChanged(String resourceName, ResourceUpdate update)
     {
-      onChanged(resourceName, update);
+      onChanged(resourceName, (D2ClusterOrServiceNameUpdate) update);
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -180,6 +180,27 @@ public abstract class XdsClient
     }
   }
 
+  public static abstract class WildcardD2ClusterOrServiceNameResourceWatcher extends WildcardResourceWatcher
+  {
+    public WildcardD2ClusterOrServiceNameResourceWatcher()
+    {
+      super(ResourceType.D2_CLUSTER_OR_SERVICE_NAME);
+    }
+
+    /**
+     * Called when a D2ClusterOrServiceName resource is added or updated.
+     * @param resourceName the resource name of the D2ClusterOrServiceName that was added or updated.
+     * @param update       the new data for the D2ClusterOrServiceName resource
+     */
+    public abstract void onChanged(String resourceName, D2ClusterOrServiceNameUpdate update);
+
+    @Override
+    final void onChanged(String resourceName, ResourceUpdate update)
+    {
+      onChanged(resourceName, update);
+    }
+  }
+
   public interface ResourceUpdate
   {
     boolean isValid();
@@ -230,6 +251,54 @@ public abstract class XdsClient
     public String toString()
     {
       return MoreObjects.toStringHelper(this).add("_nodeData", _nodeData).toString();
+    }
+  }
+
+  public static final class D2ClusterOrServiceNameUpdate implements ResourceUpdate
+  {
+    XdsD2.D2ClusterOrServiceName _nameData;
+
+    D2ClusterOrServiceNameUpdate(XdsD2.D2ClusterOrServiceName nameData)
+    {
+      _nameData = nameData;
+    }
+
+    public XdsD2.D2ClusterOrServiceName getNameData()
+    {
+      return _nameData;
+    }
+
+    @Override
+    public boolean equals(Object object)
+    {
+      if (this == object)
+      {
+        return true;
+      }
+      if (object == null || getClass() != object.getClass())
+      {
+        return false;
+      }
+      D2ClusterOrServiceNameUpdate that = (D2ClusterOrServiceNameUpdate) object;
+      return Objects.equals(_nameData, that._nameData);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hash(_nameData);
+    }
+
+    @Override
+    public boolean isValid()
+    {
+      return _nameData != null && (!_nameData.getClusterName().isEmpty() || !_nameData.getServiceName().isEmpty());
+    }
+
+    @Override
+    public String toString()
+    {
+      return MoreObjects.toStringHelper(this).add("_nameData", _nameData).toString();
     }
   }
 
@@ -302,12 +371,16 @@ public abstract class XdsClient
 
   public static final NodeUpdate EMPTY_NODE_UPDATE = new NodeUpdate(null);
   public static final D2URIMapUpdate EMPTY_D2_URI_MAP_UPDATE = new D2URIMapUpdate(null);
+  public static final D2ClusterOrServiceNameUpdate EMPTY_D2_CLUSTER_OR_SERVICE_NAME_UPDATE =
+      new D2ClusterOrServiceNameUpdate(null);
 
   enum ResourceType
   {
     NODE("type.googleapis.com/indis.Node", EMPTY_NODE_UPDATE),
     D2_URI_MAP("type.googleapis.com/indis.D2URIMap", EMPTY_D2_URI_MAP_UPDATE),
-    D2_URI("type.googleapis.com/indis.D2URI", EMPTY_D2_URI_MAP_UPDATE);
+    D2_URI("type.googleapis.com/indis.D2URI", EMPTY_D2_URI_MAP_UPDATE),
+    D2_CLUSTER_OR_SERVICE_NAME("type.googleapis.com/indis.D2ClusterOrServiceName",
+        EMPTY_D2_CLUSTER_OR_SERVICE_NAME_UPDATE);
 
     private static final Map<String, ResourceType> TYPE_URL_TO_ENUM = Arrays.stream(values())
         .filter(e -> e.typeUrl() != null)

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -135,6 +135,15 @@ public abstract class XdsClient
      * @param resourceName the name of the resource that was removed.
      */
     public abstract void onRemoval(String resourceName);
+
+    /**
+     * Just a signal to notify that all resources (including both changed and removed ones) have been processed.
+     * Default implementation does nothing.
+     */
+    public void onAllResourcesProcessed()
+    {
+      // do nothing
+    }
   }
 
   public static abstract class WildcardNodeResourceWatcher extends WildcardResourceWatcher

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -42,7 +42,6 @@ import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -72,7 +72,7 @@ public class XdsClientImpl extends XdsClient
 {
   private static final Logger _log = LoggerFactory.getLogger(XdsClientImpl.class);
   private static final RateLimitedLogger RATE_LIMITED_LOGGER =
-      new RateLimitedLogger(_log, TimeUnit.MINUTES.toMillis(10), SystemClock.instance());
+      new RateLimitedLogger(_log, TimeUnit.MINUTES.toMillis(10000), SystemClock.instance());
   public static final long DEFAULT_READY_TIMEOUT_MILLIS = 2000L;
 
   /**
@@ -625,7 +625,7 @@ public class XdsClientImpl extends XdsClient
     }
     catch (Exception e)
     {
-      _log.warn("Failed to decode nonce: {}", response.getNonce(), e);
+      RATE_LIMITED_LOGGER.warn("Failed to decode nonce: {}", response.getNonce(), e);
       remainingChunks = -1;
     }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -72,7 +72,7 @@ public class XdsClientImpl extends XdsClient
 {
   private static final Logger _log = LoggerFactory.getLogger(XdsClientImpl.class);
   private static final RateLimitedLogger RATE_LIMITED_LOGGER =
-      new RateLimitedLogger(_log, TimeUnit.SECONDS.toMillis(10), SystemClock.instance());
+      new RateLimitedLogger(_log, TimeUnit.MINUTES.toMillis(1), SystemClock.instance());
   public static final long DEFAULT_READY_TIMEOUT_MILLIS = 2000L;
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -383,7 +383,7 @@ public class XdsClientImpl extends XdsClient
   {
     Map<String, D2ClusterOrServiceNameUpdate> updates = new HashMap<>();
     List<String> errors = new ArrayList<>();
-    String errMsg = "Failed to unpack D2ClusterOrServiceName response";
+    String errMsg;
 
     for (Resource resource : data.getResourcesList())
     {
@@ -396,7 +396,7 @@ public class XdsClientImpl extends XdsClient
       }
       catch (InvalidProtocolBufferException e)
       {
-
+        errMsg = String.format("Failed to unpack D2ClusterOrServiceName response for resource: %s.", resourceName);
         _log.warn(errMsg, e);
         errors.add(errMsg);
         // Assume that the resource doesn't exist if it cannot be deserialized instead of simply ignoring it. This way
@@ -641,7 +641,6 @@ public class XdsClientImpl extends XdsClient
     _xdsClientJmx.setIsConnected(true);
   }
 
-  @VisibleForTesting
   Map<String, ResourceSubscriber> getResourceSubscriberMap(ResourceType type)
   {
     return getResourceSubscribers().get(type);
@@ -653,7 +652,6 @@ public class XdsClientImpl extends XdsClient
     return _resourceSubscribers;
   }
 
-  @VisibleForTesting
   WildcardResourceSubscriber getWildcardResourceSubscriber(ResourceType type)
   {
     return getWildcardResourceSubscribers().get(type);

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -72,7 +72,7 @@ public class XdsClientImpl extends XdsClient
 {
   private static final Logger _log = LoggerFactory.getLogger(XdsClientImpl.class);
   private static final RateLimitedLogger RATE_LIMITED_LOGGER =
-      new RateLimitedLogger(_log, TimeUnit.MINUTES.toMillis(10000), SystemClock.instance());
+      new RateLimitedLogger(_log, TimeUnit.SECONDS.toMillis(10), SystemClock.instance());
   public static final long DEFAULT_READY_TIMEOUT_MILLIS = 2000L;
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -607,26 +607,28 @@ public class XdsClientImpl extends XdsClient
   {
     ResourceType type = response.getResourceType();
     WildcardResourceSubscriber wildcardResourceSubscriber = getWildcardResourceSubscriber(type);
-    if (wildcardResourceSubscriber != null)
+    if (wildcardResourceSubscriber == null)
     {
-      int remainingChunks;
-      try
-      {
-        byte[] bytes = Hex.decodeHex(response.getNonce().toCharArray());
-        ByteBuffer bb = ByteBuffer.wrap(Arrays.copyOfRange(bytes, 8, 12));
-        remainingChunks = bb.getInt();
-      }
-      catch (Exception e)
-      {
-        _log.warn("Failed to decode nonce: {}", response.getNonce(), e);
-        remainingChunks = -1;
-      }
+      return;
+    }
 
-      if (remainingChunks == 0)
-      {
-        _log.info("Notifying wildcard subscriber of type {} for the end of response chunks.", type);
-        wildcardResourceSubscriber.onAllResourcesProcessed();
-      }
+    int remainingChunks;
+    try
+    {
+      byte[] bytes = Hex.decodeHex(response.getNonce().toCharArray());
+      ByteBuffer bb = ByteBuffer.wrap(Arrays.copyOfRange(bytes, 8, 12));
+      remainingChunks = bb.getInt();
+    }
+    catch (Exception e)
+    {
+      _log.warn("Failed to decode nonce: {}", response.getNonce(), e);
+      remainingChunks = -1;
+    }
+
+    if (remainingChunks == 0)
+    {
+      _log.info("Notifying wildcard subscriber of type {} for the end of response chunks.", type);
+      wildcardResourceSubscriber.onAllResourcesProcessed();
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
@@ -1,6 +1,7 @@
 package com.linkedin.d2.xds.balancer;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.linkedin.common.callback.Callback;
 import com.linkedin.d2.balancer.Directory;
 import com.linkedin.d2.xds.XdsClient;
@@ -96,7 +97,7 @@ public class XdsDirectory implements Directory
         }
         XdsD2.D2ClusterOrServiceName nameData = update.getNameData();
         // the data is guaranteed valid by the xds client. It has a non-empty name in either clusterName or serviceName.
-        if (!nameData.getClusterName().isEmpty())
+        if (!Strings.isNullOrEmpty(nameData.getClusterName()))
         {
           _clusterNames.put(resourceName, nameData.getClusterName());
         } else

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
@@ -33,7 +33,8 @@ public class XdsDirectory implements Directory
    * A flag that shows whether the service/cluster names data is being updated. Requests to the data should wait until
    * the update is done.
    */
-  private final AtomicBoolean _isUpdating = new AtomicBoolean(true);
+  @VisibleForTesting
+  final AtomicBoolean _isUpdating = new AtomicBoolean(true);
   /**
    * This lock will be released when the service and cluster names data have been updated and is ready to serve.
    * If the data is being updated, requests to read the data will wait indefinitely. Callers could set a shorter

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
@@ -1,0 +1,121 @@
+package com.linkedin.d2.xds.balancer;
+
+import com.linkedin.common.callback.Callback;
+import com.linkedin.d2.balancer.Directory;
+import com.linkedin.d2.xds.XdsClient;
+import io.grpc.Status;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.linkedin.d2.xds.XdsClient.*;
+
+
+public class XdsDirectory implements Directory
+{
+  private final XdsClient _xdsClient;
+  private final ConcurrentMap<String, String> _serviceNames = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, String> _clusterNames = new ConcurrentHashMap<>();
+  private XdsClient.WildcardD2ClusterOrServiceNameResourceWatcher _watcher;
+  /**
+   * If service/cluster names are empty, wait for a while before returning the names, callers could set a shorter
+   * timeout on the callback they passed in to getServiceNames or getClusterNames, as needed
+   */
+  private static final Long DEFAULT_WAIT_TIME = 10000L;
+
+  public XdsDirectory(XdsClient xdsClient)
+  {
+    _xdsClient = xdsClient;
+  }
+
+  public void start() {
+    addNameWatcher();
+  }
+
+  @Override
+  public void getServiceNames(Callback<List<String>> callback)
+  {
+    addNameWatcher();
+    waitAndRespond(true, callback);
+  }
+
+  @Override
+  public void getClusterNames(Callback<List<String>> callback)
+  {
+    addNameWatcher();
+    waitAndRespond(false, callback);
+  }
+
+  private void addNameWatcher()
+  {
+    if (_watcher != null)
+    {
+      return;
+    }
+    _watcher = createNameWatcher();
+    _xdsClient.watchAllXdsResources(_watcher);
+  }
+
+  private XdsClient.WildcardD2ClusterOrServiceNameResourceWatcher createNameWatcher()
+  {
+    return new XdsClient.WildcardD2ClusterOrServiceNameResourceWatcher()
+    {
+
+      @Override
+      public void onChanged(String resourceName, XdsClient.D2ClusterOrServiceNameUpdate update)
+      {
+        if (update == EMPTY_D2_CLUSTER_OR_SERVICE_NAME_UPDATE)
+        { // invalid data, ignore
+          return;
+        }
+        D2ClusterOrServiceName nameData = update.getNameData();
+        if (nameData.getClusterName() != null)
+        {
+          _clusterNames.put(resourceName, nameData.getClusterName());
+        } else
+        {
+          _serviceNames.put(resourceName, nameData.getServiceName());
+        }
+      }
+
+      @Override
+      public void onRemoval(String resourceName)
+      {
+        // Don't need to differentiate between cluster and service names, will have no op on the map that doesn't
+        // have the key. And the resource won't be both a cluster and a service name, since the two have different d2
+        // path (/d2/clusters vs /d2/services).
+        _clusterNames.remove(resourceName);
+        _serviceNames.remove(resourceName);
+      }
+
+      @Override
+      public void onError(Status error)
+      {
+        // do nothing
+      }
+
+      @Override
+      public void onReconnect()
+      {
+        // do nothing
+      }
+    };
+  }
+
+  private void waitAndRespond(boolean isForService, Callback<List<String>> callback) {
+    // Changes in the corresponding map will be reflected in the returned collection
+    Collection<String> names = isForService ? _serviceNames.values() : _clusterNames.values();
+    if (names.isEmpty())
+    {
+      try {
+        wait(DEFAULT_WAIT_TIME);
+      } catch (InterruptedException e) {
+        // do nothing
+      }
+    }
+
+    callback.onSuccess(new ArrayList<>(names));
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
@@ -3,6 +3,7 @@ package com.linkedin.d2.xds.balancer;
 import com.linkedin.common.callback.Callback;
 import com.linkedin.d2.balancer.Directory;
 import com.linkedin.d2.xds.XdsClient;
+import indis.XdsD2;
 import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,8 +71,8 @@ public class XdsDirectory implements Directory
         { // invalid data, ignore
           return;
         }
-        D2ClusterOrServiceName nameData = update.getNameData();
-        if (nameData.getClusterName() != null)
+        XdsD2.D2ClusterOrServiceName nameData = update.getNameData();
+        if (!nameData.getClusterName().isEmpty())
         {
           _clusterNames.put(resourceName, nameData.getClusterName());
         } else

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -65,6 +65,8 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
     XdsToD2PropertiesAdaptor adaptor = new XdsToD2PropertiesAdaptor(xdsClient, config.dualReadStateManager,
         config.serviceDiscoveryEventEmitter, config.clientServicesConfig);
 
+    XdsDirectory directory = new XdsDirectory(xdsClient);
+
     XdsLoadBalancer xdsLoadBalancer = new XdsLoadBalancer(
         adaptor,
         executorService,
@@ -72,7 +74,8 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
             config.clientFactories, config.loadBalancerStrategyFactories, config.d2ServicePath, config.sslContext,
             config.sslParameters, config.isSSLEnabled, config.clientServicesConfig, config.partitionAccessorRegistry,
             config.sslSessionValidatorFactory, d2ClientJmxManager, config.deterministicSubsettingMetadataProvider,
-            config.failoutConfigProviderFactory, config.canaryDistributionProvider, config.loadBalanceStreamException)
+            config.failoutConfigProviderFactory, config.canaryDistributionProvider, config.loadBalanceStreamException),
+        directory
     );
 
     LoadBalancerWithFacilities balancer = xdsLoadBalancer;

--- a/d2/src/main/proto/XdsD2.proto
+++ b/d2/src/main/proto/XdsD2.proto
@@ -55,6 +55,13 @@ message Node {
   bytes data = 2 ;
 }
 
+message D2ClusterOrServiceName {
+  oneof type {
+    string cluster_name = 1;
+    string service_name = 2;
+  }
+}
+
 // D2URI is a proto representation of com.linkedin.d2.balancer.properties.UriProperties. Note that a D2 UriProperties is
 // is designed to hold all the announcements of a cluster, which is why it's represented as a map of URI to data. The
 // UriProperties class is reused wholesale for serialization to write the data to ZK, which is why all fields are

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -44,12 +44,12 @@ public class TestXdsClientImpl
 {
   private static final byte[] DATA = "data".getBytes();
   private static final byte[] DATA2 = "data2".getBytes();
-  private static final String SERVICE_NAME = "FooService";
-  private static final String SERVICE_NAME_2 = "BarService";
-  private static final String SERVICE_RESOURCE_NAME = "/d2/services/" + SERVICE_NAME;
-  private static final String SERVICE_RESOURCE_NAME_2 = "/d2/services/" + SERVICE_NAME_2;
-  private static final String CLUSTER_NAME = "FooClusterMaster-prod-ltx1";
-  private static final String CLUSTER_RESOURCE_NAME = "/d2/uris/" + CLUSTER_NAME;
+  public static final String SERVICE_NAME = "FooService";
+  public static final String SERVICE_NAME_2 = "BarService";
+  public static final String SERVICE_RESOURCE_NAME = "/d2/services/" + SERVICE_NAME;
+  public static final String SERVICE_RESOURCE_NAME_2 = "/d2/services/" + SERVICE_NAME_2;
+  public static final String CLUSTER_NAME = "FooClusterMaster-prod-ltx1";
+  public static final String CLUSTER_RESOURCE_NAME = "/d2/uris/" + CLUSTER_NAME;
   private static final String URI1 = "TestURI1";
   private static final String URI2 = "TestURI2";
   private static final String VERSION1 = "1";
@@ -81,11 +81,11 @@ public class TestXdsClientImpl
   private static final Any PACKED_SERVICE_NAME_DATA = Any.pack(SERVICE_NAME_DATA);
   private static final Any PACKED_SERVICE_NAME_DATA_2 = Any.pack(SERVICE_NAME_DATA_2);
   private static final Any PACKED_NAME_DATA_WITH_NULL = Any.pack(NAME_DATA_WITH_NULL);
-  private static final XdsClient.D2ClusterOrServiceNameUpdate CLUSTER_NAME_DATA_UPDATE =
+  public static final XdsClient.D2ClusterOrServiceNameUpdate CLUSTER_NAME_DATA_UPDATE =
       new XdsClient.D2ClusterOrServiceNameUpdate(CLUSTER_NAME_DATA);
-  private static final XdsClient.D2ClusterOrServiceNameUpdate SERVICE_NAME_DATA_UPDATE =
+  public static final XdsClient.D2ClusterOrServiceNameUpdate SERVICE_NAME_DATA_UPDATE =
       new XdsClient.D2ClusterOrServiceNameUpdate(SERVICE_NAME_DATA);
-  private static final XdsClient.D2ClusterOrServiceNameUpdate SERVICE_NAME_DATA_UPDATE_2 =
+  public static final XdsClient.D2ClusterOrServiceNameUpdate SERVICE_NAME_DATA_UPDATE_2 =
       new XdsClient.D2ClusterOrServiceNameUpdate(SERVICE_NAME_DATA_2);
   private static final List<Resource> SERVICE_NAME_DATA_RESOURCES = Arrays.asList(
       Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME)
@@ -706,7 +706,8 @@ public class TestXdsClientImpl
   }
   @Test(dataProvider = "provideUseGlobCollection", timeOut = 2000)
   // Retry task should re-subscribe the resources registered in each subscriber type.
-  public void testRetry(boolean useGlobCollection) throws ExecutionException, InterruptedException {
+  public void testRetry(boolean useGlobCollection) throws ExecutionException, InterruptedException
+  {
     XdsClientImplFixture fixture = new XdsClientImplFixture(useGlobCollection);
     fixture.watchAllResourceAndWatcherTypes();
     fixture._xdsClientImpl.testRetryTask(fixture._adsStream);
@@ -715,7 +716,8 @@ public class TestXdsClientImpl
     // get all the resource types and names sent in the discovery requests and verify them
     List<ResourceType> types = fixture._resourceTypesArgumentCaptor.getAllValues();
     List<String> nameLists = fixture._resourceNamesArgumentCaptor.getAllValues().stream()
-        .map(names -> {
+        .map(names ->
+        {
           if (names.size() != 1)
           {
             Assert.fail("Resource names should be a singleton list");
@@ -741,7 +743,7 @@ public class TestXdsClientImpl
     ));
   }
 
-  private static class XdsClientImplFixture
+  private static final class XdsClientImplFixture
   {
     XdsClientImpl _xdsClientImpl;
     @Mock

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -195,6 +195,8 @@ public class TestXdsClientImpl
     XdsClientImplFixture fixture = new XdsClientImplFixture();
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_WITH_EMPTY_NODE_RESPONSE);
     fixture.verifyAckSent(1);
+    verify(fixture._clusterSubscriber, times(0)).onData(any(), any());
+    verify(fixture._uriMapWildcardSubscriber, times(0)).onData(any(), any());
   }
 
   @DataProvider(name = "badNodeUpdateTestCases")
@@ -290,6 +292,8 @@ public class TestXdsClientImpl
     // Sanity check that the code handles empty responses
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_WITH_EMPTY_URI_MAP_RESPONSE);
     fixture.verifyAckSent(1);
+    verify(fixture._clusterSubscriber, times(0)).onData(any(), any());
+    verify(fixture._uriMapWildcardSubscriber, times(0)).onData(any(), any());
   }
 
   @DataProvider(name = "badD2URIMapUpdateTestCases")
@@ -606,7 +610,6 @@ public class TestXdsClientImpl
       doNothing().when(_xdsClientImpl).watchAllXdsResources(any());
       when(_xdsClientImpl.getWildcardResourceSubscriber(any()))
           .thenAnswer(a -> _wildcardSubscribers.get((ResourceType) a.getArguments()[0]));
-
     }
 
     void verifyAckSent(int count)

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -10,13 +10,23 @@ import com.linkedin.d2.xds.XdsClient.ResourceType;
 import com.linkedin.d2.xds.XdsClientImpl.DiscoveryResponseData;
 import com.linkedin.d2.xds.XdsClientImpl.ResourceSubscriber;
 import com.linkedin.d2.xds.XdsClientImpl.WildcardResourceSubscriber;
+import com.linkedin.r2.util.NamedThreadFactory;
 import indis.XdsD2;
 import io.envoyproxy.envoy.service.discovery.v3.Resource;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -34,7 +44,10 @@ public class TestXdsClientImpl
 {
   private static final byte[] DATA = "data".getBytes();
   private static final byte[] DATA2 = "data2".getBytes();
-  private static final String SERVICE_RESOURCE_NAME = "/d2/services/FooService";
+  private static final String SERVICE_NAME = "FooService";
+  private static final String SERVICE_NAME_2 = "BarService";
+  private static final String SERVICE_RESOURCE_NAME = "/d2/services/" + SERVICE_NAME;
+  private static final String SERVICE_RESOURCE_NAME_2 = "/d2/services/" + SERVICE_NAME_2;
   private static final String CLUSTER_NAME = "FooClusterMaster-prod-ltx1";
   private static final String CLUSTER_RESOURCE_NAME = "/d2/uris/" + CLUSTER_NAME;
   private static final String URI1 = "TestURI1";
@@ -55,8 +68,35 @@ public class TestXdsClientImpl
   private static final List<Resource> NODE_RESOURCES_WITH_DATA2 = Collections.singletonList(
       Resource.newBuilder().setVersion(VERSION2).setName(SERVICE_RESOURCE_NAME).setResource(PACKED_NODE_WITH_DATA2).build());
 
-  private static final List<Resource> NODE_RESOURCES_WITH_NULL_RESOURCE_FILED = Collections.singletonList(
+  private static final List<Resource> NODE_RESOURCES_WITH_NULL_RESOURCE_FIELD = Collections.singletonList(
       Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME).setResource(PACKED_NODE_WITH_EMPTY_DATA).build());
+
+  private static final XdsD2.D2ClusterOrServiceName CLUSTER_NAME_DATA = XdsD2.D2ClusterOrServiceName.newBuilder()
+      .setClusterName(CLUSTER_NAME).build();
+  private static final XdsD2.D2ClusterOrServiceName SERVICE_NAME_DATA = XdsD2.D2ClusterOrServiceName.newBuilder()
+      .setServiceName(SERVICE_NAME).build();
+  private static final XdsD2.D2ClusterOrServiceName SERVICE_NAME_DATA_2 = XdsD2.D2ClusterOrServiceName.newBuilder()
+      .setServiceName(SERVICE_NAME_2).build();
+  private static final XdsD2.D2ClusterOrServiceName NAME_DATA_WITH_NULL = XdsD2.D2ClusterOrServiceName.newBuilder().build();
+  private static final Any PACKED_SERVICE_NAME_DATA = Any.pack(SERVICE_NAME_DATA);
+  private static final Any PACKED_SERVICE_NAME_DATA_2 = Any.pack(SERVICE_NAME_DATA_2);
+  private static final Any PACKED_NAME_DATA_WITH_NULL = Any.pack(NAME_DATA_WITH_NULL);
+  private static final XdsClient.D2ClusterOrServiceNameUpdate CLUSTER_NAME_DATA_UPDATE =
+      new XdsClient.D2ClusterOrServiceNameUpdate(CLUSTER_NAME_DATA);
+  private static final XdsClient.D2ClusterOrServiceNameUpdate SERVICE_NAME_DATA_UPDATE =
+      new XdsClient.D2ClusterOrServiceNameUpdate(SERVICE_NAME_DATA);
+  private static final XdsClient.D2ClusterOrServiceNameUpdate SERVICE_NAME_DATA_UPDATE_2 =
+      new XdsClient.D2ClusterOrServiceNameUpdate(SERVICE_NAME_DATA_2);
+  private static final List<Resource> SERVICE_NAME_DATA_RESOURCES = Arrays.asList(
+      Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME)
+          .setResource(PACKED_SERVICE_NAME_DATA).build(),
+      Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME_2)
+          .setResource(PACKED_SERVICE_NAME_DATA_2).build()
+  );
+  private static final List<Resource> NULL_NAME_RESOURCES = Arrays.asList(
+      Resource.newBuilder().setVersion(VERSION1).setName(CLUSTER_RESOURCE_NAME).build(),
+      Resource.newBuilder().setVersion(VERSION1).setName(SERVICE_RESOURCE_NAME).setResource(PACKED_NAME_DATA_WITH_NULL).build()
+      );
 
   private static final XdsD2.D2URI D2URI_1 =
       XdsD2.D2URI.newBuilder().setVersion(Long.parseLong(VERSION1)).setClusterName(CLUSTER_NAME).setUri(URI1).build();
@@ -75,6 +115,7 @@ public class TestXdsClientImpl
       new D2URIMapUpdate(D2_URI_MAP_WITH_DATA1.getUrisMap());
   private static final D2URIMapUpdate D2_URI_MAP_UPDATE_WITH_DATA2 =
       new D2URIMapUpdate(D2_URI_MAP_WITH_DATA2.getUrisMap());
+  private static final D2URIMapUpdate D_2_URI_MAP_UPDATE_WITH_EMPTY_MAP = new D2URIMapUpdate(Collections.emptyMap());
   private static final Any PACKED_D2_URI_MAP_WITH_DATA1 = Any.pack(D2_URI_MAP_WITH_DATA1);
   private static final Any PACKED_D2_URI_MAP_WITH_DATA2 = Any.pack(D2_URI_MAP_WITH_DATA2);
   private static final Any PACKED_D2_URI_MAP_WITH_EMPTY_DATA = Any.pack(D2_URI_MAP_WITH_EMPTY_DATA);
@@ -83,7 +124,6 @@ public class TestXdsClientImpl
       .setName(CLUSTER_RESOURCE_NAME)
       .setResource(PACKED_D2_URI_MAP_WITH_DATA1)
       .build());
-
   private static final List<Resource> URI_MAP_RESOURCE_WITH_DATA2 = Collections.singletonList(Resource.newBuilder()
       .setVersion(VERSION1)
       .setName(CLUSTER_RESOURCE_NAME)
@@ -95,13 +135,12 @@ public class TestXdsClientImpl
           .setName(CLUSTER_RESOURCE_NAME)
           .setResource(PACKED_D2_URI_MAP_WITH_EMPTY_DATA)
           .build());
-  //  private static final List<String> REMOVED_RESOURCE = ;
+
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_DATA1 =
       new DiscoveryResponseData(NODE, NODE_RESOURCES_WITH_DATA1, null, NONCE, null);
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_DATA2 =
       new DiscoveryResponseData(NODE, NODE_RESOURCES_WITH_DATA2, null, NONCE, null);
-
-  // case 1: Resource in ResourceUpdate is null, failed to parse which causes InvalidProtocolBufferException
+  // Resource in ResourceUpdate is null, failed to parse which causes InvalidProtocolBufferException
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_RESOURCE_IS_NULL =
       new DiscoveryResponseData(
           NODE,
@@ -111,20 +150,29 @@ public class TestXdsClientImpl
           null,
           NONCE,
           null);
-
-  // case 2: Resource field in Resource is null
-  private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_NULL_DATA_IN_RESOURCE_FILED =
-      new DiscoveryResponseData(NODE, NODE_RESOURCES_WITH_NULL_RESOURCE_FILED, null, NONCE, null);
-
-  // case3 : ResourceList is empty
+  // Resource field in Resource is null
+  private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_NULL_DATA_IN_RESOURCE_FIELD =
+      new DiscoveryResponseData(NODE, NODE_RESOURCES_WITH_NULL_RESOURCE_FIELD, null, NONCE, null);
+  // ResourceList is empty
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_WITH_EMPTY_NODE_RESPONSE =
       new DiscoveryResponseData(NODE, Collections.emptyList(), null, NONCE, null);
+
+  private static final DiscoveryResponseData RESPONSE_WITH_SERVICE_NAMES =
+      new DiscoveryResponseData(D2_CLUSTER_OR_SERVICE_NAME, SERVICE_NAME_DATA_RESOURCES, null, NONCE, null);
+  private static final DiscoveryResponseData RESPONSE_WITH_NULL_NAMES =
+      new DiscoveryResponseData(D2_CLUSTER_OR_SERVICE_NAME, NULL_NAME_RESOURCES, null, NONCE, null);
+  private static final DiscoveryResponseData RESPONSE_WITH_EMPTY_NAMES =
+      new DiscoveryResponseData(D2_CLUSTER_OR_SERVICE_NAME, Collections.emptyList(), null, NONCE, null);
+  private static final DiscoveryResponseData RESPONSE_WITH_NAME_REMOVAL =
+      new DiscoveryResponseData(D2_CLUSTER_OR_SERVICE_NAME, Collections.emptyList(),
+          Collections.singletonList(SERVICE_RESOURCE_NAME), NONCE, null);
+
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_DATA1 =
       new DiscoveryResponseData(D2_URI_MAP, URI_MAP_RESOURCE_WITH_DATA1, null, NONCE, null);
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_DATA2 =
       new DiscoveryResponseData(D2_URI_MAP, URI_MAP_RESOURCE_WITH_DATA2, null, NONCE, null);
 
-  // case1: Resource in ResourceUpdate is null, failed to parse response.resource
+  // Resource in ResourceUpdate is null, failed to parse response.resource
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_RESOURCE_IS_NULL =
       new DiscoveryResponseData(
           D2_URI_MAP,
@@ -135,13 +183,12 @@ public class TestXdsClientImpl
           NONCE,
           null);
 
-  // case2 : Resource field in Resource is null
-  private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_EMPTY_MAP =
+  private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_EMPTY =
       new DiscoveryResponseData(D2_URI_MAP, EMPTY_URI_MAP_RESOURCE, null, NONCE, null);
 
-  // case3 : ResourceList is empty
+  // ResourceList is empty
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_WITH_EMPTY_URI_MAP_RESPONSE =
-      new DiscoveryResponseData(D2_URI_MAP, null, null, NONCE, null);
+      new DiscoveryResponseData(D2_URI_MAP, Collections.emptyList(), null, NONCE, null);
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_NODE_DATA_WITH_REMOVAL =
       new DiscoveryResponseData(NODE, Collections.emptyList(), Collections.singletonList(SERVICE_RESOURCE_NAME), NONCE, null);
   private static final DiscoveryResponseData DISCOVERY_RESPONSE_URI_MAP_DATA_WITH_REMOVAL =
@@ -151,48 +198,69 @@ public class TestXdsClientImpl
   private static final String URI_URN1 = "xdstp:///indis.D2URI/" + CLUSTER_NAME + "/" + URI1;
   private static final String URI_URN2 = "xdstp:///indis.D2URI/" + CLUSTER_NAME + "/" + URI2;
 
-  @Test
-  public void testHandleD2NodeResponseWithData()
+  @DataProvider(name = "providerWatcherFlags")
+  public Object[][] watcherFlags()
   {
+    // {
+    //    toWatchIndividual --- whether to watch resources with individual watcher
+    //    toWatchWildcard --- whether to watch resources with wildcard watcher
+    // }
+    return new Object[][]
+        {
+            {true, false},
+            {false, true},
+            {true, true}
+        };
+  }
+  @Test(dataProvider = "providerWatcherFlags")
+  public void testHandleD2NodeResponseWithData(boolean toWatchIndividual, boolean toWatchWildcard)
+  {
+    // make sure the watchers are notified as expected regardless of watching only by its own type, or watching
+    // with both via individual and wildcard watchers
     XdsClientImplFixture fixture = new XdsClientImplFixture();
+    if (toWatchIndividual)
+    {
+      fixture.watchNodeResource();
+    }
+    if (toWatchWildcard)
+    {
+      fixture.watchNodeResourceViaWildcard();
+    }
     // subscriber original data is null
-    fixture._nodeSubscriber.setData(null);
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA1);
     fixture.verifyAckSent(1);
-    verify(fixture._resourceWatcher).onChanged(eq(NODE_UPDATE1));
-    verify(fixture._wildcardResourceWatcher).onChanged(eq(SERVICE_RESOURCE_NAME), eq(NODE_UPDATE1));
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 1 : 0)).onChanged(eq(NODE_UPDATE1));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 1 : 0))
+        .onChanged(eq(SERVICE_RESOURCE_NAME), eq(NODE_UPDATE1));
     verifyZeroInteractions(fixture._serverMetricsProvider); // initial update should not track latency
-    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
     // subscriber data should be updated to NODE_UPDATE1
-    Assert.assertEquals(Objects.requireNonNull(actualData).getNodeData(), NODE_UPDATE1.getNodeData());
-    actualData = (XdsClient.NodeUpdate) fixture._nodeWildcardSubscriber.getData(SERVICE_RESOURCE_NAME);
-    // subscriber data should be updated to NODE_UPDATE1
-    Assert.assertEquals(Objects.requireNonNull(actualData).getNodeData(), NODE_UPDATE1.getNodeData());
+    Assert.assertEquals(fixture._nodeSubscriber.getData(), NODE_UPDATE1);
+    Assert.assertEquals(fixture._nodeWildcardSubscriber.getData(SERVICE_RESOURCE_NAME), NODE_UPDATE1);
 
     // subscriber original data is invalid, xds server latency won't be tracked
     fixture._nodeSubscriber.setData(new XdsClient.NodeUpdate(null));
     fixture._nodeWildcardSubscriber.setData(SERVICE_RESOURCE_NAME, new XdsClient.NodeUpdate(null));
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA1);
     fixture.verifyAckSent(2);
-    verify(fixture._resourceWatcher, times(2)).onChanged(eq(NODE_UPDATE1));
-    verify(fixture._wildcardResourceWatcher, times(2)).onChanged(eq(SERVICE_RESOURCE_NAME), eq(NODE_UPDATE1));
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 2 : 0)).onChanged(eq(NODE_UPDATE1));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 2 : 0)).onChanged(eq(SERVICE_RESOURCE_NAME), eq(NODE_UPDATE1));
     verifyZeroInteractions(fixture._serverMetricsProvider);
 
     // subscriber data should be updated to NODE_UPDATE2
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA2);
-    actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
-    verify(fixture._resourceWatcher).onChanged(eq(NODE_UPDATE2));
-    verify(fixture._wildcardResourceWatcher).onChanged(eq(SERVICE_RESOURCE_NAME), eq(NODE_UPDATE2));
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 1 : 0)).onChanged(eq(NODE_UPDATE2));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 1 : 0)).
+        onChanged(eq(SERVICE_RESOURCE_NAME), eq(NODE_UPDATE2));
     verify(fixture._serverMetricsProvider).trackLatency(anyLong());
-    Assert.assertEquals(actualData.getNodeData(), NODE_UPDATE2.getNodeData());
-    actualData = (XdsClient.NodeUpdate) fixture._nodeWildcardSubscriber.getData(SERVICE_RESOURCE_NAME);
-    Assert.assertEquals(actualData.getNodeData(), NODE_UPDATE2.getNodeData());
+    Assert.assertEquals(fixture._nodeSubscriber.getData(), NODE_UPDATE2);
+    Assert.assertEquals(fixture._nodeWildcardSubscriber.getData(SERVICE_RESOURCE_NAME), NODE_UPDATE2);
   }
 
   @Test
   public void testHandleD2NodeUpdateWithEmptyResponse()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_WITH_EMPTY_NODE_RESPONSE);
     fixture.verifyAckSent(1);
     verify(fixture._clusterSubscriber, times(0)).onData(any(), any());
@@ -202,39 +270,58 @@ public class TestXdsClientImpl
   @DataProvider(name = "badNodeUpdateTestCases")
   public Object[][] provideBadNodeDataTestCases()
   {
+    // {
+    //    badData --- bad resource data to test
+    //    nackExpected --- whether nack is expected
+    //    toWatchIndividual --- whether to watch resources with individual watcher
+    //    toWatchWildcard --- whether to watch resources with wildcard watcher
+    // }
     return new Object[][]{
-        {DISCOVERY_RESPONSE_NODE_RESOURCE_IS_NULL, true},
-        {DISCOVERY_RESPONSE_NODE_NULL_DATA_IN_RESOURCE_FILED, false},
+        {DISCOVERY_RESPONSE_NODE_RESOURCE_IS_NULL, true, true, false},
+        {DISCOVERY_RESPONSE_NODE_RESOURCE_IS_NULL, true, false, true},
+        {DISCOVERY_RESPONSE_NODE_RESOURCE_IS_NULL, true, true, true},
+        {DISCOVERY_RESPONSE_NODE_NULL_DATA_IN_RESOURCE_FIELD, false, true, false},
+        {DISCOVERY_RESPONSE_NODE_NULL_DATA_IN_RESOURCE_FIELD, false, false, true},
+        {DISCOVERY_RESPONSE_NODE_NULL_DATA_IN_RESOURCE_FIELD, false, true, true},
     };
   }
 
   @Test(dataProvider = "badNodeUpdateTestCases")
-  public void testHandleD2NodeUpdateWithBadData(DiscoveryResponseData badData, boolean nackExpected)
+  public void testHandleD2NodeUpdateWithBadData(DiscoveryResponseData badData, boolean nackExpected,
+      boolean toWatchIndividual, boolean toWatchWildcard )
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
-    fixture._nodeSubscriber.setData(null);
+    if (toWatchIndividual)
+    {
+      fixture.watchNodeResource();
+    }
+    if (toWatchWildcard)
+    {
+      fixture.watchNodeResourceViaWildcard();
+    }
     fixture._xdsClientImpl.handleResponse(badData);
     fixture.verifyAckOrNack(nackExpected, 1);
-    verify(fixture._resourceWatcher).onChanged(eq(NODE.emptyData()));
-    // The wildcard subscriber doesn't care about bad data, it doesn't need to notify the watcher
-    verify(fixture._wildcardResourceWatcher, times(0)).onChanged(any(), any());
-    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
-    Assert.assertNull(Objects.requireNonNull(actualData).getNodeData());
+    // since current data is null, all watchers should be notified for bad data to stop waiting.
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 1 : 0)).onChanged(eq(NODE.emptyData()));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 1 : 0)).onChanged(any(), eq(NODE.emptyData()));
+    Assert.assertEquals(fixture._nodeSubscriber.getData(), NODE.emptyData());
 
     fixture._nodeSubscriber.setData(NODE_UPDATE1);
     fixture._xdsClientImpl.handleResponse(badData);
     fixture.verifyAckOrNack(nackExpected, 2);
-    verify(fixture._resourceWatcher).onChanged(eq(NODE_UPDATE1));
-    verify(fixture._wildcardResourceWatcher, times(0)).onChanged(any(), any());
-    actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
-    // bad data will not overwrite the original valid data
-    Assert.assertEquals(actualData.getNodeData(), NODE_UPDATE1.getNodeData());
+    // current data is not null, bad data will not overwrite the original valid data and watchers won't be notified.
+    Assert.assertEquals(fixture._nodeSubscriber.getData(), NODE_UPDATE1);
+    verify(fixture._resourceWatcher, times(0)).onChanged(eq(NODE_UPDATE1));
+    verify(fixture._wildcardResourceWatcher, times(0)).onChanged(any(), eq(NODE_UPDATE1));
   }
 
+  // Removed resource will not overwrite the original valid data for individual subscriber, but will be removed
+  // in wildcard subscriber
   @Test
   public void testHandleD2NodeResponseWithRemoval()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
     fixture._nodeSubscriber.setData(NODE_UPDATE1);
     fixture._nodeWildcardSubscriber.setData(SERVICE_RESOURCE_NAME, NODE_UPDATE1);
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA_WITH_REMOVAL);
@@ -243,45 +330,127 @@ public class TestXdsClientImpl
     verify(fixture._wildcardResourceWatcher).onRemoval(eq(SERVICE_RESOURCE_NAME));
     verify(fixture._nodeSubscriber).onRemoval();
     verify(fixture._nodeWildcardSubscriber).onRemoval(eq(SERVICE_RESOURCE_NAME));
-    XdsClient.NodeUpdate actualData = (XdsClient.NodeUpdate) fixture._nodeSubscriber.getData();
-    //  removed resource will not overwrite the original valid data
-    Assert.assertEquals(Objects.requireNonNull(actualData).getNodeData(), NODE_UPDATE1.getNodeData());
+    Assert.assertEquals(fixture._nodeSubscriber.getData(), NODE_UPDATE1);
+    Assert.assertNull(fixture._nodeWildcardSubscriber.getData(SERVICE_RESOURCE_NAME));
   }
 
   @Test
-  public void testHandleD2URIMapResponseWithData()
+  public void testHandleD2ClusterOrServiceNameResponse()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
-    // subscriber original data is null
-    fixture._clusterSubscriber.setData(null);
+    fixture.watchAllResourceAndWatcherTypes();
+    // D2ClusterOrServiceName can be subscribed only via wildcard, valid new data should update subscriber data
+    fixture._xdsClientImpl.handleResponse(RESPONSE_WITH_SERVICE_NAMES);
+    fixture.verifyAckSent(1);
+    verify(fixture._wildcardResourceWatcher).onChanged(eq(SERVICE_RESOURCE_NAME), eq(SERVICE_NAME_DATA_UPDATE));
+    verify(fixture._wildcardResourceWatcher).onChanged(eq(SERVICE_RESOURCE_NAME_2), eq(SERVICE_NAME_DATA_UPDATE_2));
+    verify(fixture._wildcardResourceWatcher).onAllResourcesProcessed();
+    Assert.assertEquals(fixture._nameWildcardSubscriber.getData(SERVICE_RESOURCE_NAME), SERVICE_NAME_DATA_UPDATE);
+    Assert.assertEquals(fixture._nameWildcardSubscriber.getData(SERVICE_RESOURCE_NAME_2), SERVICE_NAME_DATA_UPDATE_2);
+    verifyZeroInteractions(fixture._serverMetricsProvider); // initial update should not track latency
+  }
+
+  @Test
+  public void testHandleD2ClusterOrServiceNameEmptyResponse()
+  {
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
+    fixture._xdsClientImpl.handleResponse(RESPONSE_WITH_EMPTY_NAMES);
+    fixture.verifyAckSent(1);
+    verify(fixture._nameWildcardSubscriber, times(0)).onData(any(), any());
+  }
+
+  @Test
+  public void testHandleD2ClusterOrServiceNameResponseWithBadData()
+  {
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
+    // when current data is null, all watchers should be notified for bad data to stop waiting.
+    fixture._xdsClientImpl.handleResponse(RESPONSE_WITH_NULL_NAMES);
+    fixture.verifyAckOrNack(true, 1);
+    verify(fixture._wildcardResourceWatcher).onChanged(eq(CLUSTER_RESOURCE_NAME),
+        eq(D2_CLUSTER_OR_SERVICE_NAME.emptyData()));
+    verify(fixture._wildcardResourceWatcher).onChanged(eq(SERVICE_RESOURCE_NAME),
+        eq(D2_CLUSTER_OR_SERVICE_NAME.emptyData()));
+    verify(fixture._wildcardResourceWatcher).onAllResourcesProcessed();
+    Assert.assertEquals(fixture._nameWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME),
+        D2_CLUSTER_OR_SERVICE_NAME.emptyData());
+    Assert.assertEquals(fixture._nameWildcardSubscriber.getData(SERVICE_RESOURCE_NAME),
+        D2_CLUSTER_OR_SERVICE_NAME.emptyData());
+
+    // when current data is not null, bad data won't overwrite the original valid data and watchers won't be notified.
+    fixture._nameWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, CLUSTER_NAME_DATA_UPDATE);
+    fixture._nameWildcardSubscriber.setData(SERVICE_RESOURCE_NAME, SERVICE_NAME_DATA_UPDATE);
+    fixture._xdsClientImpl.handleResponse(RESPONSE_WITH_NULL_NAMES);
+    fixture.verifyAckOrNack(true, 2);
+    verify(fixture._wildcardResourceWatcher, times(0))
+        .onChanged(eq(CLUSTER_RESOURCE_NAME), eq(CLUSTER_NAME_DATA_UPDATE));
+    verify(fixture._wildcardResourceWatcher, times(0))
+        .onChanged(eq(SERVICE_RESOURCE_NAME), eq(SERVICE_NAME_DATA_UPDATE));
+    verify(fixture._wildcardResourceWatcher, times(2)).onAllResourcesProcessed();
+    Assert.assertEquals(fixture._nameWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME), CLUSTER_NAME_DATA_UPDATE);
+    Assert.assertEquals(fixture._nameWildcardSubscriber.getData(SERVICE_RESOURCE_NAME), SERVICE_NAME_DATA_UPDATE);
+  }
+
+  // Removed resource will be removed in wildcard subscriber, where other resource is still kept intact.
+  @Test
+  public void testHandleD2ClusterOrServiceNameResponseWithRemoval()
+  {
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
+    fixture._nameWildcardSubscriber.setData(SERVICE_RESOURCE_NAME, SERVICE_NAME_DATA_UPDATE);
+    fixture._nameWildcardSubscriber.setData(SERVICE_RESOURCE_NAME_2, SERVICE_NAME_DATA_UPDATE_2);
+    fixture._xdsClientImpl.handleResponse(RESPONSE_WITH_NAME_REMOVAL);
+    fixture.verifyAckSent(1);
+    verify(fixture._wildcardResourceWatcher).onRemoval(SERVICE_RESOURCE_NAME);
+    verify(fixture._nameWildcardSubscriber).onRemoval(SERVICE_RESOURCE_NAME);
+    Assert.assertNull(fixture._nameWildcardSubscriber.getData(SERVICE_RESOURCE_NAME));
+    Assert.assertEquals(fixture._nameWildcardSubscriber.getData(SERVICE_RESOURCE_NAME_2), SERVICE_NAME_DATA_UPDATE_2);
+  }
+
+  @Test(dataProvider = "providerWatcherFlags")
+  public void testHandleD2URIMapResponseWithData(boolean toWatchIndividual, boolean toWatchWildcard)
+  {
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    if (toWatchIndividual)
+    {
+      fixture.watchUriMapResource();
+    }
+    if (toWatchWildcard)
+    {
+      fixture.watchUriMapResourceViaWildcard();
+    }
+    // subscriber original data is null, watchers and subscribers will be notified/updated for new valid data, and
+    // xds server latency won't be tracked
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA1);
     fixture.verifyAckSent(1);
-    verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-    verify(fixture._wildcardResourceWatcher).onChanged(eq(CLUSTER_RESOURCE_NAME), eq(D2_URI_MAP_UPDATE_WITH_DATA1));
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 1 : 0)).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 1 : 0))
+        .onChanged(eq(CLUSTER_RESOURCE_NAME), eq(D2_URI_MAP_UPDATE_WITH_DATA1));
     verifyZeroInteractions(fixture._serverMetricsProvider);
-    D2URIMapUpdate actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
-    // subscriber data should be updated to D2_URI_MAP_UPDATE_WITH_DATA1
-    Assert.assertEquals(Objects.requireNonNull(actualData).getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
-    actualData = (D2URIMapUpdate) fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME);
-    Assert.assertEquals(Objects.requireNonNull(actualData).getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
+    Assert.assertEquals(fixture._clusterSubscriber.getData(), D2_URI_MAP_UPDATE_WITH_DATA1);
+    Assert.assertEquals(fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME), D2_URI_MAP_UPDATE_WITH_DATA1);
 
-    // subscriber original data is invalid, xds server latency won't be tracked
-    fixture._clusterSubscriber.setData(new XdsClient.D2URIMapUpdate(null));
-    fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, new XdsClient.D2URIMapUpdate(null));
-    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA1);
-    verify(fixture._resourceWatcher, times(2)).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-    verify(fixture._wildcardResourceWatcher, times(2)).onChanged(eq(CLUSTER_RESOURCE_NAME), eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-    verifyZeroInteractions(fixture._serverMetricsProvider);
+    // subscriber original data is not null, new data will overwrite the original valid data, and watchers will be
+    // notified, and xds server latency will be tracked.
+    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA2); // updated uri1, added uri2
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 1 : 0)).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA2));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 1 : 0))
+        .onChanged(eq(CLUSTER_RESOURCE_NAME), eq(D2_URI_MAP_UPDATE_WITH_DATA2));
+    verify(fixture._serverMetricsProvider, times(2)).trackLatency(anyLong());
+    Assert.assertEquals(fixture._clusterSubscriber.getData(), D2_URI_MAP_UPDATE_WITH_DATA2);
+    Assert.assertEquals(fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME), D2_URI_MAP_UPDATE_WITH_DATA2);
     fixture.verifyAckSent(2);
 
-    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA2); // updated uri1, added uri2
-    actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
-    // subscriber data should be updated to D2_URI_MAP_UPDATE_WITH_DATA2
-    verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA2));
-    verify(fixture._serverMetricsProvider, times(2)).trackLatency(anyLong());
-    Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA2.getURIMap());
-    actualData = (D2URIMapUpdate) fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME);
-    Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA2.getURIMap());
+    // new data with an empty uri map will update the original data, watchers will be notified, but xds server latency
+    // won't be tracked.
+    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_EMPTY);
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 1 : 0)).onChanged(eq(D_2_URI_MAP_UPDATE_WITH_EMPTY_MAP));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 1 : 0))
+        .onChanged(eq(CLUSTER_RESOURCE_NAME), eq(D_2_URI_MAP_UPDATE_WITH_EMPTY_MAP));
+    verifyNoMoreInteractions(fixture._serverMetricsProvider); // won't track latency for removed uris
+    Assert.assertEquals(fixture._clusterSubscriber.getData(), D_2_URI_MAP_UPDATE_WITH_EMPTY_MAP);
+    Assert.assertEquals(fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME), D_2_URI_MAP_UPDATE_WITH_EMPTY_MAP);
     fixture.verifyAckSent(3);
   }
 
@@ -289,6 +458,7 @@ public class TestXdsClientImpl
   public void testHandleD2URIMapUpdateWithEmptyResponse()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
     // Sanity check that the code handles empty responses
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_WITH_EMPTY_URI_MAP_RESPONSE);
     fixture.verifyAckSent(1);
@@ -296,60 +466,38 @@ public class TestXdsClientImpl
     verify(fixture._uriMapWildcardSubscriber, times(0)).onData(any(), any());
   }
 
-  @DataProvider(name = "badD2URIMapUpdateTestCases")
-  public Object[][] provideBadD2URIMapDataTestCases()
-  {
-    return new Object[][]{
-        {DISCOVERY_RESPONSE_URI_MAP_RESOURCE_IS_NULL, true},
-        {DISCOVERY_RESPONSE_URI_MAP_EMPTY_MAP, false},
-    };
-  }
-
-  @Test(dataProvider = "badD2URIMapUpdateTestCases")
-  public void testHandleD2URIMapUpdateWithBadData(DiscoveryResponseData badData, boolean invalidData)
+  @Test(dataProvider = "providerWatcherFlags")
+  public void testHandleD2URIMapUpdateWithBadData(boolean toWatchIndividual, boolean toWatchWildcard)
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
-    fixture._clusterSubscriber.setData(null);
-    fixture._xdsClientImpl.handleResponse(badData);
-    fixture.verifyAckOrNack(invalidData, 1);
-    // If the map is empty, we expect an empty map, but if it's invalid we expect a null
-    D2URIMapUpdate expectedUpdate =
-        invalidData
-            ? (D2URIMapUpdate) D2_URI_MAP.emptyData()
-            : new D2URIMapUpdate(Collections.emptyMap());
-    verify(fixture._resourceWatcher).onChanged(eq(expectedUpdate));
-    if (!invalidData)
+    if (toWatchIndividual)
     {
-      verify(fixture._wildcardResourceWatcher).onChanged(eq(CLUSTER_RESOURCE_NAME), eq(expectedUpdate));
+      fixture.watchUriMapResource();
     }
-    verify(fixture._clusterSubscriber).setData(eq(null));
-    verify(fixture._uriMapWildcardSubscriber, times(0)).setData(any(), any());
-    verifyZeroInteractions(fixture._serverMetricsProvider);
-    D2URIMapUpdate actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
-    Assert.assertEquals(actualData, expectedUpdate);
+    if (toWatchWildcard)
+    {
+      fixture.watchUriMapResourceViaWildcard();
+    }
+    // current data is null, all watchers should be notified for bad data to stop waiting.
+    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_RESOURCE_IS_NULL);
+    fixture.verifyAckOrNack(true, 1);
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 1 : 0)).onChanged(eq(D2_URI_MAP.emptyData()));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 1 : 0))
+        .onChanged(eq(CLUSTER_RESOURCE_NAME), eq(D2_URI_MAP.emptyData()));
+    Assert.assertEquals(fixture._clusterSubscriber.getData(), D2_URI_MAP.emptyData());
+    Assert.assertEquals(fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME), D2_URI_MAP.emptyData());
 
+    // current data is not null, bad data will not overwrite the original valid data and watchers won't be notified.
     fixture._clusterSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, D2_URI_MAP_UPDATE_WITH_DATA1);
-    fixture._xdsClientImpl.handleResponse(badData);
-    fixture.verifyAckOrNack(invalidData, 2);
-    actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
-    Objects.requireNonNull(actualData);
-    if (invalidData)
-    {
-      verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-      verify(fixture._wildcardResourceWatcher, times(0)).onChanged(any(), any());
-      // bad data will not overwrite the original valid data
-      Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
-    }
-    else
-    {
-      verify(fixture._resourceWatcher, times(2)).onChanged(eq(expectedUpdate));
-      verify(fixture._wildcardResourceWatcher, times(2)).onChanged(eq(CLUSTER_RESOURCE_NAME), eq(expectedUpdate));
-      // But an empty cluster should clear the data
-      Assert.assertEquals(actualData.getURIMap(), Collections.emptyMap());
-      actualData = (D2URIMapUpdate) fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME);
-      Assert.assertEquals(actualData.getURIMap(), Collections.emptyMap());
-    }
+    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_RESOURCE_IS_NULL);
+
+    fixture.verifyAckOrNack(true, 2);
+    verify(fixture._resourceWatcher, times(0)).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
+    verify(fixture._wildcardResourceWatcher, times(0))
+        .onChanged(any(), eq(D2_URI_MAP_UPDATE_WITH_DATA1));
+    // bad data will not overwrite the original valid data
+    Assert.assertEquals(fixture._clusterSubscriber.getData(), D2_URI_MAP_UPDATE_WITH_DATA1);
     verifyZeroInteractions(fixture._serverMetricsProvider);
   }
 
@@ -357,6 +505,7 @@ public class TestXdsClientImpl
   public void testHandleD2URIMapResponseWithRemoval()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
     fixture._clusterSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA_WITH_REMOVAL);
@@ -382,8 +531,8 @@ public class TestXdsClientImpl
             .build()
     ), null, NONCE, null);
     XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
     // subscriber original data is null
-    fixture._clusterSubscriber.setData(null);
     fixture._xdsClientImpl.handleResponse(createUri1);
     fixture.verifyAckSent(1);
     verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
@@ -444,13 +593,14 @@ public class TestXdsClientImpl
   public void testHandleD2URICollectionUpdateWithEmptyResponse()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
     // Sanity check that the code handles empty responses
     fixture._xdsClientImpl.handleResponse(new DiscoveryResponseData(D2_URI, null, null, NONCE, null));
     fixture.verifyAckSent(1);
   }
 
-  @Test
-  public void testHandleD2URICollectionUpdateWithBadData()
+  @Test(dataProvider = "providerWatcherFlags")
+  public void testHandleD2URICollectionUpdateWithBadData(boolean toWatchIndividual, boolean toWatchWildcard)
   {
     DiscoveryResponseData badData = new DiscoveryResponseData(
         D2_URI,
@@ -462,27 +612,34 @@ public class TestXdsClientImpl
         null);
 
     XdsClientImplFixture fixture = new XdsClientImplFixture();
-    fixture._clusterSubscriber.setData(null);
+    if (toWatchIndividual)
+    {
+      fixture.watchUriMapResource();
+    }
+    if (toWatchWildcard)
+    {
+      fixture.watchUriMapResourceViaWildcard();
+    }
+
+    // current data is null, empty placeholder data will be set the subscriber,
+    // and all watchers should be notified for bad data to stop waiting.
     fixture._xdsClientImpl.handleResponse(badData);
     fixture.verifyNackSent(1);
-    verify(fixture._resourceWatcher).onChanged(eq(D2_URI_MAP.emptyData()));
-    // The wildcard subscriber doesn't care about bad data, and simply treats it as the resource not existing
-    verify(fixture._wildcardResourceWatcher, times(0)).onChanged(any(), any());
+    verify(fixture._resourceWatcher, times(toWatchIndividual ? 1 : 0)).onChanged(eq(D2_URI_MAP.emptyData()));
+    verify(fixture._wildcardResourceWatcher, times(toWatchWildcard ? 1 : 0))
+        .onChanged(any(), eq(D2_URI_MAP.emptyData()));
     verifyZeroInteractions(fixture._serverMetricsProvider);
-    D2URIMapUpdate actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
-    Assert.assertNull(Objects.requireNonNull(actualData).getURIMap());
-    actualData = (D2URIMapUpdate) fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME);
-    Assert.assertNull(actualData);
 
+    // current data is not null, bad data will not overwrite the original valid data and watchers won't be notified.
     fixture._clusterSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._xdsClientImpl.handleResponse(badData);
     fixture.verifyNackSent(2);
-    // Due to the way glob collection updates are handled, bad data is dropped rather than showing any visible side
-    // effects other than NACKing the response.
     verify(fixture._resourceWatcher, times(0)).onChanged(eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-    verify(fixture._wildcardResourceWatcher, times(0)).onChanged(any(), any());
+    verify(fixture._wildcardResourceWatcher, times(0))
+        .onChanged(any(), eq(D2_URI_MAP_UPDATE_WITH_DATA1));
     verifyZeroInteractions(fixture._serverMetricsProvider);
+    Assert.assertEquals(fixture._clusterSubscriber.getData(), D2_URI_MAP_UPDATE_WITH_DATA1);
   }
 
   @Test
@@ -492,6 +649,7 @@ public class TestXdsClientImpl
         new DiscoveryResponseData(D2_URI, null, Collections.singletonList(CLUSTER_GLOB_COLLECTION), NONCE, null);
 
     XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
     fixture._clusterSubscriber.setData(D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._uriMapWildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, D2_URI_MAP_UPDATE_WITH_DATA1);
     fixture._xdsClientImpl.handleResponse(removeClusterResponse);
@@ -501,42 +659,9 @@ public class TestXdsClientImpl
     verify(fixture._clusterSubscriber).onRemoval();
     verify(fixture._uriMapWildcardSubscriber).onRemoval(eq(CLUSTER_RESOURCE_NAME));
     verifyZeroInteractions(fixture._serverMetricsProvider);
-    D2URIMapUpdate actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
     // removed resource will not overwrite the original valid data
-    Assert.assertEquals(actualData.getURIMap(), D2_URI_MAP_UPDATE_WITH_DATA1.getURIMap());
-    actualData = (D2URIMapUpdate) fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME);
-    Assert.assertNull(actualData);
-  }
-
-  @Test
-  public void testWildCardResourceSubscription()
-  {
-    XdsClientImplFixture fixture = new XdsClientImplFixture();
-
-    XdsClient.WildcardNodeResourceWatcher nodeWildCardWatcher = Mockito.mock(XdsClient.WildcardNodeResourceWatcher.class);
-    XdsClient.WildcardD2URIMapResourceWatcher uriMapWildCardWatcher = Mockito.mock(XdsClient.WildcardD2URIMapResourceWatcher.class);
-    fixture._xdsClientImpl.getWildcardResourceSubscriber(NODE).addWatcher(nodeWildCardWatcher);
-    fixture._xdsClientImpl.getWildcardResourceSubscriber(D2_URI_MAP).addWatcher(uriMapWildCardWatcher);
-
-    // NODE resource added
-    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA1);
-    fixture.verifyAckSent(1);
-    nodeWildCardWatcher.onChanged(eq(SERVICE_RESOURCE_NAME) , eq(NODE_UPDATE1));
-
-    // NODE resource removed
-    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA_WITH_REMOVAL);
-    fixture.verifyAckSent(2);
-    nodeWildCardWatcher.onRemoval(eq(SERVICE_RESOURCE_NAME));
-
-    // URI_MAP resource added
-    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA1);
-    fixture.verifyAckSent(3);
-    uriMapWildCardWatcher.onChanged(eq(CLUSTER_RESOURCE_NAME), eq(D2_URI_MAP_UPDATE_WITH_DATA1));
-
-    // URI_MAP resource removed
-    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_URI_MAP_DATA_WITH_REMOVAL);
-    fixture.verifyAckSent(4);
-    uriMapWildCardWatcher.onRemoval(eq(CLUSTER_RESOURCE_NAME));
+    Assert.assertEquals(fixture._clusterSubscriber.getData(), D2_URI_MAP_UPDATE_WITH_DATA1);
+    Assert.assertNull(fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME));
   }
 
   @Test
@@ -554,17 +679,80 @@ public class TestXdsClientImpl
       subscriber.addWatcher(watcher);
     }
     verify(watcher, times(10)).onChanged(eq(update));
+
+    WildcardResourceSubscriber wildcardSubscriber = new WildcardResourceSubscriber(D2_CLUSTER_OR_SERVICE_NAME);
+    XdsClient.WildcardResourceWatcher _wildcardWatcher = Mockito.mock(XdsClient.WildcardResourceWatcher.class);
+    wildcardSubscriber.addWatcher(_wildcardWatcher);
+    verify(_wildcardWatcher, times(0)).onChanged(any(), any());
+
+    wildcardSubscriber.setData(CLUSTER_RESOURCE_NAME, CLUSTER_NAME_DATA_UPDATE);
+    for (int i = 0; i < 10; i++)
+    {
+      wildcardSubscriber.addWatcher(_wildcardWatcher);
+    }
+    verify(_wildcardWatcher, times(10)).onChanged(eq(CLUSTER_RESOURCE_NAME), eq(CLUSTER_NAME_DATA_UPDATE));
+  }
+
+  @DataProvider(name = "provideUseGlobCollection")
+  public Object[][] provideUseGlobCollection()
+  {
+    // {
+    //   useGlobCollection --- whether to use glob collection
+    // }
+    return new Object[][]{
+        {true},
+        {false}
+    };
+  }
+  @Test(dataProvider = "provideUseGlobCollection", timeOut = 2000)
+  // Retry task should re-subscribe the resources registered in each subscriber type.
+  public void testRetry(boolean useGlobCollection) throws ExecutionException, InterruptedException {
+    XdsClientImplFixture fixture = new XdsClientImplFixture(useGlobCollection);
+    fixture.watchAllResourceAndWatcherTypes();
+    fixture._xdsClientImpl.testRetryTask(fixture._adsStream);
+    fixture._xdsClientImpl._retryRpcStreamFuture.get();
+
+    // get all the resource types and names sent in the discovery requests and verify them
+    List<ResourceType> types = fixture._resourceTypesArgumentCaptor.getAllValues();
+    List<String> nameLists = fixture._resourceNamesArgumentCaptor.getAllValues().stream()
+        .map(names -> {
+          if (names.size() != 1)
+          {
+            Assert.fail("Resource names should be a singleton list");
+          }
+          return names.iterator().next();
+        }).collect(Collectors.toList());
+    Assert.assertEquals(types.size(), 5);
+    Assert.assertEquals(nameLists.size(), 5);
+
+    List<Pair<ResourceType, String>> args = new ArrayList<>();
+    for (int i = 0; i < 5; i++)
+    {
+      args.add(Pair.of(types.get(i), nameLists.get(i)));
+    }
+    args = args.stream().sorted().collect(Collectors.toList());
+
+    Assert.assertEquals(args, Arrays.asList(
+        Pair.of(NODE, "*"),
+        Pair.of(NODE, SERVICE_RESOURCE_NAME),
+        Pair.of(useGlobCollection ? D2_URI : D2_URI_MAP, "*"),
+        Pair.of(useGlobCollection ? D2_URI : D2_URI_MAP, useGlobCollection ? CLUSTER_GLOB_COLLECTION : CLUSTER_RESOURCE_NAME),
+        Pair.of(D2_CLUSTER_OR_SERVICE_NAME, "*")
+    ));
   }
 
   private static class XdsClientImplFixture
   {
     XdsClientImpl _xdsClientImpl;
     @Mock
+    XdsClientImpl.AdsStream _adsStream;
+    @Mock
     XdsClientJmx _xdsClientJmx;
     ResourceSubscriber _nodeSubscriber;
     ResourceSubscriber _clusterSubscriber;
     XdsClientImpl.WildcardResourceSubscriber _nodeWildcardSubscriber;
     XdsClientImpl.WildcardResourceSubscriber _uriMapWildcardSubscriber;
+    XdsClientImpl.WildcardResourceSubscriber _nameWildcardSubscriber;
     Map<ResourceType, Map<String, ResourceSubscriber>> _subscribers = new HashMap<>();
     Map<ResourceType, XdsClientImpl.WildcardResourceSubscriber> _wildcardSubscribers = new HashMap<>();
 
@@ -574,6 +762,11 @@ public class TestXdsClientImpl
     XdsClient.WildcardResourceWatcher _wildcardResourceWatcher;
     @Mock
     XdsServerMetricsProvider _serverMetricsProvider;
+
+    @Captor
+    ArgumentCaptor<ResourceType> _resourceTypesArgumentCaptor;
+    @Captor
+    ArgumentCaptor<Collection<String>> _resourceNamesArgumentCaptor;
 
     XdsClientImplFixture()
     {
@@ -587,29 +780,67 @@ public class TestXdsClientImpl
       _clusterSubscriber = spy(new ResourceSubscriber(D2_URI_MAP, CLUSTER_RESOURCE_NAME, _xdsClientJmx));
       _nodeWildcardSubscriber = spy(new XdsClientImpl.WildcardResourceSubscriber(NODE));
       _uriMapWildcardSubscriber = spy(new XdsClientImpl.WildcardResourceSubscriber(D2_URI_MAP));
-
+      _nameWildcardSubscriber = spy(new XdsClientImpl.WildcardResourceSubscriber(D2_CLUSTER_OR_SERVICE_NAME));
 
       doNothing().when(_resourceWatcher).onChanged(any());
+      doNothing().when(_wildcardResourceWatcher).onChanged(any(), any());
+      doNothing().when(_serverMetricsProvider).trackLatency(anyLong());
+
+      for (ResourceSubscriber subscriber : Lists.newArrayList(_nodeSubscriber, _clusterSubscriber))
+      {
+        _subscribers.put(subscriber.getType(), Collections.singletonMap(subscriber.getResource(), subscriber));
+      }
+      for (WildcardResourceSubscriber subscriber : Lists.newArrayList(_nodeWildcardSubscriber,
+          _uriMapWildcardSubscriber, _nameWildcardSubscriber))
+      {
+        _wildcardSubscribers.put(subscriber.getType(), subscriber);
+      }
+
+      _xdsClientImpl = spy(new XdsClientImpl(null, null,
+          Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("test executor")),
+          0, useGlobCollections, _serverMetricsProvider));
+      _xdsClientImpl._adsStream = _adsStream;
+
+      doNothing().when(_xdsClientImpl).startRpcStreamLocal();
+      doNothing().when(_xdsClientImpl).sendAckOrNack(any(), any(), any());
+      doNothing().when(_adsStream).sendDiscoveryRequest(_resourceTypesArgumentCaptor.capture(), _resourceNamesArgumentCaptor.capture());
+
+      when(_xdsClientImpl.getXdsClientJmx()).thenReturn(_xdsClientJmx);
+      when(_xdsClientImpl.getResourceSubscribers()).thenReturn(_subscribers);
+      when(_xdsClientImpl.getWildcardResourceSubscribers()).thenReturn(_wildcardSubscribers);
+    }
+
+    void watchAllResourceAndWatcherTypes()
+    {
       for (ResourceSubscriber subscriber : Lists.newArrayList(_nodeSubscriber, _clusterSubscriber))
       {
         subscriber.addWatcher(_resourceWatcher);
-        _subscribers.put(subscriber.getType(), Collections.singletonMap(subscriber.getResource(), subscriber));
       }
-      for (WildcardResourceSubscriber subscriber : Lists.newArrayList(_nodeWildcardSubscriber, _uriMapWildcardSubscriber))
+      for (WildcardResourceSubscriber subscriber : Lists.newArrayList(_nodeWildcardSubscriber,
+          _uriMapWildcardSubscriber, _nameWildcardSubscriber))
       {
         subscriber.addWatcher(_wildcardResourceWatcher);
-        _wildcardSubscribers.put(subscriber.getType(), subscriber);
       }
-      doNothing().when(_serverMetricsProvider).trackLatency(anyLong());
-      _xdsClientImpl = spy(new XdsClientImpl(null, null, null, 0,
-          useGlobCollections, _serverMetricsProvider));
-      doNothing().when(_xdsClientImpl).sendAckOrNack(any(), any(), any());
-      when(_xdsClientImpl.getXdsClientJmx()).thenReturn(_xdsClientJmx);
-      when(_xdsClientImpl.getResourceSubscriberMap(any()))
-          .thenAnswer(a -> _subscribers.get((ResourceType) a.getArguments()[0]));
-      doNothing().when(_xdsClientImpl).watchAllXdsResources(any());
-      when(_xdsClientImpl.getWildcardResourceSubscriber(any()))
-          .thenAnswer(a -> _wildcardSubscribers.get((ResourceType) a.getArguments()[0]));
+    }
+
+    void watchNodeResource()
+    {
+      _nodeSubscriber.addWatcher(_resourceWatcher);
+    }
+
+    void watchNodeResourceViaWildcard()
+    {
+      _nodeWildcardSubscriber.addWatcher(_wildcardResourceWatcher);
+    }
+
+    void watchUriMapResource()
+    {
+      _clusterSubscriber.addWatcher(_resourceWatcher);
+    }
+
+    void watchUriMapResourceViaWildcard()
+    {
+      _uriMapWildcardSubscriber.addWatcher(_wildcardResourceWatcher);
     }
 
     void verifyAckSent(int count)

--- a/d2/src/test/java/com/linkedin/d2/xds/balancer/TestXdsDirectory.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/balancer/TestXdsDirectory.java
@@ -25,7 +25,8 @@ public class TestXdsDirectory
   /**
    * Simulate getting cluster and service names with multiple threads. Threads should be blocked until
    * onAllResourcesProcessed is called. They should be re-blocked if new update comes in, and unblocked again when
-   * onAllResourcesProcessed is called.
+   * onAllResourcesProcessed is called. New threads coming in while the data is not being updated should get the data
+   * immediately.
    */
   @Test(timeOut = 3000)
   public void testGetClusterAndServiceNames() throws InterruptedException {
@@ -72,6 +73,10 @@ public class TestXdsDirectory
     long serviceMatchCount = fixture._results.stream()
         .filter(result -> Objects.equals(result, Collections.singletonList(SERVICE_NAME))).count();
     Assert.assertEquals(serviceMatchCount, halfCallers);
+
+    // new caller coming in while the data is not being updated should get the data immediately
+    fixture.createCaller(true).run();
+    Assert.assertEquals(fixture._results.size(), numCallers + 1);
 
     // adding new resource will trigger updating again, caller threads should be re-blocked, and new data shouldn't be
     // added to the results

--- a/d2/src/test/java/com/linkedin/d2/xds/balancer/TestXdsDirectory.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/balancer/TestXdsDirectory.java
@@ -1,0 +1,148 @@
+package com.linkedin.d2.xds.balancer;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.common.callback.Callback;
+import com.linkedin.d2.xds.XdsClient;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.linkedin.d2.xds.TestXdsClientImpl.*;
+import static org.mockito.Mockito.*;
+
+
+public class TestXdsDirectory
+{
+  /**
+   * Simulate getting cluster and service names with multiple threads.
+   */
+  @Test(timeOut = 2000)
+  public void testGetClusterAndServiceNames() throws InterruptedException {
+    int numCallers = 20;
+    int halfCallers = numCallers / 2;
+    XdsDirectoryFixture fixture = new XdsDirectoryFixture();
+    XdsDirectory directory = fixture._xdsDirectory;
+    Assert.assertNull(directory._watcher.get());
+    directory.start();
+    ExecutorService executor = Executors.newFixedThreadPool(numCallers);
+    runCallers(fixture, executor, halfCallers);
+    XdsClient.WildcardD2ClusterOrServiceNameResourceWatcher watcher = Objects.requireNonNull(directory._watcher.get());
+
+    // verified names are not updated, results are empty, which means all threads are waiting.
+    Assert.assertTrue(directory._isUpdating.get());
+    Assert.assertTrue(fixture._results.isEmpty());
+    Assert.assertTrue(directory._serviceNames.isEmpty());
+    Assert.assertTrue(directory._clusterNames.isEmpty());
+
+    // update cluster and service names and mimic adding callers in the middle of updating
+    watcher.onChanged(SERVICE_RESOURCE_NAME, SERVICE_NAME_DATA_UPDATE);
+    watcher.onChanged(SERVICE_RESOURCE_NAME_2, SERVICE_NAME_DATA_UPDATE_2);
+    runCallers(fixture, executor, halfCallers);
+    watcher.onChanged(CLUSTER_RESOURCE_NAME, CLUSTER_NAME_DATA_UPDATE);
+    watcher.onRemoval(SERVICE_RESOURCE_NAME_2);
+
+    // verify service names and cluster names are updated, but updating flag is true, and threads are still waiting
+    Assert.assertEquals(directory._clusterNames, Collections.singletonMap(CLUSTER_RESOURCE_NAME, CLUSTER_NAME));
+    Assert.assertEquals(directory._serviceNames, Collections.singletonMap(SERVICE_RESOURCE_NAME, SERVICE_NAME));
+    Assert.assertTrue(directory._isUpdating.get());
+    Assert.assertTrue(fixture._results.isEmpty());
+
+    // finish updating and unblock all callers
+    watcher.onAllResourcesProcessed();
+    executor.shutdown();
+    Assert.assertTrue(executor.awaitTermination(1000, java.util.concurrent.TimeUnit.MILLISECONDS));
+
+    // verify updating flag is false, and all threads are unblocked and added their results
+    Assert.assertFalse(directory._isUpdating.get());
+    Assert.assertEquals(fixture._results.size(), numCallers);
+    long clusterMatchCount = fixture._results.stream()
+        .filter(result -> Objects.equals(result, Collections.singletonList(CLUSTER_NAME))).count();
+    Assert.assertEquals(clusterMatchCount, halfCallers);
+    long serviceMatchCount = fixture._results.stream()
+        .filter(result -> Objects.equals(result, Collections.singletonList(SERVICE_NAME))).count();
+    Assert.assertEquals(serviceMatchCount, halfCallers);
+
+    // adding new resource will trigger updating again
+    watcher.onChanged(SERVICE_RESOURCE_NAME_2, SERVICE_NAME_DATA_UPDATE_2);
+    Assert.assertTrue(directory._isUpdating.get());
+    Assert.assertEquals(directory._serviceNames,
+        ImmutableMap.of(SERVICE_RESOURCE_NAME, SERVICE_NAME, SERVICE_RESOURCE_NAME_2, SERVICE_NAME_2));
+
+    // finish updating again
+    watcher.onAllResourcesProcessed();
+    Assert.assertFalse(directory._isUpdating.get());
+  }
+
+  private void runCallers(XdsDirectoryFixture fixture, ExecutorService executor, int num)
+  {
+    for (int i = 0; i < num; i++)
+    {
+      executor.execute(fixture.createCaller(i % 2 == 0));
+    }
+  }
+
+  private static final class XdsDirectoryFixture
+  {
+    XdsDirectory _xdsDirectory;
+    @Mock
+    XdsClient _xdsClient;
+    List<List<String>> _results = new ArrayList<>();;
+
+    public XdsDirectoryFixture()
+    {
+      MockitoAnnotations.initMocks(this);
+      doNothing().when(_xdsClient).watchAllXdsResources(any());
+      _xdsDirectory = new XdsDirectory(_xdsClient);
+    }
+
+    CallerThread createCaller(boolean isForServiceNames)
+    {
+      return new CallerThread(isForServiceNames);
+    }
+
+    final class CallerThread implements Runnable
+    {
+      private final Callback<List<String>> _callback;
+      private final boolean _isForServiceNames;
+
+      public CallerThread(boolean isForServiceNames)
+      {
+        _callback = new Callback<List<String>>()
+        {
+          @Override
+          public void onError(Throwable e)
+          {
+            Assert.fail("Unexpected error: " + e);
+          }
+
+          @Override
+          public void onSuccess(List<String> result)
+          {
+            _results.add(result);
+          }
+        };
+        _isForServiceNames = isForServiceNames;
+      }
+
+      @Override
+      public void run()
+      {
+        if (_isForServiceNames)
+        {
+          _xdsDirectory.getServiceNames(_callback);
+        }
+        else
+        {
+          _xdsDirectory.getClusterNames(_callback);
+        }
+      }
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.63.0
+version=29.63.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
Support getting d2 service and cluster name lists from INDIS with Xds load balancer. This is needed by some apps (like d2-proxy) that need to read the names to migrate to INDIS read. 

Note that observer hasn't supported the resource D2ClusterOrServiceName yet, so build and test are failing.

## Test
UT. QEI test with d2-proxy. The names is fetched and served correctly.