### PR TITLE
Fix deadlock in R2 calls due to cluster subsetting data fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.65.3] - 2025-03-14
+- Fix deadlock in R2 calls due to cluster subsetting data fetching
+
 ## [29.65.2] - 2025-03-14
 - Add option to pass ServicePropertiesJsonSerializer to XdsToD2PropertiesAdapter
 - Change ServicePropertiesJsonSerializer attribute _clientServicesConfig from private to protected
@@ -5783,7 +5786,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.3...master
+[29.65.3]: https://github.com/linkedin/rest.li/compare/v29.65.2...v29.65.3
 [29.65.2]: https://github.com/linkedin/rest.li/compare/v29.65.1...v29.65.2
 [29.65.1]: https://github.com/linkedin/rest.li/compare/v29.65.0...v29.65.1
 [29.65.0]: https://github.com/linkedin/rest.li/compare/v29.64.1...v29.65.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/util/D2ExecutorThreadFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/util/D2ExecutorThreadFactory.java
@@ -1,0 +1,36 @@
+package com.linkedin.d2.balancer.util;
+
+import com.linkedin.r2.util.NamedThreadFactory;
+import com.linkedin.r2.util.UncaughtExceptionHandler;
+
+
+/**
+ * A {@link java.util.concurrent.ThreadFactory} that tracks whether a thread belongs to the D2 single-threaded
+ * service-discovery related executors.
+ */
+public final class D2ExecutorThreadFactory extends NamedThreadFactory {
+  private static final ThreadLocal<Boolean> BELONGS_TO_EXECUTOR = ThreadLocal.withInitial(() -> false);
+
+  public D2ExecutorThreadFactory(String name) {
+    super(name);
+  }
+
+  public D2ExecutorThreadFactory(String name, UncaughtExceptionHandler uncaughtExceptionHandler) {
+    super(name, uncaughtExceptionHandler);
+  }
+
+  @Override
+  public Thread newThread(Runnable runnable) {
+    return super.newThread(() -> {
+      BELONGS_TO_EXECUTOR.set(true);
+      runnable.run();
+    });
+  }
+
+  /**
+   * Indicates whether the thread belongs to D2 executors or not.
+   */
+  public static boolean isFromExecutor() {
+    return BELONGS_TO_EXECUTOR.get();
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.2
+version=29.65.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
A deadlock can happen when Indis/ZK data isn't available for some downstream. In that case, the calls made to that downstream get buffered (the respective callbacks get added to the [ClosableQueue](https://github.com/linkedin/rest.li/blob/5602d2b880e93eb0e61e759fd4e0ebfd184527cf/r2-core/src/main/java/com/linkedin/r2/util/ClosableQueue.java)) until Indis/ZK executor thread finally gets the data and executes all the queued callbacks. However, since the callbacks are for active RPCs, some of them may require getting the cluster subsetting metadata, which is a [blocking call](https://github.com/linkedin/rest.li/blob/5602d2b880e93eb0e61e759fd4e0ebfd184527cf/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java#L128). Since fetching this data actually happens on the Indis/ZK thread itself, this is a deadlock. See stack trace:
```
2025/03/05 00:25:32.269 WARN [ZKDeterministicSubsettingMetadataProvider] [Indis xDS client executor-4-1] [games-mt] [AAYvjWvjjkRqrRXIH2qoEg==] Failed to fetch deterministic subsetting metadata from ZooKeeper for cluster GamesMt
java.util.concurrent.TimeoutException: null
	at com.linkedin.common.callback.FutureCallback.get(FutureCallback.java:79) ~[com.linkedin.pegasus.pegasus-common-29.64.1.jar:?]
	at com.linkedin.d2.balancer.subsetting.ZKDeterministicSubsettingMetadataProvider.getSubsettingMetadata(ZKDeterministicSubsettingMetadataProvider.java:128) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.subsetting.SubsettingState.getClientsSubset(SubsettingState.java:70) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancerState.getClientsSubset(SimpleLoadBalancerState.java:794) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.getPotentialClients(SimpleLoadBalancer.java:998) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.chooseTrackerClient(SimpleLoadBalancer.java:1161) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.lambda$getClient$2(SimpleLoadBalancer.java:278) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.common.callback.Callbacks$1.onSuccess(Callbacks.java:87) ~[com.linkedin.pegasus.pegasus-common-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer$2.onSuccess(SimpleLoadBalancer.java:501) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer$2.onSuccess(SimpleLoadBalancer.java:483) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.r2.transport.http.client.TimeoutCallback.onSuccess(TimeoutCallback.java:99) ~[com.linkedin.pegasus.r2-core-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancer.lambda$listenToServiceAndCluster$4(SimpleLoadBalancer.java:557) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.SimpleLoadBalancerState$6.done(SimpleLoadBalancerState.java:560) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.balancer.simple.AbstractLoadBalancerSubscriber.onInitialize(AbstractLoadBalancerSubscriber.java:164) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.discovery.event.PropertyEventBusImpl$6.innerRun(PropertyEventBusImpl.java:218) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at com.linkedin.d2.discovery.event.PropertyEventThread$PropertyEvent.run(PropertyEventThread.java:168) ~[com.linkedin.pegasus.d2-29.64.1.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
	at com.linkedin.container.servicecall.trace.internal.ServiceCallTraceHandlerImpl.traceCallTree(ServiceCallTraceHandlerImpl.java:104) ~[com.linkedin.container-core.container-servicecall-trace-impl-1.3.409.jar:?]
	at com.linkedin.container.servicecall.ServiceCallHelperImpl.lambda$call$3(ServiceCallHelperImpl.java:150) ~[com.linkedin.container-core.container-servicecall-impl-1.3.409.jar:?]
	at com.linkedin.container.servicecall.ServiceCallHelperImpl.lambda$call$5(ServiceCallHelperImpl.java:173) ~[com.linkedin.container-core.container-servicecall-impl-1.3.409.jar:?]
	at com.linkedin.container.ic2.internal.ThreadLocalICManager.callWithIC(ThreadLocalICManager.java:120) [com.linkedin.container-core.container-ic-impl-1.3.409.jar:?]
	at com.linkedin.container.ic2.internal.ThreadLocalICManager.callWithNewIC(ThreadLocalICManager.java:101) [com.linkedin.container-core.container-ic-impl-1.3.409.jar:?]
	at com.linkedin.container.servicecall.ServiceCallHelperImpl.callWithNewIC(ServiceCallHelperImpl.java:502) [com.linkedin.container-core.container-servicecall-impl-1.3.409.jar:?]
	at com.linkedin.container.servicecall.ServiceCallHelperImpl.call(ServiceCallHelperImpl.java:166) [com.linkedin.container-core.container-servicecall-impl-1.3.409.jar:?]
	at com.linkedin.container.servicecall.ServiceCallExecutorService$DecoratedCallable.call(ServiceCallExecutorService.java:111) [com.linkedin.container-core.container-servicecall-api-1.3.409.jar:?]
	at com.linkedin.util.concurrent.AbstractExecutorServiceDecorator$2.run(AbstractExecutorServiceDecorator.java:56) [com.linkedin.util.util-core-28.4.17.jar:?]
	at com.linkedin.container.concurrent.InstrumentedScheduledThreadPoolExecutor$InstrumentedRunnable.run(InstrumentedScheduledThreadPoolExecutor.java:98) [com.linkedin.container-core.container-impl-1.3.409.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

To fix this, we can make the Indis/ZK executors use `D2ExecutorThreadFactory`. If the callback executes in such executors, we can push it to the fork join pool, which should be safe.

TESTING DONE
--------
Deployed locally and confirmed that when d2 warmup is disabled, only the first RPC is completed by the Indis executor thread:
![Screenshot 2025-03-17 at 11 52 55 AM](https://github.com/user-attachments/assets/8c332e18-9853-492a-9863-1cd0e2485f4c)
![Screenshot 2025-03-17 at 11 53 01 AM](https://github.com/user-attachments/assets/40a10351-f24a-4aa3-9185-aad640a3bd52)

Subsequent RPCs execute the callback right away, from their own threads:
![Screenshot 2025-03-17 at 11 53 45 AM](https://github.com/user-attachments/assets/6e7ef509-9829-42a5-88f5-b47ea974b0ef)
![Screenshot 2025-03-17 at 11 53 55 AM](https://github.com/user-attachments/assets/4a3ad193-c460-45f6-9601-efa41cffec3c)

Tested that the fork-join pool is working fine and RPCs are succeeding successfully.