### PR TITLE
check uris change for glob collections update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.67.1] - 2025-04-28
+- Add feature to check remove/update uris for glob collection uris.
+
 ## [29.67.0] - 2025-04-23
 - Add initial_resource_version support in XDSClient
 
@@ -5804,7 +5807,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.67.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.67.1...master
+[29.67.1]: https://github.com/linkedin/rest.li/compare/v29.67.0...v29.67.1
 [29.67.0]: https://github.com/linkedin/rest.li/compare/v29.66.0...v29.67.0
 [29.66.0]: https://github.com/linkedin/rest.li/compare/v29.65.7...v29.66.0
 [29.65.7]: https://github.com/linkedin/rest.li/compare/v29.65.6...v29.65.7

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -335,19 +335,19 @@ public abstract class XdsClient
   public static final class D2URIMapUpdate implements ResourceUpdate
   {
     Map<String, XdsD2.D2URI> _uriMap;
-    private boolean _globCollectionEnabled;
+    private final boolean _globCollectionEnabled;
     private final Set<String> _updatedUrisName = new HashSet<>();
     private final Set<String> _removedUrisName = new HashSet<>();
 
 
     D2URIMapUpdate(Map<String, XdsD2.D2URI> uriMap)
     {
-      _uriMap = uriMap;
+      this(uriMap, false);
     }
 
     D2URIMapUpdate(Map<String, XdsD2.D2URI> uriMap, boolean globCollectionEnabled)
     {
-      this(uriMap);
+      _uriMap = uriMap;
       _globCollectionEnabled = globCollectionEnabled;
     }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -23,8 +23,10 @@ import indis.XdsD2;
 import io.grpc.Status;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -333,15 +335,55 @@ public abstract class XdsClient
   public static final class D2URIMapUpdate implements ResourceUpdate
   {
     Map<String, XdsD2.D2URI> _uriMap;
+    private final Set<String> _updatedUrisName = new HashSet<>();
+    private final Set<String> _removedUrisName = new HashSet<>();
+    private boolean _globCollectionEnabled;
+
 
     D2URIMapUpdate(Map<String, XdsD2.D2URI> uriMap)
     {
       _uriMap = uriMap;
     }
 
+    D2URIMapUpdate(Map<String, XdsD2.D2URI> uriMap, boolean globCollectionEnabled)
+    {
+      this(uriMap);
+      _globCollectionEnabled = globCollectionEnabled;
+    }
+
     public Map<String, XdsD2.D2URI> getURIMap()
     {
       return _uriMap;
+    }
+
+    /**
+     * Returns the names of the updated URIs.
+     * The updated URIs are valid only if {@link #isGlobCollectionEnabled} is {@code true}.
+     * Otherwise, when {@link #isGlobCollectionEnabled} is {@code false}, the updated URIs are not tracked and should be ignored.
+     *
+     * @return a set of updated URI names
+     */
+    public Set<String> getUpdatedUrisName()
+    {
+
+      return _updatedUrisName;
+    }
+
+
+    /**
+     * Returns the names of the removed URIs.
+     * The removed URIs are valid only if {@link #isGlobCollectionEnabled} is {@code true}.
+     * Otherwise, when {@link #isGlobCollectionEnabled} is {@code false}, the removed URIs are not tracked and should be ignored.
+     *
+     * @return a set of removed URI names
+     */
+    public Set<String> getRemovedUrisName() {
+      return _removedUrisName;
+    }
+
+    public boolean isGlobCollectionEnabled()
+    {
+      return _globCollectionEnabled;
     }
 
     D2URIMapUpdate putUri(String name, XdsD2.D2URI uri)
@@ -351,6 +393,8 @@ public abstract class XdsClient
         _uriMap = new HashMap<>();
       }
       _uriMap.put(name, uri);
+      _updatedUrisName.add(name);
+      _removedUrisName.remove(name);
       return this;
     }
 
@@ -360,6 +404,8 @@ public abstract class XdsClient
       {
         _uriMap.remove(name);
       }
+      _removedUrisName.add(name);
+      _updatedUrisName.remove(name);
       return this;
     }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -335,9 +335,9 @@ public abstract class XdsClient
   public static final class D2URIMapUpdate implements ResourceUpdate
   {
     Map<String, XdsD2.D2URI> _uriMap;
+    private boolean _globCollectionEnabled;
     private final Set<String> _updatedUrisName = new HashSet<>();
     private final Set<String> _removedUrisName = new HashSet<>();
-    private boolean _globCollectionEnabled;
 
 
     D2URIMapUpdate(Map<String, XdsD2.D2URI> uriMap)
@@ -354,6 +354,16 @@ public abstract class XdsClient
     public Map<String, XdsD2.D2URI> getURIMap()
     {
       return _uriMap;
+    }
+
+    /**
+     * Returns whether the glob collection is enabled.
+     *
+     * @return {@code true} if glob collection is enabled, {@code false} otherwise
+     */
+    public boolean isGlobCollectionEnabled()
+    {
+      return _globCollectionEnabled;
     }
 
     /**
@@ -377,13 +387,9 @@ public abstract class XdsClient
      *
      * @return a set of removed URI names
      */
-    public Set<String> getRemovedUrisName() {
-      return _removedUrisName;
-    }
-
-    public boolean isGlobCollectionEnabled()
+    public Set<String> getRemovedUrisName()
     {
-      return _globCollectionEnabled;
+      return _removedUrisName;
     }
 
     D2URIMapUpdate putUri(String name, XdsD2.D2URI uri)

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -584,11 +584,11 @@ public class XdsClientImpl extends XdsClient
         }
         if (currentData == null || !currentData.isValid())
         {
-          return new D2URIMapUpdate(null);
+          return new D2URIMapUpdate(null, true);
         }
         else
         {
-          return new D2URIMapUpdate(new HashMap<>(currentData.getURIMap()));
+          return new D2URIMapUpdate(new HashMap<>(currentData.getURIMap()), true);
         }
       });
 

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -702,7 +702,6 @@ public class TestXdsClientImpl
     D2URIMapUpdate actualData = (D2URIMapUpdate) fixture._clusterSubscriber.getData();
     Assert.assertEquals(actualData, D2_URI_MAP_GLOB_COLLECTION_UPDATE_WITH_DATA1);
     Assert.assertNull(fixture._uriMapWildcardSubscriber.getData(CLUSTER_RESOURCE_NAME));
-    // Verify that the updated and removed URIs are not affected by the removal
     Assert.assertTrue(actualData.isGlobCollectionEnabled());
     Assert.assertTrue(actualData.getUpdatedUrisName().isEmpty());
     Assert.assertTrue(actualData.getRemovedUrisName().isEmpty());

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.67.0
+version=29.67.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
# Summary
Add support for updating D2 URIs in glob collections. Clients subscribed with glob collection enabled can now receive updated and removed URIs.

# Test
[✅]unit test
```
./gradlew :d2:test --tests  TestXdsClientImpl
```

# Follow up
will update/test the feature in restli-resource-explorer, and used by `indis-zk-writeback` services.