### PR TITLE
Correct xds client latency metric and SD update receipt event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.74.2] - 2025-08-14
+- Correct xds client latency metric and SD update receipt event
+
 ## [29.74.1] - 2025-08-13
 - Add new fields to D2Uri.pdl for debugging. These mirror fields in the D2URI proto in XdsD2.proto.
 
@@ -5873,7 +5876,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.74.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.74.2...master
+[29.74.2]: https://github.com/linkedin/rest.li/compare/v29.74.1...v29.74.2
 [29.74.1]: https://github.com/linkedin/rest.li/compare/v29.74.0...v29.74.1
 [29.74.0]: https://github.com/linkedin/rest.li/compare/v29.73.0...v29.74.0
 [29.73.0]: https://github.com/linkedin/rest.li/compare/v29.72.1...v29.73.0

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -65,7 +65,7 @@ public abstract class XdsClient
      */
     public void onReconnect()
     {
-      resetWatchedAt();
+      resetWatchedAt(); // Reconnected needs to reset the watchedAt time to the current time for tracking purposes.
     }
 
     abstract void onChanged(ResourceUpdate update);

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClient.java
@@ -19,6 +19,7 @@ package com.linkedin.d2.xds;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.linkedin.d2.jmx.XdsClientJmx;
+import com.linkedin.util.clock.SystemClock;
 import indis.XdsD2;
 import io.grpc.Status;
 import java.util.Arrays;
@@ -37,6 +38,7 @@ public abstract class XdsClient
   public static abstract class ResourceWatcher
   {
     private final ResourceType _type;
+    protected long _watchedAt = SystemClock.instance().currentTimeMillis();
 
     /**
      * Defining a private constructor means only classes that are defined in this file can extend this class. This way,
@@ -61,9 +63,17 @@ public abstract class XdsClient
     /**
      * Called when the resource discovery RPC reestablishes connection.
      */
-    public abstract void onReconnect();
+    public void onReconnect()
+    {
+      resetWatchedAt();
+    }
 
     abstract void onChanged(ResourceUpdate update);
+
+    private void resetWatchedAt()
+    {
+      _watchedAt = SystemClock.instance().currentTimeMillis();
+    }
   }
 
   public static abstract class NodeResourceWatcher extends ResourceWatcher
@@ -117,6 +127,7 @@ public abstract class XdsClient
   public static abstract class WildcardResourceWatcher
   {
     private final ResourceType _type;
+    protected long _watchedAt = SystemClock.instance().currentTimeMillis();
 
     /**
      * Defining a private constructor means only classes that are defined in this file can extend this class (see
@@ -140,7 +151,10 @@ public abstract class XdsClient
     /**
      * Called when the resource discovery RPC reestablishes connection.
      */
-    public abstract void onReconnect();
+    public void onReconnect()
+    {
+      resetWatchedAt();
+    }
 
     /**
      * Called when a resource is added or updated.
@@ -163,6 +177,11 @@ public abstract class XdsClient
     public void onAllResourcesProcessed()
     {
       // do nothing
+    }
+
+    private void resetWatchedAt()
+    {
+      _watchedAt = SystemClock.instance().currentTimeMillis();
     }
   }
 

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -941,7 +941,7 @@ public class XdsClientImpl extends XdsClient
     @VisibleForTesting
     void onReconnect()
     {
-      resetSubscribedAt();
+      resetSubscribedAt(); // Reconnected needs to reset the subscribe time to the current time for tracking purposes.
       for (ResourceWatcher watcher : _watchers)
       {
         watcher.onReconnect();
@@ -1074,7 +1074,7 @@ public class XdsClientImpl extends XdsClient
     @VisibleForTesting
     void onReconnect()
     {
-      resetSubscribedAt();
+      resetSubscribedAt(); // Reconnected needs to reset the subscribe time to the current time for tracking purposes.
       for (WildcardResourceWatcher watcher : _watchers)
       {
         watcher.onReconnect();

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsDirectory.java
@@ -131,12 +131,6 @@ public class XdsDirectory implements Directory
       {
         // do nothing
       }
-
-      @Override
-      public void onReconnect()
-      {
-        // do nothing
-      }
     };
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.74.1
+version=29.74.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
This PR corrects a few things for calculation xds client latency and the emission of SD update receipt event for e2e propagation latency in Kusto dashboard. It will remove false spikes for these two latencies caused by server updates happened before the client starts its subscription. 
1. When resource modified time is before the client starts subscribing, use the subscribe time.
2. When resource modified time is before the watcher starts watching, skip emitting SD update receipt event (Kusto will blindly associate the server update sent event with the client receipt event based on tracing ID, causing incorrect huge e2e latency on the dashboard. So just skip client receipt event for this case).
3. Reset subscribe/watch time when reconnected to INDIS.
4. Also correct wildcard subscribes to also calculate xds client latency for all resources it receives.

#Test Done
Verified in UTs for various cases:
1) resource modified time < subscribe/watch time
2) resource modified time > subscribe/watch time
3) reset subscribe/watch time