### PR TITLE
Handle exceptions thrown from CustomAffinityRoutingURIProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.69.7] - 2025-05-27
+- Handle exceptions thrown from CustomAffinityRoutingURIProvider
+
 ## [29.69.6] - 2025-05-27
 - Addressing duplicate ZK node creation for RawD2Client tracking
 
@@ -5834,7 +5837,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.7...master
+[29.69.7]: https://github.com/linkedin/rest.li/compare/v29.69.6...v29.69.7
 [29.69.6]: https://github.com/linkedin/rest.li/compare/v29.69.5...v29.69.6
 [29.69.5]: https://github.com/linkedin/rest.li/compare/v29.69.4...v29.69.5
 [29.69.4]: https://github.com/linkedin/rest.li/compare/v29.69.3...v29.69.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.69.7] - 2025-05-27
-- Handle exceptions thrown from CustomAffinityRoutingURIProvider
-
 ## [29.69.6] - 2025-05-27
 - Addressing duplicate ZK node creation for RawD2Client tracking
 
@@ -5837,8 +5834,7 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.7...master
-[29.69.7]: https://github.com/linkedin/rest.li/compare/v29.69.6...v29.69.7
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.6...master
 [29.69.6]: https://github.com/linkedin/rest.li/compare/v29.69.5...v29.69.6
 [29.69.5]: https://github.com/linkedin/rest.li/compare/v29.69.4...v29.69.5
 [29.69.4]: https://github.com/linkedin/rest.li/compare/v29.69.3...v29.69.4

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SafeCustomAffinityRoutingURIProviderDecorator.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SafeCustomAffinityRoutingURIProviderDecorator.java
@@ -1,0 +1,84 @@
+/*
+   Copyright (c) 2022 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package com.linkedin.d2.balancer.simple;
+
+import com.linkedin.d2.balancer.util.CustomAffinityRoutingURIProvider;
+import com.linkedin.util.RateLimitedLogger;
+import java.net.URI;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A decorator for {@link CustomAffinityRoutingURIProvider} that safely handles exceptions
+ * and logs errors without crashing the application.
+ * It provides a fallback mechanism to ensure that if the delegate is null or throws an exception,
+ * the application can continue to function without disruption.
+ */
+class SafeCustomAffinityRoutingURIProviderDecorator implements CustomAffinityRoutingURIProvider {
+  private static final RateLimitedLogger RATE_LIMITED_LOGGER =
+      new RateLimitedLogger(LoggerFactory.getLogger(SafeCustomAffinityRoutingURIProviderDecorator.class),
+          1000, // 1-second rate limit
+          System::currentTimeMillis);
+
+  @Nullable
+  private final CustomAffinityRoutingURIProvider _delegate;
+
+  public SafeCustomAffinityRoutingURIProviderDecorator(@Nullable CustomAffinityRoutingURIProvider delegate) {
+    _delegate = delegate;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    if (_delegate == null) {
+      return false;
+    }
+    try {
+      // Check if the delegate is enabled
+      return _delegate.isEnabled();
+    } catch (RuntimeException ex) {
+      RATE_LIMITED_LOGGER.error("Error checking if CustomAffinityRoutingURIProvider is enabled", ex);
+      return false;
+    }
+  }
+
+  @Override
+  public Optional<URI> getTargetHostURI(String clusterName) {
+    if (_delegate == null) {
+      return Optional.empty();
+    }
+    try {
+      // Attempt to get the target host URI from the delegate
+      return _delegate.getTargetHostURI(clusterName);
+    } catch (RuntimeException ex) {
+      RATE_LIMITED_LOGGER.error("Error getting target host URI for cluster: " + clusterName, ex);
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public void setTargetHostURI(String clusterName, URI targetHostURI) {
+    if (_delegate == null) {
+      return;
+    }
+    try {
+      // Attempt to set the target host URI in the delegate
+      _delegate.setTargetHostURI(clusterName, targetHostURI);
+    } catch (RuntimeException ex) {
+      RATE_LIMITED_LOGGER.error("Error setting target host URI for cluster: " + clusterName + " to " + targetHostURI, ex);
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SafeCustomAffinityRoutingURIProviderDecorator.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SafeCustomAffinityRoutingURIProviderDecorator.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * It provides a fallback mechanism to ensure that if the delegate is null or throws an exception,
  * the application can continue to function without disruption.
  */
-class SafeCustomAffinityRoutingURIProviderDecorator implements CustomAffinityRoutingURIProvider {
+final class SafeCustomAffinityRoutingURIProviderDecorator implements CustomAffinityRoutingURIProvider {
   private static final RateLimitedLogger RATE_LIMITED_LOGGER =
       new RateLimitedLogger(LoggerFactory.getLogger(SafeCustomAffinityRoutingURIProviderDecorator.class),
           1000, // 1-second rate limit

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -267,7 +267,8 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
 
           // Use client provided by CustomURIAffinityRoutingProvider when it's enabled
           CustomAffinityRoutingURIProvider customAffinityRoutingURIProvider =
-              (CustomAffinityRoutingURIProvider) requestContext.getLocalAttr(CustomAffinityRoutingURIProvider.CUSTOM_AFFINITY_ROUTING_URI_PROVIDER);
+              new SafeCustomAffinityRoutingURIProviderDecorator((CustomAffinityRoutingURIProvider)
+                  requestContext.getLocalAttr(CustomAffinityRoutingURIProvider.CUSTOM_AFFINITY_ROUTING_URI_PROVIDER));
 
           boolean enableCustomAffinityRouting = isCustomAffinityRoutingEnabled(requestContext, customAffinityRoutingURIProvider);
           if (enableCustomAffinityRouting)

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/SafeCustomAffinityRoutingURIProviderDecoratorTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/SafeCustomAffinityRoutingURIProviderDecoratorTest.java
@@ -1,0 +1,86 @@
+package com.linkedin.d2.balancer.simple;
+
+import com.linkedin.d2.balancer.util.CustomAffinityRoutingURIProvider;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+public class SafeCustomAffinityRoutingURIProviderDecoratorTest {
+
+  private CustomAffinityRoutingURIProvider _mockDelegate;
+  private SafeCustomAffinityRoutingURIProviderDecorator _decorator;
+
+  @BeforeMethod
+  public void setUp() {
+    _mockDelegate = Mockito.mock(CustomAffinityRoutingURIProvider.class);
+    _decorator = new SafeCustomAffinityRoutingURIProviderDecorator(_mockDelegate);
+  }
+
+  @Test
+  public void testIsEnabledWithNullDelegate() {
+    _decorator = new SafeCustomAffinityRoutingURIProviderDecorator(null);
+    Assert.assertFalse(_decorator.isEnabled());
+  }
+
+  @Test
+  public void testIsEnabledWithDelegate() {
+    when(_mockDelegate.isEnabled()).thenReturn(true);
+    Assert.assertTrue(_decorator.isEnabled());
+    verify(_mockDelegate, times(1)).isEnabled();
+  }
+
+  @Test
+  public void testIsEnabledThrowsException() {
+    when(_mockDelegate.isEnabled()).thenThrow(new RuntimeException("Mock exception"));
+    Assert.assertFalse(_decorator.isEnabled());
+    verify(_mockDelegate, times(1)).isEnabled();
+  }
+
+  @Test
+  public void testGetTargetHostURIWithNullDelegate() {
+    _decorator = new SafeCustomAffinityRoutingURIProviderDecorator(null);
+    Assert.assertEquals(_decorator.getTargetHostURI("testCluster"), Optional.empty());
+  }
+
+  @Test
+  public void testGetTargetHostURIWithDelegate() {
+    URI mockURI = URI.create("http://example.com");
+    when(_mockDelegate.getTargetHostURI("testCluster")).thenReturn(Optional.of(mockURI));
+    Assert.assertEquals(_decorator.getTargetHostURI("testCluster"), Optional.of(mockURI));
+    verify(_mockDelegate, times(1)).getTargetHostURI("testCluster");
+  }
+
+  @Test
+  public void testGetTargetHostURIThrowsException() {
+    when(_mockDelegate.getTargetHostURI("testCluster")).thenThrow(new RuntimeException("Mock exception"));
+    Assert.assertEquals(_decorator.getTargetHostURI("testCluster"), Optional.empty());
+    verify(_mockDelegate, times(1)).getTargetHostURI("testCluster");
+  }
+
+  @Test
+  public void testSetTargetHostURIWithNullDelegate() {
+    _decorator = new SafeCustomAffinityRoutingURIProviderDecorator(null);
+    _decorator.setTargetHostURI("testCluster", URI.create("http://example.com"));
+    // No exception should be thrown, and no interaction with the delegate
+  }
+
+  @Test
+  public void testSetTargetHostURIWithDelegate() {
+    URI mockURI = URI.create("http://example.com");
+    _decorator.setTargetHostURI("testCluster", mockURI);
+    verify(_mockDelegate, times(1)).setTargetHostURI("testCluster", mockURI);
+  }
+
+  @Test
+  public void testSetTargetHostURIThrowsException() {
+    doThrow(new RuntimeException("Mock exception")).when(_mockDelegate).setTargetHostURI(anyString(), any(URI.class));
+    _decorator.setTargetHostURI("testCluster", URI.create("http://example.com"));
+    verify(_mockDelegate, times(1)).setTargetHostURI("testCluster", URI.create("http://example.com"));
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.69.6
+version=29.69.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
Summary
---------
Add `SafeCustomAffinityRoutingURIProviderDecorator` to safely call user-supplied `CustomAffinityRoutingURIProvider` implementations. This is needed to avoid deadlocked requests since any exceptions thrown from here aren't caught and they result in the executor thread being killed.

Testing Done
---------
Added UTs