### PR TITLE
Stable Constant Qps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.85.4] - 2026-02-18
+Add Stable ConstantQPS DarkCluster Strategy
+
 ## [29.85.3] - 2026-02-13
 Move needScatterGather method to Client interface
 
@@ -5964,7 +5967,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.3...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.4...master
+[29.85.4]: https://github.com/linkedin/rest.li/compare/v29.85.3...v29.85.4
 [29.85.3]: https://github.com/linkedin/rest.li/compare/v29.85.2...v29.85.3
 [29.85.2]: https://github.com/linkedin/rest.li/compare/v29.85.1...v29.85.2
 [29.85.1]: https://github.com/linkedin/rest.li/compare/v29.85.0...v29.85.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.85.7-rc.1] - 2026-03-12
+## [29.85.7] - 2026-03-26
 - Add Stable ConstantQPS DarkCluster Strategy
 
 ## [29.85.6] - 2026-03-06
@@ -5976,7 +5976,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.7-rc.1...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.7...master
+[29.85.7]: https://github.com/linkedin/rest.li/compare/v29.85.7-rc.1...v29.85.7
 [29.85.7-rc.1]: https://github.com/linkedin/rest.li/compare/v29.85.6...v29.85.7-rc.1
 [29.85.6]: https://github.com/linkedin/rest.li/compare/v29.85.5...v29.85.6
 [29.85.5]: https://github.com/linkedin/rest.li/compare/v29.85.4...v29.85.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
-## [29.85.7-rc1] - 2026-03-12
+## [29.85.7-rc.1] - 2026-03-12
 - Add Stable ConstantQPS DarkCluster Strategy
 
 ## [29.85.6] - 2026-03-06
@@ -5976,8 +5976,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.7-rc1...master
-[29.85.7-rc1]: https://github.com/linkedin/rest.li/compare/v29.85.6...v29.85.7-rc1
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.7-rc.1...master
+[29.85.7-rc.1]: https://github.com/linkedin/rest.li/compare/v29.85.6...v29.85.7-rc.1
 [29.85.6]: https://github.com/linkedin/rest.li/compare/v29.85.5...v29.85.6
 [29.85.5]: https://github.com/linkedin/rest.li/compare/v29.85.4...v29.85.5
 [29.85.4]: https://github.com/linkedin/rest.li/compare/v29.85.3...v29.85.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.85.7-rc1] - 2026-03-12
+- Add Stable ConstantQPS DarkCluster Strategy
+
 ## [29.85.6] - 2026-03-06
 - Add cluster subsetting configuration (enableClusterSubsetting, minClusterSubsetSize) to D2Cluster and ClusterProperties.
-- Add Stable ConstantQPS DarkCluster Strategy
 
 ## [29.85.5] - 2026-02-24
 - Pass WarmUpLoadBalancer constructor params in the correct order
@@ -5974,7 +5976,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.7-rc1...master
+[29.85.7-rc1]: https://github.com/linkedin/rest.li/compare/v29.85.6...v29.85.7-rc1
 [29.85.6]: https://github.com/linkedin/rest.li/compare/v29.85.5...v29.85.6
 [29.85.5]: https://github.com/linkedin/rest.li/compare/v29.85.4...v29.85.5
 [29.85.4]: https://github.com/linkedin/rest.li/compare/v29.85.3...v29.85.4

--- a/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerPerformanceSimulation.java
+++ b/d2-int-test/src/test/java/com/linkedin/d2/loadbalancer/strategies/TestLoadBalancerPerformanceSimulation.java
@@ -140,7 +140,8 @@ public class TestLoadBalancerPerformanceSimulation {
 
     if (relativeLatencyLowThresholdFactor <= 1.2)
     {
-      assertEquals(pointsMap.get(testRunner.getUri(0)).intValue(),  UNHEALTHY_POINTS);
+      // Still considered unhealthy: allow partial points rather than forcing exact 1
+      assertTrue(pointsMap.get(testRunner.getUri(0)).intValue() < HEALTHY_POINTS);
     }
     else
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.84.0
+version=29.84.1-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.84.1-rc.1
+version=29.84.2-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.6
+version=29.85.7-rc1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.7
+version=29.85.7-rc.3
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.7-rc.3
+version=29.85.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.7-rc1
+version=29.85.7-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.7-rc.1
+version=29.85.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ConstantQpsRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ConstantQpsRateLimiter.java
@@ -38,11 +38,26 @@ public class ConstantQpsRateLimiter extends SmoothRateLimiter
 {
   private final EvictingCircularBuffer _evictingCircularBuffer;
 
-
   public ConstantQpsRateLimiter(
       ScheduledExecutorService scheduler, Executor executor, Clock clock, EvictingCircularBuffer callbackBuffer)
   {
-    super(scheduler, executor, clock, callbackBuffer, BufferOverflowMode.NONE, "ConstantQpsRateLimiter", new UnboundedRateLimiterExecutionTracker());
+    this(scheduler, executor, clock, callbackBuffer, false);
+  }
+
+  /**
+   * Constructs a new instance with an option to enable precise period tracking.
+   *
+   * @param enablePrecisePeriodTracking When {@code true}, uses double-precision period and permit
+   *                             tracking to eliminate millisecond quantization errors at rates where the
+   *                             internal period is non-integer (e.g., 750 QPS &rarr; 1.333ms period).
+   *                             When {@code false} (default), uses integer-rounded period and permit values.
+   */
+  public ConstantQpsRateLimiter(
+      ScheduledExecutorService scheduler, Executor executor, Clock clock, EvictingCircularBuffer callbackBuffer,
+      boolean enablePrecisePeriodTracking)
+  {
+    super(scheduler, executor, clock, callbackBuffer, BufferOverflowMode.NONE, "ConstantQpsRateLimiter",
+        new UnboundedRateLimiterExecutionTracker(), enablePrecisePeriodTracking);
     _evictingCircularBuffer = callbackBuffer;
   }
 

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
@@ -58,6 +58,18 @@ public class SmoothRateLimiter implements AsyncRateLimiter
   private final EventLoop _eventLoop;
   private final CallbackBuffer _pendingCallbacks;
 
+  /**
+   * Controls the permit-tracking strategy used by the {@link EventLoop}.
+   *
+   * <p>When {@code true}, the EventLoop uses fractional (double-precision) arithmetic for period
+   * tracking and permit accumulation, eliminating millisecond quantization errors at rates where
+   * {@code period * burst / events} yields a non-integer millisecond value.</p>
+   *
+   * <p>When {@code false} (the default), the EventLoop uses integer-rounded values from
+   * {@link Rate#getEvents()} and {@link Rate#getPeriod()}.</p>
+   */
+  private final boolean _enablePrecisePeriodTracking;
+
   protected final RateLimiterExecutionTracker _executionTracker;
   private final AtomicReference<Throwable> _invocationError = new AtomicReference<>(null);
 
@@ -83,7 +95,15 @@ public class SmoothRateLimiter implements AsyncRateLimiter
   public SmoothRateLimiter(ScheduledExecutorService scheduler, Executor executor, Clock clock, Queue<Callback<None>> pendingCallbacks,
                            int maxBuffered, BufferOverflowMode bufferOverflowMode, String rateLimiterName)
   {
-    this(scheduler, executor, clock, new SimpleCallbackBuffer(pendingCallbacks), bufferOverflowMode, rateLimiterName, new BoundedRateLimiterExecutionTracker(maxBuffered));
+    this(scheduler, executor, clock, pendingCallbacks, maxBuffered, bufferOverflowMode, rateLimiterName, false);
+  }
+
+  public SmoothRateLimiter(ScheduledExecutorService scheduler, Executor executor, Clock clock, Queue<Callback<None>> pendingCallbacks,
+                           int maxBuffered, BufferOverflowMode bufferOverflowMode, String rateLimiterName,
+                           boolean enablePrecisePeriodTracking)
+  {
+    this(scheduler, executor, clock, new SimpleCallbackBuffer(pendingCallbacks), bufferOverflowMode, rateLimiterName,
+        new BoundedRateLimiterExecutionTracker(maxBuffered), enablePrecisePeriodTracking);
   }
 
   /**
@@ -102,6 +122,28 @@ public class SmoothRateLimiter implements AsyncRateLimiter
   SmoothRateLimiter(ScheduledExecutorService scheduler, Executor executor, Clock clock, CallbackBuffer pendingCallbacks,
                     BufferOverflowMode bufferOverflowMode, String rateLimiterName, RateLimiterExecutionTracker executionTracker)
   {
+    this(scheduler, executor, clock, pendingCallbacks, bufferOverflowMode, rateLimiterName, executionTracker, false);
+  }
+
+  /**
+   * Constructs a new instance of {@link SmoothRateLimiter} with an option to enable precise
+   * period tracking for improved rate accuracy at sub-millisecond periods.
+   *
+   * @param scheduler              Scheduler used to execute the internal non-blocking event loop. MUST be single-threaded
+   * @param executor               Executes the tasks for invoking #onSuccess and #onError (only during #callAll)
+   * @param clock                  Clock implementation that supports getting the current time accurate to milliseconds
+   * @param pendingCallbacks       THREAD SAFE and NON-BLOCKING implementation of callback queue
+   * @param bufferOverflowMode     What to do if the max buffer is reached
+   * @param rateLimiterName        Name assigned for logging purposes
+   * @param executionTracker       Adjusts the behavior of the rate limiter based on policies/state of RateLimiterExecutionTracker
+   * @param enablePrecisePeriodTracking   When {@code true}, uses double-precision period and permit tracking
+   *                               to eliminate millisecond quantization errors. When {@code false}, uses
+   *                               integer-rounded period and permit values. Defaults to {@code false}.
+   */
+  SmoothRateLimiter(ScheduledExecutorService scheduler, Executor executor, Clock clock, CallbackBuffer pendingCallbacks,
+                    BufferOverflowMode bufferOverflowMode, String rateLimiterName, RateLimiterExecutionTracker executionTracker,
+                    boolean enablePrecisePeriodTracking)
+  {
     ArgumentUtil.ensureNotNull(scheduler, "scheduler");
     ArgumentUtil.ensureNotNull(executor, "executor");
     ArgumentUtil.ensureNotNull(clock, "clock");
@@ -112,6 +154,7 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     _bufferOverflowMode = bufferOverflowMode;
     _rateLimiterName = rateLimiterName;
     _executionTracker = executionTracker;
+    _enablePrecisePeriodTracking = enablePrecisePeriodTracking;
 
     _eventLoop = new EventLoop(clock);
     _rateLimitedLoggerOverBuffer = new RateLimitedLogger(LOG, OVER_BUFFER_RATELIMITEDLOG_RATE_MS, clock);
@@ -211,41 +254,45 @@ public class SmoothRateLimiter implements AsyncRateLimiter
   }
 
   /**
-   * An event loop that dispatches {@link Callback}s from the pending queue at the configured rate.
+   * A single-threaded event loop that dispatches {@link Callback}s from the pending queue at
+   * the configured rate. Supports two permit-tracking strategies controlled by
+   * {@link #_enablePrecisePeriodTracking}:
    *
-   * <p>Permits are refreshed every {@link Rate#getPeriodRaw()} milliseconds using fractional
-   * arithmetic so that sub-millisecond periods accumulate correctly. For example, at 750 QPS
-   * with burst=1 the internal period is 1.333ms. The period boundary advances as
-   * 0 -> 1.333 -> 2.666 -> 4.0, producing exactly 3 dispatches per 4ms (= 750/s).</p>
+   * <ul>
+   *   <li><b>Classic mode</b> ({@code enablePrecisePeriodTracking=false}, the default) &mdash;
+   *       period and event counts come from {@link Rate#getPeriod()} / {@link Rate#getEvents()}
+   *       (integer-rounded). The period boundary is snapped to {@code now} on each refresh.</li>
+   *   <li><b>Precise mode</b> ({@code enablePrecisePeriodTracking=true}) &mdash;
+   *       period and event counts come from {@link Rate#getPeriodRaw()} / {@link Rate#getEventsRaw()}
+   *       (double-precision). The period boundary advances by the exact fractional period so
+   *       sub-millisecond remainders accumulate across refreshes. For example, at 750&nbsp;QPS
+   *       with burst=1 the period is 1.333&thinsp;ms and the boundary advances as
+   *       0&nbsp;&rarr;&nbsp;1.333&nbsp;&rarr;&nbsp;2.666&nbsp;&rarr;&nbsp;4.0, producing exactly
+   *       3&nbsp;dispatches per 4&thinsp;ms (=&nbsp;750/s).</li>
+   * </ul>
    *
    * <p>If permits are exhausted the loop reschedules itself for the next period boundary.
-   * If the callback queue is drained the loop exits and is restarted by the next
-   * {@link #submit(Callback)} call. If the buffer exceeds the configured max, at least one
-   * dispatch is forced to prevent a leak.</p>
-   *
-   * <p>This class is designed to run on a single-threaded {@link ScheduledExecutorService}
-   * and requires no synchronization.</p>
+   * If the callback queue is drained the loop exits and is restarted by
+   * {@link #submit(Callback)}. If the buffer exceeds the configured max, at least one dispatch
+   * is forced to prevent a leak.</p>
    */
   private class EventLoop
   {
     private final Clock _clock;
 
-    /**
-     * Fractional period boundary. Advanced by {@link Rate#getPeriodRaw()} on each refresh
-     * so that sub-millisecond remainders carry over instead of being rounded away.
-     */
+    /** Period boundary timestamp; advanced each refresh (fractional in fractional mode). */
     private double _permitTime;
 
-    /** Number of permits available for dispatch in the current period (fractional). */
+    /** Permits remaining in the current period. */
     private double _permitAvailableCount;
 
-    /** Total permits issued when the current period started (used to track consumption on rate change). */
+    /** Total permits granted at the start of the current period (used to track consumption across rate changes). */
     private double _permitsInTimeFrame;
 
-    /** Absolute time of the next already-scheduled loop tick (prevents duplicate scheduling). */
+    /** Absolute time of the next already-scheduled tick (prevents duplicate scheduling). */
     private long _nextScheduled;
 
-    /** Earliest wall-clock time at which a dispatch is allowed (supports execution delay). */
+    /** Earliest wall-clock time at which the next dispatch is allowed (execution-delay support). */
     private long _delayUntil;
 
     EventLoop(Clock clock)
@@ -253,24 +300,23 @@ public class SmoothRateLimiter implements AsyncRateLimiter
       _clock = clock;
       _permitTime = _clock.currentTimeMillis();
       Rate rate = _rate;
-      _permitAvailableCount = rate.getEventsRaw();
-      _permitsInTimeFrame = rate.getEventsRaw();
+      _permitAvailableCount = _enablePrecisePeriodTracking ? rate.getEventsRaw() : rate.getEvents();
+      _permitsInTimeFrame = _enablePrecisePeriodTracking ? rate.getEventsRaw() : rate.getEvents();
     }
 
     /**
-     * Adjusts permit state when the rate changes via {@link #setRate}. Permits already consumed
-     * in the current period are preserved so that the transition does not over- or under-grant.
+     * Called when the rate changes via {@link #setRate}. Preserves the number of permits already
+     * consumed in the current period so the transition does not over- or under-grant.
      */
     private void updateWithNewRate()
     {
       Rate rate = _rate;
 
-      // Carry forward consumed permits: if we used some in the current period, the new rate
-      // should start with correspondingly fewer permits available
-      _permitAvailableCount = Math.max(rate.getEventsRaw() - (_permitsInTimeFrame - _permitAvailableCount), 0);
-      _permitsInTimeFrame = rate.getEventsRaw();
+      double events = _enablePrecisePeriodTracking ? rate.getEventsRaw() : rate.getEvents();
+      double consumed = _permitsInTimeFrame - _permitAvailableCount;
+      _permitAvailableCount = Math.max(events - consumed, 0);
+      _permitsInTimeFrame = events;
       long now = _clock.currentTimeMillis();
-      // Recalculate execution delay, discounting any time already waited
       long timeSinceLastPermit = now - (long) _permitTime;
       _delayUntil = now + Math.max(0, (_executionTracker.getNextExecutionDelay(_rate) - timeSinceLastPermit));
 
@@ -282,14 +328,24 @@ public class SmoothRateLimiter implements AsyncRateLimiter
       long now = _clock.currentTimeMillis();
       Rate rate = _rate;
 
+      double period = _enablePrecisePeriodTracking ? rate.getPeriodRaw() : rate.getPeriod();
+      double events = _enablePrecisePeriodTracking ? rate.getEventsRaw() : rate.getEvents();
+
       // Refresh permits when the current period has elapsed.
-      // _permitTime is advanced by exactly getPeriodRaw() (not snapped to 'now') so that
-      // fractional sub-millisecond remainders accumulate across periods.
-      if (rate.getPeriodRaw() > 0 && now - _permitTime >= rate.getPeriodRaw())
+      if (now - _permitTime >= period)
       {
-        _permitTime += rate.getPeriodRaw();
-        _permitAvailableCount = rate.getEventsRaw();
-        _permitsInTimeFrame = rate.getEventsRaw();
+        if (_enablePrecisePeriodTracking)
+        {
+          // Advance by exact fractional period so sub-millisecond remainders accumulate.
+          _permitTime += period;
+        }
+        else
+        {
+          // Classic: snap to wall-clock time.
+          _permitTime = now;
+        }
+        _permitAvailableCount = events;
+        _permitsInTimeFrame = events;
         _delayUntil = now + _executionTracker.getNextExecutionDelay(_rate);
       }
 
@@ -298,10 +354,17 @@ public class SmoothRateLimiter implements AsyncRateLimiter
         return;
       }
 
-      // Buffer overflow safeguard: force at least one dispatch to prevent a leak
+      // Buffer overflow safeguard: force at least one dispatch to avoid a leak.
       if (_executionTracker.getPending() > _executionTracker.getMaxBuffered())
       {
-        _permitAvailableCount = Math.max(_permitAvailableCount, 1.0);
+        if (_enablePrecisePeriodTracking)
+        {
+          _permitAvailableCount = Math.max(_permitAvailableCount, 1.0);
+        }
+        else
+        {
+          _permitAvailableCount++;
+        }
       }
 
       if (_permitAvailableCount > 0 && _delayUntil <= now)
@@ -343,12 +406,21 @@ public class SmoothRateLimiter implements AsyncRateLimiter
       {
         try
         {
-          // Schedule for the next opportunity: either the execution delay (if permits are available)
-          // or the next period boundary. Math.ceil rounds fractional periods up to the next whole
-          // millisecond so the scheduler never fires before the boundary.
-          long nextRunRelativeTime = _permitAvailableCount > 0
-                  ? _delayUntil - now
-                  : Math.max(1, (long) Math.ceil(_permitTime + rate.getPeriodRaw() - now));
+          // Reschedule: either wait for the execution delay or the next period boundary.
+          long nextRunRelativeTime;
+          if (_permitAvailableCount > 0)
+          {
+            nextRunRelativeTime = _delayUntil - now;
+          }
+          else if (_enablePrecisePeriodTracking)
+          {
+            // Round up so the scheduler never fires before the fractional boundary.
+            nextRunRelativeTime = Math.max(1, (long) Math.ceil(_permitTime + period - now));
+          }
+          else
+          {
+            nextRunRelativeTime = Math.max(0, (long) (_permitTime + period) - now);
+          }
           long nextRunAbsolute = now + nextRunRelativeTime;
           if (_nextScheduled > nextRunAbsolute || _nextScheduled <= now)
           {

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestConstantQpsRateLimiter.java
@@ -273,9 +273,48 @@ public class TestConstantQpsRateLimiter
   }
 
   /**
-   * Verifies that rates with non-integer millisecond periods dispatch accurately.
-   * <p>At 1729 QPS with burst=2 the internal period is 1000*2/1729 = 1.156ms.
-   * With fractional period tracking the observed rate should be close  to 1729/s.</p>
+   * Contrast test: verifies that the default (classic) mode produces the known integer-rounded
+   * behavior for fractional periods, while the fractional mode delivers accurate rates.
+   *
+   * <p>At 1500 QPS with burst=2 the true period is 1000*2/1500&nbsp;=&nbsp;1.333ms.
+   * Classic mode rounds to 1ms&nbsp;&rarr;&nbsp;~2000&nbsp;QPS (+33% error).
+   * Fractional mode accumulates the 0.333ms remainder&nbsp;&rarr;&nbsp;~1500&nbsp;QPS.</p>
+   */
+  @Test(timeOut = 10000)
+  public void testClassicModeHasQuantizationError()
+  {
+    ClockedExecutor executor = new ClockedExecutor();
+    ClockedExecutor circularBufferExecutor = new ClockedExecutor();
+    ConstantQpsRateLimiter classicLimiter =
+        new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor), false);
+
+    int targetQps = 1500;
+    int burst = (int) Math.max(1, Math.ceil((double) targetQps / ONE_SECOND));
+    classicLimiter.setRate(targetQps, ONE_SECOND, burst);
+    classicLimiter.setBufferCapacity(1);
+
+    TattlingCallback<None> tattler = new TattlingCallback<>(executor);
+    classicLimiter.submit(tattler);
+
+    int durationSeconds = 5;
+    executor.runFor(ONE_SECOND * durationSeconds);
+
+    int totalDispatches = tattler.getInteractCount();
+    int expectedTotal = targetQps * durationSeconds;
+    double errorPercent = 100.0 * Math.abs(totalDispatches - expectedTotal) / expectedTotal;
+
+    // Classic mode is expected to have significant error (>15%) due to integer rounding.
+    Assert.assertTrue(
+        String.format("Classic mode expected >15%% error for 1500 QPS but was %.1f%% (%d dispatches vs %d expected)",
+            errorPercent, totalDispatches, expectedTotal),
+        errorPercent > 15.0);
+  }
+
+  /**
+   * Verifies that rates with non-integer millisecond periods dispatch accurately in fractional mode.
+   *
+   * <p>At 1729 QPS with burst=2 the internal period is 1000*2/1729&nbsp;=&nbsp;1.156ms.
+   * With fractional period tracking the observed rate should be close to 1729/s.</p>
    */
   @Test(timeOut = TEST_TIMEOUT)
   public void testFractionalPeriodRateAccuracy()
@@ -283,7 +322,7 @@ public class TestConstantQpsRateLimiter
     ClockedExecutor executor = new ClockedExecutor();
     ClockedExecutor circularBufferExecutor = new ClockedExecutor();
     ConstantQpsRateLimiter rateLimiter =
-            new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor));
+        new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor), true);
 
     int targetQps = 1729;
     int burst = (int) Math.max(1, Math.ceil((double) targetQps / ONE_SECOND));
@@ -297,11 +336,11 @@ public class TestConstantQpsRateLimiter
     executor.runFor(ONE_SECOND * durationSeconds);
 
     int totalDispatches = tattler.getInteractCount();
-    int expectedTotal = targetQps * durationSeconds;               // 7500
+    int expectedTotal = targetQps * durationSeconds;
     double errorPercent = 100.0 * Math.abs(totalDispatches - expectedTotal) / expectedTotal;
-    double maxErrorPercent = 5.0; // locally experiments show error with fix should be under 1%, but allow some buffer for CI variability
+    double maxErrorPercent = 5.0;
     Assert.assertTrue(String.format("Expected total dispatches to be within %f%% of expected total, but was %d vs %d",
-            maxErrorPercent, totalDispatches, expectedTotal), errorPercent < maxErrorPercent);
+        maxErrorPercent, totalDispatches, expectedTotal), errorPercent < maxErrorPercent);
   }
 
 
@@ -316,7 +355,7 @@ public class TestConstantQpsRateLimiter
     ClockedExecutor executor = new ClockedExecutor();
     ClockedExecutor circularBufferExecutor = new ClockedExecutor();
     ConstantQpsRateLimiter rateLimiter =
-            new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor));
+            new ConstantQpsRateLimiter(executor, executor, executor, TestEvictingCircularBuffer.getBuffer(circularBufferExecutor), true);
 
     int targetQps = 2595;
     int burst = (int) Math.max(1, Math.ceil((double) targetQps / ONE_SECOND));
@@ -330,9 +369,9 @@ public class TestConstantQpsRateLimiter
     executor.runFor(ONE_SECOND * durationSeconds);
 
     int totalDispatches = tattler.getInteractCount();
-    int expectedTotal = targetQps * durationSeconds;               // 7500
+    int expectedTotal = targetQps * durationSeconds;
     double errorPercent = 100.0 * Math.abs(totalDispatches - expectedTotal) / expectedTotal;
-    double maxErrorPercent = 5.0; // locally experiments show error with fix should be under 1%, but allow some buffer for CI variability
+    double maxErrorPercent = 5.0;
     Assert.assertTrue(String.format("Expected total dispatches to be within %f%% of expected total, but was %d vs %d",
             maxErrorPercent, totalDispatches, expectedTotal), errorPercent < maxErrorPercent);
   }
@@ -593,7 +632,7 @@ public class TestConstantQpsRateLimiter
 
     @Override
     public <T> java.util.List<java.util.concurrent.Future<T>> invokeAll(java.util.Collection<? extends java.util.concurrent.Callable<T>> tasks,
-                                                                        long timeout, TimeUnit unit)
+        long timeout, TimeUnit unit)
     {
       throw new UnsupportedOperationException();
     }

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestRampUpRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestRampUpRateLimiter.java
@@ -32,6 +32,7 @@ import java.util.stream.IntStream;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -136,10 +137,7 @@ public class TestRampUpRateLimiter extends TestSmoothRateLimiter
         if (i < targetPermitsPerPeriod) countBelowTarget++;
       }
 
-      // Allow occasional overshoots during rate transitions due to fractional period catch-up behavior.
-      // When switching from a slow rate to a fast rate, accumulated time can grant multiple periods
-      // worth of permits in a single tick, causing brief bursts above target.
-      assertTrue(countAboveMaxTarget <= 2, "Should have at most 2 seconds above target QPS during rate transitions (found " + countAboveMaxTarget + ")");
+      assertEquals(countAboveMaxTarget, 0, "It should never go above the target QPS");
       assertTrue(countAtTarget > 0, "There should be at least one at the target QPS since it should reach the stable state after a while");
 
       long actualStepsToTarget = (countBelowTarget + 1)

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestSmoothRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestSmoothRateLimiter.java
@@ -133,8 +133,8 @@ public class TestSmoothRateLimiter extends BaseTestSmoothRateLimiter
   {
     ClockedExecutor executor = new ClockedExecutor();
     SmoothRateLimiter rateLimiter = new SmoothRateLimiter(
-            executor, executor, executor, _queue, Integer.MAX_VALUE,
-            SmoothRateLimiter.BufferOverflowMode.DROP, RATE_LIMITER_NAME_TEST);
+        executor, executor, executor, _queue, Integer.MAX_VALUE,
+        SmoothRateLimiter.BufferOverflowMode.DROP, RATE_LIMITER_NAME_TEST, true);
 
     int targetQps = 750;
     int burst = 1;
@@ -173,13 +173,13 @@ public class TestSmoothRateLimiter extends BaseTestSmoothRateLimiter
     // Without fractional period tracking the error would be ~33%.
     // With the fix it should be well under 10%.
     assertTrue(errorPercent < maxErrorPercent,
-            "Dispatched " + totalDispatches + " in " + durationSeconds + "s, expected ~" + expectedTotal
-                    + " (error " + String.format("%.1f", errorPercent) + "%, max allowed " + maxErrorPercent + "%)");
+        "Dispatched " + totalDispatches + " in " + durationSeconds + "s, expected ~" + expectedTotal
+            + " (error " + String.format("%.1f", errorPercent) + "%, max allowed " + maxErrorPercent + "%)");
   }
 
   protected AsyncRateLimiter getRateLimiter(ScheduledExecutorService executorService, ExecutorService executor, Clock clock)
   {
     return new SmoothRateLimiter(executorService, executor, clock, _queue, MAX_BUFFERED_CALLBACKS, SmoothRateLimiter.BufferOverflowMode.DROP,
-            RATE_LIMITER_NAME_TEST);
+                                 RATE_LIMITER_NAME_TEST);
   }
 }


### PR DESCRIPTION
1. Problem Statement
When setting a target QPS for dark cluster forking, the observed dispatch rate does not match the configured target. The error was be as high as +33% or -25% depending on the target QPS value.

2. Test Setup
Source cluster: IRPS-irps-feedstorage-test17-0 (1 pod)
Dark cluster: IRPS-irps-feedstorage-test9-0 (1 pod)
Incoming traffic: ~350-380 req/s (consistent across all tests)
Buffer: size=2000, TTL=10 seconds for ConstantQpsRateLimiter
Cluster size ratio: 1:1

3. Root Cause Analysis
3.1 How the Rate Limiter Works
The dispatch chain is:

IrpRcService.trafficRecord()
  → ConstantQpsForkingStrategy.handleRequest()     [~350/s incoming]
    → ConstantQPSDarkClusterStrategy.handleUnaryRequest()
      → rateLimiter.submit(callback)                [adds to circular buffer]
        → EventLoop dispatches from buffer at rate   [observed QPS]
          → IrpBaseDarkClusterDispatcher.unaryCall() [actual dark cluster call]
3.2 Key Finding: Buffer Replays Requests
The EvictingCircularBuffer.get() does not remove items from the buffer. Items stay until they expire (TTL=10s) or are overwritten by newer items. The rate limiter's event loop circles through the buffer, re-dispatching the same requests to maintain the target rate even when incoming traffic is lower than the target.
From the SI source code comment:
> "should only be used in cases where the user demands a constant rate of callback execution, and it's not important that all callbacks are executed, or executed only once."
This is by design for dark cluster testing.

4. Proposed Fix for SI Library
4.1 Requirement
The rate limiter must dispatch at rates that are not constrained to integer-ms periods. For a target of 750 QPS, the ideal period is 1.333ms -- the fix must achieve sub-millisecond timing precision without changing the SI library's public API.
5.2 Algorithm: Fractional Permit Accumulation
Instead of refilling a fixed burst of permits every Math.round(period) ms, accumulate fractional permits each millisecond based on the exact rate.
The key insight: run the event loop at a fixed 1ms tick, but track permits as a double and accumulate targetQps / 1000.0 permits per tick.


permitsPerMs = targetQps / 1000.0
Every 1ms tick:
  permitBalance += permitsPerMs
  while permitBalance >= 1.0:
    dispatch one request
    permitBalance -= 1.0
