### PR TITLE
Use dedicated executor service for d2 callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.65.5] - 2025-03-24
+- Use dedicated executor service for d2 callbacks
+
 ## [29.65.4] - 2025-03-17
 - Add d2 slow start configuration support
 
@@ -5789,7 +5792,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.5...master
+[29.65.5]: https://github.com/linkedin/rest.li/compare/v29.65.4...v29.65.5
 [29.65.4]: https://github.com/linkedin/rest.li/compare/v29.65.3...v29.65.4
 [29.65.3]: https://github.com/linkedin/rest.li/compare/v29.65.2...v29.65.3
 [29.65.2]: https://github.com/linkedin/rest.li/compare/v29.65.1...v29.65.2

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -151,7 +151,7 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     {
       _failoutConfigProvider = null;
     }
-    _d2CallbackExecutorService = Executors.newFixedThreadPool(1, new NamedThreadFactory("D2 Callback Executor"));
+    _d2CallbackExecutorService = Executors.newCachedThreadPool(new NamedThreadFactory("D2 Callback Executor"));
   }
 
   public Stats getServiceNotFoundStats()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.4
+version=29.65.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
In #1047 the `ForkJoinPool` common pool was used to execute d2 callbacks. However, as it turns out, the fork join pool may already be busy making RPCs (https://github.com/linkedin/venice/pull/1478) and it may result in _yet another deadlock_. To fix that issue, this change:
1. Adds a dedicated executor for d2 callbacks which isn't called from anywhere else.
2. Uses `Executors.newCachedThreadPool` for creating the executor, making it deadlock resistant. Assuming that this executor's threads would still end up making RPCs somewhere in the app code, it could result in more deadlocks otherwise.

Example of deadlocked `ForkJoinPool` (it's being used to make RPCs which need the same threadpool to be free to execute callbacks):
```
"ForkJoinPool.commonPool-worker-2" #28 daemon prio=5 os_prio=0 cpu=46.89ms elapsed=3634.41s tid=0x00007b60b441b000 nid=0x6b waiting on condition  [0x00007b60b48fb000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.5/Native Method)
	- parking to wait for  <0x000000050e295970> (a java.util.concurrent.CountDownLatch$Sync)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.5/LockSupport.java:211)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.5/AbstractQueuedSynchronizer.java:715)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@17.0.5/AbstractQueuedSynchronizer.java:1047)
	at java.util.concurrent.CountDownLatch.await(java.base@17.0.5/CountDownLatch.java:230)
	at com.linkedin.common.callback.FutureCallback.get(FutureCallback.java:62)
	at com.linkedin.d2.balancer.LoadBalancer.getClient(LoadBalancer.java:128)
	at com.linkedin.d2.balancer.util.WarmUpLoadBalancer.getClient(WarmUpLoadBalancer.java:449)
	at com.linkedin.d2.balancer.LoadBalancer.getClient(LoadBalancer.java:59)
	at com.linkedin.d2.calltracking.CallTrackingLoadBalancer.getClient(CallTrackingLoadBalancer.java:36)
	at com.linkedin.d2.balancer.clients.DynamicClient.streamRequest(DynamicClient.java:107)
	at com.linkedin.r2.transport.common.AbstractClient.restRequest(AbstractClient.java:95)
	at com.linkedin.d2.balancer.clients.DynamicClient.restRequest(DynamicClient.java:95)
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$$Lambda$1665/0x0000000801a76000.doRequest(Unknown Source)
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$1.onSuccess(BackupRequestsClient.java:244)
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$1.onSuccess(BackupRequestsClient.java:231)
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$2.onSuccess(BackupRequestsClient.java:288)
	at com.linkedin.d2.balancer.clients.BackupRequestsClient$2.onSuccess(BackupRequestsClient.java:276)
	at com.linkedin.d2.balancer.LoadBalancer.getLoadBalancedServiceProperties(LoadBalancer.java:84)
	at com.linkedin.d2.balancer.clients.BackupRequestsClient.getStrategyAsync(BackupRequestsClient.java:292)
	at com.linkedin.d2.balancer.clients.BackupRequestsClient.requestAsync(BackupRequestsClient.java:253)
	at com.linkedin.d2.balancer.clients.BackupRequestsClient.restRequest(BackupRequestsClient.java:181)
	at com.linkedin.d2.balancer.clients.RetryClient.restRequest(RetryClient.java:157)
	at com.linkedin.d2.balancer.D2ClientDelegator.restRequest(D2ClientDelegator.java:81)
	at com.linkedin.d2.calltracking.CallTrackingD2Client.restRequest(CallTrackingD2Client.java:64)
	at com.linkedin.d2.sla.SLAD2Client.restRequest(SLAD2Client.java:50)
	at com.linkedin.restli.hovr.HovrD2Client.restRequest(HovrD2Client.java:114)
	at com.linkedin.d2.client.factory.LifeCycleAwareD2ClientImpl.restRequest(LifeCycleAwareD2ClientImpl.java:73)
	at com.linkedin.d2.client.factory.DelegatorD2Client.restRequest(DelegatorD2Client.java:78)
	at com.linkedin.venice.client.store.transport.D2TransportClient.restRequest(D2TransportClient.java:305)
	at com.linkedin.venice.client.store.transport.D2TransportClient.get(D2TransportClient.java:110)
	at com.linkedin.venice.client.store.D2ServiceDiscovery.find(D2ServiceDiscovery.java:60)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.discoverD2Service(AbstractAvroStoreClient.java:300)
	- locked <0x0000000507c90bd0> (a com.linkedin.venice.client.store.AvroGenericStoreClientImpl)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.init(AbstractAvroStoreClient.java:286)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.getKeySerializerWithRetry(AbstractAvroStoreClient.java:263)
	- locked <0x0000000507c90bd0> (a com.linkedin.venice.client.store.AvroGenericStoreClientImpl)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.getKeySerializerWithRetryWithLongInterval(AbstractAvroStoreClient.java:236)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient$$Lambda$1364/0x000000080177cfb8.run(Unknown Source)
	at java.util.concurrent.CompletableFuture$AsyncRun.run(java.base@17.0.5/CompletableFuture.java:1804)
	at java.util.concurrent.CompletableFuture$AsyncRun.exec(java.base@17.0.5/CompletableFuture.java:1796)
	at java.util.concurrent.ForkJoinTask.doExec(java.base@17.0.5/ForkJoinTask.java:373)
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(java.base@17.0.5/ForkJoinPool.java:1182)
	at java.util.concurrent.ForkJoinPool.scan(java.base@17.0.5/ForkJoinPool.java:1655)
	at java.util.concurrent.ForkJoinPool.runWorker(java.base@17.0.5/ForkJoinPool.java:1622)
	at java.util.concurrent.ForkJoinWorkerThread.run(java.base@17.0.5/ForkJoinWorkerThread.java:165)
```

## Testing Done
Deployed locally and ensured that the calls succeed. When d2 warmup is disabled, the callback executor is used only for the first RPC:
![Screenshot 2025-03-24 at 6 41 28 PM](https://github.com/user-attachments/assets/5ea7a737-e0c4-46d8-a719-1ee6f80a8728)
Stacktrace:
![Screenshot 2025-03-24 at 6 41 35 PM](https://github.com/user-attachments/assets/9d64699f-69be-4423-84d9-de1a477b249f)

Subsequent RPCs execute the callback directly:
![Screenshot 2025-03-24 at 6 44 28 PM](https://github.com/user-attachments/assets/f0359f13-4591-4186-b2ac-76955f8a4554)
![Screenshot 2025-03-24 at 6 44 35 PM](https://github.com/user-attachments/assets/589e9eef-dcda-4a15-9be9-fed7765d0ec1)
