### PR TITLE
Enhanced ProjectionDataMapSerializer interface to expose serialization functionality for String & DataMap projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.68.1] - 2025-05-06
+- Enhanced ProjectionDataMapSerializer interface to expose serialization functionality for String & DataMap projections
+
 ## [29.68.0] - 2025-04-29
 - Detect LI raw d2 client builder usage
 
@@ -5810,7 +5813,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.68.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.68.1...master
+[29.68.0]: https://github.com/linkedin/rest.li/compare/v29.68.0...v29.68.1
 [29.68.0]: https://github.com/linkedin/rest.li/compare/v29.67.1...v29.68.0
 [29.67.1]: https://github.com/linkedin/rest.li/compare/v29.67.0...v29.67.1
 [29.67.0]: https://github.com/linkedin/rest.li/compare/v29.66.0...v29.67.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5814,7 +5814,7 @@ patch operations can re-use these classes for generating patch messages.
 ## [0.14.1]
 
 [Unreleased]: https://github.com/linkedin/rest.li/compare/v29.68.1...master
-[29.68.0]: https://github.com/linkedin/rest.li/compare/v29.68.0...v29.68.1
+[29.68.1]: https://github.com/linkedin/rest.li/compare/v29.68.0...v29.68.1
 [29.68.0]: https://github.com/linkedin/rest.li/compare/v29.67.1...v29.68.0
 [29.67.1]: https://github.com/linkedin/rest.li/compare/v29.67.0...v29.67.1
 [29.67.0]: https://github.com/linkedin/rest.li/compare/v29.66.0...v29.67.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.68.0
+version=29.68.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/restli-client/src/main/java/com/linkedin/restli/client/ProjectionDataMapSerializer.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/ProjectionDataMapSerializer.java
@@ -6,14 +6,48 @@ import java.util.Set;
 
 
 /**
- * An interface to serialize projection parameters (ie. a set of {@link com.linkedin.data.schema.PathSpec} instances
- * to a masked data map.
+ * An interface to serialize projection parameters to either a String or a DataMap.
  */
 public interface ProjectionDataMapSerializer
 {
   /**
+   * Serialize the given {@code String} projection value.
+   * 
+   * @param paramName The name of the projection query param to serialize.
+   * @param projection The projection to serialize.
+   * @return The serialized projection. If this returns null, this param is skipped when constructing. A valid return type could either be String or DataMap.
+   */
+  default Object serialize(String paramName, String projection) {
+    return projection;
+  }
+
+  /**
+   * Serialize the given {@link DataMap} projection value.
+   *
+   * @param paramName The name of the projection query param to serialize.
+   * @param projection The projection to serialize.
+   * @return The serialized projection. If this returns null, this param is skipped when constructing. A valid return type could either be String or DataMap.
+   */
+  default Object serialize(String paramName, DataMap projection) {
+    return projection;
+  }
+
+  /**
+   * Serialize the given {@code Set<PathSpec>} projection value.
+   *
+   * @param paramName The name of the projection query param to serialize.
+   * @param projection The projection to serialize.
+   * @return The serialized projection. If this returns null, this param is skipped when constructing. A valid return type could either be String or DataMap.
+   */
+  default Object serialize(String paramName, Set<PathSpec> projection) {
+    return toDataMap(paramName, projection);
+  }
+
+  /**
    * Serialize the given set of specs to a data map. The serialized map must be a valid
    * {@link com.linkedin.data.transform.filter.request.MaskTree} representation.
+   * This method will not be called if the projection is a {@code String} or {@link DataMap},
+   * as well as if {@link #serialize(String, Set<PathSpec>)} is implemented.
    *
    * @param paramName The name of the projection query param to serialize.
    * @param pathSpecs The set of path specs to serialize.

--- a/restli-client/src/main/java/com/linkedin/restli/internal/client/QueryParamsUtil.java
+++ b/restli-client/src/main/java/com/linkedin/restli/internal/client/QueryParamsUtil.java
@@ -74,19 +74,32 @@ public class QueryParamsUtil
 
       if (RestConstants.PROJECTION_PARAMETERS.contains(key))
       {
-        // Short-circuit already serialized projection params or projection params already represented as simplified mask tree.
-        if (value instanceof String || value instanceof DataMap)
+        Object serializedValue;
+        if (value instanceof String)
         {
-          result.put(key, value);
-          continue;
+          serializedValue = projectionDataMapSerializer.serialize(key, (String) value);
         }
-
-        @SuppressWarnings("unchecked")
-        Set<PathSpec> pathSpecs = (Set<PathSpec>)value;
-        DataMap serializedDataMap = projectionDataMapSerializer.toDataMap(key, pathSpecs);
-        if (serializedDataMap != null)
+        else if (value instanceof DataMap)
         {
-          result.put(key, serializedDataMap);
+          serializedValue = projectionDataMapSerializer.serialize(key, (DataMap) value);
+        }
+        else if (value instanceof Set)
+        {
+          serializedValue = projectionDataMapSerializer.serialize(key, (Set<PathSpec>) value);
+        }
+        else
+        {
+          serializedValue = value;
+        }
+        
+        if (serializedValue != null)
+        {
+          if (!(serializedValue instanceof String || serializedValue instanceof DataMap))
+          {
+            throw new IllegalArgumentException("Serialized projection parameter " + key + " must be a String or DataMap");
+          }
+
+          result.put(key, serializedValue);
         }
       }
       else


### PR DESCRIPTION
This is so we can intercept String & DataMap projections before they're sent downstream

Added unit tests to cover the new functionality