### PR TITLE
Add fields from D2URI proto to the pdl to return for debugging with restli-resource-explorer

### DIFF
--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Uri.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Uri.pdl
@@ -11,6 +11,23 @@ record D2Uri {
   URI: string
 
   /**
+   * [optional] URI for this machine with the hostname replaced with an ipv4.
+   */
+  ipv4VariantURI: string
+
+  /**
+   * [optional] URI for this machine with the hostname replaced with an ipv4.
+   */
+  ipv6VariantURI: string
+
+  // TODO: add modified_time
+  hostname: string
+  ipv4Address: string
+  ipv6Address: string
+  isIpv4InSan: boolean
+  isIpv6InSan: boolean
+
+  /**
    * The cluster where this URI belongs.
    */
   clusterName: string


### PR DESCRIPTION
the D2URI proto defined in XdsD2.proto has a lot of fields that might be relevant for debuggging D2-related issues, but none of these are surfaced in the legacy PDL. This PR backports these fields into the D2Uri.pdl for ease of debugging when all you have is the PDL 