### PR TITLE
Don't call _executorService.execute on new tasks once the XdsClient has been shut down

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -322,9 +322,9 @@ public class XdsClientImpl extends XdsClient
 
   private void checkShutdownAndExecute(Runnable runnable)
   {
-    if (_shutdown)
+    if (_executorService.isShutdown())
     {
-      _log.warn("Attempting to execute after shutdown, will do nothing");
+      _log.warn("Attempting to execute a task after _executorService was shutdown, will do nothing");
       return;
     }
 
@@ -1380,7 +1380,7 @@ public class XdsClientImpl extends XdsClient
             @Override
             public void onError(Throwable t)
             {
-              checkShutdownAndExecute((() -> handleRpcError(t));
+              checkShutdownAndExecute((() -> handleRpcError(t)));
             }
 
             @Override

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -334,8 +334,8 @@ public class TestXdsClientImpl
     XdsClientImplFixture fixture = new XdsClientImplFixture();
     fixture._executorService.shutdown();
 
-    // once the _executorService is shutdown, all of these calls should be no-ops
-    // due to the checks in checkShutdownAndExecute and checkShutdownAndSchedule
+    // once the _executorService is shutdown, all of these calls should be no-ops and not throw
+    // RejectedExecutionExceptions due to the checks in checkShutdownAndExecute and checkShutdownAndSchedule
     fixture._xdsClientImpl.startRpcStream();
     fixture._xdsClientImpl.watchXdsResource(CLUSTER_RESOURCE_NAME, fixture._resourceWatcher);
     fixture._xdsClientImpl.watchAllXdsResources(fixture._wildcardResourceWatcher);


### PR DESCRIPTION
We discovered an edge case where the `AdsStream`'s onError callback can be called **after** the `_executorService` has been shut down, which leads to a `RejectedExecutionException` being thrown, which the caller might not expect or be able to handle.

To avoid this, let's protect calls to the `_executorService` with a check on whether it's already been shut down.

## Testing done

1. Added a test `testExecutorServiceNotUsedAfterShutdown` which passes
2. Checked out the current version of `XdsClientImpl` from master and verified `testExecutorServiceNotUsedAfterShutdown` **fails** with `java.util.concurrent.RejectedExecutionException` (confirms that the test is in fact verifying the new behavior)