### PR TITLE
Configure xds stream retry max backoff time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.70.0] - 2025-06-20
+- Configure xds stream retry max backoff time 
+
 ## [29.69.8] - 2025-06-19
 - Pass in xds channel load balancing policy configs
 
@@ -5840,7 +5843,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.69.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.70.0...master
+[29.70.0]: https://github.com/linkedin/rest.li/compare/v29.69.8...v29.70.0
 [29.69.8]: https://github.com/linkedin/rest.li/compare/v29.69.7...v29.69.8
 [29.69.7]: https://github.com/linkedin/rest.li/compare/v29.69.6...v29.69.7
 [29.69.6]: https://github.com/linkedin/rest.li/compare/v29.69.5...v29.69.6

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -230,7 +230,8 @@ public class D2ClientBuilder
                   _config.loadBalanceStreamException,
                   _config.xdsInitialResourceVersionsEnabled,
                   _config.disableDetectLiRawD2Client,
-                  _config.isLiRawD2Client
+                  _config.isLiRawD2Client,
+                  _config.xdsStreamMaxRetryBackoffSeconds
     );
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
@@ -819,6 +820,12 @@ public class D2ClientBuilder
   public D2ClientBuilder setXdsInitialResourceVersionsEnabled(boolean xdsIRVEnabled)
   {
     _config.xdsInitialResourceVersionsEnabled = xdsIRVEnabled;
+    return this;
+  }
+
+  public D2ClientBuilder setXdsStreamMaxRetryBackoffSeconds(int xdsStreamMaxRetryBackoffSeconds)
+  {
+    _config.xdsStreamMaxRetryBackoffSeconds = xdsStreamMaxRetryBackoffSeconds;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -175,6 +175,7 @@ public class D2ClientConfig
   public XdsServerMetricsProvider _xdsServerMetricsProvider = new NoOpXdsServerMetricsProvider();
   public boolean loadBalanceStreamException = false;
   public boolean xdsInitialResourceVersionsEnabled = false;
+  public Integer xdsStreamMaxRetryBackoffSeconds = null;
 
   /**
    * D2 client builder by default will detect if it's used to build a raw D2 client (as opposed to used by standard
@@ -267,7 +268,8 @@ public class D2ClientConfig
                  boolean loadBalanceStreamException,
                  boolean xdsInitialResourceVersionsEnabled,
                  boolean disableDetectLiRawD2Client,
-                 boolean isLiRawD2Client)
+                 boolean isLiRawD2Client,
+                 Integer xdsStreamMaxRetryBackoffSeconds)
   {
     this.zkHosts = zkHosts;
     this.xdsServer = xdsServer;
@@ -345,5 +347,6 @@ public class D2ClientConfig
     this.xdsInitialResourceVersionsEnabled = xdsInitialResourceVersionsEnabled;
     this.disableDetectLiRawD2Client = disableDetectLiRawD2Client;
     this.isLiRawD2Client = isLiRawD2Client;
+    this.xdsStreamMaxRetryBackoffSeconds = xdsStreamMaxRetryBackoffSeconds;
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -60,7 +60,8 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
         xdsStreamReadyTimeout,
         config.subscribeToUriGlobCollection,
         config._xdsServerMetricsProvider,
-        config.xdsInitialResourceVersionsEnabled
+        config.xdsInitialResourceVersionsEnabled,
+        config.xdsStreamMaxRetryBackoffSeconds
     );
     d2ClientJmxManager.registerXdsClientJmx(xdsClient.getXdsClientJmx());
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.69.8
+version=29.70.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
Current default max retry backoff time in [grpc](https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/internal/ExponentialBackoffPolicy.java#L41) is 2min, which is way too long for INDIS. This change makes it configurable so that we can set it for our need (like 10s, 30s, etc.).

## Testing Done
TODO