### PR TITLE
Remove invalid characters from multipart/mixed encoded requests

### DIFF
--- a/r2-core/src/main/java/com/linkedin/r2/message/QueryTunnelUtil.java
+++ b/r2-core/src/main/java/com/linkedin/r2/message/QueryTunnelUtil.java
@@ -182,7 +182,8 @@ public class QueryTunnelUtil
       // If we have a body, we must preserve it, so use multipart/mixed encoding
 
       MimeMultipart multi = createMultiPartEntity(entity, request.getHeader(HEADER_CONTENT_TYPE), uri.getRawQuery());
-      requestBuilder.setHeader(HEADER_CONTENT_TYPE, multi.getContentType());
+      // The javax.mail code inserts a newline, return, and tab which aren't allowed in HTTP headers so strip them out
+      requestBuilder.setHeader(HEADER_CONTENT_TYPE, multi.getContentType().replaceAll("\\s{2,}", " "));
       ByteArrayOutputStream os = new ByteArrayOutputStream();
       multi.writeTo(os);
       requestBuilder.setEntity(ByteString.copy(os.toByteArray()));

--- a/r2-core/src/test/java/test/r2/message/TestQueryTunnel.java
+++ b/r2-core/src/test/java/test/r2/message/TestQueryTunnel.java
@@ -133,7 +133,7 @@ public class TestQueryTunnel
     Assert.assertEquals(encoded.getMethod(), "POST");
     Assert.assertEquals(encoded.getURI().toString(), "http://localhost:7279");
     Assert.assertTrue(encoded.getEntity().length() > 0);
-    Assert.assertTrue(encoded.getHeader("Content-Type").startsWith("multipart/mixed"));
+    Assert.assertTrue(encoded.getHeader("Content-Type").startsWith("multipart/mixed; boundary="));
     Assert.assertEquals(encoded.getHeader("Content-Length"), Integer.toString(encoded.getEntity().length()));
 
     // Decode, and we should get the original request back
@@ -161,7 +161,7 @@ public class TestQueryTunnel
     Assert.assertEquals(encoded.getMethod(), "POST");
     Assert.assertEquals(encoded.getURI().toString(), "http://localhost:7279");
     Assert.assertTrue(encoded.getEntity().length() > 0);
-    Assert.assertTrue(encoded.getHeader("Content-Type").startsWith("multipart/mixed"));
+    Assert.assertTrue(encoded.getHeader("Content-Type").startsWith("multipart/mixed; boundary="));
     Assert.assertEquals(encoded.getHeader("Content-Length"), Integer.toString(encoded.getEntity().length()));
 
     // Decode, and we should get the original request back
@@ -282,7 +282,7 @@ public class TestQueryTunnel
     Assert.assertEquals(encoded.getMethod(), "POST");
     Assert.assertEquals(encoded.getURI().toString(), "http://localhost:7279");
     Assert.assertTrue(encoded.getEntity().length() > 0);
-    Assert.assertTrue(encoded.getHeader("Content-Type").startsWith("multipart/mixed"));
+    Assert.assertTrue(encoded.getHeader("Content-Type").startsWith("multipart/mixed; boundary="));
     Assert.assertEquals(encoded.getHeader("Content-Length"), Integer.toString(encoded.getEntity().length()));
 
     // Decode and make sure we have the original request back
@@ -291,7 +291,7 @@ public class TestQueryTunnel
     Assert.assertEquals(decoded.getURI().toString(), "http://localhost:7279?args=xyz");
     Assert.assertEquals(decoded.getMethod(), "PUT");
     Assert.assertEquals(decoded.getEntity(), request.getEntity());
-    Assert.assertTrue(encoded.getHeader("Content-Type").startsWith("multipart/mixed"));
+    Assert.assertTrue(encoded.getHeader("Content-Type").startsWith("multipart/mixed; boundary="));
     Assert.assertTrue((Boolean) requestContext.getLocalAttr(R2Constants.IS_QUERY_TUNNELED));
     Assert.assertEquals(decoded.getHeader("Content-Length"), Integer.toString(request.getEntity().length()));
   }


### PR DESCRIPTION
The Java Mail code that is used for query tunneling creates an invalid Content-Type header for multipart/mixed encoded requests, containing a newline, return, and tab character (e.g. multipart/mixed; \r\n\tboundary="----=_Part_0_1587908352.1744332411531"). This isn't compliant with HTTP RFCs and the Netty client has become more strict about validating header values. This change replaces any whitespace of two or more characters with a single space.

Tests for encoding a request have been updated to validate the Content-Type doesn't contain invalid characters, and existing tests decoding these encoded requests continue to pass.