### PR TITLE
null guards for xds server and channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.79.1] - 2025-10-02
+- null guards for xds server and channel
+
 ## [29.79.0] - 2025-10-01
 - Preliminary readiness management
 
@@ -5909,7 +5912,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.79.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.79.1...master
+[29.79.1]: https://github.com/linkedin/rest.li/compare/v29.79.0...v29.79.1
 [29.79.0]: https://github.com/linkedin/rest.li/compare/v29.78.0...v29.79.0
 [29.78.0]: https://github.com/linkedin/rest.li/compare/v29.77.0...v29.78.0
 [29.77.0]: https://github.com/linkedin/rest.li/compare/v29.76.0...v29.77.0

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -67,6 +67,7 @@ import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.*;
 
 /**
  * Implementation of {@link XdsClient} interface.
@@ -199,6 +200,7 @@ public class XdsClientImpl extends XdsClient
   {
     _readyTimeoutMillis = readyTimeoutMillis;
     _node = node;
+    checkNotNull(managedChannel, "managedChannel");
     _managedChannel = managedChannel;
     _executorService = executorService;
     _subscribeToUriGlobCollection = subscribeToUriGlobCollection;

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -18,6 +18,7 @@ import com.linkedin.util.clock.Clock;
 import com.linkedin.util.clock.Time;
 import indis.XdsD2;
 import io.envoyproxy.envoy.service.discovery.v3.Resource;
+import io.grpc.ManagedChannel;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -1221,7 +1222,7 @@ public class TestXdsClientImpl
 
       _executorService = spy(Executors.newScheduledThreadPool(1));
 
-      _xdsClientImpl = spy(new XdsClientImpl(null, null,
+      _xdsClientImpl = spy(new XdsClientImpl(null, mock(ManagedChannel.class),
           _executorService,
           0, useGlobCollections, _serverMetricsProvider, useIRV));
       _xdsClientImpl._adsStream = _adsStream;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.79.0
+version=29.79.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
As the title, add null guards for critical params. Also add a setter to disable detecting raw d2 client, so test apps like indis-canary can use it to disable the detection as needed.

## Test Done
N/A