### PR TITLE
updating AppIdentityName logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.69.6] - 2025-05-27
+- Addressing duplicate ZK node creation for RawD2Client tracking
+
 ## [29.69.5] - 2025-05-22
 - Detect more dev/testing app paths for raw d2 cient builder
 
@@ -5831,7 +5834,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.5...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.6...master
+[29.69.6]: https://github.com/linkedin/rest.li/compare/v29.69.5...v29.69.6
 [29.69.5]: https://github.com/linkedin/rest.li/compare/v29.69.4...v29.69.5
 [29.69.4]: https://github.com/linkedin/rest.li/compare/v29.69.3...v29.69.4
 [29.69.3]: https://github.com/linkedin/rest.li/compare/v29.69.2...v29.69.3

--- a/d2/src/main/java/com/linkedin/d2/discovery/util/D2Utils.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/util/D2Utils.java
@@ -7,6 +7,7 @@ package com.linkedin.d2.discovery.util;
 import com.linkedin.d2.balancer.properties.PropertyKeys;
 import com.linkedin.d2.balancer.zkfs.ZKFSUtil;
 import com.linkedin.d2.discovery.stores.zk.SymlinkUtil;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -25,6 +26,8 @@ public class D2Utils
   private static final Logger LOG = LoggerFactory.getLogger(D2Utils.class);
   private static final String RAW_D2_CLIENT_BASE_PATH = "/d2/rawD2ClientBuilders";
   private static final String USR_DIR_SYS_PROPERTY = "user.dir";
+  private static final String SPARK_APP_NAME = "spark.app.name";
+  private static final String APP_NAME = "com.linkedin.app.name";
   // This is needed to avoid creating Zookeeper node for testing and dev environments
   private static final Set<String> USR_DIRS_TO_EXCLUDE = Stream.of(
       "/dev-",
@@ -107,7 +110,20 @@ public class D2Utils
   // for example: export-content-lid-apps-indis-canary-install nodeName is being used.
   public static String getAppIdentityName()
   {
-    String userDir = System.getProperties().getProperty(USR_DIR_SYS_PROPERTY);
+    Properties properties = System.getProperties();
+    if (properties.getProperty(SPARK_APP_NAME) != null)
+    {
+      return properties.getProperty(SPARK_APP_NAME);
+    }
+
+    // for samza jobs using the app name
+    if (properties.getProperty(APP_NAME) != null)
+    {
+      return properties.getProperty(APP_NAME);
+    }
+
+    // if APP_NAME is not present then using userDir as node identifier.
+    String userDir = properties.getProperty(USR_DIR_SYS_PROPERTY);
     LOG.info("User dir for raw D2 Client usages: {}", userDir);
     return userDir.replace("/", "-").substring(1);
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.69.5
+version=29.69.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
updating AppIdentityName logic

for avoiding multiple node creation for samza/yarn jobs, updating AppIdentityName to use app.name as node identifier, if it present, if not then it will fall back to use user.dir property. 



