### PR TITLE
SI-37780, Change log level of ads stream closure from err to warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.65.6] - 2025-03-26
+- Change log level of ads stream closure from err to warn
+
 ## [29.65.5] - 2025-03-24
 - Use dedicated executor service for d2 callbacks
 
@@ -5792,7 +5795,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.6...master
+[29.65.6]: https://github.com/linkedin/rest.li/compare/v29.65.5...v29.65.6
 [29.65.5]: https://github.com/linkedin/rest.li/compare/v29.65.4...v29.65.5
 [29.65.4]: https://github.com/linkedin/rest.li/compare/v29.65.3...v29.65.4
 [29.65.3]: https://github.com/linkedin/rest.li/compare/v29.65.2...v29.65.3

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -1358,7 +1358,7 @@ public class XdsClientImpl extends XdsClient
       {
         return;
       }
-      _log.error("ADS stream closed with status {}: {}", error.getCode(), error.getDescription(), error.getCause());
+      _log.warn("ADS stream closed with status {}: {}", error.getCode(), error.getDescription(), error.getCause());
       _closed = true;
       notifyStreamError(error);
       cleanUp();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.5
+version=29.65.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
As the title, to avoid excessive error exception tickets created to the app owner, where nothing needs their attention or action, since the stream will be re-established with another indis observer.

## Test Done
N/A