### PR TITLE
Add potential clients cache to avoid recomputation on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Add optional precomputed potential clients cache to SimpleLoadBalancerState, moving O(n) per-request
+  host filtering in SimpleLoadBalancer.getPotentialClients() to state-change event handlers for O(1) lookups.
+  Gated behind new `enablePotentialClientsCache` config flag (default: off).
 
 ## [29.85.8] - 2026-04-14
 - Add `invalidProjectionAs5xx` flag to `RestLiValidationFilter` to report projected fields missing from schema as HTTP 500 instead of 400, so server-side schema regressions trigger alerts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.85.9] - 2026-04-21
 - Add optional precomputed potential clients cache to SimpleLoadBalancerState, moving O(n) per-request
   host filtering in SimpleLoadBalancer.getPotentialClients() to state-change event handlers for O(1) lookups.
   Gated behind new `enablePotentialClientsCache` config flag (default: off).
@@ -5982,7 +5984,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.8...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.9...master
+[29.85.9]: https://github.com/linkedin/rest.li/compare/v29.85.8...v29.85.9
 [29.85.8]: https://github.com/linkedin/rest.li/compare/v29.85.7...v29.85.8
 [29.85.7]: https://github.com/linkedin/rest.li/compare/v29.85.6...v29.85.7
 [29.85.6]: https://github.com/linkedin/rest.li/compare/v29.85.5...v29.85.6

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -240,6 +240,7 @@ public class D2ClientBuilder
                   _config.subscribeToUriGlobCollection,
                   _config._xdsServerMetricsProvider,
                   _config.loadBalanceStreamException,
+                  _config.enablePotentialClientsCache,
                   _config.xdsInitialResourceVersionsEnabled,
                   _config.disableDetectLiRawD2Client,
                   _config.isLiRawD2Client,
@@ -874,6 +875,11 @@ public class D2ClientBuilder
 
   public D2ClientBuilder setLoadBalanceStreamException(boolean loadBalanceStreamException) {
     _config.loadBalanceStreamException = loadBalanceStreamException;
+    return this;
+  }
+
+  public D2ClientBuilder setEnablePotentialClientsCache(boolean enablePotentialClientsCache) {
+    _config.enablePotentialClientsCache = enablePotentialClientsCache;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -190,6 +190,7 @@ public class D2ClientConfig
    */
   public XdsClientOtelMetricsProvider xdsClientOtelMetricsProvider = new NoOpXdsClientOtelMetricsProvider();
   public boolean loadBalanceStreamException = false;
+  public boolean enablePotentialClientsCache = false;
   public boolean xdsInitialResourceVersionsEnabled = false;
   public Integer xdsStreamMaxRetryBackoffSeconds = null;
   public String xdsMinimumJavaVersion = DEFAULT_MINIMUM_JAVA_VERSION;
@@ -291,6 +292,7 @@ public class D2ClientConfig
                  boolean subscribeToUriGlobCollection,
                  XdsServerMetricsProvider xdsServerMetricsProvider,
                  boolean loadBalanceStreamException,
+                 boolean enablePotentialClientsCache,
                  boolean xdsInitialResourceVersionsEnabled,
                  boolean disableDetectLiRawD2Client,
                  boolean isLiRawD2Client,
@@ -343,6 +345,7 @@ public class D2ClientConfig
         subscribeToUriGlobCollection,
         xdsServerMetricsProvider,
         loadBalanceStreamException,
+        enablePotentialClientsCache,
         xdsInitialResourceVersionsEnabled,
         disableDetectLiRawD2Client,
         isLiRawD2Client,
@@ -429,6 +432,7 @@ public class D2ClientConfig
                  boolean subscribeToUriGlobCollection,
                  XdsServerMetricsProvider xdsServerMetricsProvider,
                  boolean loadBalanceStreamException,
+                 boolean enablePotentialClientsCache,
                  boolean xdsInitialResourceVersionsEnabled,
                  boolean disableDetectLiRawD2Client,
                  boolean isLiRawD2Client,
@@ -515,6 +519,7 @@ public class D2ClientConfig
     this.subscribeToUriGlobCollection = subscribeToUriGlobCollection;
     this._xdsServerMetricsProvider = xdsServerMetricsProvider;
     this.loadBalanceStreamException = loadBalanceStreamException;
+    this.enablePotentialClientsCache = enablePotentialClientsCache;
     this.xdsInitialResourceVersionsEnabled = xdsInitialResourceVersionsEnabled;
     this.disableDetectLiRawD2Client = disableDetectLiRawD2Client;
     this.isLiRawD2Client = isLiRawD2Client;

--- a/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LastSeenBalancerWithFacilitiesFactory.java
@@ -108,7 +108,7 @@ public class LastSeenBalancerWithFacilitiesFactory implements LoadBalancerWithFa
       config._executorService, uriBus, clusterBus, serviceBus, config.clientFactories, config.loadBalancerStrategyFactories,
       config.sslContext, config.sslParameters, config.isSSLEnabled, config.partitionAccessorRegistry,
       config.sslSessionValidatorFactory, config.deterministicSubsettingMetadataProvider, config.canaryDistributionProvider,
-      config.loadBalanceStreamException);
+      config.loadBalanceStreamException, config.enablePotentialClientsCache);
     d2ClientJmxManager.setSimpleLoadBalancerState(state);
 
     SimpleLoadBalancer simpleLoadBalancer = new SimpleLoadBalancer(state, config.lbWaitTimeout, config.lbWaitUnit, config._executorService,

--- a/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/LoadBalancerState.java
@@ -103,6 +103,18 @@ public interface LoadBalancerState
   List<SchemeStrategyPair> getStrategiesForService(String serviceName,
                                                     List<String> prioritizedSchemes);
 
+  /**
+   * Returns the precomputed potential clients for the given service, scheme, and partition.
+   * These are the TrackerClients available for load balancing, with banned URIs filtered out
+   * and subsetting applied (if enabled).
+   *
+   * @return the cached client map, or null if no precomputed cache is available.
+   */
+  default Map<URI, TrackerClient> getPotentialClients(String serviceName, String scheme, int partitionId)
+  {
+    return null;
+  }
+
   default SubsettingState.SubsetItem getClientsSubset(String serviceName,
                                                    int minClusterSubsetSize,
                                                    int partitionId,

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -107,6 +107,7 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    config.serviceDiscoveryEventEmitter,
                                                    config.dualReadStateManager,
                                                    config.loadBalanceStreamException,
+                                                   config.enablePotentialClientsCache,
                                                    config.isLiRawD2Client
     );
   }

--- a/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/ZKFSLoadBalancerWithFacilitiesFactory.java
@@ -107,8 +107,8 @@ public class ZKFSLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFa
                                                    config.serviceDiscoveryEventEmitter,
                                                    config.dualReadStateManager,
                                                    config.loadBalanceStreamException,
-                                                   config.enablePotentialClientsCache,
-                                                   config.isLiRawD2Client
+                                                   config.isLiRawD2Client,
+                                                   config.enablePotentialClientsCache
     );
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/properties/UriProperties.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/properties/UriProperties.java
@@ -146,6 +146,11 @@ public class UriProperties
     return _uriSpecificProperties;
   }
 
+  public Map<String, Map<Integer, Set<URI>>> getUrisBySchemeAndPartition()
+  {
+    return _urisBySchemeAndPartition;
+  }
+
   public Set<URI> getUriBySchemeAndPartition(String scheme, int partitionId)
   {
     Map<Integer, Set<URI>> schemeUris = _urisBySchemeAndPartition.get(scheme);

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/ClusterLoadBalancerSubscriber.java
@@ -71,6 +71,7 @@ class ClusterLoadBalancerSubscriber extends
       }
 
       _simpleLoadBalancerState.notifyListenersOnClusterInfoUpdates(newClusterInfoItem);
+      _simpleLoadBalancerState.rebuildPotentialClientsForCluster(listenTo);
       // notify the cluster listeners only when discoveryProperties is not null, because we don't
       // want to count initialization (just because listenToCluster is called)
       _simpleLoadBalancerState.notifyClusterListenersOnAdd(listenTo);
@@ -87,6 +88,7 @@ class ClusterLoadBalancerSubscriber extends
   @Override
   protected void handleRemove(final String listenTo)
   {
+    _simpleLoadBalancerState.invalidatePotentialClientsForCluster(listenTo);
     ClusterInfoItem clusterInfoRemoved = _simpleLoadBalancerState.getClusterInfo().remove(listenTo);
     _simpleLoadBalancerState.notifyListenersOnClusterInfoRemovals(clusterInfoRemoved);
     _simpleLoadBalancerState.notifyClusterListenersOnRemove(listenTo);

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/ServiceLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/ServiceLoadBalancerSubscriber.java
@@ -98,6 +98,8 @@ class ServiceLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<Servi
       }
 
       serviceNames.add(pickedProperties.getServiceName());
+
+      _simpleLoadBalancerState.rebuildPotentialClientsForService(pickedProperties.getServiceName());
     }
     else if (oldServicePropertiesItem != null)
     {
@@ -147,6 +149,7 @@ class ServiceLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<Servi
       }
 
       _simpleLoadBalancerState.notifyListenersOnServicePropertiesRemovals(serviceItem);
+      _simpleLoadBalancerState.invalidatePotentialClientsForService(listenTo);
       _simpleLoadBalancerState.shutdownClients(listenTo);
 
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -1001,11 +1001,6 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
     Map<URI, TrackerClient> cached = _state.getPotentialClients(serviceName, scheme, partitionId);
     if (cached != null)
     {
-      debug(_log,
-          "got clients to load balance for ",
-          serviceName,
-          " from cache: ",
-          cached);
       return new TrackerClientSubsetItem(false, cached);
     }
 
@@ -1037,12 +1032,6 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
         shouldForceUpdate = subsetItem.shouldForceUpdate();
       }
     }
-
-    debug(_log,
-        "got clients to load balance for ",
-        serviceName,
-        ": ",
-        clientsToBalance);
 
     if (clientsToBalance.isEmpty())
     {

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/SimpleLoadBalancer.java
@@ -996,6 +996,20 @@ public class SimpleLoadBalancer implements LoadBalancer, HashRingProvider, Clien
                                                   int partitionId,
                                                   long version)
   {
+    // Fast path: use the precomputed cache from SimpleLoadBalancerState (O(1) lookup).
+    // The cache is rebuilt on state change events (URI/service/cluster property updates).
+    Map<URI, TrackerClient> cached = _state.getPotentialClients(serviceName, scheme, partitionId);
+    if (cached != null)
+    {
+      debug(_log,
+          "got clients to load balance for ",
+          serviceName,
+          " from cache: ",
+          cached);
+      return new TrackerClientSubsetItem(false, cached);
+    }
+
+    // Fallback for non-SimpleLoadBalancerState implementations: existing O(n) logic.
     Set<URI> possibleUris = uris.getUriBySchemeAndPartition(scheme, partitionId);
     Map<URI, TrackerClient> clientsToBalance = Collections.emptyMap();
     boolean shouldForceUpdate = false;

--- a/d2/src/main/java/com/linkedin/d2/balancer/simple/UriLoadBalancerSubscriber.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/simple/UriLoadBalancerSubscriber.java
@@ -171,6 +171,12 @@ class UriLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<UriProper
       // cache file, or we just started listening to a cluster without any uris yet.
       RATE_LIMITED_LOGGER.warn("Received a null uri properties for cluster: {}", cluster);
     }
+
+    // Rebuild the potential clients cache for all services on this cluster
+    if (uriProperties != null)
+    {
+      _simpleLoadBalancerState.rebuildPotentialClientsForCluster(uriProperties.getClusterName());
+    }
   }
 
   @Override
@@ -178,6 +184,7 @@ class UriLoadBalancerSubscriber extends AbstractLoadBalancerSubscriber<UriProper
   {
     _simpleLoadBalancerState.getUriProperties().remove(cluster);
     warn(RATE_LIMITED_LOGGER, "received a uri properties event remove() for cluster: ", cluster);
+    _simpleLoadBalancerState.invalidatePotentialClientsForCluster(cluster);
     _simpleLoadBalancerState.removeTrackerClients(cluster);
   }
 }

--- a/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
@@ -98,6 +98,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
   private final ServiceDiscoveryEventEmitter _serviceDiscoveryEventEmitter;
   private final DualReadStateManager _dualReadStateManager;
   private final boolean _loadBalanceStreamException;
+  private final boolean _enablePotentialClientsCache;
   private final boolean _isRawD2Client;
 
   private static final Logger _log = LoggerFactory.getLogger(ZKFSTogglingLoadBalancerFactoryImpl.class);
@@ -369,7 +370,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
          sslContext, sslParameters, isSSLEnabled, clientServicesConfig, useNewEphemeralStoreWatcher, partitionAccessorRegistry,
          enableSaveUriDataOnDisk, sslSessionValidatorFactory, d2ClientJmxManager, zookeeperReadWindowMs,
          deterministicSubsettingMetadataProvider, failoutConfigProviderFactory, canaryDistributionProvider,
-         serviceDiscoveryEventEmitter, dualReadStateManager, false, false);
+         serviceDiscoveryEventEmitter, dualReadStateManager, false, false, false);
   }
 
   public ZKFSTogglingLoadBalancerFactoryImpl(ComponentFactory factory,
@@ -396,6 +397,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
       ServiceDiscoveryEventEmitter serviceDiscoveryEventEmitter,
       DualReadStateManager dualReadStateManager,
       boolean loadBalanceStreamException,
+      boolean enablePotentialClientsCache,
       boolean isRawD2Client)
   {
     _factory = factory;
@@ -422,6 +424,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
     _serviceDiscoveryEventEmitter = serviceDiscoveryEventEmitter;
     _dualReadStateManager = dualReadStateManager;
     _loadBalanceStreamException = loadBalanceStreamException;
+    _enablePotentialClientsCache = enablePotentialClientsCache;
     _isRawD2Client = isRawD2Client;
   }
 
@@ -484,7 +487,8 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
     SimpleLoadBalancerState state = new SimpleLoadBalancerState(
         executorService, uriBus, clusterBus, serviceBus, _clientFactories, _loadBalancerStrategyFactories, _sslContext,
         _sslParameters, _isSSLEnabled, _partitionAccessorRegistry, _sslSessionValidatorFactory,
-        _deterministicSubsettingMetadataProvider, _canaryDistributionProvider, _loadBalanceStreamException);
+        _deterministicSubsettingMetadataProvider, _canaryDistributionProvider, _loadBalanceStreamException,
+        _enablePotentialClientsCache);
     _d2ClientJmxManager.setSimpleLoadBalancerState(state);
 
     SimpleLoadBalancer balancer = new SimpleLoadBalancer(state, _lbTimeout, _lbTimeoutUnit, executorService, _failoutConfigProviderFactory);

--- a/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/zkfs/ZKFSTogglingLoadBalancerFactoryImpl.java
@@ -98,8 +98,8 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
   private final ServiceDiscoveryEventEmitter _serviceDiscoveryEventEmitter;
   private final DualReadStateManager _dualReadStateManager;
   private final boolean _loadBalanceStreamException;
-  private final boolean _enablePotentialClientsCache;
   private final boolean _isRawD2Client;
+  private final boolean _enablePotentialClientsCache;
 
   private static final Logger _log = LoggerFactory.getLogger(ZKFSTogglingLoadBalancerFactoryImpl.class);
 
@@ -370,7 +370,7 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
          sslContext, sslParameters, isSSLEnabled, clientServicesConfig, useNewEphemeralStoreWatcher, partitionAccessorRegistry,
          enableSaveUriDataOnDisk, sslSessionValidatorFactory, d2ClientJmxManager, zookeeperReadWindowMs,
          deterministicSubsettingMetadataProvider, failoutConfigProviderFactory, canaryDistributionProvider,
-         serviceDiscoveryEventEmitter, dualReadStateManager, false, false, false);
+         serviceDiscoveryEventEmitter, dualReadStateManager, false, false);
   }
 
   public ZKFSTogglingLoadBalancerFactoryImpl(ComponentFactory factory,
@@ -397,8 +397,42 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
       ServiceDiscoveryEventEmitter serviceDiscoveryEventEmitter,
       DualReadStateManager dualReadStateManager,
       boolean loadBalanceStreamException,
-      boolean enablePotentialClientsCache,
       boolean isRawD2Client)
+  {
+    this(factory, timeout, timeoutUnit, baseZKPath, fsBasePath, clientFactories, loadBalancerStrategyFactories,
+         d2ServicePath, sslContext, sslParameters, isSSLEnabled, clientServicesConfig, useNewEphemeralStoreWatcher,
+         partitionAccessorRegistry, enableSaveUriDataOnDisk, sslSessionValidatorFactory, d2ClientJmxManager,
+         zookeeperReadWindowMs, deterministicSubsettingMetadataProvider, failoutConfigProviderFactory,
+         canaryDistributionProvider, serviceDiscoveryEventEmitter, dualReadStateManager,
+         loadBalanceStreamException, isRawD2Client, false);
+  }
+
+  public ZKFSTogglingLoadBalancerFactoryImpl(ComponentFactory factory,
+      long timeout,
+      TimeUnit timeoutUnit,
+      String baseZKPath,
+      String fsBasePath,
+      Map<String, TransportClientFactory> clientFactories,
+      Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories,
+      String d2ServicePath,
+      SSLContext sslContext,
+      SSLParameters sslParameters,
+      boolean isSSLEnabled,
+      Map<String, Map<String, Object>> clientServicesConfig,
+      boolean useNewEphemeralStoreWatcher,
+      PartitionAccessorRegistry partitionAccessorRegistry,
+      boolean enableSaveUriDataOnDisk,
+      SslSessionValidatorFactory sslSessionValidatorFactory,
+      D2ClientJmxManager d2ClientJmxManager,
+      int zookeeperReadWindowMs,
+      DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider,
+      FailoutConfigProviderFactory failoutConfigProviderFactory,
+      CanaryDistributionProvider canaryDistributionProvider,
+      ServiceDiscoveryEventEmitter serviceDiscoveryEventEmitter,
+      DualReadStateManager dualReadStateManager,
+      boolean loadBalanceStreamException,
+      boolean isRawD2Client,
+      boolean enablePotentialClientsCache)
   {
     _factory = factory;
     _lbTimeout = timeout;
@@ -424,8 +458,8 @@ public class ZKFSTogglingLoadBalancerFactoryImpl implements ZKFSLoadBalancer.Tog
     _serviceDiscoveryEventEmitter = serviceDiscoveryEventEmitter;
     _dualReadStateManager = dualReadStateManager;
     _loadBalanceStreamException = loadBalanceStreamException;
-    _enablePotentialClientsCache = enablePotentialClientsCache;
     _isRawD2Client = isRawD2Client;
+    _enablePotentialClientsCache = enablePotentialClientsCache;
   }
 
   @Override

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsFsTogglingLoadBalancerFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsFsTogglingLoadBalancerFactory.java
@@ -81,6 +81,7 @@ public class XdsFsTogglingLoadBalancerFactory
   private final CanaryDistributionProvider _canaryDistributionProvider;
   private final FailoutConfigProviderFactory _failoutConfigProviderFactory;
   private final boolean _loadBalanceStreamException;
+  private final boolean _enablePotentialClientsCache;
 
   @Deprecated
   public XdsFsTogglingLoadBalancerFactory(long timeout, TimeUnit timeoutUnit, String fsBasePath,
@@ -98,6 +99,7 @@ public class XdsFsTogglingLoadBalancerFactory
         canaryDistributionProvider, false);
   }
 
+  @Deprecated
   public XdsFsTogglingLoadBalancerFactory(long timeout, TimeUnit timeoutUnit, String fsBasePath,
       Map<String, TransportClientFactory> clientFactories,
       Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories,
@@ -107,6 +109,22 @@ public class XdsFsTogglingLoadBalancerFactory
       DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider,
       FailoutConfigProviderFactory failoutConfigProviderFactory, CanaryDistributionProvider canaryDistributionProvider,
       boolean loadBalanceStreamException)
+  {
+    this(timeout, timeoutUnit, fsBasePath, clientFactories, loadBalancerStrategyFactories, d2ServicePath, sslContext,
+        sslParameters, isSSLEnabled, clientServicesConfig, partitionAccessorRegistry, sslSessionValidatorFactory,
+        d2ClientJmxManager, deterministicSubsettingMetadataProvider, failoutConfigProviderFactory,
+        canaryDistributionProvider, loadBalanceStreamException, false);
+  }
+
+  public XdsFsTogglingLoadBalancerFactory(long timeout, TimeUnit timeoutUnit, String fsBasePath,
+      Map<String, TransportClientFactory> clientFactories,
+      Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> loadBalancerStrategyFactories,
+      String d2ServicePath, SSLContext sslContext, SSLParameters sslParameters, boolean isSSLEnabled,
+      Map<String, Map<String, Object>> clientServicesConfig, PartitionAccessorRegistry partitionAccessorRegistry,
+      SslSessionValidatorFactory sslSessionValidatorFactory, D2ClientJmxManager d2ClientJmxManager,
+      DeterministicSubsettingMetadataProvider deterministicSubsettingMetadataProvider,
+      FailoutConfigProviderFactory failoutConfigProviderFactory, CanaryDistributionProvider canaryDistributionProvider,
+      boolean loadBalanceStreamException, boolean enablePotentialClientsCache)
   {
     _lbTimeout = timeout;
     _lbTimeoutUnit = timeoutUnit;
@@ -125,6 +143,7 @@ public class XdsFsTogglingLoadBalancerFactory
     _failoutConfigProviderFactory = failoutConfigProviderFactory;
     _canaryDistributionProvider = canaryDistributionProvider;
     _loadBalanceStreamException = loadBalanceStreamException;
+    _enablePotentialClientsCache = enablePotentialClientsCache;
   }
 
   public TogglingLoadBalancer create(ScheduledExecutorService executorService, XdsToD2PropertiesAdaptor xdsAdaptor)
@@ -166,7 +185,7 @@ public class XdsFsTogglingLoadBalancerFactory
         new SimpleLoadBalancerState(executorService, uriBus, clusterBus, serviceBus, _clientFactories,
             _loadBalancerStrategyFactories, _sslContext, _sslParameters, _isSSLEnabled, _partitionAccessorRegistry,
             _sslSessionValidatorFactory, _deterministicSubsettingMetadataProvider, _canaryDistributionProvider,
-            _loadBalanceStreamException);
+            _loadBalanceStreamException, _enablePotentialClientsCache);
     _d2ClientJmxManager.setSimpleLoadBalancerState(state);
 
     SimpleLoadBalancer balancer =

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -89,7 +89,8 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
             config.clientFactories, config.loadBalancerStrategyFactories, config.d2ServicePath, config.sslContext,
             config.sslParameters, config.isSSLEnabled, config.clientServicesConfig, config.partitionAccessorRegistry,
             config.sslSessionValidatorFactory, d2ClientJmxManager, config.deterministicSubsettingMetadataProvider,
-            config.failoutConfigProviderFactory, config.canaryDistributionProvider, config.loadBalanceStreamException),
+            config.failoutConfigProviderFactory, config.canaryDistributionProvider, config.loadBalanceStreamException,
+            config.enablePotentialClientsCache),
         directory
     );
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/PotentialClientsCacheTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/PotentialClientsCacheTest.java
@@ -1,0 +1,544 @@
+/*
+   Copyright (c) 2024 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.simple;
+
+import com.linkedin.common.callback.FutureCallback;
+import com.linkedin.common.util.None;
+import com.linkedin.d2.balancer.ServiceUnavailableException;
+import com.linkedin.d2.balancer.clients.RewriteLoadBalancerClient;
+import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.properties.ClusterProperties;
+import com.linkedin.d2.balancer.properties.NullPartitionProperties;
+import com.linkedin.d2.balancer.properties.PartitionData;
+import com.linkedin.d2.balancer.properties.PropertyKeys;
+import com.linkedin.d2.balancer.properties.ServiceProperties;
+import com.linkedin.d2.balancer.properties.UriProperties;
+import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
+import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
+import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategyFactoryV3;
+import com.linkedin.d2.balancer.util.URIRequest;
+import com.linkedin.d2.discovery.event.PropertyEventBusImpl;
+import com.linkedin.d2.discovery.event.SynchronousExecutorService;
+import com.linkedin.d2.discovery.stores.mock.MockStore;
+import com.linkedin.r2.message.RequestContext;
+import com.linkedin.r2.util.NamedThreadFactory;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.linkedin.d2.balancer.util.partitions.DefaultPartitionAccessor.*;
+import static org.testng.Assert.*;
+
+
+/**
+ * Property-style tests that verify the precomputed potential clients cache produces
+ * results equivalent to the original O(n) per-request computation.
+ *
+ * For each test scenario, two load balancers are created — one with the cache enabled,
+ * one without — populated identically, and then compared for behavioral equivalence.
+ */
+public class PotentialClientsCacheTest
+{
+  private ScheduledExecutorService _d2Executor;
+
+  @BeforeSuite
+  public void initialize()
+  {
+    _d2Executor = Executors.newSingleThreadScheduledExecutor(
+        new NamedThreadFactory("D2 PropertyEventExecutor for PotentialClientsCacheTest"));
+  }
+
+  @AfterSuite
+  public void shutdown()
+  {
+    _d2Executor.shutdown();
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a started SimpleLoadBalancer backed by a SimpleLoadBalancerState
+   * with the given enablePotentialClientsCache flag.
+   */
+  private static class LBSetup
+  {
+    final MockStore<ServiceProperties> serviceRegistry = new MockStore<>();
+    final MockStore<ClusterProperties> clusterRegistry = new MockStore<>();
+    final MockStore<UriProperties> uriRegistry = new MockStore<>();
+    final SimpleLoadBalancerState state;
+    final SimpleLoadBalancer loadBalancer;
+
+    LBSetup(boolean enableCache, ScheduledExecutorService d2Executor) throws Exception
+    {
+      ScheduledExecutorService executorService = new SynchronousExecutorService();
+
+      Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> strategyFactories = new HashMap<>();
+      strategyFactories.put("degrader", new DegraderLoadBalancerStrategyFactoryV3());
+
+      Map<String, com.linkedin.r2.transport.common.TransportClientFactory> clientFactories = new HashMap<>();
+      clientFactories.put(PropertyKeys.HTTP_SCHEME, new SimpleLoadBalancerTest.DoNothingClientFactory());
+
+      state = new SimpleLoadBalancerState(
+          executorService,
+          new PropertyEventBusImpl<>(executorService, uriRegistry),
+          new PropertyEventBusImpl<>(executorService, clusterRegistry),
+          new PropertyEventBusImpl<>(executorService, serviceRegistry),
+          clientFactories,
+          strategyFactories,
+          null, null, false, null, null, null, null, false,
+          enableCache);
+
+      loadBalancer = new SimpleLoadBalancer(state, 5, TimeUnit.SECONDS, d2Executor);
+      FutureCallback<None> cb = new FutureCallback<>();
+      loadBalancer.start(cb);
+      cb.get();
+    }
+
+    /**
+     * Populates registries and triggers a getClient() call to force the
+     * PropertyEventBus subscriber callbacks to fire (MockStore only publishes
+     * when startPublishing has been called, which happens lazily on first listen).
+     */
+    void populate(String cluster, String service, ClusterProperties clusterProps,
+                  ServiceProperties serviceProps, UriProperties uriProps) throws Exception
+    {
+      clusterRegistry.put(cluster, clusterProps);
+      serviceRegistry.put(service, serviceProps);
+      uriRegistry.put(cluster, uriProps);
+
+      // Trigger listening — this causes startPublishing → publishInitialize for each property
+      triggerListening(service);
+    }
+
+    /**
+     * Triggers listening for a service by calling getClient(), which causes the
+     * PropertyEventBus to call startPublishing on the MockStore registries.
+     */
+    void triggerListening(String service)
+    {
+      URIRequest request = new URIRequest("d2://" + service + "/resource");
+      try
+      {
+        loadBalancer.getClient(request, new RequestContext());
+      }
+      catch (ServiceUnavailableException e)
+      {
+        // May happen if setup is incomplete — that's fine, the subscribers have still fired
+      }
+    }
+  }
+
+  private static UriProperties buildUriProperties(String cluster, List<URI> uris, int partitionId)
+  {
+    Map<URI, Map<Integer, PartitionData>> uriData = new HashMap<>();
+    for (URI uri : uris)
+    {
+      uriData.put(uri, Collections.singletonMap(partitionId, new PartitionData(1d)));
+    }
+    return new UriProperties(cluster, uriData);
+  }
+
+  private static List<URI> generateUris(int count)
+  {
+    List<URI> uris = new ArrayList<>(count);
+    for (int i = 0; i < count; i++)
+    {
+      uris.add(URI.create("http://host" + i + ".example.com:8080"));
+    }
+    return uris;
+  }
+
+  /**
+   * Asserts that the two load balancers route the same request to the same set of
+   * possible hosts. Since the strategy may pick different individual hosts due to ring
+   * randomness, we compare the potential client maps directly from the state.
+   */
+  private void assertPotentialClientsEquivalent(LBSetup cached, LBSetup uncached,
+                                                String service, String scheme, int partitionId)
+  {
+    Map<URI, TrackerClient> cachedClients = cached.state.getPotentialClients(service, scheme, partitionId);
+    // The uncached state returns null (cache disabled) — build the set from _trackerClients instead
+    // by querying the load balancer which exercises the fallback O(n) path.
+    // We compare the URI key sets since the TrackerClient instances differ between the two states.
+    assertNotNull(cachedClients, "Cached potential clients should not be null when cache is enabled");
+
+    // Get the uncached set by querying through the uncached load balancer.
+    // The uncached state.getPotentialClients returns null, so we use the tracker clients as ground truth.
+    Map<URI, TrackerClient> uncachedTrackerClients = uncached.state.getTrackerClients().get(service);
+
+    // Both should have the same URI key set (modulo banned URIs which are filtered identically)
+    assertEquals(cachedClients.keySet(), filterForPartition(uncachedTrackerClients, cached, service, scheme, partitionId),
+        "Cached and uncached potential clients should have the same URI set");
+  }
+
+  /**
+   * Filters the uncached tracker clients to match what getPotentialClients would produce:
+   * only URIs in the given scheme+partition, excluding banned URIs.
+   */
+  private Set<URI> filterForPartition(Map<URI, TrackerClient> allClients, LBSetup setup,
+                                      String service, String scheme, int partitionId)
+  {
+    if (allClients == null)
+    {
+      return Collections.emptySet();
+    }
+    ServiceProperties serviceProps = setup.state.getServiceProperties().get(service).getProperty();
+    String cluster = serviceProps.getClusterName();
+    UriProperties uriProps = setup.state.getUriProperties().get(cluster).getProperty();
+    ClusterProperties clusterProps = setup.state.getClusterInfo().get(cluster)
+        .getClusterPropertiesItem().getProperty();
+
+    Set<URI> possibleUris = uriProps.getUriBySchemeAndPartition(scheme, partitionId);
+    if (possibleUris == null)
+    {
+      return Collections.emptySet();
+    }
+
+    Set<URI> result = new HashSet<>();
+    for (URI uri : possibleUris)
+    {
+      if (!serviceProps.isBanned(uri) && !clusterProps.isBanned(uri) && allClients.containsKey(uri))
+      {
+        result.add(uri);
+      }
+    }
+    return result;
+  }
+
+  // ─── Data Providers ───────────────────────────────────────────────────────
+
+  @DataProvider
+  public Object[][] potentialClientsScenarios()
+  {
+    return new Object[][] {
+        // {numUris, numBannedFromCluster, numBannedFromService, partitionId}
+        {1,  0, 0, 0},   // single host, no bans
+        {5,  0, 0, 0},   // multiple hosts, no bans
+        {10, 0, 0, 0},   // more hosts, no bans
+        {5,  1, 0, 0},   // cluster-banned host
+        {5,  0, 1, 0},   // service-banned host
+        {5,  2, 1, 0},   // mixed bans
+        {10, 5, 0, 0},   // half banned
+        {10, 0, 5, 0},   // half service-banned
+        {10, 3, 3, 0},   // mixed heavy bans (some may overlap)
+        {10, 10, 0, 0},  // all banned
+        {20, 0, 0, 0},   // larger cluster
+        {20, 5, 3, 0},   // larger cluster with bans
+    };
+  }
+
+  // ─── Tests ────────────────────────────────────────────────────────────────
+
+  @Test(dataProvider = "potentialClientsScenarios")
+  public void testCachedEqualsUncached(int numUris, int numClusterBanned,
+                                       int numServiceBanned, int partitionId) throws Exception
+  {
+    String cluster = "cluster-1";
+    String service = "foo";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    List<URI> allUris = generateUris(numUris);
+
+    // Pick banned URIs from the beginning of the list
+    Set<URI> clusterBanned = new HashSet<>(allUris.subList(0, Math.min(numClusterBanned, numUris)));
+    Set<URI> serviceBanned = new HashSet<>();
+    int serviceStart = Math.min(numClusterBanned, numUris);
+    int serviceEnd = Math.min(serviceStart + numServiceBanned, numUris);
+    serviceBanned.addAll(allUris.subList(serviceStart, serviceEnd));
+
+    ClusterProperties clusterProps = new ClusterProperties(cluster, Collections.emptyList(),
+        Collections.emptyMap(), clusterBanned, NullPartitionProperties.getInstance());
+
+    ServiceProperties serviceProps = new ServiceProperties(service, cluster, "/" + service,
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), serviceBanned);
+
+    UriProperties uriProps = buildUriProperties(cluster, allUris, partitionId);
+
+    LBSetup cached = new LBSetup(true, _d2Executor);
+    LBSetup uncached = new LBSetup(false, _d2Executor);
+
+    cached.populate(cluster, service, clusterProps, serviceProps, uriProps);
+    uncached.populate(cluster, service, clusterProps, serviceProps, uriProps);
+
+    assertPotentialClientsEquivalent(cached, uncached, service, scheme, partitionId);
+
+    // Also verify the cached set has the expected size
+    Map<URI, TrackerClient> cachedClients = cached.state.getPotentialClients(service, scheme, partitionId);
+    int expectedSize = numUris - Math.min(numClusterBanned, numUris)
+        - (serviceEnd - serviceStart);
+    assertEquals(cachedClients.size(), expectedSize,
+        "Expected " + expectedSize + " clients after filtering " + numClusterBanned + " cluster-banned and "
+            + numServiceBanned + " service-banned from " + numUris + " total");
+  }
+
+  @Test
+  public void testCacheRebuiltOnUriChange() throws Exception
+  {
+    String cluster = "cluster-1";
+    String service = "foo";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    LBSetup setup = new LBSetup(true, _d2Executor);
+
+    ClusterProperties clusterProps = new ClusterProperties(cluster);
+    ServiceProperties serviceProps = new ServiceProperties(service, cluster, "/" + service,
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), null);
+
+    List<URI> initialUris = generateUris(3);
+    setup.populate(cluster, service, clusterProps, serviceProps,
+        buildUriProperties(cluster, initialUris, 0));
+
+    Map<URI, TrackerClient> initial = setup.state.getPotentialClients(service, scheme, 0);
+    assertNotNull(initial);
+    assertEquals(initial.size(), 3);
+
+    // Add more URIs
+    List<URI> expandedUris = generateUris(6);
+    setup.uriRegistry.put(cluster, buildUriProperties(cluster, expandedUris, 0));
+
+    Map<URI, TrackerClient> expanded = setup.state.getPotentialClients(service, scheme, 0);
+    assertNotNull(expanded);
+    assertEquals(expanded.size(), 6);
+
+    // Remove URIs
+    List<URI> reducedUris = generateUris(2);
+    setup.uriRegistry.put(cluster, buildUriProperties(cluster, reducedUris, 0));
+
+    Map<URI, TrackerClient> reduced = setup.state.getPotentialClients(service, scheme, 0);
+    assertNotNull(reduced);
+    assertEquals(reduced.size(), 2);
+  }
+
+  @Test
+  public void testCacheRebuiltOnBanListChange() throws Exception
+  {
+    String cluster = "cluster-1";
+    String service = "foo";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    LBSetup setup = new LBSetup(true, _d2Executor);
+
+    List<URI> uris = generateUris(5);
+    ClusterProperties clusterProps = new ClusterProperties(cluster);
+    ServiceProperties serviceProps = new ServiceProperties(service, cluster, "/" + service,
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), null);
+
+    setup.populate(cluster, service, clusterProps, serviceProps,
+        buildUriProperties(cluster, uris, 0));
+
+    assertEquals(setup.state.getPotentialClients(service, scheme, 0).size(), 5);
+
+    // Ban 2 URIs via cluster properties update
+    Set<URI> banned = new HashSet<>(uris.subList(0, 2));
+    setup.clusterRegistry.put(cluster, new ClusterProperties(cluster, Collections.emptyList(),
+        Collections.emptyMap(), banned, NullPartitionProperties.getInstance()));
+
+    assertEquals(setup.state.getPotentialClients(service, scheme, 0).size(), 3);
+  }
+
+  @Test
+  public void testCacheInvalidatedOnServiceRemoval() throws Exception
+  {
+    String cluster = "cluster-1";
+    String service = "foo";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    LBSetup setup = new LBSetup(true, _d2Executor);
+
+    setup.populate(cluster, service,
+        new ClusterProperties(cluster),
+        new ServiceProperties(service, cluster, "/" + service,
+            Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+            Collections.singletonList(scheme), null),
+        buildUriProperties(cluster, generateUris(3), 0));
+
+    assertNotNull(setup.state.getPotentialClients(service, scheme, 0));
+
+    // Remove the service
+    setup.serviceRegistry.remove(service);
+
+    assertNull(setup.state.getPotentialClients(service, scheme, 0),
+        "Cache should be invalidated after service removal");
+  }
+
+  @Test
+  public void testCacheDisabledReturnsNull() throws Exception
+  {
+    String cluster = "cluster-1";
+    String service = "foo";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    LBSetup setup = new LBSetup(false, _d2Executor);
+
+    setup.populate(cluster, service,
+        new ClusterProperties(cluster),
+        new ServiceProperties(service, cluster, "/" + service,
+            Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+            Collections.singletonList(scheme), null),
+        buildUriProperties(cluster, generateUris(3), 0));
+
+    assertNull(setup.state.getPotentialClients(service, scheme, 0),
+        "getPotentialClients should return null when cache is disabled");
+  }
+
+  @Test(dataProvider = "potentialClientsScenarios")
+  public void testGetClientEquivalence(int numUris, int numClusterBanned,
+                                       int numServiceBanned, int partitionId) throws Exception
+  {
+    // Skip edge case where all URIs are banned — getClient throws ServiceUnavailableException
+    if (numUris == 0 || numClusterBanned + numServiceBanned >= numUris)
+    {
+      return;
+    }
+
+    String cluster = "cluster-1";
+    String service = "foo";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    List<URI> allUris = generateUris(numUris);
+
+    Set<URI> clusterBanned = new HashSet<>(allUris.subList(0, Math.min(numClusterBanned, numUris)));
+    int serviceStart = Math.min(numClusterBanned, numUris);
+    int serviceEnd = Math.min(serviceStart + numServiceBanned, numUris);
+    Set<URI> serviceBanned = new HashSet<>(allUris.subList(serviceStart, serviceEnd));
+
+    ClusterProperties clusterProps = new ClusterProperties(cluster, Collections.emptyList(),
+        Collections.emptyMap(), clusterBanned, NullPartitionProperties.getInstance());
+    ServiceProperties serviceProps = new ServiceProperties(service, cluster, "/" + service,
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), serviceBanned);
+    UriProperties uriProps = buildUriProperties(cluster, allUris, partitionId);
+
+    LBSetup cached = new LBSetup(true, _d2Executor);
+    LBSetup uncached = new LBSetup(false, _d2Executor);
+
+    cached.populate(cluster, service, clusterProps, serviceProps, uriProps);
+    uncached.populate(cluster, service, clusterProps, serviceProps, uriProps);
+
+    // Both load balancers should be able to route requests successfully.
+    // We verify the selected host is in the expected set (not banned).
+    URIRequest request = new URIRequest("d2://" + service + "/resource");
+    Set<URI> expectedUris = new HashSet<>(allUris);
+    expectedUris.removeAll(clusterBanned);
+    expectedUris.removeAll(serviceBanned);
+    // Transform to expected form with path appended
+    Set<URI> expectedWithPath = new HashSet<>();
+    for (URI uri : expectedUris)
+    {
+      expectedWithPath.add(URI.create(uri + "/" + service));
+    }
+
+    RewriteLoadBalancerClient cachedClient =
+        (RewriteLoadBalancerClient) cached.loadBalancer.getClient(request, new RequestContext());
+    assertTrue(expectedWithPath.contains(cachedClient.getUri()),
+        "Cached LB selected " + cachedClient.getUri() + " which is not in expected set " + expectedWithPath);
+
+    RewriteLoadBalancerClient uncachedClient =
+        (RewriteLoadBalancerClient) uncached.loadBalancer.getClient(request, new RequestContext());
+    assertTrue(expectedWithPath.contains(uncachedClient.getUri()),
+        "Uncached LB selected " + uncachedClient.getUri() + " which is not in expected set " + expectedWithPath);
+  }
+
+  @Test
+  public void testMultipleServicesOnSameCluster() throws Exception
+  {
+    String cluster = "cluster-1";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    LBSetup cached = new LBSetup(true, _d2Executor);
+    LBSetup uncached = new LBSetup(false, _d2Executor);
+
+    ClusterProperties clusterProps = new ClusterProperties(cluster);
+    List<URI> uris = generateUris(5);
+    UriProperties uriProps = buildUriProperties(cluster, uris, 0);
+
+    // Two services on the same cluster, one with bans
+    Set<URI> svc2Banned = new HashSet<>(uris.subList(0, 2));
+    ServiceProperties svc1Props = new ServiceProperties("svc1", cluster, "/svc1",
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), null);
+    ServiceProperties svc2Props = new ServiceProperties("svc2", cluster, "/svc2",
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), svc2Banned);
+
+    for (LBSetup setup : new LBSetup[]{cached, uncached})
+    {
+      setup.clusterRegistry.put(cluster, clusterProps);
+      setup.serviceRegistry.put("svc1", svc1Props);
+      setup.serviceRegistry.put("svc2", svc2Props);
+      setup.uriRegistry.put(cluster, uriProps);
+      setup.triggerListening("svc1");
+      setup.triggerListening("svc2");
+    }
+
+    // svc1 should see all 5 hosts
+    assertPotentialClientsEquivalent(cached, uncached, "svc1", scheme, 0);
+    assertEquals(cached.state.getPotentialClients("svc1", scheme, 0).size(), 5);
+
+    // svc2 should see 3 hosts (2 banned)
+    assertPotentialClientsEquivalent(cached, uncached, "svc2", scheme, 0);
+    assertEquals(cached.state.getPotentialClients("svc2", scheme, 0).size(), 3);
+  }
+
+  @Test
+  public void testCacheRebuiltOnUriChangeMultipleServices() throws Exception
+  {
+    String cluster = "cluster-1";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    LBSetup setup = new LBSetup(true, _d2Executor);
+
+    ClusterProperties clusterProps = new ClusterProperties(cluster);
+    ServiceProperties svc1 = new ServiceProperties("svc1", cluster, "/svc1",
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), null);
+    ServiceProperties svc2 = new ServiceProperties("svc2", cluster, "/svc2",
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), null);
+
+    setup.clusterRegistry.put(cluster, clusterProps);
+    setup.serviceRegistry.put("svc1", svc1);
+    setup.serviceRegistry.put("svc2", svc2);
+    setup.uriRegistry.put(cluster, buildUriProperties(cluster, generateUris(4), 0));
+    setup.triggerListening("svc1");
+    setup.triggerListening("svc2");
+
+    assertEquals(setup.state.getPotentialClients("svc1", scheme, 0).size(), 4);
+    assertEquals(setup.state.getPotentialClients("svc2", scheme, 0).size(), 4);
+
+    // URI change should rebuild cache for BOTH services
+    setup.uriRegistry.put(cluster, buildUriProperties(cluster, generateUris(7), 0));
+
+    assertEquals(setup.state.getPotentialClients("svc1", scheme, 0).size(), 7);
+    assertEquals(setup.state.getPotentialClients("svc2", scheme, 0).size(), 7);
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/simple/PotentialClientsCacheTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/simple/PotentialClientsCacheTest.java
@@ -18,6 +18,7 @@ package com.linkedin.d2.balancer.simple;
 
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
+import com.linkedin.d2.balancer.LoadBalancerStateItem;
 import com.linkedin.d2.balancer.ServiceUnavailableException;
 import com.linkedin.d2.balancer.clients.RewriteLoadBalancerClient;
 import com.linkedin.d2.balancer.clients.TrackerClient;
@@ -31,12 +32,27 @@ import com.linkedin.d2.balancer.strategies.LoadBalancerStrategy;
 import com.linkedin.d2.balancer.strategies.LoadBalancerStrategyFactory;
 import com.linkedin.d2.balancer.strategies.degrader.DegraderLoadBalancerStrategyFactoryV3;
 import com.linkedin.d2.balancer.util.URIRequest;
+import com.linkedin.d2.balancer.util.TogglingLoadBalancer;
+import com.linkedin.d2.balancer.zkfs.ZKFSTogglingLoadBalancerFactoryImpl;
+import com.linkedin.d2.discovery.PropertySerializer;
 import com.linkedin.d2.discovery.event.PropertyEventBusImpl;
 import com.linkedin.d2.discovery.event.SynchronousExecutorService;
 import com.linkedin.d2.discovery.stores.mock.MockStore;
+import com.linkedin.d2.discovery.stores.zk.ZKConnection;
+import com.linkedin.d2.discovery.stores.zk.ZooKeeperEphemeralStore;
+import com.linkedin.d2.discovery.stores.zk.ZooKeeperPermanentStore;
+import com.linkedin.d2.discovery.stores.zk.ZooKeeperPropertyMerger;
+import com.linkedin.d2.jmx.D2ClientJmxManager;
+import com.linkedin.d2.xds.XdsToD2PropertiesAdaptor;
+import com.linkedin.d2.xds.balancer.XdsFsTogglingLoadBalancerFactory;
 import com.linkedin.r2.message.RequestContext;
+import com.linkedin.r2.transport.common.TransportClientFactory;
 import com.linkedin.r2.util.NamedThreadFactory;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,9 +60,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.DataProvider;
@@ -98,19 +117,13 @@ public class PotentialClientsCacheTest
     {
       ScheduledExecutorService executorService = new SynchronousExecutorService();
 
-      Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> strategyFactories = new HashMap<>();
-      strategyFactories.put("degrader", new DegraderLoadBalancerStrategyFactoryV3());
-
-      Map<String, com.linkedin.r2.transport.common.TransportClientFactory> clientFactories = new HashMap<>();
-      clientFactories.put(PropertyKeys.HTTP_SCHEME, new SimpleLoadBalancerTest.DoNothingClientFactory());
-
       state = new SimpleLoadBalancerState(
           executorService,
           new PropertyEventBusImpl<>(executorService, uriRegistry),
           new PropertyEventBusImpl<>(executorService, clusterRegistry),
           new PropertyEventBusImpl<>(executorService, serviceRegistry),
-          clientFactories,
-          strategyFactories,
+          createClientFactories(),
+          createStrategyFactories(),
           null, null, false, null, null, null, null, false,
           enableCache);
 
@@ -131,8 +144,6 @@ public class PotentialClientsCacheTest
       clusterRegistry.put(cluster, clusterProps);
       serviceRegistry.put(service, serviceProps);
       uriRegistry.put(cluster, uriProps);
-
-      // Trigger listening — this causes startPublishing → publishInitialize for each property
       triggerListening(service);
     }
 
@@ -152,6 +163,128 @@ public class PotentialClientsCacheTest
         // May happen if setup is incomplete — that's fine, the subscribers have still fired
       }
     }
+  }
+
+  /**
+   * Runs a factory callback that registers state on a mock D2ClientJmxManager,
+   * then captures and returns the SimpleLoadBalancerState via ArgumentCaptor.
+   */
+  private static SimpleLoadBalancerState captureStateFromFactory(
+      Consumer<D2ClientJmxManager> factoryAction)
+  {
+    D2ClientJmxManager jmxManager = Mockito.mock(D2ClientJmxManager.class);
+    factoryAction.accept(jmxManager);
+
+    ArgumentCaptor<SimpleLoadBalancerState> captor =
+        ArgumentCaptor.forClass(SimpleLoadBalancerState.class);
+    Mockito.verify(jmxManager).setSimpleLoadBalancerState(captor.capture());
+    return captor.getValue();
+  }
+
+  /**
+   * Creates a SimpleLoadBalancerState through XdsFsTogglingLoadBalancerFactory (the real
+   * XDS factory code path).
+   */
+  private static SimpleLoadBalancerState createStateViaXdsFactory(boolean enableCache) throws IOException
+  {
+    Path tempDir = Files.createTempDirectory("d2-xds-test");
+    return captureStateFromFactory(jmxManager ->
+    {
+      XdsFsTogglingLoadBalancerFactory factory = new XdsFsTogglingLoadBalancerFactory(
+          5000, TimeUnit.MILLISECONDS, tempDir.toString(),
+          createClientFactories(), createStrategyFactories(), "/d2",
+          null, null, false, null, null, null, jmxManager,
+          null, null, null, false, enableCache);
+      factory.create(new SynchronousExecutorService(), Mockito.mock(XdsToD2PropertiesAdaptor.class));
+    });
+  }
+
+  /**
+   * Creates a SimpleLoadBalancerState through ZKFSTogglingLoadBalancerFactoryImpl (the real
+   * ZK factory code path). Store creation methods are overridden to avoid requiring a real
+   * ZooKeeper connection.
+   */
+  private static SimpleLoadBalancerState createStateViaZkFactory(boolean enableCache) throws IOException
+  {
+    Path tempDir = Files.createTempDirectory("d2-zk-test");
+    ZKFSTogglingLoadBalancerFactoryImpl.ComponentFactory componentFactory =
+        Mockito.mock(ZKFSTogglingLoadBalancerFactoryImpl.ComponentFactory.class);
+    Mockito.when(componentFactory.createBalancer(Mockito.any(), Mockito.any(),
+        Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(Mockito.mock(TogglingLoadBalancer.class));
+
+    return captureStateFromFactory(jmxManager ->
+    {
+      ZKFSTogglingLoadBalancerFactoryImpl factory = new ZKFSTogglingLoadBalancerFactoryImpl(
+          componentFactory, 5000, TimeUnit.MILLISECONDS, "/d2", tempDir.toString(),
+          createClientFactories(), createStrategyFactories(), "/d2",
+          null, null, false, null, false, null, false, null,
+          jmxManager, 0, null, null, null, null, null,
+          false, false, enableCache)
+      {
+        @Override
+        protected <T> ZooKeeperPermanentStore<T> createPermanentStore(
+            ZKConnection zkConnection, String nodePath, PropertySerializer<T> serializer,
+            ScheduledExecutorService executorService, int zookeeperReadWindowMs)
+        {
+          return Mockito.mock(ZooKeeperPermanentStore.class);
+        }
+
+        @Override
+        protected <T> ZooKeeperEphemeralStore<T> createEphemeralStore(
+            ZKConnection zkConnection, String nodePath, PropertySerializer<T> serializer,
+            ZooKeeperPropertyMerger<T> merger, boolean useNewWatcher, String backupStoreFilePath,
+            ScheduledExecutorService executorService, int readWindow, boolean isRawD2Client)
+        {
+          return Mockito.mock(ZooKeeperEphemeralStore.class);
+        }
+      };
+      factory.createLoadBalancer(null, new SynchronousExecutorService());
+    });
+  }
+
+  private static Map<String, TransportClientFactory> createClientFactories()
+  {
+    Map<String, TransportClientFactory> clientFactories = new HashMap<>();
+    clientFactories.put(PropertyKeys.HTTP_SCHEME, new SimpleLoadBalancerTest.DoNothingClientFactory());
+    return clientFactories;
+  }
+
+  private static Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> createStrategyFactories()
+  {
+    Map<String, LoadBalancerStrategyFactory<? extends LoadBalancerStrategy>> strategyFactories = new HashMap<>();
+    strategyFactories.put("degrader", new DegraderLoadBalancerStrategyFactoryV3());
+    return strategyFactories;
+  }
+
+  /**
+   * Populates a SimpleLoadBalancerState directly (bypassing property buses) and
+   * rebuilds the potential clients cache. Used for states created by factories
+   * whose internal buses are not accessible from the test.
+   */
+  private static void populateAndRebuildCache(SimpleLoadBalancerState state,
+      String cluster, String service, ClusterProperties clusterProps,
+      ServiceProperties serviceProps, UriProperties uriProps)
+  {
+    state.getServiceProperties().put(service,
+        new LoadBalancerStateItem<>(serviceProps, 1, System.currentTimeMillis()));
+    state.getClusterInfo().put(cluster,
+        new ClusterInfoItem(state, clusterProps, null));
+    state.getUriProperties().put(cluster,
+        new LoadBalancerStateItem<>(uriProps, 1, System.currentTimeMillis()));
+
+    Map<URI, TrackerClient> trackerClients = new ConcurrentHashMap<>();
+    for (URI uri : uriProps.Uris())
+    {
+      trackerClients.put(uri, Mockito.mock(TrackerClient.class));
+    }
+    state.getTrackerClients().put(service, trackerClients);
+
+    Set<String> services = ConcurrentHashMap.newKeySet();
+    services.add(service);
+    state.getServicesPerCluster().put(cluster, services);
+
+    state.rebuildPotentialClientsForService(service);
   }
 
   private static UriProperties buildUriProperties(String cluster, List<URI> uris, int partitionId)
@@ -1027,5 +1160,67 @@ public class PotentialClientsCacheTest
 
     assertEquals(setup.state.getPotentialClients("svc1", scheme, 0).size(), 7);
     assertEquals(setup.state.getPotentialClients("svc2", scheme, 0).size(), 7);
+  }
+
+  // ─── Config propagation tests ───────────────────────────────────────
+  //
+  // Regression tests verifying that enablePotentialClientsCache is propagated through
+  // all factory code paths to SimpleLoadBalancerState. The flag was originally only
+  // plumbed through the ZK path, not the XDS or LastSeen paths.
+
+  @DataProvider
+  public Object[][] cacheFlagPropagationScenarios()
+  {
+    return new Object[][] {
+        // {useXdsFactory, enableCache}
+        {false, true},   // ZK path, cache enabled
+        {false, false},  // ZK path, cache disabled
+        {true,  true},   // XDS path, cache enabled
+        {true,  false},  // XDS path, cache disabled
+    };
+  }
+
+  /**
+   * Verifies that enablePotentialClientsCache is correctly propagated to SimpleLoadBalancerState
+   * through both the ZK and XDS factory paths.
+   *
+   * <ul>
+   *   <li><b>ZK path:</b> exercises ZKFSTogglingLoadBalancerFactoryImpl.createLoadBalancer(),
+   *       with ZooKeeper stores mocked out since no real ZK connection is available.</li>
+   *   <li><b>XDS path:</b> exercises XdsFsTogglingLoadBalancerFactory.create().</li>
+   * </ul>
+   *
+   * Both paths capture the resulting SimpleLoadBalancerState via a mock D2ClientJmxManager,
+   * populate it with data, and verify that getPotentialClients returns cached data (when
+   * enabled) or null (when disabled).
+   */
+  @Test(dataProvider = "cacheFlagPropagationScenarios")
+  public void testCacheFlagPropagation(boolean useXdsFactory, boolean enableCache) throws Exception
+  {
+    String cluster = "cluster-1";
+    String service = "foo";
+    String scheme = PropertyKeys.HTTP_SCHEME;
+
+    ClusterProperties clusterProps = new ClusterProperties(cluster);
+    ServiceProperties serviceProps = new ServiceProperties(service, cluster, "/" + service,
+        Collections.singletonList("degrader"), Collections.emptyMap(), null, null,
+        Collections.singletonList(scheme), null);
+    UriProperties uriProps = buildUriProperties(cluster, generateUris(3), 0);
+
+    SimpleLoadBalancerState state = useXdsFactory
+        ? createStateViaXdsFactory(enableCache)
+        : createStateViaZkFactory(enableCache);
+    populateAndRebuildCache(state, cluster, service, clusterProps, serviceProps, uriProps);
+
+    Map<URI, TrackerClient> cached = state.getPotentialClients(service, scheme, 0);
+    if (enableCache)
+    {
+      assertNotNull(cached, "getPotentialClients should return cached data when cache is enabled");
+      assertEquals(cached.size(), 3);
+    }
+    else
+    {
+      assertNull(cached, "getPotentialClients should return null when cache is disabled");
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.8
+version=29.85.7-rc.1
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.7-rc.6
+version=29.85.9
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.7-rc.1
+version=29.85.7-rc.6
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary

`SimpleLoadBalancer.getPotentialClients()` is a hotspot in production profiles. It runs O(n) loops on every request (n = total hosts in partition) to build a `Map<URI, TrackerClient>` by iterating all URIs, filtering banned hosts, resolving TrackerClients, and applying subsetting. All inputs to this computation change only on state events (host join/leave, config updates), yet the work was repeated on every request.

This PR moves the O(n) computation into the state-change event handlers in `SimpleLoadBalancerState`, precomputing and caching the result in a `ConcurrentHashMap`. The request path becomes a single O(1) map lookup. The feature is gated behind a new config flag `enablePotentialClientsCache` (default: `false`) so it can be rolled out incrementally.

Key changes:
- `SimpleLoadBalancerState` maintains a `_potentialClientsCache` keyed by `(serviceName, scheme, partitionId)`, rebuilt eagerly by subscriber callbacks after URI, service, or cluster property updates
- `SimpleLoadBalancer.getPotentialClients()` checks the cache first, falling back to the existing O(n) logic when the cache is disabled or returns null
- New `enablePotentialClientsCache` flag plumbed through `D2ClientConfig` → `D2ClientBuilder` → `ZKFSTogglingLoadBalancerFactoryImpl` → `SimpleLoadBalancerState`
- Removed expensive `LogUtil.debug()` calls from the hot path (`Logger.isDebugEnabled()` is costly at high call rates)

## Testing Done

- 30 new property-style tests in `PotentialClientsCacheTest` verify equivalence between the cached and uncached code paths across 12 input scenarios varying URI count (1–20), cluster-banned count (0–10), and service-banned count (0–5)
- Lifecycle tests verify cache rebuild on URI changes, ban-list changes, service removal, and multi-service-per-cluster behavior
- All existing d2 tests pass