### PR TITLE
fix passing in xds channel load balancing policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.69.8] - 2025-06-19
+- Pass in xds channel load balancing policy configs
+
 ## [29.69.7] - 2025-05-30
 - Changing child count logic for RawD2Client tracking node
 
@@ -5837,7 +5840,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.7...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.8...master
+[29.69.8]: https://github.com/linkedin/rest.li/compare/v29.69.7...v29.69.8
 [29.69.7]: https://github.com/linkedin/rest.li/compare/v29.69.6...v29.69.7
 [29.69.6]: https://github.com/linkedin/rest.li/compare/v29.69.5...v29.69.6
 [29.69.5]: https://github.com/linkedin/rest.li/compare/v29.69.4...v29.69.5

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -54,7 +54,8 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
         XdsClientImpl.DEFAULT_READY_TIMEOUT_MILLIS);
     XdsClient xdsClient = new XdsClientImpl(
         new Node(config.hostName),
-        new XdsChannelFactory(config.grpcSslContext, config.xdsServer).createChannel(),
+        new XdsChannelFactory(config.grpcSslContext, config.xdsServer,
+            config.xdsChannelLoadBalancingPolicy, config.xdsChannelLoadBalancingPolicyConfig).createChannel(),
         executorService,
         xdsStreamReadyTimeout,
         config.subscribeToUriGlobCollection,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.69.7
+version=29.69.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary ##
The d2 client configs from container for xds channel load balancing policy were never passed into the xds channel factory. This bug was introduced in https://github.com/linkedin/rest.li/pull/979. This change fixes this bug.

## Testing Done
QEI deploy indis-canary. See the connected INDIS observer:
```
2025/06/20 08:56:48.422 INFO [XdsClientImpl] [Indis xDS client executor-15-1] [indis-canary] [AAY4AujhIIuaxXGX/yNpXA==] Successfully received response from ADS server: ltx1-app10343.stg.linkedin.com
```

, restart indis-canary, See the client connected to another observer: 
```
2025/06/20 09:42:49.354 INFO [XdsClientImpl] [Indis xDS client executor-15-1] [indis-canary] [AAY4A41xk8DBnEbVjp7QGQ==] Successfully received response from ADS server: ltx1-app10448.stg.linkedin.com
```