### PR TITLE
Add options for connection jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
-
-## [29.65.8] - 2025-04-18
 - Add options for connection jitter
 
 ## [29.65.7] - 2025-04-11
@@ -5801,8 +5799,7 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.8...master
-[29.65.8]: https://github.com/linkedin/rest.li/compare/v29.65.7...v29.65.8
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.7...master
 [29.65.7]: https://github.com/linkedin/rest.li/compare/v29.65.6...v29.65.7
 [29.65.6]: https://github.com/linkedin/rest.li/compare/v29.65.5...v29.65.6
 [29.65.5]: https://github.com/linkedin/rest.li/compare/v29.65.4...v29.65.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.65.8] - 2025-04-18
 - Add options for connection jitter
 
 ## [29.65.7] - 2025-04-11
@@ -5799,7 +5801,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.8...master
+[29.65.8]: https://github.com/linkedin/rest.li/compare/v29.65.7...v29.65.8
 [29.65.7]: https://github.com/linkedin/rest.li/compare/v29.65.6...v29.65.7
 [29.65.6]: https://github.com/linkedin/rest.li/compare/v29.65.5...v29.65.6
 [29.65.5]: https://github.com/linkedin/rest.li/compare/v29.65.4...v29.65.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add options for connection jitter
 
 ## [29.65.7] - 2025-04-11
 - Fix invalid Content-Type for multipart/mixed query tunneled requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.66.0] - 2025-04-21
 - Add options for connection jitter
 
 ## [29.65.7] - 2025-04-11
@@ -5799,7 +5801,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.65.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.66.0...master
+[29.66.0]: https://github.com/linkedin/rest.li/compare/v29.65.7...v29.66.0
 [29.65.7]: https://github.com/linkedin/rest.li/compare/v29.65.6...v29.65.7
 [29.65.6]: https://github.com/linkedin/rest.li/compare/v29.65.5...v29.65.6
 [29.65.5]: https://github.com/linkedin/rest.li/compare/v29.65.4...v29.65.5

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/ConnectionOptions.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/ConnectionOptions.pdl
@@ -1,0 +1,24 @@
+namespace com.linkedin.d2
+
+/**
+ * Options for configuring the connection pool. Only used by gRPC clients.
+ */
+record ConnectionOptions {
+  /**
+   * Amount of jitter to apply when establishing a new connection. When a new host is added to the pool, the client will
+   * wait a random amount of time between 0 and this value before attempting to connect to the host. This is done to
+   * prevent a thundering herd problem when a large number of clients are trying to connect to the same host at the
+   * same time. A value of 0 disables connection jitter.
+   */
+  connectionJitterSeconds: int
+
+  /**
+   * Controls the maximum number of connections that can be delayed by connection jitter before the client will start
+   * immediately establishing connections. This value represents a ratio between the number of delayed connections and
+   * the total number of connections. For example, if this value is set to 0.2, the client will start immediately
+   * establishing connections when 20% of the connections are delayed by connection jitter. Connections are established
+   * by random selection from the delayed connections. Value must be between 0 and 1.0. Only applies if
+   * connectionJitterSeconds is enabled.
+   */
+  maxDelayedConnectionRatio: float
+}

--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Cluster.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Cluster.pdl
@@ -44,4 +44,9 @@ record D2Cluster includes D2ChangeTimeStamps {
    * D2 slow start properties. Currently used by clients of gRPC clusters.
    */
   slowStartProperties: optional SlowStartProperties
+
+  /**
+   * Options for configuring the connection pool. Only used by gRPC clients.
+   */
+  connectionOptions: optional ConnectionOptions
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterProperties.java
@@ -65,6 +65,7 @@ public class ClusterProperties
   private final boolean              _delegated;
   private long               _version;
   private final SlowStartProperties _slowStartProperties;
+  private final ConnectionOptions _connectionOptions;
 
   public ClusterProperties(String clusterName)
   {
@@ -185,6 +186,21 @@ public class ClusterProperties
       boolean delegated,
       long version,
       @Nullable SlowStartProperties slowStartProperties) {
+    this(clusterName, prioritizedSchemes, properties, bannedUris, partitionProperties, sslSessionValidationStrings,
+        darkClusters, delegated, version, slowStartProperties, null);
+  }
+
+  public ClusterProperties(String clusterName,
+      List<String> prioritizedSchemes,
+      Map<String, String> properties,
+      Set<URI> bannedUris,
+      PartitionProperties partitionProperties,
+      List<String> sslSessionValidationStrings,
+      Map<String, Object> darkClusters,
+      boolean delegated,
+      long version,
+      @Nullable SlowStartProperties slowStartProperties,
+      @Nullable ConnectionOptions connectionOptions) {
     _clusterName = clusterName;
     _prioritizedSchemes =
         (prioritizedSchemes != null) ? Collections.unmodifiableList(prioritizedSchemes)
@@ -198,6 +214,7 @@ public class ClusterProperties
     _delegated = delegated;
     _version = version;
     _slowStartProperties = slowStartProperties;
+    _connectionOptions = connectionOptions;
   }
 
 
@@ -205,7 +222,7 @@ public class ClusterProperties
   {
     this(other._clusterName, other._prioritizedSchemes, other._properties, other._bannedUris, other._partitionProperties,
         other._sslSessionValidationStrings, other._darkClusters, other._delegated, other._version,
-        other._slowStartProperties);
+        other._slowStartProperties, other._connectionOptions);
   }
 
   public boolean isBanned(URI uri)
@@ -275,6 +292,12 @@ public class ClusterProperties
     return _slowStartProperties;
   }
 
+  @Nullable
+  public ConnectionOptions getConnectionOptions()
+  {
+    return _connectionOptions;
+  }
+
   @Override
   public String toString()
   {
@@ -282,7 +305,7 @@ public class ClusterProperties
         + _prioritizedSchemes + ", _properties=" + _properties + ", _bannedUris=" + _bannedUris
         + ", _partitionProperties=" + _partitionProperties + ", _sslSessionValidationStrings=" + _sslSessionValidationStrings
         + ", _darkClusterConfigMap=" + _darkClusters + ", _delegated=" + _delegated + ", _slowStartProperties="
-        + _slowStartProperties + "]";
+        + _slowStartProperties + ", _connectionOptions=" + _connectionOptions + "]";
   }
 
   @Override
@@ -301,6 +324,7 @@ public class ClusterProperties
     result = prime * result + ((_darkClusters == null) ? 0 : _darkClusters.hashCode());
     result = prime * result + ((_delegated) ? 1 : 0);
     result = prime * result + ((_slowStartProperties == null) ? 0 : _slowStartProperties.hashCode());
+    result = prime * result + ((_connectionOptions == null) ? 0 : _connectionOptions.hashCode());
     return result;
   }
 
@@ -349,6 +373,10 @@ public class ClusterProperties
       return false;
     }
     if (!Objects.equals(_slowStartProperties, other._slowStartProperties))
+    {
+      return false;
+    }
+    if (!Objects.equals(_connectionOptions, other._connectionOptions))
     {
       return false;
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterPropertiesJsonSerializer.java
@@ -18,12 +18,10 @@ package com.linkedin.d2.balancer.properties;
 
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
-import com.linkedin.d2.balancer.properties.util.PropertyUtil;
 import com.linkedin.d2.balancer.util.JacksonUtil;
 import com.linkedin.d2.discovery.PropertyBuilder;
 import com.linkedin.d2.discovery.PropertySerializationException;
 import com.linkedin.d2.discovery.PropertySerializer;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,7 +159,7 @@ public class ClusterPropertiesJsonSerializer implements
     Set<URI> banned = (bannedList == null) ? Collections.emptySet()
         : bannedList.stream().map(URI::create).collect(Collectors.toSet());
 
-    String clusterName = PropertyUtil.checkAndGetValue(map, PropertyKeys.CLUSTER_NAME, String.class, "ClusterProperties");
+    String clusterName = checkAndGetValue(map, PropertyKeys.CLUSTER_NAME, String.class, "ClusterProperties");
     List<String> prioritizedSchemes = mapGet(map, PropertyKeys.PRIORITIZED_SCHEMES);
     Map<String, String> properties = mapGet(map, "properties");
     Map<String, Object> partitionPropertiesMap = mapGet(map, PropertyKeys.PARTITION_PROPERTIES);
@@ -171,19 +169,19 @@ public class ClusterPropertiesJsonSerializer implements
     if (partitionPropertiesMap != null)
     {
       PartitionProperties.PartitionType partitionType =
-          PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_TYPE, PartitionProperties.PartitionType.class, scope);
+          checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_TYPE, PartitionProperties.PartitionType.class, scope);
       switch (partitionType)
       {
         case RANGE:
         {
           long keyRangeStart =
-              PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.KEY_RANGE_START, Number.class, scope).longValue();
+              checkAndGetValue(partitionPropertiesMap, PropertyKeys.KEY_RANGE_START, Number.class, scope).longValue();
           long partitionSize =
-              PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_SIZE, Number.class, scope).longValue();
+              checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_SIZE, Number.class, scope).longValue();
           int partitionCount =
-              PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_COUNT, Number.class, scope).intValue();
+              checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_COUNT, Number.class, scope).intValue();
           String partitionKeyRegex =
-              PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_KEY_REGEX, String.class, scope);
+              checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_KEY_REGEX, String.class, scope);
           partitionProperties =
               new RangeBasedPartitionProperties(partitionKeyRegex, keyRangeStart, partitionSize, partitionCount);
 
@@ -192,11 +190,11 @@ public class ClusterPropertiesJsonSerializer implements
         case HASH:
         {
           int partitionCount =
-              PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_COUNT, Number.class, scope).intValue();
+              checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_COUNT, Number.class, scope).intValue();
           String partitionKeyRegex =
-              PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_KEY_REGEX, String.class, scope);
+              checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_KEY_REGEX, String.class, scope);
           HashBasedPartitionProperties.HashAlgorithm algorithm =
-              PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.HASH_ALGORITHM, HashBasedPartitionProperties.HashAlgorithm.class, scope);
+              checkAndGetValue(partitionPropertiesMap, PropertyKeys.HASH_ALGORITHM, HashBasedPartitionProperties.HashAlgorithm.class, scope);
           partitionProperties =
               new HashBasedPartitionProperties(partitionKeyRegex, partitionCount, algorithm);
           break;
@@ -204,12 +202,12 @@ public class ClusterPropertiesJsonSerializer implements
         case CUSTOM:
         {
           int partitionCount = partitionPropertiesMap.containsKey(PropertyKeys.PARTITION_COUNT)
-              ? PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_COUNT, Number.class, scope).intValue()
+              ? checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_COUNT, Number.class, scope).intValue()
               : 0;
 
           @SuppressWarnings("unchecked")
           List<String> partitionAccessorList =partitionPropertiesMap.containsKey(PropertyKeys.PARTITION_ACCESSOR_LIST)
-              ? PropertyUtil.checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_ACCESSOR_LIST, List.class, scope)
+              ? checkAndGetValue(partitionPropertiesMap, PropertyKeys.PARTITION_ACCESSOR_LIST, List.class, scope)
               : Collections.emptyList();
           partitionProperties = new CustomizedPartitionProperties(partitionCount, partitionAccessorList);
           break;
@@ -257,9 +255,9 @@ public class ClusterPropertiesJsonSerializer implements
     if (connectionOptionsMap == null) {
       return null;
     }
-    int connectionJitterSeconds = PropertyUtil.checkAndGetValue(connectionOptionsMap, PropertyKeys.CONNECTION_JITTER_SECONDS,
+    int connectionJitterSeconds = checkAndGetValue(connectionOptionsMap, PropertyKeys.CONNECTION_JITTER_SECONDS,
         Number.class, PropertyKeys.CONNECTION_OPTIONS).intValue();
-    float maxDelayedConnectionRatio = PropertyUtil.checkAndGetValue(connectionOptionsMap, PropertyKeys.MAX_DELAYED_CONNECTION_RATIO,
+    float maxDelayedConnectionRatio = checkAndGetValue(connectionOptionsMap, PropertyKeys.MAX_DELAYED_CONNECTION_RATIO,
         Number.class, PropertyKeys.CONNECTION_OPTIONS).floatValue();
     return new ConnectionOptions(connectionJitterSeconds, maxDelayedConnectionRatio);
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterStoreProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ClusterStoreProperties.java
@@ -151,7 +151,8 @@ public class ClusterStoreProperties extends ClusterProperties
     super(stableConfigs.getClusterName(), stableConfigs.getPrioritizedSchemes(),
         stableConfigs.getProperties(), stableConfigs.getBannedUris(), stableConfigs.getPartitionProperties(),
         stableConfigs.getSslSessionValidationStrings(), stableConfigs.getDarkClusters(),
-        stableConfigs.isDelegated(), stableConfigs.getVersion(), stableConfigs.getSlowStartProperties());
+        stableConfigs.isDelegated(), stableConfigs.getVersion(), stableConfigs.getSlowStartProperties(),
+        stableConfigs.getConnectionOptions());
     _canaryConfigs = canaryConfigs;
     _canaryDistributionStrategy = distributionStrategy;
     _failoutProperties = failoutProperties;

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/ConnectionOptions.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/ConnectionOptions.java
@@ -1,0 +1,48 @@
+package com.linkedin.d2.balancer.properties;
+
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+
+public class ConnectionOptions {
+  private final int _connectionJitterSeconds;
+  private final float _maxDelayedConnectionRatio;
+
+  public ConnectionOptions(int connectionJitterSeconds, float maxDelayedConnectionRatio) {
+    _connectionJitterSeconds = connectionJitterSeconds;
+    _maxDelayedConnectionRatio = maxDelayedConnectionRatio;
+  }
+
+  public int getConnectionJitterSeconds() {
+    return _connectionJitterSeconds;
+  }
+
+  public float getMaxDelayedConnectionRatio() {
+    return _maxDelayedConnectionRatio;
+  }
+
+  @Override
+  public String toString() {
+    return "ConnectionOptions{" + "_connectionJitterSeconds=" + _connectionJitterSeconds
+        + ", _maxDelayedConnectionRatio=" + _maxDelayedConnectionRatio + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ConnectionOptions that = (ConnectionOptions) o;
+    return _connectionJitterSeconds == that._connectionJitterSeconds
+        && Float.compare(_maxDelayedConnectionRatio, that._maxDelayedConnectionRatio) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_connectionJitterSeconds, _maxDelayedConnectionRatio);
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/PropertyKeys.java
@@ -144,6 +144,9 @@ public class PropertyKeys
   public static final String CLUSTER_NAME = "clusterName";
   public static final String PARTITION_PROPERTIES = "partitionProperties";
   public static final String SLOW_START_PROPERTIES = "slowStartProperties";
+  public static final String CONNECTION_OPTIONS = "connectionOptions";
+  public static final String CONNECTION_JITTER_SECONDS = "connectionJitterSeconds";
+  public static final String MAX_DELAYED_CONNECTION_RATIO = "maxDelayedConnectionRatio";
   public static final String SLOW_START_DISABLED = "disabled";
   public static final String SLOW_START_AGGRESSION = "aggression";
   public static final String SLOW_START_WINDOW_DURATION = "windowDurationSeconds";

--- a/d2/src/test/java/com/linkedin/d2/balancer/properties/ClusterPropertiesSerializerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/properties/ClusterPropertiesSerializerTest.java
@@ -194,6 +194,17 @@ public class ClusterPropertiesSerializerTest
         new ClusterStoreProperties(property, null, null));
   }
 
+  @Test
+  public void testConnectionOptions() throws PropertySerializationException {
+    ClusterPropertiesJsonSerializer jsonSerializer = new ClusterPropertiesJsonSerializer();
+    ConnectionOptions connectionOptions = new ConnectionOptions(10, 0.5f);
+    ClusterProperties property = new ClusterProperties("test", new ArrayList<>(), new HashMap<>(), new HashSet<>(),
+        NullPartitionProperties.getInstance(), Arrays.asList("principal1", "principal2"), null, false,
+        ClusterProperties.DEFAULT_VERSION, null, connectionOptions);
+    assertEquals(jsonSerializer.fromBytes(jsonSerializer.toBytes(property)),
+        new ClusterStoreProperties(property, null, null));
+  }
+
   @DataProvider(name = "distributionStrategies")
   public Object[][] getDistributionStrategies() {
     Map<String, Object> percentageProperties = new HashMap<>();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.7
+version=29.66.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.8
+version=29.65.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.65.7
+version=29.65.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Add options to d2 config for connection jittering. Will be used by the gRPC client to add random delay when establishing new connections to avoid a thundering herd problem. 