### PR TITLE
Add isIndisOnly to LoadBalancerWithFacilitiesFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.71.0] - 2025-08-04
+- Add isIndisOnly to LoadBalancerWithFacilitiesFactory
+
 ## [29.70.2] - 2025-08-01
 - Add error log for raw D2 client call stack
 
@@ -5855,7 +5858,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.70.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.71.0...master
+[29.71.0]: https://github.com/linkedin/rest.li/compare/v29.70.2...v29.71.0
 [29.70.2]: https://github.com/linkedin/rest.li/compare/v29.70.1...v29.70.2
 [29.70.1]: https://github.com/linkedin/rest.li/compare/v29.70.0...v29.70.1
 [29.70.0]: https://github.com/linkedin/rest.li/compare/v29.69.10...v29.70.0

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -95,7 +95,8 @@ public class D2ClientBuilder
    */
   public D2Client build()
   {
-    if (!_config.disableDetectLiRawD2Client && isLiRawD2Client()) {
+    if (!_config.disableDetectLiRawD2Client && isLiRawD2Client())
+    {
       LOG.warn("ATTENTION: Using hard-coded D2ClientBuilder to create a raw LI D2 client. Always consider using the "
           + "D2DefaultClientFactory in container. Raw D2 client will not have future features and migrations done "
           + "automatically, requiring lots of manual toil from your team.");

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -95,26 +95,6 @@ public class D2ClientBuilder
    */
   public D2Client build()
   {
-    if (!_config.disableDetectLiRawD2Client && isLiRawD2Client())
-    {
-      LOG.warn("ATTENTION: Using hard-coded D2ClientBuilder to create a raw LI D2 client. Always consider using the "
-          + "D2DefaultClientFactory in container. Raw D2 client will not have future features and migrations done "
-          + "automatically, requiring lots of manual toil from your team.");
-      _config.isLiRawD2Client = true;
-
-      // log error for not using INDIS in raw d2 client
-      if (!(_config.lbWithFacilitiesFactory instanceof XdsLoadBalancerWithFacilitiesFactory))
-      {
-        String stackTrace = Arrays.stream(Thread.currentThread().getStackTrace())
-            .map(StackTraceElement::toString)
-            .collect(Collectors.joining("\n"));
-        //TODO: In FY26Q2, Throw exception to hard fail non INDIS raw d2 client
-        LOG.error("[ACTION REQUIRED] Using Zookeeper-reading raw D2 Client. WILL CRASH in OCTOBER 2025. "
-            + "See instructions at go/onboardindis.\n"
-            + "Using in stack: {}", stackTrace);
-      }
-    }
-
     final Map<String, TransportClientFactory> transportClientFactories = (_config.clientFactories == null) ?
         createDefaultTransportClientFactories() :  // if user didn't provide transportClientFactories we'll use default ones
         _config.clientFactories;
@@ -253,6 +233,26 @@ public class D2ClientBuilder
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() :
       _config.lbWithFacilitiesFactory;
+
+    if (!_config.disableDetectLiRawD2Client && isLiRawD2Client())
+    {
+      LOG.warn("ATTENTION: Using hard-coded D2ClientBuilder to create a raw LI D2 client. Always consider using the "
+          + "D2DefaultClientFactory in container. Raw D2 client will not have future features and migrations done "
+          + "automatically, requiring lots of manual toil from your team.");
+      _config.isLiRawD2Client = true;
+
+      // log error for not using INDIS in raw d2 client
+      if (!loadBalancerFactory.isIndisOnly())
+      {
+        String stackTrace = Arrays.stream(Thread.currentThread().getStackTrace())
+            .map(StackTraceElement::toString)
+            .collect(Collectors.joining("\n"));
+        //TODO: In FY26Q2, Throw exception to hard fail non INDIS raw d2 client
+        LOG.error("[ACTION REQUIRED] Using Zookeeper-reading raw D2 Client. WILL CRASH in OCTOBER 2025. "
+            + "See instructions at go/onboardindis.\n"
+            + "Using in stack: {}", stackTrace);
+      }
+    }
 
     LoadBalancerWithFacilities loadBalancer = loadBalancerFactory.create(cfg);
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerWithFacilitiesFactory.java
@@ -33,6 +33,14 @@ public interface LoadBalancerWithFacilitiesFactory
       + "stability.";
 
   /**
+   * Returns true if the load balancer is backed only by INDIS (i.e. not ZK or dual read).
+   */
+  default boolean isIndisOnly()
+  {
+    return false;
+  }
+
+  /**
    * Creates instance of {@link LoadBalancerWithFacilities}
    * @param config configuration of d2 client
    * @return new instance of {@link LoadBalancerWithFacilities}

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -39,6 +39,12 @@ import org.apache.commons.lang3.ObjectUtils;
 public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFacilitiesFactory
 {
   @Override
+  public boolean isIndisOnly()
+  {
+    return true;
+  }
+
+  @Override
   public LoadBalancerWithFacilities create(D2ClientConfig config)
   {
     D2ClientJmxManager d2ClientJmxManager = new D2ClientJmxManager(config.d2JmxManagerPrefix, config.jmxManager,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.70.2
+version=29.71.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
As a followup to previous PR https://github.com/linkedin/rest.li/pull/1085, use isIndisOnly in LoadBalancerWithFacilitiesFactory to check if the load balancer is indis-only read, instead of checking if it's an instance of XdsLoadBalancerWithFacilitiesFactory. Since some [user app code](https://jarvis.corp.linkedin.com/codesearch/result/?name=RestClientFactoryUtils.java&path=nuage-sdk%2Fnuage-sdk%2Fsrc%2Fmain%2Fjava%2Fcom%2Flinkedin%2Fnuagesdk%2Futil&reponame=linkedin-multiproduct%2Fnuage-sdk#118) is wrapping a XdsLoadBalancerWithFacilitiesFactory inside a CallTrackingLoadBalancerFactory. 

Created a [container PR](https://github.com/linkedin-multiproduct/container/pull/1847) to let CallTrackingLoadBalancerFactory returns isIndisOnly from its inner wrapped factory.

## Test Done
QEI deploy indis-canary