### PR TITLE
deprecate SchemaTranslator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.75.3] - 2025-09-08
+- DataTranslator: support no fieldDiscriminator in Avro union aliases. Deprecate SchemaTranslator for runtime use. 
+
 ## [29.75.2] - 2025-09-05
 - Rename the outlier detection field in the D2 cluster
 
@@ -5891,7 +5894,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.75.2...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.75.3...master
+[29.75.3]: https://github.com/linkedin/rest.li/compare/v29.75.2...v29.75.3
 [29.75.2]: https://github.com/linkedin/rest.li/compare/v29.75.1...v29.75.2
 [29.75.1]: https://github.com/linkedin/rest.li/compare/v29.75.0...v29.75.1
 [29.75.0]: https://github.com/linkedin/rest.li/compare/v29.74.4...v29.75.0

--- a/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
+++ b/data-avro/src/main/java/com/linkedin/data/avro/SchemaTranslator.java
@@ -46,8 +46,11 @@ import org.slf4j.LoggerFactory;
 
 
 /**
+ * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+ * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
  * Translates Avro {@link Schema} to and from Pegasus {@link DataSchema}.
  */
+@Deprecated
 public class SchemaTranslator
 {
   private static final Logger log = LoggerFactory.getLogger(SchemaTranslator.class);
@@ -112,7 +115,10 @@ public class SchemaTranslator
    * @param options specifies the {@link AvroToDataSchemaTranslationOptions}.
    * @return the translated {@link DataSchema}.
    * @throws IllegalArgumentException if the Avro {@link Schema} cannot be translated.
+   * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+   * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
    */
+  @Deprecated
   public static DataSchema avroToDataSchema(String avroSchemaInJson, AvroToDataSchemaTranslationOptions options)
     throws IllegalArgumentException
   {
@@ -195,7 +201,10 @@ public class SchemaTranslator
    * @param avroSchemaInJson provides the JSON representation of the Avro {@link Schema}.
    * @return the translated {@link DataSchema}.
    * @throws IllegalArgumentException if the Avro {@link Schema} cannot be translated.
+   * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+   * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
    */
+  @Deprecated
   public static DataSchema avroToDataSchema(String avroSchemaInJson) throws IllegalArgumentException
   {
     return avroToDataSchema(avroSchemaInJson, new AvroToDataSchemaTranslationOptions());
@@ -218,7 +227,10 @@ public class SchemaTranslator
    * @param options specifies the {@link AvroToDataSchemaTranslationOptions}.
    * @return the translated {@link DataSchema}.
    * @throws IllegalArgumentException if the Avro {@link Schema} cannot be translated.
+   * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+   * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
    */
+  @Deprecated
   public static DataSchema avroToDataSchema(Schema avroSchema, AvroToDataSchemaTranslationOptions options) throws IllegalArgumentException
   {
     String avroSchemaInJson = avroSchema.toString();
@@ -231,7 +243,10 @@ public class SchemaTranslator
    * @param avroSchema provides the Avro {@link Schema}.
    * @return the translated {@link DataSchema}.
    * @throws IllegalArgumentException if the Avro {@link Schema} cannot be translated.
+   * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+   * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
    */
+  @Deprecated
   public static DataSchema avroToDataSchema(Schema avroSchema) throws IllegalArgumentException
   {
     String avroSchemaInJson = avroSchema.toString();
@@ -245,7 +260,10 @@ public class SchemaTranslator
    *
    * @param dataSchema provides the {@link DataSchema}.
    * @return the Avro {@link Schema}.
+   * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+   * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
    */
+  @Deprecated
   public static Schema dataToAvroSchema(DataSchema dataSchema)
   {
     String jsonAvroSchema = dataToAvroSchemaJson(dataSchema, new DataToAvroSchemaTranslationOptions());
@@ -261,7 +279,10 @@ public class SchemaTranslator
    * @param dataSchema provides the {@link DataSchema}.
    * @param options provides the {@link DataToAvroSchemaTranslationOptions}.
    * @return the Avro {@link Schema}.
+   * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+   * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
    */
+  @Deprecated
   public static Schema dataToAvroSchema(DataSchema dataSchema, DataToAvroSchemaTranslationOptions options)
   {
     String jsonAvroSchema = dataToAvroSchemaJson(dataSchema, options);
@@ -276,7 +297,10 @@ public class SchemaTranslator
    *
    * @param dataSchema provides the {@link DataSchema}.
    * @return the JSON representation of the Avro {@link Schema}.
+   * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+   * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
    */
+  @Deprecated
   public static String dataToAvroSchemaJson(DataSchema dataSchema)
   {
     return dataToAvroSchemaJson(dataSchema, new DataToAvroSchemaTranslationOptions());
@@ -314,7 +338,10 @@ public class SchemaTranslator
    * @param options specifies the {@link DataToAvroSchemaTranslationOptions}.
    * @return the JSON representation of the Avro {@link Schema}.
    * @throws IllegalArgumentException if the {@link DataSchema} cannot be translated.
+   * @deprecated DO NOT USE SchemaTranslator AT RUNTIME. PLEASE FIND THE SCHEMA THAT IS CREATED AT BUILD TIME AND USE THAT
+   * SCHEMA AT RUNTIME. THIS CLASS IS INTENDED FOR BUILD TIME USE ONLY. For more info, see https://go/noRuntimeSchemaGen
    */
+  @Deprecated
   public static String dataToAvroSchemaJson(DataSchema dataSchema, DataToAvroSchemaTranslationOptions options) throws IllegalArgumentException
   {
     // Create a copy of the schema before the actual translation, since the translation process ends up modifying the

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.75.2
+version=29.75.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
As part of the move to protobuf @ linkedin, SchemaTranslator should not be invoked anymore. To discourage usage, we are deprecating SchemaTranslator.