### PR TITLE
add error log for raw D2 client call stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.70.2] - 2025-08-01
+- Add error log for raw D2 client call stack
+
 ## [29.70.1] - 2025-07-17
 - log full announcement data at markup. Use samza container name and process user dir for tracking raw d2 client.
 
@@ -5852,7 +5855,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.70.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.70.2...master
+[29.70.2]: https://github.com/linkedin/rest.li/compare/v29.70.1...v29.70.2
 [29.70.1]: https://github.com/linkedin/rest.li/compare/v29.70.0...v29.70.1
 [29.70.0]: https://github.com/linkedin/rest.li/compare/v29.69.10...v29.70.0
 [29.69.10]: https://github.com/linkedin/rest.li/compare/v29.69.9...v29.69.10

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -60,8 +60,6 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
   public LoadBalancerWithFacilities create(D2ClientConfig config)
   {
     LOG.info("Creating D2 LoadBalancer based on LastSeenLoadBalancerWithFacilities");
-    //TODO: In FY26Q2, Throw exception to hard fail raw d2 client using non INDIS load balancer type, unless talking
-    // to a local or EI ZK (for some tests).
     logLoadBalancerTypeWarning(LOG);
     if (config.isLiRawD2Client)
     {

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesFactory.java
@@ -30,7 +30,7 @@ public interface LoadBalancerWithFacilitiesFactory
       + "is deprecated (unless talking to a locally-deployed ZK, or for testing EI ZK) and must be migrated to INDIS. "
       + "See instructions at go/onboardindis.\n"
       + "Failing to do so will block other apps from stopping ZK announcements and will be escalated for site-up "
-      + "stability. Non-INDIS D2 Client will CRASH in OCTOBER 2025.";
+      + "stability.";
 
   /**
    * Creates instance of {@link LoadBalancerWithFacilities}
@@ -41,7 +41,7 @@ public interface LoadBalancerWithFacilitiesFactory
 
   default void logLoadBalancerTypeWarning(@Nonnull Logger LOG)
   {
-    LOG.warn(LOAD_BALANCER_TYPE_WARNING);
+    LOG.error(LOAD_BALANCER_TYPE_WARNING);
   }
 
   default void logAppProps(@Nonnull Logger LOG)

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -39,8 +39,6 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
   public LoadBalancerWithFacilities create(D2ClientConfig config)
   {
     LOG.info("Creating D2 LoadBalancer based on ZKFSLoadBalancerWithFacilitiesFactory");
-    //TODO: In FY26Q2, Throw exception to hard fail raw d2 client using non INDIS load balancer type, unless talking
-    // to a local or EI ZK (for some tests).
     logLoadBalancerTypeWarning(LOG);
     if (config.isLiRawD2Client)
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.70.1
+version=29.70.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
To solve the issue that consumer app owners doesn't know which library is creating zk-reading raw d2 client in their app,
log an error with the call stack, so that consumer app owner and us will see exactly which code is creating zk-reading raw d2 client.

## Test Done
QEI deploy indis-canary, see the error log shows the call stack.
 
2025/08/01 11:03:53.085 ERROR [D2ClientBuilder] [main] [indis-canary] [] [ACTION REQUIRED] Using Zookeeper-reading raw D2 Client. WILL CRASH in OCTOBER 2025. See instructions at go/onboardindis.
Using in stack: java.base/java.lang.Thread.getStackTrace(Thread.java:1607)
com.linkedin.d2.balancer.D2ClientBuilder.build(D2ClientBuilder.java:108)
com.linkedin.indis.canary.grpc.RawD2Client.createRawD2Client(RawD2Client.java:40)
com.linkedin.indis.canary.grpc.RawD2Client.<init>(RawD2Client.java:22)
com.linkedin.indis.canary.factories.RawD2ClientFactory.createInstance(RawD2ClientFactory.java:43)
com.linkedin.indis.canary.factories.RawD2ClientFactory.createInstance(RawD2ClientFactory.java:20)
com.linkedin.util.factory.SimpleSingletonFactory.createInstance(SimpleSingletonFactory.java:20)
com.linkedin.util.factory.SimpleSingletonFactory.createInstance(SimpleSingletonFactory.java:14)
com.linkedin.util.factory.Generator.doGetBean(Generator.java:574)
com.linkedin.util.factory.Generator.getBean(Generator.java:437)
com.linkedin.indis.canary.factories.IndisCanaryBootListener.onBoot(IndisCanaryBootListener.java:51)
com.linkedin.aves.boot.Main.boot(Main.java:55)
com.linkedin.aves.boot.Main.main(Main.java:37)