### PR TITLE
log full announcement data at markup. Use samza container name and process user dir for tracking raw d2 client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.70.1] - 2025-07-17
+- log full announcement data at markup
+
 ## [29.70.0] - 2025-07-15
 - Configure xds stream max retry backoff time and xds channel keep alive time 
 
@@ -5849,7 +5852,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.70.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.70.1...master
+[29.70.1]: https://github.com/linkedin/rest.li/compare/v29.70.0...v29.70.1
 [29.70.0]: https://github.com/linkedin/rest.li/compare/v29.69.10...v29.70.0
 [29.69.10]: https://github.com/linkedin/rest.li/compare/v29.69.9...v29.69.10
 [29.69.9]: https://github.com/linkedin/rest.li/compare/v29.69.8...v29.69.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and what APIs have changed, if applicable.
 ## [Unreleased]
 
 ## [29.70.1] - 2025-07-17
-- log full announcement data at markup
+- log full announcement data at markup. Use samza container name and process user dir for tracking raw d2 client.
 
 ## [29.70.0] - 2025-07-15
 - Configure xds stream max retry backoff time and xds channel keep alive time 

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -395,7 +395,8 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper, Announ
         _isMarkUpIntentSent.set(true);
         emitSDStatusActiveUpdateIntentAndWriteEvents(_cluster, true, true, _markUpStartAtRef.get());
         _markUpFailed = false;
-        _log.info("markUp for uri = {} on cluster {} succeeded.", _uri, _cluster);
+        _log.info("markUp succeeded for uri = {}, cluster = {}, partitionData = {}, uriSpecificProperties = {}.",
+            _uri, _cluster, _partitionDataMap, _uriSpecificProperties);
         // Note that the pending callbacks we see at this point are
         // from the requests that are filed before us because zookeeper
         // guarantees the ordering of callback being invoked.

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ZooKeeperAnnouncer.java
@@ -368,7 +368,8 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper, Announ
         emitSDStatusActiveUpdateIntentAndWriteEvents(_cluster, true, false, _markUpStartAtRef.get());
         if (e instanceof KeeperException.ConnectionLossException || e instanceof KeeperException.SessionExpiredException)
         {
-          _log.warn("failed to mark up uri {} for cluster {} due to {}.", _uri, _cluster, e.getClass().getSimpleName());
+          _log.warn("failed to mark up uri = {}, cluster = {}, partitionData = {}, uriSpecificProperties = {} due to {}.",
+              _uri, _cluster, _partitionDataMap, _uriSpecificProperties, e.getClass().getSimpleName());
           // Setting to null because if that connection dies, when don't want to continue making operations before
           // the connection is up again.
           // When the connection will be up again, the ZKAnnouncer will be restarted and it will read the _isUp
@@ -395,7 +396,7 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper, Announ
         _isMarkUpIntentSent.set(true);
         emitSDStatusActiveUpdateIntentAndWriteEvents(_cluster, true, true, _markUpStartAtRef.get());
         _markUpFailed = false;
-        _log.info("markUp succeeded for uri = {}, cluster = {}, partitionData = {}, uriSpecificProperties = {}.",
+        _log.info("markUp for uri = {}, cluster = {}, partitionData = {}, uriSpecificProperties = {} succeeded.",
             _uri, _cluster, _partitionDataMap, _uriSpecificProperties);
         // Note that the pending callbacks we see at this point are
         // from the requests that are filed before us because zookeeper
@@ -480,7 +481,8 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper, Announ
         emitSDStatusActiveUpdateIntentAndWriteEvents(_warmupClusterName, true, false, _warmupClusterMarkUpStartAtRef.get());
         if (e instanceof KeeperException.ConnectionLossException || e instanceof KeeperException.SessionExpiredException)
         {
-          _log.warn("failed to mark up uri {} for warm-up cluster {} due to {}.", _uri, _cluster, e.getClass().getSimpleName());
+          _log.warn("failed to mark up uri = {}, warm-up cluster = {}, partitionData = {}, uriSpecificProperties = {} "
+              + "due to {}.", _uri, _warmupClusterName, _partitionDataMap, _uriSpecificProperties, e.getClass().getSimpleName());
           // Setting to null because if that connection dies, we don't want to continue making operations before
           // the connection is up again.
           // When the connection will be up again, the ZKAnnouncer will be restarted and it will read the _isUp
@@ -506,7 +508,8 @@ public class ZooKeeperAnnouncer implements D2ServiceDiscoveryEventHelper, Announ
       {
         _isDarkWarmupMarkUpIntentSent.set(true);
         emitSDStatusActiveUpdateIntentAndWriteEvents(_warmupClusterName, true, true, _warmupClusterMarkUpStartAtRef.get());
-        _log.info("markUp for uri {} on warm-up cluster {} succeeded", _uri, _warmupClusterName);
+        _log.info("markUp for uri = {}, warm-up cluster = {}, partitionData = {}, uriSpecificProperties = {} succeeded.",
+            _uri, _warmupClusterName, _partitionDataMap, _uriSpecificProperties);
         // Mark _isWarmingUp to true to indicate warm up is in progress
         _isWarmingUp = true;
         // Add mark down as pending, so that in case of ZK connection loss, on retry there is a mark down attempted

--- a/d2/src/main/java/com/linkedin/d2/discovery/util/D2Utils.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/util/D2Utils.java
@@ -28,6 +28,7 @@ public class D2Utils
   private static final String USR_DIR_SYS_PROPERTY = "user.dir";
   private static final String SPARK_APP_NAME = "spark.app.name";
   private static final String APP_NAME = "com.linkedin.app.name";
+  private static final String SAMZA_CONTAINER_NAME = "samza.container.name";
   // This is needed to avoid creating Zookeeper node for testing and dev environments
   private static final Set<String> USR_DIRS_TO_EXCLUDE = Stream.of(
       "/dev-",
@@ -120,6 +121,12 @@ public class D2Utils
     if (properties.getProperty(APP_NAME) != null)
     {
       return properties.getProperty(APP_NAME);
+    }
+
+    // for samza jobs using the container name
+    if (properties.getProperty(SAMZA_CONTAINER_NAME) != null)
+    {
+      return properties.getProperty(SAMZA_CONTAINER_NAME);
     }
 
     // if APP_NAME is not present then using userDir as node identifier.

--- a/d2/src/main/java/com/linkedin/d2/discovery/util/D2Utils.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/util/D2Utils.java
@@ -134,6 +134,7 @@ public class D2Utils
 
     // Process user.dir property to identify the app
     String userDir = properties.getProperty(USR_DIR_SYS_PROPERTY);
+    String originalUserDir = userDir;
     if (userDir.startsWith(USER_DIR_EXPORT_CONTENT_PREFIX))
     {
       // sample: /export/content/lid/apps/seas-cloud-searcher/11ed246acf2e0be26bd44b29fb620df45ca14481
@@ -160,8 +161,11 @@ public class D2Utils
       }
       userDir = String.join("-", parts.toArray(new String[0]));
     }
-
-    LOG.info("user.dir for raw D2 Client usages: {}", userDir);
+    if (!userDir.equals(originalUserDir))
+    {
+      LOG.info("Transformed user.dir from {} to {}", originalUserDir, userDir);
+    }
+    LOG.info("Use user.dir for raw D2 Client usages: {}", userDir);
     return userDir.substring(1); // remove the leading slash
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.70.0
+version=29.70.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
1. log full announcement data so that app users can observe announcement changes in weight/partition, uri specific properties, etc.
2. For raw d2 client tracking, 
    1) use samza container name if present, for apps like: samza.container.name = waterloo-member-company-standardizer.
    2) remove random string parts in the user.dir, such as:
        `/export/content/lid/apps/seas-cloud-searcher/11ed246acf2e0be26bd44b29fb620df45ca14481` 
and
`/grid/g/tmp/yarn/usercache/seascloud/appcache/application_1747631859816_3737754/container_e42_1747631859816_3737754_01_000011`