### PR TITLE
fix shutdown issue for xdsLoadBalancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.69.4] - 2025-05-21
+- Fix the XdsLoadBalancer shutdown issue
+
 ## [29.69.3] - 2025-05-20
 - Fix the shutdown issue for XdsClientImpl and add more comments for Raw D2 Client usages tracking
 
@@ -5825,7 +5828,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.4...master
+[29.69.4]: https://github.com/linkedin/rest.li/compare/v29.69.3...v29.69.4
 [29.69.3]: https://github.com/linkedin/rest.li/compare/v29.69.2...v29.69.3
 [29.69.2]: https://github.com/linkedin/rest.li/compare/v29.69.1...v29.69.2
 [29.69.1]: https://github.com/linkedin/rest.li/compare/v29.69.0...v29.69.1

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -314,6 +314,11 @@ public class XdsClientImpl extends XdsClient
       {
         _adsStream.close(Status.CANCELLED.withDescription("shutdown").asException());
       }
+
+      if(!_managedChannel.isShutdown())
+      {
+        _managedChannel.shutdown();
+      }
     });
   }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancer.java
@@ -189,8 +189,8 @@ public class XdsLoadBalancer implements LoadBalancerWithFacilities, WarmUpServic
   public void shutdown(PropertyEventThread.PropertyEventShutdownCallback shutdown)
   {
     _xdsAdaptor.shutdown();
+    _loadBalancer.shutdown(shutdown);
     _executorService.shutdown();
-    shutdown.done();
   }
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.69.3
+version=29.69.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Context

During the shutdown of xdsLoadBalancer, several important resources are not being properly released:
- **R2 Transport Layer**: The R2 transport client is not explicitly shut down. This may leave threads and network resources lingering.
- **gRPC Resources**: The gRPC ManagedChannel and its associated event loop groups are not properly terminated. As a result, gRPC worker threads remain alive.

**These omissions can lead to a situation where non-daemon threads continue running, preventing the JVM from exiting cleanly.** In Hadoop-based environments, this can cause job hangs, as the process appears to be stuck with active runnables.

Below is a thread dump captured during such a hang, highlighting the lingering threads:
```
"main@1" prio=5 tid=0x1 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at com.linkedin.audience.flows.common.jobs.UpstreamDataChecker.run(UpstreamDataChecker.java:97)
	  at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(NativeMethodAccessorImpl.java:-1)
	  at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	  at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	  at java.lang.reflect.Method.invoke(Method.java:566)
	  at azkaban.jobtype.HadoopJavaJobRunnerMain.runMethod(HadoopJavaJobRunnerMain.java:266)
	  at azkaban.jobtype.HadoopJavaJobRunnerMain.lambda$runMethodAsUser$0(HadoopJavaJobRunnerMain.java:256)
	  at azkaban.jobtype.HadoopJavaJobRunnerMain$$Lambda$101.1279852178.run(Unknown Source:-1)
	  at java.security.AccessController.doPrivileged(AccessController.java:-1)
	  at javax.security.auth.Subject.doAs(Subject.java:423)
	  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1920)
	  at azkaban.jobtype.HadoopJavaJobRunnerMain.runMethodAsUser(HadoopJavaJobRunnerMain.java:248)
	  at azkaban.jobtype.HadoopJavaJobRunnerMain.<init>(HadoopJavaJobRunnerMain.java:199)
	  at azkaban.jobtype.HadoopJavaJobRunnerMain.main(HadoopJavaJobRunnerMain.java:85)

"R2 Nio Event Loop-1-1@7143" prio=5 tid=0x20 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at sun.nio.ch.EPoll.wait(EPoll.java:-1)
	  at sun.nio.ch.EPollSelectorImpl.doSelect(EPollSelectorImpl.java:120)
	  at sun.nio.ch.SelectorImpl.lockAndDoSelect(SelectorImpl.java:124)
	  - locked <0x1e72> (a sun.nio.ch.EPollSelectorImpl)
	  - locked <0x1e73> (a io.netty.channel.nio.SelectedSelectionKeySet)
	  at sun.nio.ch.SelectorImpl.select(SelectorImpl.java:141)
	  at io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
	  at io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
	  at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
	  at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	  at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	  at java.lang.Thread.run(Thread.java:834)

"process reaper@1769" daemon prio=10 tid=0xe nid=NA waiting
  java.lang.Thread.State: WAITING
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
	  at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:462)
	  at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:361)
	  at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:937)
	  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1053)
	  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1114)
	  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	  at java.lang.Thread.run(Thread.java:834)

"grpc-default-executor-0@4775" daemon prio=5 tid=0x1a nid=NA waiting
  java.lang.Thread.State: WAITING
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
	  at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:462)
	  at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:361)
	  at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:937)
	  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1053)
	  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1114)
	  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	  at java.lang.Thread.run(Thread.java:834)

"grpc-default-executor-1@4955" daemon prio=5 tid=0x1b nid=NA waiting
  java.lang.Thread.State: WAITING
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
	  at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:462)
	  at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:361)
	  at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:937)
	  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1053)
	  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1114)
	  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	  at java.lang.Thread.run(Thread.java:834)

"grpc-default-executor-2@5093" daemon prio=5 tid=0x1c nid=NA waiting
  java.lang.Thread.State: WAITING
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
	  at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:462)
	  at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:361)
	  at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:937)
	  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1053)
	  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1114)
	  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	  at java.lang.Thread.run(Thread.java:834)

"R2 Netty Scheduler-2-1@6963" prio=5 tid=0x1f nid=NA waiting
  java.lang.Thread.State: WAITING
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
	  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2123)
	  at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1182)
	  at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:899)
	  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1054)
	  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1114)
	  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	  at java.lang.Thread.run(Thread.java:834)

"grpc-default-worker-ELG-1-1@4749" daemon prio=5 tid=0x19 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at io.grpc.netty.shaded.io.netty.channel.epoll.Native.epollWait0(Native.java:-1)
	  at io.grpc.netty.shaded.io.netty.channel.epoll.Native.epollWait(Native.java:182)
	  at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.epollWait(EpollEventLoop.java:312)
	  at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:376)
	  at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	  at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	  at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	  at java.lang.Thread.run(Thread.java:834)

"grpc-default-worker-ELG-1-2@5604" daemon prio=5 tid=0x1d nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at io.grpc.netty.shaded.io.netty.channel.epoll.Native.epollWait0(Native.java:-1)
	  at io.grpc.netty.shaded.io.netty.channel.epoll.Native.epollWait(Native.java:182)
	  at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.epollWait(EpollEventLoop.java:312)
	  at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:376)
	  at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	  at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	  at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	  at java.lang.Thread.run(Thread.java:834)

"pool-2-thread-1@7715" prio=5 tid=0x21 nid=NA waiting
  java.lang.Thread.State: WAITING
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
	  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2081)
	  at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:433)
	  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1054)
	  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1114)
	  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	  at java.lang.Thread.run(Thread.java:834)

"pool-5-thread-1@7784" daemon prio=5 tid=0x22 nid=NA waiting
  java.lang.Thread.State: WAITING
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
	  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2081)
	  at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:433)
	  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1054)
	  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1114)
	  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	  at java.lang.Thread.run(Thread.java:834)

"Common-Cleaner@619" daemon prio=8 tid=0xc nid=NA waiting
  java.lang.Thread.State: WAITING
	  at java.lang.Object.wait(Object.java:-1)
	  at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:155)
	  at jdk.internal.ref.CleanerImpl.run(CleanerImpl.java:148)
	  at java.lang.Thread.run(Thread.java:834)
	  at jdk.internal.misc.InnocuousThread.run(InnocuousThread.java:134)

"ForkJoinPool.commonPool-worker-3@6372" daemon prio=5 tid=0x1e nid=NA waiting
  java.lang.Thread.State: WAITING
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
	  at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1628)
	  at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)

"Reference Handler@616" daemon prio=10 tid=0x2 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at java.lang.ref.Reference.waitForReferencePendingList(Reference.java:-1)
	  at java.lang.ref.Reference.processPendingReferences(Reference.java:241)
	  at java.lang.ref.Reference$ReferenceHandler.run(Reference.java:213)

"Finalizer@617" daemon prio=8 tid=0x3 nid=NA waiting
  java.lang.Thread.State: WAITING
	  at java.lang.Object.wait(Object.java:-1)
	  at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:155)
	  at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:176)
	  at java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:170)

"Signal Dispatcher@618" daemon prio=9 tid=0x4 nid=NA runnable
  java.lang.Thread.State: RUNNABLE

"pool-6-thread-1@7787" prio=5 tid=0x23 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
```

The fix has been verified here. 
https://ltx1-holdemaz05.grid.linkedin.com/executor?execid=131470237

And we also see the missing shutdown for r2 now
```
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,041  INFO : com.linkedin.d2.balancer.simple.SimpleLoadBalancerState - shutting down cluster clients
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,042  INFO : com.linkedin.r2.transport.http.client.common.AbstractNettyClient - Shutdown requested
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,042  INFO : com.linkedin.r2.transport.http.client.common.AbstractNettyClient - Shutting down
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,043  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutting down 0 connection pools
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,043  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shutdown
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,043  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shut down, closing all channels
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,047  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,047  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutting down 1 connection pools
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,047  INFO : com.linkedin.r2.transport.http.client.AsyncPoolImpl - lva1-app5269.corp.linkedin.com/10.139.121.189:3975/2bba35ef: shutdown requested
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,047  INFO : com.linkedin.r2.transport.http.client.AsyncPoolImpl - lva1-app5269.corp.linkedin.com/10.139.121.189:3975/2bba35ef: shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,047  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shutdown
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shut down, closing all channels
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.AbstractNettyClient - Shutdown requested
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.AbstractNettyClient - Shutting down
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutting down 0 connection pools
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shutdown
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shut down, closing all channels
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutting down 0 connection pools
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shutdown
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,048  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shut down, closing all channels
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,049  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.AbstractNettyClient - Shutdown requested
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.AbstractNettyClient - Shutting down
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutting down 0 connection pools
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shutdown
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shut down, closing all channels
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutting down 0 connection pools
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shutdown
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,050  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shut down, closing all channels
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.AbstractNettyClient - Shutdown requested
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.AbstractNettyClient - Shutting down
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutting down 0 connection pools
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shutdown
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shut down, closing all channels
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutting down 0 connection pools
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shutdown
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - All connection pools shut down, closing all channels
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,051  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,053  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,053  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,053  INFO : com.linkedin.r2.transport.http.client.common.ChannelPoolManagerImpl - Shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,053  INFO : com.linkedin.d2.balancer.clients.DynamicClient - dynamic client shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,054  INFO : com.linkedin.r2.transport.http.client.HttpClientFactory - Shutdown Netty Event Loop
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,054  INFO : com.linkedin.r2.transport.http.client.HttpClientFactory - Scheduler shutdown complete
21-05-2025 16:34:26 PDT UpstreamDataCheck INFO - 2025-05-21 23:34:26,054  INFO : com.linkedin.r2.transport.http.client.HttpClientFactory - Shutdown complete
```
