### PR TITLE
Throw when setting xds server address to null while lbWithFacilitiesFactory is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.80.2] - 2025-10-15
+- Throw when setting xds server address to null while lbWithFacilitiesFactory is null.  
+
 ## [29.80.1] - 2025-10-15
 - Not to throw for duplicate xDS client start. Throw when setting xds server address to null only for indis-only.  
 
@@ -5921,7 +5924,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.80.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.80.2...master
+[29.80.2]: https://github.com/linkedin/rest.li/compare/v29.80.1...v29.80.2
 [29.80.1]: https://github.com/linkedin/rest.li/compare/v29.80.0...v29.80.1
 [29.80.0]: https://github.com/linkedin/rest.li/compare/v29.79.1...v29.80.0
 [29.79.1]: https://github.com/linkedin/rest.li/compare/v29.79.0...v29.79.1

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -359,7 +359,7 @@ public class D2ClientBuilder
 
   public D2ClientBuilder setXdsServer(String xdsServer)
   {
-    if (_config.lbWithFacilitiesFactory.isIndisOnly())
+    if (_config.lbWithFacilitiesFactory == null || _config.lbWithFacilitiesFactory.isIndisOnly())
     {
       checkNotNull(xdsServer, "xdsServer");
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.80.1
+version=29.80.2
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
A quick add-on to the [previous change](https://github.com/linkedin/rest.li/pull/1114) to catch a corner case that when setXdsServer is called with null, lbWithFacilitiesFactory may be null (user code will either use the default ZK LB in Dev env, or will call setLoadBalancerWithFacilitiesFactory to use indis LB later)