### PR TITLE
Bump gRPC version to fix IPv6AwarePickFirstLoadBalancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.74.0] - 2025-08-12
+- Bump gRPC version to fix IPv6AwarePickFirstLoadBalancer
+
 ## [29.73.0] - 2025-08-08
 - Empty version bump
 
@@ -5867,7 +5870,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.73.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.74.0...master
+[29.74.0]: https://github.com/linkedin/rest.li/compare/v29.73.0...v29.74.0
 [29.73.0]: https://github.com/linkedin/rest.li/compare/v29.72.1...v29.73.0
 [29.72.1]: https://github.com/linkedin/rest.li/compare/v29.72.0...v29.72.1
 [29.72.0]: https://github.com/linkedin/rest.li/compare/v29.71.0...v29.72.0

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+//import org.gradle.api.attributes.java.TargetJvmEnvironment;
+
 buildscript {
   repositories {
     mavenCentral()
@@ -115,21 +117,21 @@ project.ext.externalDependency = [
   'springBeans': 'org.springframework:spring-beans:3.2.18.RELEASE',
 
   // for restli-guice-bridge ONLY, we should keep these dependencies isolated
-  'guice': 'com.google.inject:guice:3.0',
-  'guiceServlet': 'com.google.inject.extensions:guice-servlet:3.0',
+  'guice'                  : 'com.google.inject:guice:3.0',
+  'guiceServlet'           : 'com.google.inject.extensions:guice-servlet:3.0',
 
-  'jsr305': 'com.google.code.findbugs:jsr305:3.0.0',
-  "avroSpotBugsPlugin": "com.linkedin.avroutil1:spotbugs-plugin:0.2.56",
-  "classgraph": "io.github.classgraph:classgraph:4.8.149",
+  'jsr305'                 : 'com.google.code.findbugs:jsr305:3.0.0',
+  "avroSpotBugsPlugin"     : "com.linkedin.avroutil1:spotbugs-plugin:0.2.56",
+  "classgraph"             : "io.github.classgraph:classgraph:4.8.149",
 
   // for integrating with xDS service discovery
-  'grpcNettyShaded': 'io.grpc:grpc-netty-shaded:1.59.1',
-  'grpcProtobuf': 'io.grpc:grpc-protobuf:1.59.1',
-  'grpcStub': 'io.grpc:grpc-stub:1.59.1',
-  'protoc': 'com.google.protobuf:protoc:3.24.0',
-  'protobufJava': 'com.google.protobuf:protobuf-java:3.24.0',
-  'protobufJavaUtil': 'com.google.protobuf:protobuf-java-util:3.24.0',
-  'envoyApi': 'io.envoyproxy.controlplane:api:0.1.35',
+  'grpcNettyShaded'        : 'io.grpc:grpc-netty-shaded:1.68.3',
+  'grpcProtobuf'           : 'io.grpc:grpc-protobuf:1.68.3',
+  'grpcStub'               : 'io.grpc:grpc-stub:1.68.3',
+  'protoc'                 : 'com.google.protobuf:protoc:3.25.5',
+  'protobufJava'           : 'com.google.protobuf:protobuf-java:3.25.5',
+  'protobufJavaUtil'       : 'com.google.protobuf:protobuf-java-util:3.25.5',
+  'envoyApi'               : 'io.envoyproxy.controlplane:api:0.1.35',
 ];
 
 if (!project.ext.isDefaultEnvironment)
@@ -434,6 +436,25 @@ subprojects {
     }
     logger.lifecycle "Tests for subproject ${project.name} will be skipped."
   }
+
+  dependencies.constraints {
+    add("compile", "com.google.guava:guava") {
+      attributes {
+        attribute(Attribute.of("org.gradle.jvm.environment", String),"standard-jvm")
+//        attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+//                objects.named(TargetJvmEnvironment.STANDARD_JVM))
+      }
+    }
+  }
+
+  configurations.configureEach {
+    resolutionStrategy.capabilitiesResolution.withCapability("com.google.guava:guava") {
+      select(candidates.single { it.variantName.contains("jreRuntimeElements") })
+    }
+    resolutionStrategy.capabilitiesResolution.withCapability("com.google.collections:google-collections") {
+      select(candidates.single { it.variantName.contains("jreRuntimeElements") })
+    }
+  }
 }
 
 final skippedTests = [:].withDefault {[]}
@@ -474,4 +495,3 @@ project.gradle.buildFinished { BuildResult result ->
     logger.warn msgBuilder.toString()
   }
 }
-

--- a/d2/src/main/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/IPv6AwarePickFirstLoadBalancer.java
@@ -6,7 +6,6 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
-import io.grpc.internal.PickFirstLoadBalancerProvider;
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -14,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 
 /**
@@ -48,16 +46,13 @@ public class IPv6AwarePickFirstLoadBalancer extends LoadBalancer
 
   IPv6AwarePickFirstLoadBalancer(Helper helper)
   {
-    this(new PickFirstLoadBalancerProvider().newLoadBalancer(helper));
-  }
-
-  IPv6AwarePickFirstLoadBalancer(LoadBalancer delegate)
-  {
-    _delegate = delegate;
+    _delegate = LoadBalancerRegistry.getDefaultRegistry()
+        .getProvider("pick_first")
+        .newLoadBalancer(helper);
   }
 
   @Override
-  public boolean acceptResolvedAddresses(ResolvedAddresses resolvedAddresses)
+  public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses)
   {
     return _delegate.acceptResolvedAddresses(resolvedAddresses.toBuilder()
         .setAddresses(ipAwareShuffle(resolvedAddresses.getAddresses()))
@@ -156,7 +151,6 @@ public class IPv6AwarePickFirstLoadBalancer extends LoadBalancer
     @Override
     public String getPolicyName()
     {
-
       return POLICY_NAME;
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.73.0
+version=29.74.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
The signature of `LoadBalancer#acceptResolvedAddresses` was changed from returning a boolean to a `io.grpc.Status`. This meant invoking `IPv6AwarePickFirstLoadBalancer#acceptResolvedAddresses` was invoking the default definition in the parent abstract class instead of the actual overridden definition in `IPv6AwarePickFirstLoadBalancer`. Strangely, it did not cause any runtime exceptions such as NoSuchMethodError.