### PR TITLE
Add Full Restli Resource to RequestContext (as String)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.69.8] - 2025-06-04
+- Add Restli Resource to R2 Request Context
+
 ## [29.69.7] - 2025-05-30
 - Changing child count logic for RawD2Client tracking node
 
@@ -5837,7 +5840,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.8...master
+[29.69.8]: https://github.com/linkedin/rest.li/compare/v29.69.7...v29.69.8
 [29.69.7]: https://github.com/linkedin/rest.li/compare/v29.69.6...v29.69.7
 [29.69.6]: https://github.com/linkedin/rest.li/compare/v29.69.5...v29.69.6
 [29.69.5]: https://github.com/linkedin/rest.li/compare/v29.69.4...v29.69.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.69.7
+version=29.69.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/filter/R2Constants.java
+++ b/r2-core/src/main/java/com/linkedin/r2/filter/R2Constants.java
@@ -73,6 +73,7 @@ public class R2Constants
   public static final String PROJECTION_INFO = "PROJECTION_INFO";
   public static final String RESTLI_INFO = "RESTLI_INFO";
   public static final String RESTLI_TRACE_INFO = "RESTLI_TRACE_INFO";
+  public static final String RESTLI_RESOURCE = "RESTLI_RESOURCE";
 
   /**
    * Client uses this key to designate a request as belonging to a group of requests that will be monitored in a


### PR DESCRIPTION
This pull request introduces a new constant `RESTLI_RESOURCE` to store the full Restli Resource + SubResource  information in the RequestContext for processing within the Restli stack.

For example, in given a Restli Subresource, e.g. `/assets/foo/artifacts/bar`.

The logic will now add the following to the RequestContext, (it strips the IDs)
`assets/artifacts`