### PR TITLE
[WIP]: Add OpenTelemetry metrics support for ClusterInfo

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoOtelMetricsProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/ClusterInfoOtelMetricsProvider.java
@@ -1,0 +1,17 @@
+package com.linkedin.d2.jmx;
+
+/**
+ * Interface for OpenTelemetry metrics collection for ClusterInfo.
+ */
+public interface ClusterInfoOtelMetricsProvider {
+
+    /**
+   * Records the current canary distribution policy for the cluster 
+   * (0=STABLE, 1=CANARY, -1=UNSPECIFIED)
+   * 
+   * @param clusterName the name of the cluster
+   * @param policy the canary distribution policy
+   */
+    void recordCanaryDistributionPolicy(String clusterName, int policy);
+    
+}

--- a/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/JmxManager.java
@@ -50,10 +50,17 @@ public class JmxManager
 
   private final MBeanServer   _server;
   private final Set<ObjectName> _registeredNames = new HashSet<>();
+  private ClusterInfoOtelMetricsProvider _clusterInfoOtelMetricsProvider;
 
   public JmxManager()
   {
+    this(new NoOpClusterInfoOtelMetricsProvider());
+  }
+
+  public JmxManager(ClusterInfoOtelMetricsProvider clusterInfoOtelMetricsProvider)
+  {
     _server = ManagementFactory.getPlatformMBeanServer();
+    _clusterInfoOtelMetricsProvider = clusterInfoOtelMetricsProvider;
   }
 
   MBeanServer getMBeanServer()
@@ -118,7 +125,7 @@ public class JmxManager
 
   public synchronized JmxManager registerClusterInfo(String name, ClusterInfoItem clusterInfo)
   {
-    checkReg(new ClusterInfoJmx(clusterInfo), name);
+    checkReg(new ClusterInfoJmx(clusterInfo, _clusterInfoOtelMetricsProvider), name);
 
     return this;
   }

--- a/d2/src/main/java/com/linkedin/d2/jmx/NoOpClusterInfoOtelMetricsProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/NoOpClusterInfoOtelMetricsProvider.java
@@ -1,0 +1,10 @@
+package com.linkedin.d2.jmx;
+
+public class NoOpClusterInfoOtelMetricsProvider implements ClusterInfoOtelMetricsProvider
+{
+  @Override
+  public void recordCanaryDistributionPolicy(String clusterName, int policy)
+  {
+    // No-op
+  }
+}


### PR DESCRIPTION
### Summary
This PR adds OpenTelemetry (OTel) metrics instrumentation to the ClusterInfoSensor.

### Changes
- **New Interface**: Added `ClusterInfoOtelMetricsProvider` interface for collecting ClusterInfo metrics via OpenTelemetry
  - CanaryDistributionPolicy

- **No-op Implementation**: Added `NoOpClusterInfoOtelMetricsProvider` as default implementation when metrics are disabled

- **Integration**: 
  - Integrated metrics provider into `JmxManager` constructor which is called from container MP.
  - Metrics provider passed to `ClusterInfoJmx` for metrics collection.

- **Metrics Tracked**:
  - Gauges: CanaryDistributionPolicy

### Testing
- Updated test fixtures to mock the new metrics provider

### Backward Compatibility
- Fully backward compatible - defaults to no-op provider when not configured