### PR TITLE
detect more dev/testing app paths for raw d2 cient builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.69.5] - 2025-05-22
+- Detect more dev/testing app paths for raw d2 cient builder
+
 ## [29.69.4] - 2025-05-21
 - Fix the XdsLoadBalancer shutdown issue
 
@@ -5828,7 +5831,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.5...master
+[29.69.5]: https://github.com/linkedin/rest.li/compare/v29.69.4...v29.69.5
 [29.69.4]: https://github.com/linkedin/rest.li/compare/v29.69.3...v29.69.4
 [29.69.3]: https://github.com/linkedin/rest.li/compare/v29.69.2...v29.69.3
 [29.69.2]: https://github.com/linkedin/rest.li/compare/v29.69.1...v29.69.2

--- a/d2/src/main/java/com/linkedin/d2/discovery/util/D2Utils.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/util/D2Utils.java
@@ -24,6 +24,13 @@ public class D2Utils
 {
   private static final Logger LOG = LoggerFactory.getLogger(D2Utils.class);
   private static final String RAW_D2_CLIENT_BASE_PATH = "/d2/rawD2ClientBuilders";
+  private static final String USR_DIR_SYS_PROPERTY = "user.dir";
+  // This is needed to avoid creating Zookeeper node for testing and dev environments
+  private static final Set<String> USR_DIRS_TO_EXCLUDE = Stream.of(
+      "/dev-",
+      "/dev/",
+      "/multiproduct-post-commit-mpdep/" // post-commit runs
+  ).collect(Collectors.toSet());
 
   // Keeping the max threshold to 10K, this would ensure that we accidentally won't create more than max ZK tracking nodes.
   public static final int RAW_D2_CLIENT_MAX_TRACKING_NODE = 10000;
@@ -90,11 +97,17 @@ public class D2Utils
     return properties.toString();
   }
 
+  public static Boolean isAppToExclude()
+  {
+    String userDir = System.getProperties().getProperty(USR_DIR_SYS_PROPERTY);
+    return userDir != null && USR_DIRS_TO_EXCLUDE.stream().anyMatch(userDir::contains);
+  }
+
   // ZK don't allow / in the node name, we are replacing / with -, This name would be unique for each app.
   // for example: export-content-lid-apps-indis-canary-install nodeName is being used.
   public static String getAppIdentityName()
   {
-    String userDir = System.getProperties().getProperty("user.dir");
+    String userDir = System.getProperties().getProperty(USR_DIR_SYS_PROPERTY);
     LOG.info("User dir for raw D2 Client usages: {}", userDir);
     return userDir.replace("/", "-").substring(1);
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.69.4
+version=29.69.5
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
To explicitly catch more dev/testing app paths to be excluded from creating znode for raw d2 client builder users, and only check once at startup instead of every zk uri queries.

## Testing Done
QEI deploy indis-canary, verified that the log about creating znode "setting up node for rawClientTracking with name: xxx" no longer shows up:
