### PR TITLE
chore(deps): fix CVE-2024-36124 (org.iq80.snappy:snappy)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,8 +99,8 @@ project.ext.externalDependency = [
   'servletApi': 'javax.servlet:javax.servlet-api:3.1.0',
   'slf4jApi': 'org.slf4j:slf4j-api:1.7.30',
   'slf4jLog4j2': 'org.apache.logging.log4j:log4j-slf4j-impl:2.0.2',
-  'snappy': 'org.iq80.snappy:snappy:0.4',
-  'xerialSnappy': 'org.xerial.snappy:snappy-java:1.1.7.7',
+  'snappy': 'org.iq80.snappy:snappy:0.5',
+  'xerialSnappy': 'org.xerial.snappy:snappy-java:1.1.10.4',
   'spock': 'org.spockframework:spock-core:1.3-groovy-2.5',
   'testng': 'org.testng:testng:6.13.1',
   'velocity': 'org.apache.velocity:velocity-engine-core:2.2',
@@ -475,4 +475,3 @@ project.gradle.buildFinished { BuildResult result ->
     logger.warn msgBuilder.toString()
   }
 }
-

--- a/r2-filter-compression/build.gradle
+++ b/r2-filter-compression/build.gradle
@@ -5,5 +5,6 @@ dependencies {
   compile externalDependency.commonsCompress
   compile externalDependency.commonsIo
   compile externalDependency.snappy
+  compile externalDependency.xerialSnappy
   testCompile externalDependency.testng
 }

--- a/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/SnappyCompressor.java
+++ b/r2-filter-compression/src/main/java/com/linkedin/r2/filter/compression/SnappyCompressor.java
@@ -39,13 +39,13 @@ public class SnappyCompressor extends AbstractCompressor
   @Override
   protected InputStream createInflaterInputStream(InputStream compressedDataStream) throws IOException
   {
-    return new org.iq80.snappy.SnappyInputStream(compressedDataStream, true);
+    return new org.xerial.snappy.SnappyInputStream(compressedDataStream);
   }
 
   @SuppressWarnings("deprecation")
   @Override
   protected OutputStream createDeflaterOutputStream(OutputStream decompressedDataStream) throws IOException
   {
-    return new org.iq80.snappy.SnappyOutputStream(decompressedDataStream);
+    return new org.xerial.snappy.SnappyOutputStream(decompressedDataStream);
   }
 }


### PR DESCRIPTION
[CVE-2024-36124](https://github.com/advisories/GHSA-8wh2-6qhj-h7j9)
iq80 Snappy out-of-bounds read when uncompressing data, leading to JVM crash

I have upgraded the snappy package to a non-vulnerable version which is 0.5, This has breaking changes where the SnappyInputStream and SnappyOutputStream deprecated methods are removed. So I have replaced it with the org.xerial.snappy package.