### PR TITLE
deprecate ZK-related methods in D2ClientBuilder and D2ClientConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.65.0] - 2025-03-06
 - Deprecate ZK-related methods in D2ClientBuilder and D2ClientConfig
 
 ## [29.64.1] - 2025-02-15
@@ -5774,7 +5776,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.64.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.0...master
+[29.65.0]: https://github.com/linkedin/rest.li/compare/v29.64.1...v29.65.0
 [29.64.1]: https://github.com/linkedin/rest.li/compare/v29.64.0...v29.64.1
 [29.64.0]: https://github.com/linkedin/rest.li/compare/v29.63.2...v29.64.0
 [29.63.2]: https://github.com/linkedin/rest.li/compare/v29.63.1...v29.63.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Deprecate ZK-related methods in D2ClientBuilder and D2ClientConfig
 
 ## [29.64.1] - 2025-02-15
 - Fix warmUp -- record service as used regardless of whether getClient succeeds

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -51,6 +51,7 @@ import com.linkedin.d2.discovery.stores.zk.ZooKeeper;
 import com.linkedin.d2.jmx.XdsServerMetricsProvider;
 import com.linkedin.d2.jmx.JmxManager;
 import com.linkedin.d2.jmx.NoOpJmxManager;
+import com.linkedin.d2.xds.balancer.XdsLoadBalancerWithFacilitiesFactory;
 import com.linkedin.r2.transport.common.TransportClientFactory;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
 import com.linkedin.r2.util.NamedThreadFactory;
@@ -225,6 +226,16 @@ public class D2ClientBuilder
       new ZKFSLoadBalancerWithFacilitiesFactory() :
       _config.lbWithFacilitiesFactory;
 
+    // Warn for non-INDIS load balancer factory usage
+    if (!(loadBalancerFactory instanceof XdsLoadBalancerWithFacilitiesFactory))
+    {
+      LOG.warn(String.format("ACTION REQUIRED: Zookeeper-based D2 Client is deprecated (except locally-deployed ZK) "
+          + "and must be migrated to INDIS. See instructions at " +
+          "https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps" +
+          "\nFailing to do so will block other apps from stopping ZK announcements and will be escalated for site-up stability. " +
+          "Use XdsLoadBalancerWithFacilitiesFactory instead of %s", loadBalancerFactory.getClass().getSimpleName()));
+    }
+
     LoadBalancerWithFacilities loadBalancer = loadBalancerFactory.create(cfg);
 
     D2Client d2Client = new DynamicClient(loadBalancer, loadBalancer, _restOverStream);
@@ -291,6 +302,11 @@ public class D2ClientBuilder
     return d2Client;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. Use setXdsServer instead. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setZkHosts(String zkHosts)
   {
     _config.zkHosts = zkHosts;
@@ -309,13 +325,22 @@ public class D2ClientBuilder
     return this;
   }
 
-
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. Use setXdsServer instead. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setZkSessionTimeout(long zkSessionTimeout, TimeUnit unit)
   {
     _config.zkSessionTimeoutInMs = unit.toMillis(zkSessionTimeout);
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setZkStartupTimeout(long zkStartupTimeout, TimeUnit unit)
   {
     _config.zkStartupTimeoutInMs = unit.toMillis(zkStartupTimeout);
@@ -353,6 +378,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setComponentFactory(ZKFSTogglingLoadBalancerFactoryImpl.ComponentFactory componentFactory)
   {
     _config.componentFactory = componentFactory;
@@ -389,6 +419,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. INDIS always support symlink. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setIsSymlinkAware(boolean isSymlinkAware)
   {
     _config.isSymlinkAware = isSymlinkAware;
@@ -401,6 +436,10 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * Legacy feature that has been deprecated for years. Do not use.
+   */
+  @Deprecated
   public D2ClientBuilder setD2ServicePath(String d2ServicePath)
   {
     _config.d2ServicePath = d2ServicePath;
@@ -523,6 +562,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setUseNewEphemeralStoreWatcher(boolean useNewEphemeralStoreWatcher)
   {
     _config.useNewEphemeralStoreWatcher = useNewEphemeralStoreWatcher;
@@ -534,6 +578,10 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
   public D2ClientBuilder setWarmUpTimeoutSeconds(int warmUpTimeoutSeconds)
   {
     _config.warmUpTimeoutSeconds = warmUpTimeoutSeconds;
@@ -546,12 +594,22 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setZookeeperReadWindowMs(int zookeeperReadWindowMs)
   {
     _config.zookeeperReadWindowMs = zookeeperReadWindowMs;
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setWarmUpConcurrentRequests(int warmUpConcurrentRequests)
   {
     _config.warmUpConcurrentRequests = warmUpConcurrentRequests;
@@ -576,6 +634,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setDownstreamServicesFetcher(DownstreamServicesFetcher downstreamServicesFetcher)
   {
     _config.downstreamServicesFetcher = downstreamServicesFetcher;
@@ -599,6 +662,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setZooKeeperDecorator(Function<ZooKeeper, ZooKeeper> zooKeeperDecorator){
     _config.zooKeeperDecorator = zooKeeperDecorator;
     return this;
@@ -617,6 +685,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   public D2ClientBuilder setZKConnectionForloadBalancer(ZKPersistentConnection connection)
   {
     _config.zkConnectionToUseForLB = connection;

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -54,29 +54,66 @@ import javax.net.ssl.SSLParameters;
 
 public class D2ClientConfig
 {
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. Use xdsServer instead. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   String zkHosts = null;
   public String xdsServer = null;
   public String hostName = null;
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   long zkSessionTimeoutInMs = 3600000L;
+  @Deprecated
   long zkStartupTimeoutInMs = 10000L;
+  @Deprecated
+  ZKFSTogglingLoadBalancerFactoryImpl.ComponentFactory componentFactory = null;
+  @Deprecated
+  boolean useNewEphemeralStoreWatcher = true;
+  @Deprecated
+  public int warmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
+  @Deprecated
+  public int warmUpConcurrentRequests = WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS;
+  @Deprecated
+  public DownstreamServicesFetcher downstreamServicesFetcher = null;
+  @Deprecated
+  Function<ZooKeeper, ZooKeeper> zooKeeperDecorator = null;
+  @Deprecated
+  int zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
+  @Deprecated
+  ZKPersistentConnection zkConnectionToUseForLB = null;
+
   public long lbWaitTimeout = 5000L;
   public TimeUnit lbWaitUnit = TimeUnit.MILLISECONDS;
   String flagFile = "/no/flag/file/set";
   String basePath = "/d2";
   public String fsBasePath = "/tmp/d2";
   public String indisFsBasePath = "/tmp/d2/indis";
-  ZKFSTogglingLoadBalancerFactoryImpl.ComponentFactory componentFactory = null;
+
   public Map<String, TransportClientFactory> clientFactories = null;
   LoadBalancerWithFacilitiesFactory lbWithFacilitiesFactory = null;
+  /**
+   * Legacy feature that has been deprecated for years. Do not use.
+   */
+  @Deprecated
   public String d2ServicePath = null;
   public SSLContext sslContext = null;
   public SslContext grpcSslContext = null;
   public SSLParameters sslParameters = null;
   public boolean isSSLEnabled = false;
   boolean shutdownAsynchronously = false;
+  /**
+   * @deprecated ZK-based D2 is deprecated. Please onboard to INDIS. INDIS always support symlink. See instructions at
+   * https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/INDIS+Rollout+Issue+Guidelines+for+Java+Apps
+   */
+  @Deprecated
   boolean isSymlinkAware = true;
   public Map<String, Map<String, Object>> clientServicesConfig = Collections.<String, Map<String, Object>>emptyMap();
-  boolean useNewEphemeralStoreWatcher = true;
+
   HealthCheckOperations healthCheckOperations = null;
   boolean enableSaveUriDataOnDisk = false;
   /**
@@ -97,12 +134,8 @@ public class D2ClientConfig
   long retryUpdateIntervalMs = RetryClient.DEFAULT_UPDATE_INTERVAL_MS;
   int retryAggregatedIntervalNum = RetryClient.DEFAULT_AGGREGATED_INTERVAL_NUM;
   public boolean warmUp = true;
-  public int warmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
   public int indisWarmUpTimeoutSeconds = WarmUpLoadBalancer.DEFAULT_SEND_REQUESTS_TIMEOUT_SECONDS;
-  int zookeeperReadWindowMs = ZooKeeperStore.DEFAULT_READ_WINDOW_MS;
-  public int warmUpConcurrentRequests = WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS;
   public int indisWarmUpConcurrentRequests = WarmUpLoadBalancer.DEFAULT_CONCURRENT_REQUESTS;
-  public DownstreamServicesFetcher downstreamServicesFetcher = null;
   public DownstreamServicesFetcher indisDownstreamServicesFetcher = null;
   boolean backupRequestsEnabled = true;
   BackupRequestsStrategyStatsConsumer backupRequestsStrategyStatsConsumer = null;
@@ -112,11 +145,9 @@ public class D2ClientConfig
   boolean enableBackupRequestsClientAsync = false;
   EventEmitter eventEmitter = null;
   public PartitionAccessorRegistry partitionAccessorRegistry = null;
-  Function<ZooKeeper, ZooKeeper> zooKeeperDecorator = null;
   public Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories = Collections.emptyMap();
   boolean requestTimeoutHandlerEnabled = false;
   public SslSessionValidatorFactory sslSessionValidatorFactory = null;
-  ZKPersistentConnection zkConnectionToUseForLB = null;
   public ScheduledExecutorService startUpExecutorService = null;
   public ScheduledExecutorService indisStartUpExecutorService = null;
   public JmxManager jmxManager = new NoOpJmxManager();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.64.1
+version=29.65.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
As the title, so that users of the raw D2ClientBuilder and D2ClientConfig can be aware of the required migration.

Also log a warning when the d2 client being built is not INDIS-based. As we've migrated ~98% of Offspring standard d2 client usages, it's good to add this warning to help migrating the long-tailing non-standard clients.

## Testing Done
N/A