### PR TITLE
Add support for XdsClient metrics for grpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.75.0] - 2025-09-05
+- Add D2 service MethodLevelProperties configuration support
+
 ## [29.74.3] - 2025-08-26
 - Add outlier detection config into D2Cluster
 
@@ -5879,7 +5882,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.74.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.75.0...master
+[29.75.0]: https://github.com/linkedin/rest.li/compare/v29.74.3...v29.75.0
 [29.74.3]: https://github.com/linkedin/rest.li/compare/v29.74.2...v29.74.3
 [29.74.2]: https://github.com/linkedin/rest.li/compare/v29.74.1...v29.74.2
 [29.74.1]: https://github.com/linkedin/rest.li/compare/v29.74.0...v29.74.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.76.0] - 2025-09-05
+- Add D2 service MethodLevelProperties configuration support
+
 ## [29.75.2] - 2025-09-05
 - Rename the outlier detection field in the D2 cluster
 
@@ -5891,7 +5894,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.74.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.76.0...master
+[29.76.0]: https://github.com/linkedin/rest.li/compare/v29.74.3...v29.76.0
 [29.74.3]: https://github.com/linkedin/rest.li/compare/v29.74.2...v29.74.3
 [29.74.2]: https://github.com/linkedin/rest.li/compare/v29.74.1...v29.74.2
 [29.74.1]: https://github.com/linkedin/rest.li/compare/v29.74.0...v29.74.1

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Service.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Service.pdl
@@ -106,4 +106,9 @@ record D2Service includes D2ChangeTimeStamps {
    * The minimum cluster subset size for this service. Will only take effect when it is a positive integer and enableClusterSubsetting is set to true. Will be capped at the number of hosts in the cluster.
    */
   minClusterSubsetSize: int = -1
+
+  /**
+  * Method level properties array for configuring custom method level configurations, used by gRPC.
+  */
+  methodLevelProperties: optional array[MethodLevelProperties]
 }

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/MethodLevelProperties.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/MethodLevelProperties.pdl
@@ -1,0 +1,28 @@
+namespace com.linkedin.d2
+
+/**
+ * D2 Service Method Level properties related configuration.
+ * This property is only used for gRPC method level configuration and
+ * with this service owners can set configurations with the following levels of granularity.
+ * - Exact method match (service + method)
+ * - Service match (service only)
+ */
+record MethodLevelProperties {
+  /**
+   * name is a list of NameProperties object, on which these method level properties will be configured.
+   * NameProperties consists of service (gRPC service name) and method (gRPC method name)
+   */
+  name: array[NameProperties]
+
+  /**
+   * Metadata properties about the service e.g. retry, hedging etc
+   * configuring any properties not supported by gRPC, will be ignored
+   */
+  serviceMetadataProperties: map[string, string]
+
+  /**
+   * The transport client properties for this service
+   * configuring any properties not supported by gRPC, will be ignored
+   */
+  transportClientProperties: D2TransportClientProperties
+}

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/NameProperties.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/NameProperties.pdl
@@ -1,0 +1,16 @@
+namespace com.linkedin.d2
+
+/**
+ * D2 Service Name properties under Method Level properties
+ */
+record NameProperties {
+  /**
+   * service is gRPC service name
+   */
+  service: string
+
+  /**
+   * method is gRPC service method name.
+   */
+  method: optional string
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/MethodLevelProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/MethodLevelProperties.java
@@ -1,0 +1,65 @@
+package com.linkedin.d2.balancer.properties;
+
+import com.google.common.base.MoreObjects;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+
+/**
+ * Method level properties is configuration for supporting service/method level overrides in gRPC.
+ */
+public class MethodLevelProperties {
+  // name properties, to configure service and method names
+  private final List<NameProperties> _name;
+  // transport client properties overrides per configured service and method names
+  private final Map<String, Object> _transportClientProperties;
+  // service metadata properties overrides per configured service and method names
+  private final Map<String, Object> _serviceMetadataProperties;
+
+  public MethodLevelProperties(List<NameProperties> name, Map<String, Object> transportClientProperties, Map<String, Object> serviceMetadataProperties) {
+    _name = name;
+    _transportClientProperties = transportClientProperties;
+    _serviceMetadataProperties = serviceMetadataProperties;
+  }
+
+  public List<NameProperties> getName() {
+    return _name;
+  }
+
+  public Map<String, Object> getTransportClientProperties() {
+    return _transportClientProperties;
+  }
+
+  public Map<String, Object> getServiceMetadataProperties() {
+    return _serviceMetadataProperties;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("nameProperties", _name)
+        .add("transportClientProperties", _transportClientProperties )
+        .add("serviceMetadataProperties", _serviceMetadataProperties)
+        .toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_name, _transportClientProperties, _serviceMetadataProperties);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    MethodLevelProperties other = (MethodLevelProperties) obj;
+    return Objects.equals(_name, other._name)
+        && Objects.equals(_transportClientProperties, other._transportClientProperties)
+        && Objects.equals(_serviceMetadataProperties, other._serviceMetadataProperties);
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/NameProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/NameProperties.java
@@ -1,0 +1,55 @@
+package com.linkedin.d2.balancer.properties;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+
+/**
+ * Name properties
+ */
+public class NameProperties {
+  // gRPC service name
+  private final String _service;
+  // gRPC method name
+  private final String _method;
+
+  public NameProperties(String service, @Nullable String method) {
+    _service = service;
+    _method = method;
+  }
+
+  public String getService() {
+    return _service;
+  }
+
+  public String getMethod() {
+    return _method;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("service", _service)
+        .add("method", _method)
+        .toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_service, _method);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    NameProperties other = (NameProperties) obj;
+    return Objects.equals(_service, other._service)
+        && Objects.equals(_method, other._method);
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -254,6 +254,12 @@ public class PropertyKeys
   public static final String FAILOUT_REDIRECT_CONFIGS = "failoutRedirectConfigs";
   public static final String FAILOUT_BUCKET_CONFIGS = "failoutBucketConfigs";
 
+  // used by MethodLevelProperties
+  public static final String METHOD_LEVEL_PROPERTIES = "methodLevelProperties";
+  public static final String METHOD_LEVEL_PROPERTIES_NAME = "name";
+  public static final String METHOD_LEVEL_PROPERTIES_NAME_SERVICE = "service";
+  public static final String METHOD_LEVEL_PROPERTIES_NAME_METHOD = "method";
+
   private static String getFieldName(PathSpec pathSpec)
   {
     if (pathSpec.getPathComponents().size() != 1)

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceProperties.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 
 /**
@@ -55,6 +56,7 @@ public class ServiceProperties
   private final boolean _enableClusterSubsetting;
   private final int _minClusterSubsetSize;
   private long _version;
+  private final List<MethodLevelProperties> _methodLevelProperties;
 
   public ServiceProperties(String serviceName,
                            String clusterName,
@@ -183,6 +185,29 @@ public class ServiceProperties
       int minClusterSubsetSize,
       long version)
   {
+    this(serviceName, clusterName, path, prioritizedStrategyList, loadBalancerStrategyProperties,
+        transportClientProperties, degraderProperties, prioritizedSchemes, banned,
+        serviceMetadataProperties, backupRequests, relativeStrategyProperties, enableClusterSubsetting,
+        minClusterSubsetSize, version, Collections.emptyList());
+  }
+
+  public ServiceProperties(String serviceName,
+      String clusterName,
+      String path,
+      List<String> prioritizedStrategyList,
+      Map<String,Object> loadBalancerStrategyProperties,
+      Map<String,Object> transportClientProperties,
+      Map<String,String> degraderProperties,
+      List<String> prioritizedSchemes,
+      Set<URI> banned,
+      Map<String,Object> serviceMetadataProperties,
+      List<Map<String,Object>> backupRequests,
+      Map<String, Object> relativeStrategyProperties,
+      boolean enableClusterSubsetting,
+      int minClusterSubsetSize,
+      long version,
+      @Nullable List<MethodLevelProperties> methodLevelProperties)
+  {
     ArgumentUtil.notNull(serviceName, PropertyKeys.SERVICE_NAME);
     ArgumentUtil.notNull(clusterName, PropertyKeys.CLUSTER_NAME);
     ArgumentUtil.notNull(path, PropertyKeys.PATH);
@@ -214,6 +239,8 @@ public class ServiceProperties
     _enableClusterSubsetting = enableClusterSubsetting;
     _minClusterSubsetSize = minClusterSubsetSize;
     _version = version;
+    _methodLevelProperties = (methodLevelProperties != null) ? Collections.unmodifiableList(methodLevelProperties) :
+        Collections.emptyList();
   }
 
   public ServiceProperties(ServiceProperties other)
@@ -320,6 +347,11 @@ public class ServiceProperties
     return _minClusterSubsetSize;
   }
 
+  public List<com.linkedin.d2.balancer.properties.MethodLevelProperties> getMethodLevelProperties()
+  {
+    return _methodLevelProperties;
+  }
+
   @Override
   public String toString()
   {
@@ -346,6 +378,8 @@ public class ServiceProperties
         + _enableClusterSubsetting
         + ", minimumClusterSubsetSize="
         + _minClusterSubsetSize
+        + ", methodLevelProperties="
+        + _methodLevelProperties
         + "]";
   }
 
@@ -368,6 +402,7 @@ public class ServiceProperties
     result = prime * result + _relativeStrategyProperties.hashCode();
     result = prime * result + Boolean.hashCode(_enableClusterSubsetting);
     result = prime * result + Integer.hashCode(_minClusterSubsetSize);
+    result = prime * result + _methodLevelProperties.hashCode();
     return result;
   }
 
@@ -408,6 +443,8 @@ public class ServiceProperties
     if (_enableClusterSubsetting != other._enableClusterSubsetting)
       return false;
     if (_minClusterSubsetSize != other._minClusterSubsetSize)
+      return false;
+    if (!_methodLevelProperties.equals(other._methodLevelProperties))
       return false;
     return true;
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceStoreProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ServiceStoreProperties.java
@@ -142,7 +142,8 @@ public class ServiceStoreProperties extends ServiceProperties
         stableConfigs.getTransportClientProperties(), stableConfigs.getDegraderProperties(),
         stableConfigs.getPrioritizedSchemes(), stableConfigs.getBanned(), stableConfigs.getServiceMetadataProperties(),
         stableConfigs.getBackupRequests(), stableConfigs.getRelativeStrategyProperties(),
-        stableConfigs.isEnableClusterSubsetting(), stableConfigs.getMinClusterSubsetSize());
+        stableConfigs.isEnableClusterSubsetting(), stableConfigs.getMinClusterSubsetSize(), -1,
+        stableConfigs.getMethodLevelProperties());
     _canaryConfigs = canaryConfigs;
     _canaryDistributionStrategy = distributionStrategy;
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.75.2
+version=29.76.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.74.3
+version=29.75.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Description:

Add support for XdsClientMetrics interface to be able to record Otel metrics in gRPC. 

Testing Done:

Tested this along with associated changes in grpc-infra PR, using toki test app, more testing info in the grpc-infra PR.