### PR TITLE
Use concurrent set for used service bookkeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.65.1] - 2025-03-13
+- Use concurrent set for used service bookkeeping
+
 ## [29.65.0] - 2025-03-06
 - Deprecate ZK-related methods in D2ClientBuilder and D2ClientConfig
 
@@ -5776,7 +5779,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.1...master
+[29.65.1]: https://github.com/linkedin/rest.li/compare/v29.65.0...v29.65.1
 [29.65.0]: https://github.com/linkedin/rest.li/compare/v29.64.1...v29.65.0
 [29.64.1]: https://github.com/linkedin/rest.li/compare/v29.64.0...v29.64.1
 [29.64.0]: https://github.com/linkedin/rest.li/compare/v29.63.2...v29.64.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/WarmUpLoadBalancer.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -120,7 +121,7 @@ public class WarmUpLoadBalancer extends LoadBalancerWithFacilitiesDelegator {
     _warmUpTimeoutMillis = warmUpTimeoutMillis;
     _concurrentRequests = concurrentRequests;
     _outstandingRequests = new ConcurrentLinkedDeque<>();
-    _usedServices = new HashSet<>();
+    _usedServices = ConcurrentHashMap.newKeySet();
     _dualReadStateManager = dualReadStateManager;
     _isIndis = isIndis;
     _printName = String.format("%s WarmUp", _isIndis ? "xDS" : "ZK");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.0
+version=29.65.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
There have been reports that somehow this map is failing to track the usage of all services (see LPS-33281 for an internal ticket). Make it concurrency safe to see if that fixes the issue.

Stacktrace (relevant sections) below. Notice `WarmUpLoadBalancer.getClient`:
```
2025/03/05 00:25:32.272 WARN [ZKDeterministicSubsettingMetadataProvider] [R2 Callback Executor-2-10] [games-mt] [AAYvjWxkeX4PfPf6iaMF6g==] Failed to fetch deterministic subsetting metadata from ZooKeeper for cluster GamesMt
java.util.concurrent.TimeoutException: null
	at com.linkedin.common.callback.FutureCallback.get(FutureCallback.java:79) ~[com.linkedin.pegasus.pegasus-common-29.64.1.jar:?]
	at com.linkedin.d2.balancer.subsetting.ZKDeterministicSubsettingMetadataProvider.getSubsettingMetadata(ZKDeterministicSubsettingMetadataProvider.java:128) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.subsetting.SubsettingState.getClientsSubset(SubsettingState.java:70) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancerState.getClientsSubset(SimpleLoadBalancerState.java:794) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.getPotentialClients(SimpleLoadBalancer.java:998) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.chooseTrackerClient(SimpleLoadBalancer.java:1161) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.lambda$getClient$2(SimpleLoadBalancer.java:278) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.common.callback.Callbacks$1.onSuccess(Callbacks.java:87) ~[com.linkedin.pegasus.pegasus-common-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer$2.onSuccess(SimpleLoadBalancer.java:501) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer$2.onSuccess(SimpleLoadBalancer.java:483) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.r2.transport.http.client.TimeoutCallback.onSuccess(TimeoutCallback.java:99) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.lambda$listenToServiceAndCluster$4(SimpleLoadBalancer.java:557) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancerState$6.done(SimpleLoadBalancerState.java:560) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.AbstractLoadBalancerSubscriber.ensureListening(AbstractLoadBalancerSubscriber.java:87) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancerState.listenToCluster(SimpleLoadBalancerState.java:566) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.listenToCluster(SimpleLoadBalancer.java:565) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.lambda$listenToServiceAndCluster$5(SimpleLoadBalancer.java:557) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.common.callback.Callbacks$1.onSuccess(Callbacks.java:87) ~[com.linkedin.pegasus.pegasus-common-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.lambda$getLoadBalancedServiceProperties$7(SimpleLoadBalancer.java:816) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.lambda$getLoadBalancedServiceProperties$8(SimpleLoadBalancer.java:822) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.AbstractLoadBalancerSubscriber.ensureListening(AbstractLoadBalancerSubscriber.java:87) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancerState.listenToService(SimpleLoadBalancerState.java:539) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.getLoadBalancedServiceProperties(SimpleLoadBalancer.java:822) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.listenToServiceAndCluster(SimpleLoadBalancer.java:554) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.listenToServiceAndCluster(SimpleLoadBalancer.java:510) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.getClient(SimpleLoadBalancer.java:234) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.util.TogglingLoadBalancer.getClient(TogglingLoadBalancer.java:132) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.xds.balancer.XdsLoadBalancer.getClient(XdsLoadBalancer.java:128) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.LoadBalancer.getClient(LoadBalancer.java:125) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.util.WarmUpLoadBalancer.getClient(WarmUpLoadBalancer.java:448) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.LoadBalancer.getClient(LoadBalancer.java:59) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.calltracking.CallTrackingLoadBalancer.getClient(CallTrackingLoadBalancer.java:36) ~[com.linkedin.container.pegasus-d2-impl-38.13.32.jar:?]
	at com.linkedin.d2.balancer.clients.DynamicClient.streamRequest(DynamicClient.java:107) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.r2.transport.common.AbstractClient.restRequest(AbstractClient.java:95) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.DynamicClient.restRequest(DynamicClient.java:95) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$1.onSuccess(BackupRequestsClient.java:248) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$1.onSuccess(BackupRequestsClient.java:231) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$2.onSuccess(BackupRequestsClient.java:288) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$2.onSuccess(BackupRequestsClient.java:276) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.LoadBalancer.getLoadBalancedServiceProperties(LoadBalancer.java:84) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.BackupRequestsClient.getStrategyAsync(BackupRequestsClient.java:292) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.BackupRequestsClient.requestAsync(BackupRequestsClient.java:253) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.BackupRequestsClient.restRequest(BackupRequestsClient.java:181) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.RetryClient.restRequest(RetryClient.java:157) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.D2ClientDelegator.restRequest(D2ClientDelegator.java:81) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.FailoutClient.access$201(FailoutClient.java:40) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.FailoutClient$1.onSuccess(FailoutClient.java:90) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.FailoutClient$1.onSuccess(FailoutClient.java:78) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.FailoutClient$3.onSuccess(FailoutClient.java:154) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.FailoutClient$3.onSuccess(FailoutClient.java:133) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.LoadBalancer.getLoadBalancedServiceProperties(LoadBalancer.java:84) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.FailoutClient.determineRequestUri(FailoutClient.java:132) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.FailoutClient.restRequest(FailoutClient.java:77) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.D2ClientDelegator.restRequest(D2ClientDelegator.java:81) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.calltracking.CallTrackingD2Client.restRequest(CallTrackingD2Client.java:64) ~[com.linkedin.container.pegasus-d2-impl-38.13.32.jar:?]
	at com.linkedin.d2.sla.SLAD2Client.restRequest(SLAD2Client.java:50) ~[com.linkedin.container.pegasus-d2-impl-38.13.32.jar:?]
	at com.linkedin.restli.hovr.HovrD2Client.restRequest(HovrD2Client.java:114) ~[com.linkedin.container.pegasus-restli-hovr-impl-38.13.32.jar:?]
	at com.linkedin.d2.client.factory.LifeCycleAwareD2ClientImpl.restRequest(LifeCycleAwareD2ClientImpl.java:73) ~[com.linkedin.container.pegasus-d2-client-factory-38.13.32.jar:?]
	at com.linkedin.d2.client.factory.DelegatorD2Client.restRequest(DelegatorD2Client.java:78) ~[com.linkedin.container.pegasus-d2-client-factory-38.13.32.jar:?]
	at com.linkedin.restli.client.RestClient.sendRestRequestImpl(RestClient.java:808) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.client.RestClient.access$400(RestClient.java:135) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.client.RestClient$2.onSuccess(RestClient.java:415) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.client.RestClient$2.onSuccess(RestClient.java:397) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.client.RestClient.getProtocolVersionForService(RestClient.java:462) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.client.RestClient.sendRestRequest(RestClient.java:396) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.client.RestClient.sendRequestNoScatterGather(RestClient.java:325) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.client.RestClient.sendRequest(RestClient.java:298) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.client.DisruptRestClient.sendRequest(DisruptRestClient.java:98) ~[com.linkedin.pegasus.restli-client-29.64.1.jar:?]
	at com.linkedin.restli.sla.SLARestLiClient.sendRequest(SLARestLiClient.java:89) ~[com.linkedin.container.pegasus-restli-client-impl-38.13.32.jar:?]
	at com.linkedin.grpc.interop.RestLiOverGrpcClient.sendRequest(RestLiOverGrpcClient.java:416) ~[com.linkedin.grpc-infra.si-grpc-impl-38.3.37.jar:?]
	at com.linkedin.grpc.interop.RestLiOverGrpcClient.sendRequest(RestLiOverGrpcClient.java:449) ~[com.linkedin.grpc-infra.si-grpc-impl-38.3.37.jar:?]
	at com.linkedin.games.api.client.AsyncRestliClient.sendRequest(AsyncRestliClient.java:54) ~[games-mt-1.0.774.jar:?]
	at com.linkedin.games.api.client.AsyncRestliClient.sendRequest(AsyncRestliClient.java:28) ~[games-mt-1.0.774.jar:?]
	at com.linkedin.games.api.client.SimpleSettingsClient.batchGetSimpleSettingsUsp(SimpleSettingsClient.java:63) ~[games-mt-1.0.774.jar:?]
	at com.linkedin.games.api.client.SimpleSettingsClient.batchGetMembersWithVisibilitySettingConnections(SimpleSettingsClient.java:71) ~[games-mt-1.0.774.jar:?]
	at com.linkedin.games.api.client.LiquidClient.lambda$getGamesPlayedByConnections$4(LiquidClient.java:144) ~[games-mt-1.0.774.jar:?]
	at java.util.Optional.map(Optional.java:260) ~[?:?]
	at com.linkedin.games.api.client.LiquidClient.lambda$getGamesPlayedByConnections$6(LiquidClient.java:134) ~[games-mt-1.0.774.jar:?]
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1150) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
	at com.linkedin.games.api.client.AsyncRestliClient$1.onSuccess(AsyncRestliClient.java:44) ~[games-mt-1.0.774.jar:?]
	at com.linkedin.games.api.client.AsyncRestliClient$1.onSuccess(AsyncRestliClient.java:36) ~[games-mt-1.0.774.jar:?]
	at com.linkedin.r2.message.timing.TimingCallback.onSuccess(TimingCallback.java:87) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.common.callback.CallbackAdapter.onSuccess(CallbackAdapter.java:77) ~[com.linkedin.pegasus.pegasus-common-29.64.1.jar:?]
	at com.linkedin.r2.message.timing.TimingCallback.onSuccess(TimingCallback.java:87) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.d2.calltracking.CallTrackingD2Client$CallTrackingCallback.onSuccess(CallTrackingD2Client.java:108) ~[com.linkedin.container.pegasus-d2-impl-38.13.32.jar:?]
	at com.linkedin.d2.calltracking.CallTrackingD2Client$CallTrackingCallback.onSuccess(CallTrackingD2Client.java:80) ~[com.linkedin.container.pegasus-d2-impl-38.13.32.jar:?]
	at com.linkedin.d2.balancer.clients.RetryClient$RetryRequestCallback.onSuccess(RetryClient.java:304) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.clients.RetryClient$RetryRequestCallback.onSuccess(RetryClient.java:285) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.r2.message.Messages$5$2.onSuccess(Messages.java:255) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.r2.message.Messages$5$2.onSuccess(Messages.java:245) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.r2.message.Messages$3.onSuccess(Messages.java:119) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.r2.message.Messages$3.onSuccess(Messages.java:104) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.r2.message.stream.entitystream.FullEntityReader.onDone(FullEntityReader.java:42) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.r2.message.stream.entitystream.adapter.ByteStringToGenericReader.onDone(ByteStringToGenericReader.java:64) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.entitystream.EntityStreamImpl$WriteHandleImpl.done(EntityStreamImpl.java:276) ~[com.linkedin.pegasus.entity-stream-29.64.1.jar:?]
```