### PR TITLE
DataTranslator: simple name union check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.74.3-rc.1] - 2025-09-02
+## [29.74.4-rc.1] - 2025-09-02
 - DataTranslator: fall back to matching simple 
 
 ## [29.74.3] - 2025-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.74.3-rc.1] - 2025-09-02
+- DataTranslator: fall back to matching simple 
+
 ## [29.74.3] - 2025-08-26
 - Add outlier detection config into D2Cluster
 
@@ -5879,7 +5882,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.74.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.74.3-rc.1...master
+[29.74.3-rc.1]: https://github.com/linkedin/rest.li/compare/v29.74.3...v29.74.3-rc.1
 [29.74.3]: https://github.com/linkedin/rest.li/compare/v29.74.2...v29.74.3
 [29.74.2]: https://github.com/linkedin/rest.li/compare/v29.74.1...v29.74.2
 [29.74.1]: https://github.com/linkedin/rest.li/compare/v29.74.0...v29.74.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.74.4-rc.1] - 2025-09-02
+## [29.74.4] - 2025-09-02
 - DataTranslator: fall back to matching simple 
 
 ## [29.74.3] - 2025-08-26

--- a/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/DataTranslator.java
@@ -456,7 +456,7 @@ public class DataTranslator implements DataTranslatorContext
           key = memberAvroSchema.getType().toString().toLowerCase();
       }
       DataSchema memberDataSchema = unionDataSchema.getTypeByMemberKey(key);
-      if (memberDataSchema == null)
+      if (memberDataSchema == null && isSimpleNullUnion(unionDataSchema))
       {
         for (UnionDataSchema.Member member : unionDataSchema.getMembers())
         {
@@ -1110,24 +1110,25 @@ public class DataTranslator implements DataTranslatorContext
     }
 
     // fallback check if key and name (simple names -- strip the namespaces) are equal
-    for (Schema member : members)
-    {
-      String name;
-      switch (member.getType())
+    if (isSimpleNullUnion(members)) {
+      for (Schema member : members)
       {
-        case ENUM:
-        case FIXED:
-        case RECORD:
-          name = getUnionMemberKey(member);
-          break;
-        default:
-          name = member.getType().toString().toLowerCase();
+        String name;
+        switch (member.getType())
+        {
+          case ENUM:
+          case FIXED:
+          case RECORD:
+            name = getUnionMemberKey(member);
+            break;
+          default:
+            name = member.getType().toString().toLowerCase();
+        }
+        // strip namespace (if it exists)
+        String simpleName = getSimpleName(name);
+        String simpleKey = getSimpleName(key);
+        if (simpleName.equals(simpleKey)) return new AbstractMap.SimpleEntry<>(name, member);
       }
-      // strip namespace (if it exists)
-      String simpleName = getSimpleName(name);
-      String simpleKey = getSimpleName(key);
-      if (simpleName.equals(simpleKey))
-        return new AbstractMap.SimpleEntry<>(name, member);
     }
     appendMessage("cannot find %1$s in union %2$s", key, avroSchema);
     return null;
@@ -1181,5 +1182,16 @@ public class DataTranslator implements DataTranslatorContext
       sb.append(o);
     }
     return sb.toString();
+  }
+  private static boolean isSimpleNullUnion(UnionDataSchema unionDataSchema) {
+    return unionDataSchema.getMembers().size() == 2 && (
+        unionDataSchema.getMembers().get(0).getType().getType() == DataSchema.Type.NULL
+            || unionDataSchema.getMembers().get(1).getType().getType() == DataSchema.Type.NULL);
+  }
+
+  private static boolean isSimpleNullUnion(List<Schema> members) {
+    return members.size() == 2 && (
+        members.get(0).getType() == Schema.Type.NULL
+            || members.get(1).getType() == Schema.Type.NULL);
   }
 }

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -2335,6 +2335,12 @@ public class TestDataTranslator
     assertEquals(toDataMap.get("field1"), "value1");
     assertEquals(((DataMap)toDataMap.get("field2")).get("field1"), "value1.1");
     assertEquals(((DataMap)toDataMap.get("field2")).get("field2"), "value1.2");
+
+    // now go the other way
+    GenericRecord fromDataMap = DataTranslator.dataMapToGenericRecord(toDataMap, pegasusSchema, avroSchema);
+    assertEquals(fromDataMap.get("field1").toString(), "value1");
+    assertEquals(((GenericRecord)fromDataMap.get("field2")).get("field1").toString(), "value1.1");
+    assertEquals(((GenericRecord)fromDataMap.get("field2")).get("field2").toString(), "value1.2");
   }
 }
 

--- a/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
+++ b/data-avro/src/test/java/com/linkedin/data/avro/TestDataTranslator.java
@@ -17,6 +17,7 @@
 package com.linkedin.data.avro;
 
 import com.google.common.collect.ImmutableMap;
+import com.linkedin.avroutil1.compatibility.RandomRecordGenerator;
 import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.TestUtil;
@@ -2290,6 +2291,50 @@ public class TestDataTranslator
 
     Assert.assertTrue(mapOfMapOfArrayOfMapArrayUnion.get(0) instanceof Map);
     Assert.assertEquals(((Map<?, ?>) mapOfMapOfArrayOfMapArrayUnion.get(0)).get("recordMap"), mapOfArrayOfMapArrayUnion);
+  }
+
+  @Test
+  public void testWithProtoformedAvroAndDataSchema() throws IOException {
+    // the avro and data schema should have the same shape but different namespaces
+    String avroSchemaString = "{\n" + "  \"type\" : \"record\",\n" + "  \"name\" : \"NativeProtoMessage\",\n"
+        + "  \"namespace\" : \"avro.com.linkedin.avsc\",\n" + "  \"fields\" : [ {\n" + "    \"name\" : \"field1\",\n"
+        + "    \"type\" : [ \"null\", \"string\" ],\n" + "    \"default\" : null,\n"
+        + "    \"li.data.proto.fieldNumber\" : 1\n" + "  }, {\n" + "    \"name\" : \"field2\",\n"
+        + "    \"type\" : [ \"null\", {\n" + "      \"type\" : \"record\",\n"
+        + "      \"name\" : \"MessageUsedWithinField\",\n" + "      \"fields\" : [ {\n"
+        + "        \"name\" : \"field1\",\n" + "        \"type\" : [ \"null\", \"string\" ],\n"
+        + "        \"default\" : null,\n" + "        \"li.data.proto.fieldNumber\" : 1\n" + "      }, {\n"
+        + "        \"name\" : \"field2\",\n" + "        \"type\" : [ \"null\", \"string\" ],\n"
+        + "        \"default\" : null,\n" + "        \"li.data.proto.fieldNumber\" : 2\n" + "      } ],\n"
+        + "      \"li.data.proto.fullyQualifiedName\" : \"proto.com.linkedin.avsc.MessageUsedWithinField\"\n"
+        + "    } ],\n" + "    \"default\" : null,\n" + "    \"li.data.proto.fieldNumber\" : 2\n" + "  } ],\n"
+        + "  \"li.data.proto.fullyQualifiedName\" : \"proto.com.linkedin.avsc.NativeProtoMessage\"\n" + "}";
+
+    String dataSchemaString = "{\n" + "  \"type\" : \"record\",\n" + "  \"name\" : \"NativeProtoMessage\",\n"
+        + "  \"namespace\" : \"pegasus.com.linkedin.pdl\",\n" + "  \"fields\" : [ {\n" + "    \"name\" : \"field1\",\n"
+        + "    \"type\" : \"string\",\n" + "    \"optional\" : true\n" + "  }, {\n" + "    \"name\" : \"field2\",\n"
+        + "    \"type\" : {\n" + "  \"type\" : \"record\",\n" + "  \"name\" : \"MessageUsedWithinField\",\n"
+        + "  \"namespace\" : \"pegasus.com.linkedin.pdl\",\n" + "  \"fields\" : [ {\n" + "    \"name\" : \"field1\",\n"
+        + "    \"type\" : \"string\",\n" + "    \"optional\" : true\n" + "  }, {\n" + "    \"name\" : \"field2\",\n"
+        + "    \"type\" : \"string\",\n" + "    \"optional\" : true\n" + "  } ]\n" + "},\n" + "    \"optional\" : true\n"
+        + "  } ]\n" + "}";
+
+
+    RecordDataSchema pegasusSchema = (RecordDataSchema)TestUtil.dataSchemaFromString(dataSchemaString);
+    Schema avroSchema = Schema.parse(avroSchemaString);
+
+    // set array field after the fact to prevent the type from being set as GenericArray in dataMapToGenericRecord
+    GenericRecord newRecord = new GenericData.Record(avroSchema);
+    newRecord.put("field1", "value1");
+    GenericRecord newRecord2 = new GenericData.Record(avroSchema.getField("field2").schema().getTypes().get(1));
+    newRecord2.put("field1", "value1.1");
+    newRecord2.put("field2", "value1.2");
+    newRecord.put("field2", newRecord2);
+    DataMap toDataMap = DataTranslator.genericRecordToDataMap(newRecord, pegasusSchema, avroSchema);
+
+    assertEquals(toDataMap.get("field1"), "value1");
+    assertEquals(((DataMap)toDataMap.get("field2")).get("field1"), "value1.1");
+    assertEquals(((DataMap)toDataMap.get("field2")).get("field2"), "value1.2");
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.74.4-rc.1
+version=29.74.4-rc.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.74.4-rc.2
+version=29.74.4-rc.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.74.3-rc.1
+version=29.74.4-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.74.3
+version=29.74.3-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.74.4-rc.3
+version=29.74.4-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.74.4-rc.1
+version=29.74.4
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
In DataTranslator, first try to do an example name match. If this does not work, fall back to a simple name match. Only match simple names if the union in question is union of 2 types, one of which is the null type.

With curent schema limitations at Linkedin, all unions should be simple unions (`union[null, X]`), so this matching should always work.

The only change for existing cases: if a user did not use SchemaTranslator to generate their PDL-Avro pair and if the have a union where the simple names match but not the full name, they will get an exception later on in the transcoding (not at union resolution).