### PR TITLE
Introduce new IPv6 aware Pick First policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.71.1] - 2025-08-07
+- Introduce new IPv6 aware Pick First policy
+
 ## [29.71.0] - 2025-08-04
 - Add isIndisOnly to LoadBalancerWithFacilitiesFactory
 
@@ -5858,7 +5861,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.71.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.71.1...master
+[29.71.1]: https://github.com/linkedin/rest.li/compare/v29.71.0...v29.71.1
 [29.71.0]: https://github.com/linkedin/rest.li/compare/v29.70.2...v29.71.0
 [29.70.2]: https://github.com/linkedin/rest.li/compare/v29.70.1...v29.70.2
 [29.70.1]: https://github.com/linkedin/rest.li/compare/v29.70.0...v29.70.1

--- a/d2/src/main/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancer.java
@@ -1,0 +1,158 @@
+package com.linkedin.d2.xds;
+
+import com.google.common.collect.ImmutableList;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.Status;
+import io.grpc.internal.JsonUtil;
+import io.grpc.internal.PickFirstLoadBalancerProvider;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class IPv6AwarePickFirstLoadBalancer extends LoadBalancer
+{
+  public static final String POLICY_NAME = "ipv6_aware_random_pick_first";
+  public static final String IPV4_FIRST = "ipv4_first";
+
+  private final LoadBalancer _pickFirst;
+
+  IPv6AwarePickFirstLoadBalancer(Helper helper)
+  {
+    _pickFirst = new PickFirstLoadBalancerProvider().newLoadBalancer(helper);
+  }
+
+  @Override
+  public boolean acceptResolvedAddresses(ResolvedAddresses addresses)
+  {
+    List<EquivalentAddressGroup> ipv6EAGs = new ArrayList<>();
+    List<EquivalentAddressGroup> ipv4EAGs = new ArrayList<>();
+    for (EquivalentAddressGroup eag : addresses.getAddresses())
+    {
+      (hasIPv6Address(eag) ? ipv6EAGs : ipv4EAGs).add(eag);
+    }
+
+    Collections.shuffle(ipv6EAGs);
+    Collections.shuffle(ipv4EAGs);
+
+    List<EquivalentAddressGroup> shuffledEAGs = new ArrayList<>();
+    if (addresses.getLoadBalancingPolicyConfig() instanceof Config
+        && ((Config) addresses.getLoadBalancingPolicyConfig())._ipv4First)
+    {
+      shuffledEAGs.addAll(ipv4EAGs);
+      shuffledEAGs.addAll(ipv6EAGs);
+    }
+    else
+    {
+      shuffledEAGs.addAll(ipv6EAGs);
+      shuffledEAGs.addAll(ipv4EAGs);
+    }
+
+    return _pickFirst.acceptResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setAddresses(shuffledEAGs)
+            .setAttributes(addresses.getAttributes())
+            .setLoadBalancingPolicyConfig(addresses.getLoadBalancingPolicyConfig())
+            .build()
+    );
+  }
+
+  private static boolean hasIPv6Address(EquivalentAddressGroup eag)
+  {
+    for (SocketAddress address : eag.getAddresses())
+    {
+      if (!(address instanceof InetSocketAddress))
+      {
+        continue;
+      }
+      if (((InetSocketAddress) address).getAddress() instanceof Inet6Address)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void handleNameResolutionError(Status error)
+  {
+    _pickFirst.handleNameResolutionError(error);
+  }
+
+  @Override
+  public void shutdown()
+  {
+    _pickFirst.shutdown();
+  }
+
+  @Override
+  public void requestConnection()
+  {
+    _pickFirst.requestConnection();
+  }
+
+  private static class Config
+  {
+    private final boolean _ipv4First;
+
+    private Config(@Nullable Boolean ipv4First)
+    {
+      _ipv4First = (ipv4First != null) ? ipv4First : false;
+    }
+  }
+
+  private static final class Provider extends LoadBalancerProvider
+  {
+    static
+    {
+      LoadBalancerRegistry.getDefaultRegistry().register(new Provider());
+    }
+
+    @Override
+    public boolean isAvailable()
+    {
+      return true;
+    }
+
+    @Override
+    public int getPriority()
+    {
+      return 5;
+    }
+
+    @Override
+    public String getPolicyName()
+    {
+      return POLICY_NAME;
+    }
+
+    @Override
+    public LoadBalancer newLoadBalancer(LoadBalancer.Helper helper)
+    {
+      return new IPv6AwarePickFirstLoadBalancer(helper);
+    }
+
+    @Override
+    public ConfigOrError parseLoadBalancingPolicyConfig(Map<String, ?> rawLoadBalancingPolicyConfig)
+    {
+      try
+      {
+        return ConfigOrError.fromConfig(new Config(JsonUtil.getBoolean(rawLoadBalancingPolicyConfig, IPV4_FIRST)));
+      }
+      catch (RuntimeException e)
+      {
+        return ConfigOrError.fromError(
+            Status.UNAVAILABLE.withCause(e).withDescription(
+                "Failed parsing configuration for " + getPolicyName()));
+      }
+    }
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancer.java
@@ -26,12 +26,21 @@ import java.util.Map;
  */
 public class IPv6AwarePickFirstLoadBalancer extends LoadBalancer
 {
+  // The initialization of this variable deliberately prevents the compiler from using this string as a compile-time
+  // constant. This way, referencing the policy by its name like the following code *always* executes this static
+  // block, registering the Provider:
+  //   LoadBalancerRegistry.getDefaultRegistry().getProvider(POLICY_NAME);
+  // Similarly, referencing the policy during a ManagedChannel builder will also implicitly register the policy:
+  //   builder.defaultLoadBalancingPolicy(POLICY_NAME);
+  // Otherwise, POLICY_NAME would get resolved at compile-time, the static block would not get executed and the policy
+  // would not be registered.
+  public static final String POLICY_NAME;
+
   static
   {
+    POLICY_NAME = "ipv6_aware_random_pick_first";
     LoadBalancerRegistry.getDefaultRegistry().register(new Provider());
   }
-
-  public static final String POLICY_NAME = "ipv6_aware_random_pick_first";
 
   private final LoadBalancer _delegate;
 
@@ -144,6 +153,7 @@ public class IPv6AwarePickFirstLoadBalancer extends LoadBalancer
     @Override
     public String getPolicyName()
     {
+
       return POLICY_NAME;
     }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancer.java
@@ -12,7 +12,9 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 /**
@@ -82,17 +84,17 @@ public class IPv6AwarePickFirstLoadBalancer extends LoadBalancer
 
     List<EquivalentAddressGroup> shuffledEAGs = new ArrayList<>(addresses);
 
-    int ipv4Index = 0;
-    int ipv6Index = 0;
+    Iterator<EquivalentAddressGroup> ipv4Iterator = ipv4EAGs.iterator();
+    Iterator<EquivalentAddressGroup> ipv6Iterator = ipv6EAGs.iterator();
     for (int i = 0; i < shuffledEAGs.size(); i++)
     {
       if (hasIPv6Address(shuffledEAGs.get(i)))
       {
-        shuffledEAGs.set(i, ipv6EAGs.get(ipv6Index++));
+        shuffledEAGs.set(i, ipv6Iterator.next());
       }
       else
       {
-        shuffledEAGs.set(i, ipv4EAGs.get(ipv4Index++));
+        shuffledEAGs.set(i, ipv4Iterator.next());
       }
     }
 
@@ -147,6 +149,7 @@ public class IPv6AwarePickFirstLoadBalancer extends LoadBalancer
     @Override
     public int getPriority()
     {
+      // 5 is the same priority as PickFirstLoadBalancerProvider.
       return 5;
     }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
@@ -16,11 +16,28 @@
 
 package com.linkedin.d2.xds;
 
+import com.google.common.collect.ImmutableList;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.NameResolver;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancerProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.JsonUtil;
+import io.grpc.internal.PickFirstLoadBalancerProvider;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsChannelFactory.java
@@ -16,28 +16,11 @@
 
 package com.linkedin.d2.xds;
 
-import com.google.common.collect.ImmutableList;
-import io.grpc.EquivalentAddressGroup;
-import io.grpc.LoadBalancerRegistry;
-import io.grpc.NameResolver;
-import io.grpc.NameResolver.ConfigOrError;
-import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancerProvider;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.JsonUtil;
-import io.grpc.internal.PickFirstLoadBalancerProvider;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;

--- a/d2/src/test/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancerTest.java
@@ -1,0 +1,85 @@
+package com.linkedin.d2.xds;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.NameResolver;
+import io.grpc.NameResolver.ConfigOrError;
+import io.grpc.SynchronizationContext;
+import io.grpc.internal.PickFirstLoadBalancerProvider;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.linkedin.d2.xds.IPv6AwarePickFirstLoadBalancer.*;
+import static org.mockito.Matchers.intThat;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.*;
+
+public class IPv6AwarePickFirstLoadBalancerTest
+{
+  @Test(invocationCount = 10)
+  public void testShuffling()
+  {
+    List<EquivalentAddressGroup> addresses = new ArrayList<>();
+    for (int i = 0; i < 100; i++)
+    {
+      addresses.add(newGroup(ThreadLocalRandom.current().nextBoolean()));
+    }
+
+    LoadBalancer mock = Mockito.mock(LoadBalancer.class);
+    IPv6AwarePickFirstLoadBalancer lb = new IPv6AwarePickFirstLoadBalancer(mock);
+    lb.acceptResolvedAddresses(ResolvedAddresses.newBuilder().setAddresses(addresses).build());
+
+    ArgumentCaptor<ResolvedAddresses> addressesCaptor = ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(mock).acceptResolvedAddresses(addressesCaptor.capture());
+
+    List<EquivalentAddressGroup> shuffledAddresses = addressesCaptor.getValue().getAddresses();
+    assertNotEquals(addresses, shuffledAddresses);
+    assertEquals(new HashSet<>(addresses), new HashSet<>(shuffledAddresses));
+
+    for (int i = 0; i < addresses.size(); i++)
+    {
+      assertEquals(hasIPv6Address(addresses.get(i)), hasIPv6Address(shuffledAddresses.get(i)));
+    }
+  }
+
+  private static EquivalentAddressGroup newGroup(boolean ipv6)
+  {
+    byte[] addressBytes = new byte[ipv6 ? 4 : 16];
+    ThreadLocalRandom.current().nextBytes(addressBytes);
+    try
+    {
+      return new EquivalentAddressGroup(
+          Collections.singletonList(new InetSocketAddress(InetAddress.getByAddress(addressBytes), 0)));
+    }
+    catch (UnknownHostException e)
+    {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancerTest.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancerTest.java
@@ -1,47 +1,32 @@
 package com.linkedin.d2.xds;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import io.grpc.Attributes;
-import io.grpc.ConnectivityState;
-import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
-import io.grpc.NameResolver;
-import io.grpc.NameResolver.ConfigOrError;
-import io.grpc.SynchronizationContext;
-import io.grpc.internal.PickFirstLoadBalancerProvider;
-import java.net.Inet6Address;
+import io.grpc.LoadBalancerRegistry;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static com.linkedin.d2.xds.IPv6AwarePickFirstLoadBalancer.*;
-import static org.mockito.Matchers.intThat;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.*;
 
 public class IPv6AwarePickFirstLoadBalancerTest
 {
+  @Test
+  public void testRegistration()
+  {
+    assertNotNull(LoadBalancerRegistry.getDefaultRegistry().getProvider(POLICY_NAME));
+  }
+
   @Test(invocationCount = 10)
   public void testShuffling()
   {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.71.0
+version=29.71.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
This new policy, registered under `ipv6_aware_random_pick_first`, is smart enough to only shuffle the addresses within their group. In other words, instead of shuffling IPv4 addresses in between IPv6 addresses, it shuffles the IPv6 and IPv4 addresses independently, and an additional property determines whether IPv4 addresses should appear before IPv6 addresses (defaults to IPv6 first).