### PR TITLE
Support consistent hashing at cluster level

### DIFF
--- a/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Cluster.pdl
+++ b/d2-schemas/src/main/pegasus/com/linkedin/d2/D2Cluster.pdl
@@ -54,4 +54,9 @@ record D2Cluster includes D2ChangeTimeStamps {
   * Options for configuring the outlier detection. Only used by gRPC clients.
   */
   outlierDetectionConfig: optional OutlierDetectionConfig
+
+  /**
+   * Properties used for the relative load balancing strategy. Only used by gRPC clients.
+   */
+  relativeStrategyProperties: optional D2RelativeStrategyProperties
 }


### PR DESCRIPTION
Copy `D2RelativeStrategyProperties` from D2Service to D2Cluster. Reusing this schema will maintain backward compatability, and the move is to align with long-term vision that load balancing strategy should be configured at the cluster level for all gRPC clients. 

With this change, users will be able to configure Consistent Hashing strategy similar like before, but at the cluster level:
```
<entry key="relativeStrategyProperties">
  <map>
    <entry key="ringProperties">
      <map>
        <entry key="consistentHashAlgorithm" value="pointBased"/>
      </map>
    </entry>
  </map>
</entry>
```