### PR TITLE
Preliminary readiness management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.76.0] - 2025-09-15
+- Preliminary readiness management
+
 ## [29.75.4] - 2025-09-10
 - Fix notifyOnLastChunk handling for D2URIMap WildcardResourceSubscriber 
 
@@ -5897,7 +5900,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.75.4...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.76.0...master
+[29.76.0]: https://github.com/linkedin/rest.li/compare/v29.75.4...v29.76.0
 [29.75.4]: https://github.com/linkedin/rest.li/compare/v29.75.3...v29.75.4
 [29.75.3]: https://github.com/linkedin/rest.li/compare/v29.75.2...v29.75.3
 [29.75.2]: https://github.com/linkedin/rest.li/compare/v29.75.1...v29.75.2

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/NoOpReadinessStatusManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/NoOpReadinessStatusManager.java
@@ -1,0 +1,22 @@
+package com.linkedin.d2.balancer.servers;
+
+public class NoOpReadinessStatusManager implements ReadinessStatusManager
+{
+  @Override
+  public void registerAnnouncerStatus(AnnouncerStatus status)
+  {
+    // no-op
+  }
+
+  @Override
+  public void onAnnouncerStatusUpdated()
+  {
+    // no-op
+  }
+
+  @Override
+  public void addWatcher(ReadinessStatusWatcher watcher)
+  {
+    // no-op
+  }
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/servers/ReadinessStatusManager.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/servers/ReadinessStatusManager.java
@@ -1,0 +1,113 @@
+package com.linkedin.d2.balancer.servers;
+
+import javax.annotation.Nonnull;
+
+
+/**
+ * This class manages the readiness status of the server.
+ * Currently, it's based on D2 announcements' statuses as a preliminary design, can be extended in future for internal
+ * components' readiness status.
+ * See the <a href="preliminary design doc">https://shorturl.at/hmjz8</a> for details of determining the readiness status based on
+ * D2 announcements. Treating D2 announcements as the app servers’ intent to serve traffic, the readiness status is
+ * determined by the combination of D2 announcements' sent status.
+ */
+public interface ReadinessStatusManager
+{
+  void registerAnnouncerStatus(AnnouncerStatus status);
+
+  void onAnnouncerStatusUpdated();
+
+  void addWatcher(ReadinessStatusWatcher watcher);
+
+  interface ReadinessStatusWatcher
+  {
+    void onReadinessStatusChanged(ReadinessStatus newStatus);
+  }
+
+  enum ReadinessStatus
+  {
+    /**
+     * When the D2 clusters that are intended to be announced have sent announcements successfully.
+     * (And if any D2 cluster is intended to be de-announced, the corresponding de-announcement is also sent successfully)
+     */
+    SERVING,
+    /**
+     * When all D2 clusters are intended to be de-announced and the de-announcements are sent successfully, or never
+     * announced before.
+     * OR: if some D2 clusters have isRequiredToServe set to true, any of them is de-announced.
+     */
+    NOT_SERVING,
+    /**
+     * There is a time gap between when a serving intent changes (either static config loaded at startup, or dynamic
+     * markup/markdown API is called at runtime) and when the intent is fulfilled ---- (de-)announcement sent successfully.
+     * During this gap, the intent is not fulfilled, and the readiness status is INCONSISTENT. Or, the (de-)announcements
+     * failed to be sent, the readiness status is also INCONSISTENT.
+     * This status can be deprecated in future when the readiness status is based on internal components' readiness
+     * rather than D2 announcements' statuses.
+     */
+    INCONSISTENT
+  }
+
+  class AnnouncerStatus
+  {
+    // whether this announcer is to be announced and defined in static config
+    private final boolean isToBeAnnouncedFromStaticConfig;
+
+    private AnnouncementStatus announcementStatus;
+
+    public AnnouncerStatus(boolean isToBeAnnouncedFromStaticConfig, @Nonnull AnnouncementStatus announcementStatus)
+    {
+      this.isToBeAnnouncedFromStaticConfig = isToBeAnnouncedFromStaticConfig;
+      this.announcementStatus = announcementStatus;
+    }
+
+    public boolean isToBeAnnouncedFromStaticConfig()
+    {
+      return isToBeAnnouncedFromStaticConfig;
+    }
+
+    public boolean isAnnounced()
+    {
+      return announcementStatus == AnnouncementStatus.ANNOUNCED;
+    }
+
+    public boolean isDeAnnounced()
+    {
+      return announcementStatus == AnnouncementStatus.DE_ANNOUNCED;
+    }
+
+    public boolean isAnnouncing()
+    {
+      return announcementStatus == AnnouncementStatus.ANNOUNCING;
+    }
+
+    public boolean isDeAnnouncing()
+    {
+      return announcementStatus == AnnouncementStatus.DE_ANNOUNCING;
+    }
+
+    public AnnouncementStatus getAnnouncementStatus()
+    {
+      return announcementStatus;
+    }
+
+    public synchronized void setAnnouncementStatus(@Nonnull AnnouncementStatus announcementStatus)
+    {
+      this.announcementStatus = announcementStatus;
+    }
+
+    public boolean isEqual(AnnouncerStatus other)
+    {
+      return other != null && this.isToBeAnnouncedFromStaticConfig == other.isToBeAnnouncedFromStaticConfig
+          && this.announcementStatus == other.announcementStatus;
+    }
+
+    public enum AnnouncementStatus
+    {
+      ANNOUNCING, // an announcement is to be or is being sent
+      ANNOUNCED, // announcement sent successfully
+      DE_ANNOUNCING, // a de-announcement is to be or is being sent
+      DE_ANNOUNCED // de-announcement sent successfully
+    }
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/servers/TestZooKeeperAnnouncer.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/servers/TestZooKeeperAnnouncer.java
@@ -2,20 +2,31 @@ package com.linkedin.d2.balancer.servers;
 
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.util.None;
-import com.linkedin.d2.balancer.LoadBalancerServer;
 import com.linkedin.d2.balancer.properties.PartitionData;
 import com.linkedin.d2.balancer.properties.PropertyKeys;
+import com.linkedin.d2.balancer.servers.ReadinessStatusManager.AnnouncerStatus;
+import com.linkedin.d2.balancer.servers.ReadinessStatusManager.AnnouncerStatus.AnnouncementStatus;
+import com.linkedin.d2.balancer.servers.ZooKeeperAnnouncer.ActionOnWeightBreach;
 
 import com.linkedin.d2.discovery.event.LogOnlyServiceDiscoveryEventEmitter;
+import com.linkedin.r2.util.NamedThreadFactory;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.testng.annotations.BeforeMethod;
+import org.mockito.invocation.InvocationOnMock;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static com.linkedin.d2.balancer.servers.ReadinessStatusManager.AnnouncerStatus.AnnouncementStatus.*;
+import static java.util.concurrent.TimeUnit.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -25,13 +36,6 @@ import static org.mockito.Mockito.*;
  */
 public class TestZooKeeperAnnouncer
 {
-  private ZooKeeperAnnouncer _announcer;
-
-  @Mock
-  private ZooKeeperServer _server;
-  @Mock
-  private Callback<None> _callback;
-
   private static final Map<Integer, PartitionData> MAX_WEIGHT_BREACH_PARTITION_DATA =
       Collections.singletonMap(0, new PartitionData(1000));
   private static final Map<Integer, PartitionData> DECIMAL_PLACES_BREACH_PARTITION_DATA =
@@ -41,24 +45,21 @@ public class TestZooKeeperAnnouncer
   private static final Map<Integer, PartitionData> VALID_PARTITION_DATA =
       Collections.singletonMap(0, new PartitionData(2.3));
 
-  @BeforeMethod
-  public void setUp()
-  {
-    MockitoAnnotations.initMocks(this);
-
-    _announcer = new ZooKeeperAnnouncer((LoadBalancerServer) _server);
-  }
+  private static final Exception DUMMY_EXCEPTION =  new RuntimeException("dummy error");
 
   @Test
   public void testSetDoNotLoadBalance()
   {
-    _announcer.setDoNotLoadBalance(_callback, true);
+    ZooKeeperAnnouncerFixture fixture = new ZooKeeperAnnouncerFixture();
+    ZooKeeperAnnouncer announcer = fixture._announcer;
+    Callback<None> callback = fixture.getCallback();
+    announcer.setDoNotLoadBalance(callback, true);
 
-    verify(_server).addUriSpecificProperty(any(), any(), any(), any(), eq(PropertyKeys.DO_NOT_LOAD_BALANCE), eq(true), any());
+    verify(fixture._server).addUriSpecificProperty(any(), any(), any(), any(), eq(PropertyKeys.DO_NOT_LOAD_BALANCE), eq(true), any());
 
-    _announcer.setDoNotLoadBalance(_callback, false);
+    announcer.setDoNotLoadBalance(callback, false);
 
-    verify(_server).addUriSpecificProperty(any(), any(), any(), any(), eq(PropertyKeys.DO_NOT_LOAD_BALANCE), eq(false), any());
+    verify(fixture._server).addUriSpecificProperty(any(), any(), any(), any(), eq(PropertyKeys.DO_NOT_LOAD_BALANCE), eq(false), any());
   }
 
   @DataProvider(name = "validatePartitionDataDataProvider")
@@ -121,9 +122,8 @@ public class TestZooKeeperAnnouncer
       Map<Integer, PartitionData> input, Map<Integer, PartitionData> expected, Exception expectedException,
       int expectedMaxWeightBreachedCount, int expectedWeightDecimalPlacesBreachedCount)
   {
-    ZooKeeperAnnouncer announcer = new ZooKeeperAnnouncer(_server, true, false, null, 0,
-        null, new LogOnlyServiceDiscoveryEventEmitter(),
-        maxWeight == null ? null : new BigDecimal(maxWeight), action);
+    ZooKeeperAnnouncer announcer = new ZooKeeperAnnouncerFixture(
+        maxWeight == null ? null : new BigDecimal(maxWeight), action)._announcer;
 
     if (expectedException != null)
     {
@@ -144,5 +144,268 @@ public class TestZooKeeperAnnouncer
     }
     assertEquals(expectedMaxWeightBreachedCount, announcer.getMaxWeightBreachedCount());
     assertEquals(expectedWeightDecimalPlacesBreachedCount, announcer.getWeightDecimalPlacesBreachedCount());
+  }
+
+  @DataProvider(name = "testUpdateAnnouncerStatusForMarkUpDataProvider")
+  public Object[][] testUpdateAnnouncerStatusForMarkUpDataProvider()
+  {
+    return new Object[][]
+        {
+            // Arguments:
+            // initStatus - initial announcer's announcement status
+            // isDarkWarmupEnabled - is dark warmup cluster enabled
+            // isWarmUpMarkUpSuccess - is warmup cluster markup successful
+            // isWarmUpMarkDownSuccess - is warmup cluster markdown successful
+            // isRealMarkUpSuccess - is real cluster markup successful
+            // expectedStatuses - expected announcer status sequence
+
+            // Cases:
+            // --- init status is de-announced ---
+            // dark warmup enabled, all markup and markdown successful
+            {DE_ANNOUNCED, true, true, true, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            // dark warmup enabled, warmup cluster markup successful but markdown failed, real cluster markup successful
+            {DE_ANNOUNCED, true, true, false, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            // dark warmup enabled, warmup cluster markup failed, real cluster markup successful
+            {DE_ANNOUNCED, true, false, true, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            // dark warmup enabled, warmup cluster markup failed, real cluster markup failed
+            {DE_ANNOUNCED, true, false, true, false, Collections.singletonList(ANNOUNCING)},
+            // dark warmup disabled, real cluster markup successful
+            {DE_ANNOUNCED, false, true, true, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            // dark warmup disabled, real cluster markup failed
+            {DE_ANNOUNCED, false, true, true, false, Collections.singletonList(ANNOUNCING)},
+
+            // --- init status is announcing ---
+            // dark warmup enabled, all markup and markdown successful
+            {ANNOUNCING, true, true, true, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            // dark warmup enabled, warmup cluster markup successful but markdown failed, real cluster markup successful
+            {ANNOUNCING, true, true, false, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            // dark warmup enabled, warmup cluster markup failed, real cluster markup successful
+            {ANNOUNCING, true, false, true, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            // dark warmup enabled, warmup cluster markup failed, real cluster markup failed
+            {ANNOUNCING, true, false, true, false, Collections.singletonList(ANNOUNCING)},
+            // dark warmup disabled, real cluster markup successful
+            {ANNOUNCING, false, true, true, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            // dark warmup disabled, real cluster markup failed
+            {ANNOUNCING, false, true, true, false, Collections.singletonList(ANNOUNCING)},
+
+            // --- other init statuses have the same behavior ---
+            {ANNOUNCED, false, true, true, true, Arrays.asList(ANNOUNCING, ANNOUNCED)},
+            {DE_ANNOUNCING, false, true, true, true, Arrays.asList(ANNOUNCING, ANNOUNCED)}
+        };
+  }
+  @Test(dataProvider = "testUpdateAnnouncerStatusForMarkUpDataProvider")
+  public void testUpdateAnnouncerStatusForMarkUp(AnnouncementStatus initStatus, boolean isDarkWarmupEnabled,
+      boolean isWarmUpMarkUpSuccess, boolean isWarmUpMarkDownSuccess, boolean isRealMarkUpSuccess,
+      List<AnnouncementStatus> expectedStatuses)
+  {
+    ZooKeeperAnnouncerFixture fixture = new ZooKeeperAnnouncerFixture(isDarkWarmupEnabled, isWarmUpMarkUpSuccess,
+        isWarmUpMarkDownSuccess, isRealMarkUpSuccess, initStatus);
+
+    fixture._announcer.markUp(fixture.getCallback());
+
+    fixture.waitForCallback(true);
+    fixture.verifyAnnouncementStatusUpdates(expectedStatuses);
+    fixture.shutdown();
+  }
+
+  @DataProvider(name = "testUpdateAnnouncerStatusForMarkDownDataProvider")
+  public Object[][] testUpdateAnnouncerStatusForMarkDownDataProvider()
+  {
+    return new Object[][]{
+        // Arguments:
+        // initStatus - initial announcer's announcement status
+        // isRealMarkDownSuccess - is real cluster markdown successful
+        // expectedStatuses - expected announcer status sequence
+
+        // Cases:
+        // --- init status is announced ---
+        // real cluster markdown successful
+        {ANNOUNCED, true, Arrays.asList(DE_ANNOUNCING, DE_ANNOUNCED)},
+        // real cluster markdown failed
+        {ANNOUNCED, false, Collections.singletonList(DE_ANNOUNCING)},
+
+        // --- init status is de-announcing ---
+        // real cluster markdown successful
+        {DE_ANNOUNCING, true, Arrays.asList(DE_ANNOUNCING, DE_ANNOUNCED)},
+        // real cluster markdown failed
+        {DE_ANNOUNCING, false, Collections.singletonList(DE_ANNOUNCING)},
+
+        // --- other init statuses have the same behavior ---
+        {DE_ANNOUNCED, true, Arrays.asList(DE_ANNOUNCING, DE_ANNOUNCED)},
+        {ANNOUNCING, true, Arrays.asList(DE_ANNOUNCING, DE_ANNOUNCED)}
+    };
+  }
+  @Test(dataProvider = "testUpdateAnnouncerStatusForMarkDownDataProvider")
+  public void testUpdateAnnouncerStatusForMarkDown(AnnouncementStatus initStatus, boolean isRealClusterMarkdownSuccess,
+      List<AnnouncementStatus> expectedStatuses)
+  {
+    ZooKeeperAnnouncerFixture fixture = new ZooKeeperAnnouncerFixture(isRealClusterMarkdownSuccess, initStatus);
+
+    fixture._announcer.markDown(fixture.getCallback());
+
+    fixture.waitForCallback(false);
+    fixture.verifyAnnouncementStatusUpdates(expectedStatuses);
+    fixture.shutdown();
+  }
+
+  static class ZooKeeperAnnouncerFixture
+  {
+    @Mock
+    private ZooKeeperServer _server;
+    @Mock
+    private ReadinessStatusManager _readinessStatusManager;
+
+    private ZooKeeperAnnouncer _announcer;
+    private final ScheduledExecutorService _executorService;
+    private final AnnouncerStatus _status;
+    private final boolean _isDarkWarmupEnabled;
+    private final boolean _isDarkWarmupMarkupSuccess;
+    private ArgumentCaptor<AnnouncementStatus> _announcementStatusCaptor =
+        ArgumentCaptor.forClass(AnnouncementStatus.class);
+    private CountDownLatch _callbackLatch = new CountDownLatch(1);
+
+    private static final String REAL_CLUSTER = "RealCluster";
+    private static final String DARK_CLUSTER = "DarkCluster";
+    private static final int WARMUP_DURATION = 1; // in seconds
+    private static final int CALLBACK_TIMEOUT_MS = 200;
+
+    public ZooKeeperAnnouncerFixture()
+    {
+      this(false, false, false, true, true,
+          null, ActionOnWeightBreach.IGNORE, DE_ANNOUNCED);
+    }
+
+    public ZooKeeperAnnouncerFixture(BigDecimal maxWeight, ActionOnWeightBreach actionOnWeightBreach)
+    {
+      this(false, false, false, true, true,
+          maxWeight, actionOnWeightBreach, DE_ANNOUNCED);
+    }
+
+    public ZooKeeperAnnouncerFixture(boolean isDarkWarmupEnabled, boolean isDarkWarmupMarkupSuccess, boolean isDarkWarmupMarkdownSuccess,
+    boolean isRealClusterMarkupSuccess, AnnouncementStatus initStatus)
+    {
+      this(isDarkWarmupEnabled, isDarkWarmupMarkupSuccess, isDarkWarmupMarkdownSuccess, isRealClusterMarkupSuccess,
+          true, null, ActionOnWeightBreach.IGNORE, initStatus);
+    }
+
+    public ZooKeeperAnnouncerFixture(boolean isRealClusterMarkdownSuccess, AnnouncementStatus initStatus)
+    {
+      this(false, false, false, true, isRealClusterMarkdownSuccess,
+          null, ActionOnWeightBreach.IGNORE, initStatus);
+    }
+
+    public ZooKeeperAnnouncerFixture(boolean isDarkWarmupEnabled, boolean isDarkWarmupMarkupSuccess, boolean isDarkWarmupMarkdownSuccess,
+        boolean isRealClusterMarkupSuccess, boolean isRealClusterMarkdownSuccess, BigDecimal maxWeight,
+        ActionOnWeightBreach actionOnWeightBreach, AnnouncementStatus initStatus)
+    {
+      MockitoAnnotations.initMocks(this);
+      doNothing().when(_readinessStatusManager).registerAnnouncerStatus(any());
+      doNothing().when(_readinessStatusManager).onAnnouncerStatusUpdated();
+
+      _executorService = isDarkWarmupEnabled ? Executors.newSingleThreadScheduledExecutor(
+          new NamedThreadFactory("ZooKeeperAnnouncerFixtureExecutor")) : null;
+      _status = spy(new AnnouncerStatus(true, initStatus));
+      doCallRealMethod().when(_status).setAnnouncementStatus(_announcementStatusCaptor.capture());
+      _isDarkWarmupEnabled = isDarkWarmupEnabled;
+      _isDarkWarmupMarkupSuccess = isDarkWarmupMarkupSuccess;
+
+      _announcer = new ZooKeeperAnnouncer(_server, true, isDarkWarmupEnabled, DARK_CLUSTER, WARMUP_DURATION,
+          _executorService, new LogOnlyServiceDiscoveryEventEmitter(), maxWeight, actionOnWeightBreach, _status,
+          _readinessStatusManager);
+      _announcer.setCluster(REAL_CLUSTER);
+      _announcer.setPartitionData(VALID_PARTITION_DATA);
+      _announcer.setUriSpecificProperties(Collections.emptyMap());
+
+      if (isDarkWarmupEnabled)
+      {
+        mockInvokeClusterCallback(DARK_CLUSTER, true, isDarkWarmupMarkupSuccess);
+        mockInvokeClusterCallback(DARK_CLUSTER, false, isDarkWarmupMarkdownSuccess);
+      }
+      mockInvokeClusterCallback(REAL_CLUSTER, true, isRealClusterMarkupSuccess);
+      mockInvokeClusterCallback(REAL_CLUSTER, false, isRealClusterMarkdownSuccess);
+    }
+
+    private void mockInvokeClusterCallback(String cluster, boolean isMarkUp, boolean isSuccess)
+    {
+      if (isMarkUp)
+      {
+        doAnswer(invoc -> invokeCallbackHelper(invoc, 4, isSuccess))
+            .when(_server).markUp(eq(cluster), any(), any(), any(), any());
+      }
+      else
+      {
+        doAnswer(invoc -> invokeCallbackHelper(invoc, 2, isSuccess))
+            .when(_server).markDown(eq(cluster), any(), any());
+      }
+    }
+
+    public void shutdown() {
+      if (_executorService != null) {
+        _executorService.shutdownNow();
+      }
+    }
+
+    public Callback<None> getCallback()
+    {
+      return new Callback<None>()
+      {
+        @Override
+        public void onError(Throwable e)
+        {
+          _callbackLatch.countDown();
+        }
+
+        @Override
+        public void onSuccess(None result)
+        {
+          _callbackLatch.countDown();
+        }
+      };
+    }
+
+    public void waitForCallback(boolean isMarkup)
+    {
+      try
+      {
+        // for markup, if dark warmup is enabled and succeeded, wait for the warmup duration + callback timeout,
+        // otherwise just wait for the callback timeout
+        if(!_callbackLatch.await(isMarkup && _isDarkWarmupEnabled && _isDarkWarmupMarkupSuccess
+            ? WARMUP_DURATION * 1000 + CALLBACK_TIMEOUT_MS : CALLBACK_TIMEOUT_MS, MILLISECONDS))
+        {
+          fail("Timed out waiting for callback");
+        }
+      }
+      catch (InterruptedException e)
+      {
+        fail("Test interrupted while waiting for markup callback");
+        Thread.currentThread().interrupt();
+      }
+      finally {
+        _callbackLatch = new CountDownLatch(1); // reset for next usage
+      }
+    }
+
+    public void verifyAnnouncementStatusUpdates(List<AnnouncementStatus> expectedStatuses)
+    {
+      assertEquals(expectedStatuses, _announcementStatusCaptor.getAllValues());
+      verify(_readinessStatusManager, times(_announcementStatusCaptor.getAllValues().size()))
+          .onAnnouncerStatusUpdated();
+      reset(_status); // reset the spy to clear the invocation history
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object invokeCallbackHelper(InvocationOnMock invoc, int callbackIdx, boolean isSuccess)
+    {
+      Callback<None> cb = (Callback<None>) invoc.getArguments()[callbackIdx];
+      if (isSuccess)
+      {
+        cb.onSuccess(None.none());
+      }
+      else
+      {
+        cb.onError(DUMMY_EXCEPTION);
+      }
+      return null;
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.75.4
+version=29.76.0
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
As designed in [the doc](https://docs.google.com/document/d/1oa-gCLbNlWuEIQxIqscIEC24h0slI-7S_aItpjJZZLU/edit?usp=sharing).
Register each announcer's announcement status to readiness manager in container, see container PR.

## Test Done
UT. 
Will do QEI deploy indis-canary