### PR TITLE
fix d2ClientBuilder shutdown corner case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.65.7] - 2025-04-02
+- Fix a corner case bug in d2ClientBuilder shutdown logic.
+
 ## [29.65.6] - 2025-03-26
 - Change log level of ads stream closure from err to warn
 
@@ -5795,7 +5798,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.7...master
+[29.65.7]: https://github.com/linkedin/rest.li/compare/v29.65.6...v29.65.7
 [29.65.6]: https://github.com/linkedin/rest.li/compare/v29.65.5...v29.65.6
 [29.65.5]: https://github.com/linkedin/rest.li/compare/v29.65.4...v29.65.5
 [29.65.4]: https://github.com/linkedin/rest.li/compare/v29.65.3...v29.65.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -886,17 +886,33 @@ public class D2ClientBuilder
         @Override
         public void onError(Throwable e)
         {
-          _executors.forEach(ExecutorService::shutdown);
+          shutdownExecutorServices();
           callback.onError(e);
         }
 
         @Override
         public void onSuccess(None result)
         {
-          _executors.forEach(ExecutorService::shutdown);
+          shutdownExecutorServices();
           callback.onSuccess(result);
         }
       });
+    }
+
+    private void shutdownExecutorServices()
+    {
+      for (ExecutorService executor : _executors)
+      {
+        if (executor.isShutdown())
+        {
+          LOG.warn("Executor is already shut down");
+        }
+        else
+        {
+          LOG.info("Shutting down executor");
+          executor.shutdown();
+        }
+      }
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.6
+version=29.65.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Fix a corner case bug in d2ClientBuilder shutdown logic.


Corner case: when `_config._executorService == null`

```
  if (_config._executorService == null)
    {
      LOG.warn("No executor service passed as argument. Pass it for " +
        "enhanced monitoring and to have better control over the executor.");
      _config._executorService =
        Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("D2 PropertyEventExecutor"));
      executorsToShutDown.add(_config._executorService);
    }
```

Then `_executorService` will be added to `executorsToShutDown`. Finally, when d2Client call the shutdown method, the _executorService may be closed twice. Like

1. [first place](https://github.com/linkedin/rest.li/blob/38e48ecee0476ce49dae65c273f9aaff90e0ce16/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancer.java#L192)
2. [second place](https://github.com/linkedin/rest.li/blob/38e48ecee0476ce49dae65c273f9aaff90e0ce16/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java#L894)

