### PR TITLE
Add option to send ServicePropertiesJsonSerializer to XdsToD2Properti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.65.2] - 2025-03-14
+- Add option to pass ServicePropertiesJsonSerializer to XdsToD2PropertiesAdapter
+- Change ServicePropertiesJsonSerializer attribute _clientServicesConfig from private to protected
+
 ## [29.65.1] - 2025-03-13
 - Use concurrent set for used service bookkeeping
 
@@ -5779,7 +5783,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.2...master
+[29.65.2]: https://github.com/linkedin/rest.li/compare/v29.65.1...v29.65.2
 [29.65.1]: https://github.com/linkedin/rest.li/compare/v29.65.0...v29.65.1
 [29.65.0]: https://github.com/linkedin/rest.li/compare/v29.64.1...v29.65.0
 [29.64.1]: https://github.com/linkedin/rest.li/compare/v29.64.0...v29.64.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServicePropertiesJsonSerializer.java
@@ -60,7 +60,7 @@ public class ServicePropertiesJsonSerializer implements
    * (e.g. http.loadBalancer.hashMethod, degrader.maxDropRate) allow the inner map to be flat.
    */
 
-  private final Map<String, Map<String, Object>> _clientServicesConfig;
+  protected final Map<String, Map<String, Object>> _clientServicesConfig;
 
 
   public ServicePropertiesJsonSerializer()

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -100,10 +100,15 @@ public class XdsToD2PropertiesAdaptor
   public XdsToD2PropertiesAdaptor(XdsClient xdsClient, DualReadStateManager dualReadStateManager,
       ServiceDiscoveryEventEmitter eventEmitter, Map<String, Map<String, Object>> clientServicesConfig)
   {
+    this(xdsClient, dualReadStateManager, eventEmitter, new ServicePropertiesJsonSerializer(clientServicesConfig));
+  }
+
+  public XdsToD2PropertiesAdaptor(XdsClient xdsClient, DualReadStateManager dualReadStateManager,
+      ServiceDiscoveryEventEmitter eventEmitter, ServicePropertiesJsonSerializer servicePropertiesJsonSerializer) {
     _xdsClient = xdsClient;
     _dualReadStateManager = dualReadStateManager;
     _eventEmitter = eventEmitter;
-    _servicePropertiesJsonSerializer = new ServicePropertiesJsonSerializer(clientServicesConfig);
+    _servicePropertiesJsonSerializer = servicePropertiesJsonSerializer;
   }
 
   public void start()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.1
+version=29.65.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.64.1
+version=29.64.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Description:

Add option to send ServicePropertiesJsonSerializer to XdsToD2PropertiesAdapter

Testing Done:

Tested it with corresponding changes in grpc-infra, will share that PR

Tested sending request from toki to tokiGrpcBackend with setting a lower timeout and it worked as expected

Below is an example of successful request with these changes with just 2 seconds delay
![Screenshot 2025-03-05 at 6 05 06 PM](https://github.com/user-attachments/assets/a8013e19-4e93-46ca-8499-e7e9c978ab84)


Below is example where the timeout is overidded on the client side with 5 seconds, compared to whats set by the server at 10 seconds, so sending a request with larger delay gets timed out now

![Screenshot 2025-03-05 at 6 06 09 PM](https://github.com/user-attachments/assets/649e6b64-2fdc-47ac-b84b-ebc5b66ddbca)
![Screenshot 2025-03-05 at 6 06 29 PM](https://github.com/user-attachments/assets/dfc11515-9f2a-4423-b3fc-ff25f53ac0a6)




