### PR TITLE
Adding IRV support for reconnect scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.67.0] - 2025-04-23
+- Add initial_resource_version support in XDSClient
+
 ## [29.66.0] - 2025-04-21
 - Add options for connection jitter
 
@@ -5801,7 +5804,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.66.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.67.0...master
+[29.67.0]: https://github.com/linkedin/rest.li/compare/v29.66.0...v29.67.0
 [29.66.0]: https://github.com/linkedin/rest.li/compare/v29.65.7...v29.66.0
 [29.65.7]: https://github.com/linkedin/rest.li/compare/v29.65.6...v29.65.7
 [29.65.6]: https://github.com/linkedin/rest.li/compare/v29.65.5...v29.65.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-## [29.65.7] - 2025-04-08
-- Add initial_resource_version support in XDSClient
 
 ## [29.66.0] - 2025-04-21
 - Add options for connection jitter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+## [29.65.7] - 2025-04-08
+- Add initial_resource_version support in XDSClient
 
 ## [29.66.0] - 2025-04-21
 - Add options for connection jitter

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -804,6 +804,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  public D2ClientBuilder setXdsInitialResourceVersionEnabled(boolean xdsIRVEnabled) {
+    _config.xdsInitialResourceVersionEnabled = xdsIRVEnabled;
+    return this;
+  }
+
   private Map<String, TransportClientFactory> createDefaultTransportClientFactories()
   {
     final Map<String, TransportClientFactory> clientFactories = new HashMap<>();

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -804,7 +804,8 @@ public class D2ClientBuilder
     return this;
   }
 
-  public D2ClientBuilder setXdsInitialResourceVersionsEnabled(boolean xdsIRVEnabled) {
+  public D2ClientBuilder setXdsInitialResourceVersionsEnabled(boolean xdsIRVEnabled)
+  {
     _config.xdsInitialResourceVersionsEnabled = xdsIRVEnabled;
     return this;
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -219,7 +219,8 @@ public class D2ClientBuilder
                   _config.xdsChannelLoadBalancingPolicyConfig,
                   _config.subscribeToUriGlobCollection,
                   _config._xdsServerMetricsProvider,
-                  _config.loadBalanceStreamException
+                  _config.loadBalanceStreamException,
+                  _config.xdsInitialResourceVersionEnabled
     );
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -220,7 +220,7 @@ public class D2ClientBuilder
                   _config.subscribeToUriGlobCollection,
                   _config._xdsServerMetricsProvider,
                   _config.loadBalanceStreamException,
-                  _config.xdsInitialResourceVersionEnabled
+                  _config.xdsInitialResourceVersionsEnabled
     );
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
@@ -804,8 +804,8 @@ public class D2ClientBuilder
     return this;
   }
 
-  public D2ClientBuilder setXdsInitialResourceVersionEnabled(boolean xdsIRVEnabled) {
-    _config.xdsInitialResourceVersionEnabled = xdsIRVEnabled;
+  public D2ClientBuilder setXdsInitialResourceVersionsEnabled(boolean xdsIRVEnabled) {
+    _config.xdsInitialResourceVersionsEnabled = xdsIRVEnabled;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -171,6 +171,8 @@ public class D2ClientConfig
   public XdsServerMetricsProvider _xdsServerMetricsProvider = new NoOpXdsServerMetricsProvider();
   public boolean loadBalanceStreamException = false;
 
+  public boolean xdsInitialResourceVersionEnabled = false;
+
   public D2ClientConfig()
   {
   }
@@ -247,7 +249,8 @@ public class D2ClientConfig
                  Map<String, ?> xdsChannelLoadBalancingPolicyConfig,
                  boolean subscribeToUriGlobCollection,
                  XdsServerMetricsProvider xdsServerMetricsProvider,
-                 boolean loadBalanceStreamException
+                 boolean loadBalanceStreamException,
+                 boolean xdsInitialResourceVersionEnabled
       )
   {
     this.zkHosts = zkHosts;
@@ -323,5 +326,6 @@ public class D2ClientConfig
     this.subscribeToUriGlobCollection = subscribeToUriGlobCollection;
     this._xdsServerMetricsProvider = xdsServerMetricsProvider;
     this.loadBalanceStreamException = loadBalanceStreamException;
+    this.xdsInitialResourceVersionEnabled = xdsInitialResourceVersionEnabled;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -171,7 +171,7 @@ public class D2ClientConfig
   public XdsServerMetricsProvider _xdsServerMetricsProvider = new NoOpXdsServerMetricsProvider();
   public boolean loadBalanceStreamException = false;
 
-  public boolean xdsInitialResourceVersionEnabled = false;
+  public boolean xdsInitialResourceVersionsEnabled = false;
 
   public D2ClientConfig()
   {
@@ -250,7 +250,7 @@ public class D2ClientConfig
                  boolean subscribeToUriGlobCollection,
                  XdsServerMetricsProvider xdsServerMetricsProvider,
                  boolean loadBalanceStreamException,
-                 boolean xdsInitialResourceVersionEnabled
+                 boolean xdsInitialResourceVersionsEnabled
       )
   {
     this.zkHosts = zkHosts;
@@ -326,6 +326,6 @@ public class D2ClientConfig
     this.subscribeToUriGlobCollection = subscribeToUriGlobCollection;
     this._xdsServerMetricsProvider = xdsServerMetricsProvider;
     this.loadBalanceStreamException = loadBalanceStreamException;
-    this.xdsInitialResourceVersionEnabled = xdsInitialResourceVersionEnabled;
+    this.xdsInitialResourceVersionsEnabled = xdsInitialResourceVersionsEnabled;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -170,7 +170,6 @@ public class D2ClientConfig
   public boolean subscribeToUriGlobCollection = false;
   public XdsServerMetricsProvider _xdsServerMetricsProvider = new NoOpXdsServerMetricsProvider();
   public boolean loadBalanceStreamException = false;
-
   public boolean xdsInitialResourceVersionsEnabled = false;
 
   public D2ClientConfig()

--- a/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
@@ -108,12 +108,6 @@ public class GlobCollectionUtils
         GLOB_COLLECTION_SUFFIX;
   }
 
-  public static String globCollectionBaseUrlForClusterResource(String clusterPath)
-  {
-    return D2_URI_NODE_GLOB_COLLECTION_PREFIX +
-        clusterPath.substring(clusterPath.lastIndexOf('/') + 1);
-  }
-
   public static String globCollectionUrn(String clusterName, String uri)
   {
     try

--- a/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/GlobCollectionUtils.java
@@ -108,6 +108,12 @@ public class GlobCollectionUtils
         GLOB_COLLECTION_SUFFIX;
   }
 
+  public static String globCollectionBaseUrlForClusterResource(String clusterPath)
+  {
+    return D2_URI_NODE_GLOB_COLLECTION_PREFIX +
+        clusterPath.substring(clusterPath.lastIndexOf('/') + 1);
+  }
+
   public static String globCollectionUrn(String clusterName, String uri)
   {
     try

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -347,7 +347,7 @@ public class XdsClientImpl extends XdsClient
   {
     ResourceType resourceType = response.getResourceType();
     // Setting up received resource version, which will be used to set IRV for re-connect scenarios.
-    Map<String, String> resourceVersions = _resourceVersions.get(resourceType);
+    Map<String, String> resourceVersions = getResourceVersions().get(resourceType);
     for (Resource res: response.getResourcesList()){
       resourceVersions.put(res.getName(), res.getVersion());
     }
@@ -728,6 +728,13 @@ public class XdsClientImpl extends XdsClient
     return _resourceSubscribers;
   }
 
+
+  @VisibleForTesting
+  Map<ResourceType, Map<String, String>> getResourceVersions()
+  {
+    return _resourceVersions;
+  }
+
   WildcardResourceSubscriber getWildcardResourceSubscriber(ResourceType type)
   {
     return getWildcardResourceSubscribers().get(type);
@@ -1080,7 +1087,7 @@ public class XdsClientImpl extends XdsClient
         Map<String, String> irv = new HashMap<>();
         if (isIRVEnabled()) {
           for (String resourceName : subscribers.keySet()) {
-            Map<String, String> resourceVersionsMap = _resourceVersions.get(originalType);
+            Map<String, String> resourceVersionsMap = getResourceVersions().get(originalType);
             if (resourceVersionsMap.containsKey(resourceName)) {
               irv.put(resourceName, resourceVersionsMap.get(resourceName));
             } else {
@@ -1116,7 +1123,7 @@ public class XdsClientImpl extends XdsClient
         ResourceType adjustedType = shouldSubscribeUriGlobCollection(originalType) ? ResourceType.D2_URI : originalType;
 
         Map<String, String> irv = new HashMap<>();
-        Map<String, String> resourceVersionsMap = _resourceVersions.get(originalType);
+        Map<String, String> resourceVersionsMap = getResourceVersions().get(originalType);
         if (isIRVEnabled()) {
           Set<String> resourceNames = entry.getValue().getResourceKeys();
           for (String resourceName: resourceNames) {

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -1132,7 +1132,8 @@ public class XdsClientImpl extends XdsClient
           continue;
         }
 
-        Map<String, String> irv = _initialResourceVersionsEnabled ? getResourceVersions().get(adjustedType) : Collections.emptyMap();
+        Map<String, String> irv = _initialResourceVersionsEnabled
+            ? getResourceVersions().get(adjustedType) : Collections.emptyMap();
         _adsStream.sendDiscoveryRequest(adjustedType, resources, irv);
       }
     }
@@ -1173,7 +1174,7 @@ public class XdsClientImpl extends XdsClient
     public String toString()
     {
       return "DiscoveryRequestData{" + "_node=" + _node + ", _resourceType=" + _resourceType + ", _resourceNames="
-          + _resourceNames + ", _initialResourceVersions=" + _initialResourceVersions.entrySet() + '}';
+          + _resourceNames + ", _initialResourceVersions=" + _initialResourceVersions + '}';
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -1132,14 +1132,9 @@ public class XdsClientImpl extends XdsClient
           continue;
         }
 
-        Map<String, String> irv = isIRVEnabled() ? getResourceVersions().get(adjustedType) : Collections.emptyMap();
+        Map<String, String> irv = _initialResourceVersionsEnabled ? getResourceVersions().get(adjustedType) : Collections.emptyMap();
         _adsStream.sendDiscoveryRequest(adjustedType, resources, irv);
       }
-    }
-
-    private boolean isIRVEnabled()
-    {
-      return _initialResourceVersionsEnabled;
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -59,7 +59,7 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
         xdsStreamReadyTimeout,
         config.subscribeToUriGlobCollection,
         config._xdsServerMetricsProvider,
-        config.xdsInitialResourceVersionEnabled
+        config.xdsInitialResourceVersionsEnabled
     );
     d2ClientJmxManager.registerXdsClientJmx(xdsClient.getXdsClientJmx());
 

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -58,7 +58,8 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
         executorService,
         xdsStreamReadyTimeout,
         config.subscribeToUriGlobCollection,
-        config._xdsServerMetricsProvider
+        config._xdsServerMetricsProvider,
+        config.xdsInitialResourceVersionEnabled
     );
     d2ClientJmxManager.registerXdsClientJmx(xdsClient.getXdsClientJmx());
 

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -867,13 +867,14 @@ public class TestXdsClientImpl
 
       _xdsClientImpl = spy(new XdsClientImpl(null, null,
           Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("test executor")),
-          0, useGlobCollections, _serverMetricsProvider));
+          0, useGlobCollections, _serverMetricsProvider, false));
       _xdsClientImpl._adsStream = _adsStream;
 
       doNothing().when(_xdsClientImpl).startRpcStreamLocal();
       doNothing().when(_xdsClientImpl).sendAckOrNack(any(), any(), any());
-      doNothing().when(_adsStream).sendDiscoveryRequest(_resourceTypesArgumentCaptor.capture(), _resourceNamesArgumentCaptor.capture());
-
+      doNothing().when(_adsStream).sendDiscoveryRequestWithIRV(_resourceTypesArgumentCaptor.capture(),
+                                                               _resourceNamesArgumentCaptor.capture(),
+                                                               any());
       when(_xdsClientImpl.getXdsClientJmx()).thenReturn(_xdsClientJmx);
       when(_xdsClientImpl.getResourceSubscribers()).thenReturn(_subscribers);
       when(_xdsClientImpl.getWildcardResourceSubscribers()).thenReturn(_wildcardSubscribers);

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -773,6 +773,16 @@ public class TestXdsClientImpl
   }
 
   @Test
+  public void testUpdateResourceVersions()
+  {
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture._xdsClientImpl.handleResponse(DISCOVERY_RESPONSE_NODE_DATA1);
+
+    Assert.assertTrue(fixture._resourceVersions.get(NODE).containsKey(SERVICE_RESOURCE_NAME)
+        && fixture._resourceVersions.get(NODE).get(SERVICE_RESOURCE_NAME).equals(VERSION1));
+  }
+
+  @Test
   public void testWatchD2Uri()
   {
     XdsClientImplFixture fixture = new XdsClientImplFixture();

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -709,6 +709,8 @@ public class TestXdsClientImpl
     // }
     return new Object[][]{
         {true, true},
+        {true, false},
+        {false, true},
         {false, false}
     };
   }
@@ -906,7 +908,7 @@ public class TestXdsClientImpl
       doNothing().when(_xdsClientImpl).startRpcStreamLocal();
       doNothing().when(_xdsClientImpl).sendAckOrNack(any(), any(), any());
 
-      doNothing().when(_adsStream).sendDiscoveryRequestWithIRV(_resourceTypesArgumentCaptor.capture(),
+      doNothing().when(_adsStream).sendDiscoveryRequest(_resourceTypesArgumentCaptor.capture(),
           _resourceNamesArgumentCaptor.capture(),
           _resourceVersionsArgumentCaptor.capture());
 

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -780,6 +780,12 @@ public class TestXdsClientImpl
 
     Assert.assertTrue(fixture._resourceVersions.get(NODE).containsKey(SERVICE_RESOURCE_NAME)
         && fixture._resourceVersions.get(NODE).get(SERVICE_RESOURCE_NAME).equals(VERSION1));
+
+    // validate resource removal
+    DiscoveryResponseData removeServiceResponse =
+        new DiscoveryResponseData(NODE, null, Collections.singletonList(SERVICE_RESOURCE_NAME), NONCE, null);
+    fixture._xdsClientImpl.handleResponse(removeServiceResponse);
+    Assert.assertFalse(fixture._resourceVersions.get(NODE).containsKey(SERVICE_RESOURCE_NAME));
   }
 
   @Test

--- a/d2/src/test/java/com/linkedin/d2/xds/XdsToD2SampleClient.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/XdsToD2SampleClient.java
@@ -91,7 +91,7 @@ public class XdsToD2SampleClient
     XdsChannelFactory xdsChannelFactory = new XdsChannelFactory(sslContext, xdsServer);
     XdsClient xdsClient = new XdsClientImpl(node, xdsChannelFactory.createChannel(),
         Executors.newSingleThreadScheduledExecutor(), XdsClientImpl.DEFAULT_READY_TIMEOUT_MILLIS, false,
-        new NoOpXdsServerMetricsProvider());
+        new NoOpXdsServerMetricsProvider(), false);
 
     DualReadStateManager dualReadStateManager = new DualReadStateManager(
         () -> DualReadModeProvider.DualReadMode.DUAL_READ,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.66.0
+version=29.67.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Problem & Solution Overview
Adding support for [Intial_resource_version](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/discovery.proto#envoy-v3-api-field-service-discovery-v3-deltadiscoveryrequest-initial-resource-versions) in xdsClient implementation. 

if Intial_resource_version is used. This will help to enable same logical xDS session even in stream reconnection. xds server will only reply back with the resources which has changed and skipping the resource which xDS client already aware of (based on the resource version being send in request).

More Details: https://docs.google.com/document/d/1fKNQBqbQDmZcYaSCnaXBnyEApN-WReNSfay5-6dVoV4/edit?tab=t.0#heading=h.psi98t855m9r



## Testing Done
1. unit tests. 
2. tested with INDIS-canary against the observer in ei fabric. 

```
2025/04/14 12:44:25.490 WARN [XdsClientImpl] [Indis xDS client executor-4-1] [indis-canary] [AAYywkeJQUGvMT6qxVcNtw==] ADS stream closed with status UNAVAILABLE: Network closed for unknown reason
2025/04/14 12:44:25.490 WARN [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkeJQVtd2kwk7oicZQ==] ADS stream closed with status UNAVAILABLE: Network closed for unknown reason
2025/04/14 12:44:25.499 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [indis-canary] [AAYywkeJQUGvMT6qxVcNtw==] Retry ADS stream in 0 ns
2025/04/14 12:44:25.500 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkeJQVtd2kwk7oicZQ==] Retry ADS stream in 0 ns
2025/04/14 12:44:25.535 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [indis-canary] [AAYywkeJ6CWW90uXlHPhwA==] Starting ADS stream, connecting to server: lor1-0005139.int.linkedin.com:32123
2025/04/14 12:44:25.537 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkeJ18SeuvYy/gq4vw==] Starting ADS stream, connecting to server: lor1-0005139.int.linkedin.com:32123
2025/04/14 12:44:25.539 ERROR [XdsClientImpl] [Indis xDS client executor-4-1] [indis-canary] [AAYywkeJ6CWW90uXlHPhwA==] IRV: could not find version for resource: /d2/clusters/NonExistentCluster
2025/04/14 12:44:25.539 ERROR [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkeJ18SeuvYy/gq4vw==] IRV: could not find version for resource: /d2/clusters/NonExistentCluster
2025/04/14 12:44:25.542 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkeJ18SeuvYy/gq4vw==] Sending NODE request with IRV for resources: [/d2/clusters/NonExistentCluster, /d2/clusters/SloProxy, /d2/services/sloThresholds], resourceVersions: [/d2/clusters/SloProxy=25778919889, /d2/services/sloThresholds=322137106118]
2025/04/14 12:44:25.542 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [indis-canary] [AAYywkeJ6CWW90uXlHPhwA==] Sending NODE request with IRV for resources: [/d2/clusters/DataVaultAclService, /d2/services/dataVaultAclChanges, /d2/clusters/NonExistentCluster, /d2/clusters/LixBackend, /d2/clusters/DataVaultChangeMgmt, /d2/services/dataVaultAccessControlList, /d2/services/lixClientContexts, /d2/clusters/SloProxy, /d2/services/sloThresholds], resourceVersions: [/d2/clusters/DataVaultAclService=4294970704, /d2/services/dataVaultAclChanges=150344749341, /d2/clusters/LixBackend=227634113400, /d2/clusters/DataVaultChangeMgmt=25771383504, /d2/services/dataVaultAccessControlList=369397242158, /d2/services/lixClientContexts=227634113436, /d2/clusters/SloProxy=25778919889, /d2/services/sloThresholds=322137106118]
2025/04/14 12:44:25.547 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkeJ18SeuvYy/gq4vw==] Sending D2_URI request with IRV for resources: [xdstp:///indis.D2URI/SloProxy/*], resourceVersions: [xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0003679.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137820187, xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0007373.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137821755, xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0006473.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137820960]
2025/04/14 12:44:25.548 INFO [XdsClientImpl] [Indis xDS client executor-4-1] [indis-canary] [AAYywkeJ6CWW90uXlHPhwA==] Sending D2_URI request with IRV for resources: [xdstp:///indis.D2URI/SloProxy/*, xdstp:///indis.D2URI/DataVaultChangeMgmt/*, xdstp:///indis.D2URI/DataVaultAclService/*, xdstp:///indis.D2URI/LixBackend/*], resourceVersions: [xdstp:///indis.D2URI/DataVaultChangeMgmt/https%3A%2F%2Flor1-0000872.int.linkedin.com%3A8161%2Fdatavault-change-mgmt=395137520698, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0007403.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390848336823, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-4784.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846466256, xdstp:///indis.D2URI/DataVaultAclService/https%3A%2F%2Flor1-0003032.int.linkedin.com%3A1147%2Fdatavault-acl-service=390847054523, xdstp:///indis.D2URI/DataVaultChangeMgmt/https%3A%2F%2Flor1-0000006.int.linkedin.com%3A8161%2Fdatavault-change-mgmt=395137520006, xdstp:///indis.D2URI/DataVaultAclService/https%3A%2F%2Flor1-0005291.int.linkedin.com%3A1147%2Fdatavault-acl-service=390847059976, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0005101.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846460797, xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0006473.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137820960, xdstp:///indis.D2URI/DataVaultAclService/https%3A%2F%2Flor1-0003139.int.linkedin.com%3A1147%2Fdatavault-acl-service=390847057324, xdstp:///indis.D2URI/DataVaultAclService/https%3A%2F%2Flor1-0003562.int.linkedin.com%3A1147%2Fdatavault-acl-service=390847058569, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0005999.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846461721, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0002432.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846435030, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0002805.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846456199, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0005359.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390849544759, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0004305.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846459676, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0002256.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846688986, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0006056.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846462520, xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0007373.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137821755, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0002362.int.linkedin.com%3A2590%2Flix-backend%2Fresources=395137267158, xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0003679.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137820187, xdstp:///indis.D2URI/DataVaultAclService/https%3A%2F%2Flor1-4591.int.linkedin.com%3A1147%2Fdatavault-acl-service=390847061334, xdstp:///indis.D2URI/DataVaultAclService/https%3A%2F%2Flor1-0003103.int.linkedin.com%3A1147%2Fdatavault-acl-service=390847055789, xdstp:///indis.D2URI/LixBackend/https%3A%2F%2Flor1-0003529.int.linkedin.com%3A2590%2Flix-backend%2Fresources=390846458391, xdstp:///indis.D2URI/DataVaultChangeMgmt/https%3A%2F%2Flor1-0006810.int.linkedin.com%3A8161%2Fdatavault-change-mgmt=395137521349, xdstp:///indis.D2URI/DataVaultChangeMgmt/https%3A%2F%2Flor1-0007619.int.linkedin.com%3A8161%2Fdatavault-change-mgmt=395137522009]

2025/04/14 12:44:27.537 WARN [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkeoc2DwhW/n+hx1Xw==] ADS stream not ready within 2000 milliseconds
2025/04/14 12:44:27.537 WARN [XdsClientImpl] [Indis xDS client executor-4-1] [indis-canary] [AAYywkeoc2D8yrMzEKdbrw==] ADS stream not ready within 2000 milliseconds
2025/04/14 12:44:34.656 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgVKD6Vjxz0MfA2CQ==] ADS stream ready, cancelled timeout task: false
2025/04/14 12:44:34.718 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgWIZzV5nbkpX+eJQ==] Successfully received response from ADS server: lor1-0005139.int.linkedin.com
2025/04/14 12:44:34.719 WARN [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgWIZzV5nbkpX+eJQ==] Received response that NODE /d2/clusters/NonExistentCluster was removed
2025/04/14 12:44:34.722 WARN [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgWIZzV5nbkpX+eJQ==] Received response that NODE /d2/services/sloThresholds was removed
2025/04/14 12:44:34.830 WARN [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgXzNOC3Vxh2DsSQA==] ADS stream closed with status UNAVAILABLE: io exception
2025/04/14 12:44:34.837 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgXzNOC3Vxh2DsSQA==] Retry ADS stream in 0 ns
2025/04/14 12:44:34.847 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgYCGPMVR/q86p7nA==] Starting ADS stream, connecting to server: lor1-0005139.int.linkedin.com:32123
2025/04/14 12:44:34.847 ERROR [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgYCGPMVR/q86p7nA==] IRV: could not find version for resource: /d2/clusters/NonExistentCluster
2025/04/14 12:44:34.847 ERROR [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgYCGPMVR/q86p7nA==] IRV: could not find version for resource: /d2/services/sloThresholds
2025/04/14 12:44:34.849 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgYCGPMVR/q86p7nA==] Sending NODE request with IRV for resources: [/d2/clusters/NonExistentCluster, /d2/clusters/SloProxy, /d2/services/sloThresholds], resourceVersions: [/d2/clusters/SloProxy=25778919889]
2025/04/14 12:44:34.850 INFO [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkgYCGPMVR/q86p7nA==] Sending D2_URI request with IRV for resources: [xdstp:///indis.D2URI/SloProxy/*], resourceVersions: [xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0003679.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137820187, xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0007373.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137821755, xdstp:///indis.D2URI/SloProxy/https%3A%2F%2Flor1-0006473.int.linkedin.com%3A8027%2Fslo-proxy%2Fresources=395137820960]
2025/04/14 12:44:36.845 WARN [XdsClientImpl] [Indis xDS client executor-13-1] [indis-canary] [AAYywkg2lHIoB/+m41J0mQ==] ADS stream not ready within 2000 milliseconds
```

3. logs for scenario: when new resource added/removed when client was disconnected. 
https://paste.corp.linkedin.com/show/71474679/
