### PR TITLE
Update pre-check to prevent duplicate xDS client start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.80.1] - 2025-10-15
+- Update pre-check to prevent duplicate xDS client start
+
 ## [29.80.0] - 2025-10-10
 - Update methodLevelProperties in ServiceProperties constructor
 
@@ -5918,7 +5921,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.80.0...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.80.1...master
+[29.80.1]: https://github.com/linkedin/rest.li/compare/v29.80.0...v29.80.1
 [29.80.0]: https://github.com/linkedin/rest.li/compare/v29.79.1...v29.80.0
 [29.79.1]: https://github.com/linkedin/rest.li/compare/v29.79.0...v29.79.1
 [29.79.0]: https://github.com/linkedin/rest.li/compare/v29.78.0...v29.79.0

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -235,7 +235,8 @@ public class XdsClientImpl extends XdsClient
   {
     if (!_started.compareAndSet(false, true))
     {
-      throw new IllegalStateException("Cannot start XdsClient more than once");
+      _log.info("XdsClientImpl.start() called multiple times, ignoring subsequent calls.");
+      return;
     }
 
     _xdsClientJmx.setXdsClient(this);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.80.0
+version=29.80.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
While the pre-check checks for various issues for indis connection. **The start()** method indeed can be called multiple times for valid reasons, since app owners are allowed to explicitly call d2Client.start and wait for the callback to ensure a d2 client is started before using it. We should change the throw to an info log and just return (no-op) in that case. 