### PR TITLE
chore(deps): fix CVE-2025-48924 (commons-lang:commons-lang)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ project.ext.externalDependency = [
   'commonsCompress': 'org.apache.commons:commons-compress:1.2',
   'commonsHttpClient': 'commons-httpclient:commons-httpclient:3.1',
   'commonsIo': 'commons-io:commons-io:2.4',
-  'commonsLang': 'commons-lang:commons-lang:2.6',
   'commonsText': 'org.apache.commons:commons-text:1.10.0',
   'disruptor': 'com.lmax:disruptor:3.2.0',
   'easymock': 'org.easymock:easymock:4.0.2',

--- a/darkcluster-test-api/src/main/java/com/linkedin/darkcluster/MockClient.java
+++ b/darkcluster-test-api/src/main/java/com/linkedin/darkcluster/MockClient.java
@@ -29,7 +29,7 @@ import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.message.rest.RestResponseBuilder;
 import com.linkedin.r2.transport.common.Client;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * MockClient that allows failing requests and recording url authority

--- a/multipart-mime/build.gradle
+++ b/multipart-mime/build.gradle
@@ -2,7 +2,6 @@ dependencies {
   compile project(':r2-core')
   compile project(':data')
   compile externalDependency.javaxActivation
-  compile externalDependency.commonsLang
   testCompile project(':r2-int-test')
   testCompile externalDependency.testng
   testCompile externalDependency.mail

--- a/r2-int-test/build.gradle
+++ b/r2-int-test/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     testCompile project(path: ':r2-core', configuration: 'testArtifacts')
     testCompile externalDependency.testng
     testCompile externalDependency.junit
-    compile externalDependency.commonsLang
 }
 
 tasks.withType(Test) {

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestAlpnUpgradePromise.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestAlpnUpgradePromise.java
@@ -20,7 +20,7 @@ import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.r2.sample.Bootstrap;
 import com.linkedin.r2.sample.echo.EchoService;
 import com.linkedin.r2.sample.echo.rest.RestEchoClient;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.testng.Assert;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamClientTimeout.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamClientTimeout.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.testng.Assert;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;

--- a/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamingTimeout.java
+++ b/r2-int-test/src/test/java/test/r2/integ/clientserver/TestStreamingTimeout.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.testng.Assert;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;

--- a/r2-netty/build.gradle
+++ b/r2-netty/build.gradle
@@ -5,7 +5,6 @@ dependencies {
   compile project(':r2-disruptor')
   compile project(':r2-filter-compression')
 
-  compile externalDependency.commonsLang
   compile externalDependency.netty
 
   testCompile project(path: ':r2-core', configuration: 'testArtifacts')

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http/HttpChannelPoolFactory.java
@@ -34,7 +34,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 /**

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
@@ -34,7 +34,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 /**

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
@@ -75,7 +75,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/restli-client/build.gradle
+++ b/restli-client/build.gradle
@@ -11,7 +11,6 @@ dependencies {
   compile externalDependency.parseq
   compile externalDependency.parseq_restClient
   compile externalDependency.mail
-  compile externalDependency.commonsLang
   implementation externalDependency.caffeine
   testCompile project(path: ':restli-common', configuration: 'testArtifacts')
   testCompile project(path: ':restli-internal-testutils', configuration: 'testArtifacts')

--- a/restli-client/src/main/java/com/linkedin/restli/client/util/RestliRequestUriSignature.java
+++ b/restli-client/src/main/java/com/linkedin/restli/client/util/RestliRequestUriSignature.java
@@ -40,10 +40,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 
 /**

--- a/restli-common-testutils/build.gradle
+++ b/restli-common-testutils/build.gradle
@@ -4,7 +4,6 @@ dependencies {
   compile project(':data')
   compile project(':restli-common')
   compile externalDependency.testng
-  compile externalDependency.commonsLang
 
   testCompile project(path: ':restli-int-test-api', configuration: 'dataTemplate')
   testCompile project(path: ':restli-example-api', configuration: 'dataTemplate')

--- a/restli-common-testutils/src/main/java/com/linkedin/restli/common/testutils/DataAssert.java
+++ b/restli-common-testutils/src/main/java/com/linkedin/restli/common/testutils/DataAssert.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 
 

--- a/restli-docgen/build.gradle
+++ b/restli-docgen/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   compile project(':restli-common')
   compile project(':restli-server')
   compile project(':restli-client')
-  compile externalDependency.commonsLang
   compile externalDependency.jacksonCore
   compile externalDependency.velocity
 

--- a/restli-int-test-server/build.gradle
+++ b/restli-int-test-server/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   compile project(':restli-server')
   compile project(':restli-server-extras')
   compile project(':restli-common')
-  compile externalDependency.commonsLang
   compile externalDependency.javaxInject
   compile externalDependency.parseq
   testCompile project(path: ':restli-int-test-api', configuration: 'testDataTemplate')

--- a/restli-int-test/build.gradle
+++ b/restli-int-test/build.gradle
@@ -14,7 +14,6 @@ dependencies {
   compile project(':restli-tools')
   compile project(':d2')
   compile externalDependency.guava
-  compile externalDependency.commonsLang
   compile externalDependency.javaxInject
   compile externalDependency.parseq
   testCompile project(path: ':restli-common', configuration: 'testArtifacts')

--- a/restli-int-test/src/test/java/com/linkedin/restli/examples/TestGreetingsClientAcceptTypes.java
+++ b/restli-int-test/src/test/java/com/linkedin/restli/examples/TestGreetingsClientAcceptTypes.java
@@ -43,7 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -238,7 +238,7 @@ public class TestGreetingsClientAcceptTypes extends RestLiIntegrationTest
     Object[][] result = new Object[oldBuildersDataProvider.length + newBuildersDataProvider.length][];
 
     int currResultIndex = 0;
-    for (Object[] arguments : (Object[][]) ArrayUtils.addAll(oldBuildersDataProvider, newBuildersDataProvider))
+    for (Object[] arguments : ArrayUtils.addAll(oldBuildersDataProvider, newBuildersDataProvider))
     {
       Object[] newArguments = arguments;
       newArguments[builderIndex] = new RootBuilderWrapper<Long, Greeting>(newArguments[builderIndex]);

--- a/restli-server-extras/build.gradle
+++ b/restli-server-extras/build.gradle
@@ -10,7 +10,6 @@ dependencies {
   compile project(':restli-server')
   compile project(':pegasus-common')
   compile project(':multipart-mime')
-  compile externalDependency.commonsLang
   compile externalDependency.commonsIo
   compile externalDependency.parseq
   testCompile project(path: ':restli-internal-testutils', configuration: 'testArtifacts')

--- a/restli-server-extras/src/main/java/com/linkedin/restli/server/ParseqTraceDebugRequestHandler.java
+++ b/restli-server-extras/src/main/java/com/linkedin/restli/server/ParseqTraceDebugRequestHandler.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 
 /**
@@ -297,7 +297,7 @@ public class ParseqTraceDebugRequestHandler implements RestLiDebugRequestHandler
     String result = String.format(
         TRACE_RENDER_SCRIPT,
         TRACE_RENDER_FUNCTION,
-        StringEscapeUtils.escapeJavaScript(trace));
+        StringEscapeUtils.escapeEcmaScript(trace));
 
     return result;
   }

--- a/restli-server/build.gradle
+++ b/restli-server/build.gradle
@@ -12,7 +12,6 @@ dependencies {
   compile externalDependency.caffeine
   compile externalDependency.javaxInject
   compile externalDependency.mail
-  compile externalDependency.commonsLang
   compile externalDependency.commonsIo
   compile externalDependency.jacksonCore
   compile externalDependency.parseq

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/util/MIMEParse.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/util/MIMEParse.java
@@ -12,8 +12,8 @@ import java.util.Map;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * Released Under the MIT license
@@ -302,7 +302,7 @@ public final class MIMEParse
         .reduce((first, second) -> second)
         .orElseThrow(() -> new InvalidMimeTypeException(header));
 
-    return NumberUtils.compare(lastOne.quality, 0) != 0 ? lastOne.mimeType : "";
+    return Float.compare(lastOne.quality, 0f) != 0 ? lastOne.mimeType : "";
   }
 
   /**

--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/util/RestUtils.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/util/RestUtils.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 /**

--- a/restli-server/src/main/java/com/linkedin/restli/server/PagingContext.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/PagingContext.java
@@ -16,8 +16,8 @@
 
 package com.linkedin.restli.server;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * @author dellamag

--- a/restli-server/src/main/java/com/linkedin/restli/server/RestliServlet.java
+++ b/restli-server/src/main/java/com/linkedin/restli/server/RestliServlet.java
@@ -35,7 +35,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServlet;
 
 import com.linkedin.r2.transport.http.server.RAPServlet;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/restli-server/src/test/java/com/linkedin/restli/server/multiplexer/SynchronousRequestHandler.java
+++ b/restli-server/src/test/java/com/linkedin/restli/server/multiplexer/SynchronousRequestHandler.java
@@ -22,7 +22,7 @@ import com.linkedin.r2.message.RequestContext;
 import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.transport.common.RestRequestHandler;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 
 
 /**

--- a/restli-tools/build.gradle
+++ b/restli-tools/build.gradle
@@ -49,7 +49,6 @@ dependencies {
   compile externalDependency.commonsIo
   compile externalDependency.codemodel
   compile externalDependency.commonsCli
-  compile externalDependency.commonsLang
   compile externalDependency.jacksonCore
   compile externalDependency.jacksonDataBind
   compile externalDependency.jdkTools
@@ -76,7 +75,6 @@ dependencies {
     java11Compile externalDependency.commonsIo
     java11Compile externalDependency.codemodel
     java11Compile externalDependency.commonsCli
-    java11Compile externalDependency.commonsLang
     java11Compile externalDependency.jacksonCore
     java11Compile externalDependency.jacksonDataBind
     java11Compile externalDependency.velocity

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ActionMethodSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ActionMethodSpec.java
@@ -24,7 +24,7 @@ import com.linkedin.restli.restspec.ParameterSchemaArray;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang3.ClassUtils;
 
 
 public class ActionMethodSpec extends MethodSpec

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/AssociationResourceSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/AssociationResourceSpec.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang.ClassUtils;
 
 import static org.apache.commons.lang3.ClassUtils.getShortClassName;
 

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/BaseResourceSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/BaseResourceSpec.java
@@ -89,7 +89,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/CollectionResourceSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/CollectionResourceSpec.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang3.ClassUtils;
 
 
 public class CollectionResourceSpec extends BaseResourceSpec

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ComplexKeySpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ComplexKeySpec.java
@@ -18,7 +18,7 @@ package com.linkedin.restli.tools.clientgen.fluentspec;
 
 import com.linkedin.restli.common.ComplexResourceKey;
 import java.util.Map;
-import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang3.ClassUtils;
 
 
 /**

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ParameterSpec.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/clientgen/fluentspec/ParameterSpec.java
@@ -22,7 +22,7 @@ import com.linkedin.pegasus.generator.spec.ClassTemplateSpec;
 import com.linkedin.restli.internal.tools.RestLiToolsUtils;
 import com.linkedin.restli.restspec.ParameterSchema;
 import com.linkedin.restli.restspec.RestSpecCodec;
-import org.apache.commons.lang.ClassUtils;
+import org.apache.commons.lang3.ClassUtils;
 
 
 public class ParameterSpec

--- a/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityInfo.java
+++ b/restli-tools/src/main/java/com/linkedin/restli/tools/idlcheck/CompatibilityInfo.java
@@ -17,9 +17,9 @@
 package com.linkedin.restli.tools.idlcheck;
 
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.List;
 

--- a/test-util/build.gradle
+++ b/test-util/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
     compile externalDependency.testng
-    compile externalDependency.commonsLang
     compile project(':pegasus-common')
 }


### PR DESCRIPTION
Remove commons-lang and migrate to commons-lang3 to address vulnerabilities
This PR removes the usage of the deprecated commons-lang (org.apache.commons.lang) library and replaces it with commons-lang3 (org.apache.commons.lang3).

Details:
	•	Removed the commons-lang dependency from the project.
	•	Replaced all references to deprecated classes such as StringUtils, NumberUtils, and SerializationUtils with their equivalents from commons-lang3.
	•	Verified API compatibility and functional equivalence for all replacements.

scanner started reporting two items in commons-lang 2.6 as blocker bugs.

https://issues.apache.org/jira/browse/LANG-1049
https://issues.apache.org/jira/browse/LANG-805


I have created a issue to address this: https://github.com/linkedin/rest.li/issues/1084
