### PR TITLE
Fix gRPC hanging forever on name resolution errors in XdsClientImpl

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -400,21 +400,8 @@ public class XdsClientImpl extends XdsClient
         AggregatedDiscoveryServiceGrpc.newStub(_managedChannel);
     AdsStream stream = new AdsStream(stub);
     _adsStream = stream;
-    _readyTimeoutFuture = checkShutdownAndSchedule(() ->
-    {
-      // There is a race condition where the task can be executed right as it's being cancelled. This checks whether
-      // the current state is still pointing to the right stream, and whether it is ready before notifying of an error.
-      if (_adsStream != stream || stream.isReady())
-      {
-        return;
-      }
-      _log.warn("ADS stream not ready within {} milliseconds. Underlying grpc channel will keep retrying to connect to "
-          + "xds servers.", _readyTimeoutMillis);
-      // notify subscribers about the error and wait for the stream to be ready by keeping it open.
-      notifyStreamError(Status.DEADLINE_EXCEEDED);
-      // note: no need to start a retry task explicitly since xds stream internally will keep on retrying to connect
-      // to one of the sub-channels (unless an error or complete callback is called).
-    }, _readyTimeoutMillis, TimeUnit.MILLISECONDS);
+    _readyTimeoutFuture = checkShutdownAndSchedule(
+        () -> handleReadyTimeout(stream), _readyTimeoutMillis, TimeUnit.MILLISECONDS);
     _adsStream.start();
     _log.info("Starting ADS stream, connecting to server: {}", _managedChannel.authority());
   }
@@ -1366,6 +1353,47 @@ public class XdsClientImpl extends XdsClient
     }
     _adsStream = testStream;
     _retryRpcStreamFuture = checkShutdownAndSchedule(new RpcRetryTask(), 0, TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Handles the ready timeout for the given ADS stream. If the stream is not ready by the timeout, closes the stream
+   * and schedules a retry with backoff to ensure calls do not hang forever. This is necessary because
+   * {@link AdsStream#start()} uses {@code withWaitForReady()}, which causes gRPC calls to hang indefinitely when the
+   * channel is in TRANSIENT_FAILURE state (e.g., due to a name resolution error).
+   *
+   * Must be called from the executor.
+   */
+  @VisibleForTesting
+  void handleReadyTimeout(AdsStream stream)
+  {
+    // There is a race condition where the task can be executed right as it's being cancelled. This checks whether
+    // the current state is still pointing to the right stream, and whether it is ready before acting.
+    if (_adsStream != stream || stream.isReady())
+    {
+      return;
+    }
+    _log.warn("ADS stream not ready within {} milliseconds. This may be caused by a name resolution error leaving "
+        + "the gRPC channel in TRANSIENT_FAILURE. Closing stream and scheduling retry.", _readyTimeoutMillis);
+    // Close the stream, notify subscribers with an error, and schedule a retry with backoff.
+    stream.handleRpcStreamClosed(Status.DEADLINE_EXCEEDED.withDescription(
+        "ADS stream not ready within " + _readyTimeoutMillis + " ms, possible name resolution error"));
+    // Cancel the hanging gRPC call that is waiting for the channel to become ready. This triggers onError on the
+    // response observer, which is a no-op since _closed is already set by handleRpcStreamClosed above.
+    if (stream._requestWriter != null)
+    {
+      ((ClientCallStreamObserver<?>) stream._requestWriter).cancel(
+          "Cancelling ADS stream call that timed out waiting for channel to be ready", null);
+    }
+  }
+
+  /**
+   * Creates a new {@link AdsStream} for testing. The returned stream has not been started ({@code _requestWriter} is
+   * null and {@code isReady()} returns false). Must only be called from tests.
+   */
+  @VisibleForTesting
+  AdsStream createTestAdsStream()
+  {
+    return new AdsStream(AggregatedDiscoveryServiceGrpc.newStub(_managedChannel));
   }
 
   // Return true if the client should subscribe to URI glob collection for the given resource type.

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsClientImpl.java
@@ -20,6 +20,7 @@ import com.linkedin.util.clock.Time;
 import indis.XdsD2;
 import io.envoyproxy.envoy.service.discovery.v3.Resource;
 import io.grpc.ManagedChannel;
+import io.grpc.Status;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -809,6 +810,67 @@ public class TestXdsClientImpl {
     } else {
       resourceVersions.forEach(x -> Assert.assertEquals(x.size(), 0));
     }
+  }
+
+  /**
+   * Verifies that when the ready timeout fires and the stream is not ready, the stream is closed and a retry is
+   * scheduled with backoff. This tests the fix for the bug where gRPC hangs indefinitely on name resolution errors:
+   * {@code withWaitForReady()} prevents {@code onError} from ever being called on the stream observer when the channel
+   * is in TRANSIENT_FAILURE, so the old code's "no need to start a retry task" assumption was incorrect.
+   */
+  @Test(timeOut = 2000)
+  public void testReadyTimeoutClosesStreamAndSchedulesRetry()
+  {
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
+
+    // Create a real AdsStream attached to the fixture's XdsClientImpl. The stream has not been started, so
+    // isReady() returns false, simulating a gRPC channel stuck in TRANSIENT_FAILURE (e.g., name resolution error).
+    XdsClientImpl.AdsStream stream = fixture._xdsClientImpl.createTestAdsStream();
+    fixture._xdsClientImpl._adsStream = stream;
+
+    // Simulate the ready timeout firing
+    fixture._xdsClientImpl.handleReadyTimeout(stream);
+
+    // All subscribers should be notified of the DEADLINE_EXCEEDED error
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    verify(fixture._resourceWatcher, times(4)).onError(statusCaptor.capture());
+    statusCaptor.getAllValues().forEach(s -> Assert.assertEquals(s.getCode(), Status.Code.DEADLINE_EXCEEDED));
+
+    ArgumentCaptor<Status> wildcardStatusCaptor = ArgumentCaptor.forClass(Status.class);
+    verify(fixture._wildcardResourceWatcher, times(4)).onError(wildcardStatusCaptor.capture());
+    wildcardStatusCaptor.getAllValues().forEach(s -> Assert.assertEquals(s.getCode(), Status.Code.DEADLINE_EXCEEDED));
+
+    // Stream should be closed — old code left it open and hanging
+    Assert.assertNull(fixture._xdsClientImpl._adsStream, "ADS stream should be closed after ready timeout");
+
+    // A retry should be scheduled — key new behavior; old code only called notifyStreamError() with no retry
+    Assert.assertNotNull(fixture._xdsClientImpl._retryRpcStreamFuture,
+        "Retry should be scheduled after ready timeout to recover from name resolution errors");
+  }
+
+  /**
+   * Verifies that the ready timeout is a no-op when the stream reference has changed (race condition guard),
+   * i.e. when {@code _adsStream != stream}.
+   */
+  @Test
+  public void testReadyTimeoutIsNoOpWhenStreamMismatch()
+  {
+    XdsClientImplFixture fixture = new XdsClientImplFixture();
+    fixture.watchAllResourceAndWatcherTypes();
+
+    XdsClientImpl.AdsStream stream1 = fixture._xdsClientImpl.createTestAdsStream();
+    XdsClientImpl.AdsStream stream2 = fixture._xdsClientImpl.createTestAdsStream();
+    // _adsStream points to stream2, but the timeout was scheduled for stream1 — simulates the race condition
+    fixture._xdsClientImpl._adsStream = stream2;
+
+    fixture._xdsClientImpl.handleReadyTimeout(stream1);
+
+    // Nothing should happen — no subscriber notifications, no retry scheduled
+    verify(fixture._resourceWatcher, never()).onError(any());
+    verify(fixture._wildcardResourceWatcher, never()).onError(any());
+    Assert.assertNotNull(fixture._xdsClientImpl._adsStream, "ADS stream should be unchanged");
+    Assert.assertNull(fixture._xdsClientImpl._retryRpcStreamFuture, "No retry should be scheduled");
   }
 
   @Test


### PR DESCRIPTION
## Problem

When DNS resolution fails, the gRPC channel enters `TRANSIENT_FAILURE`. Because `AdsStream.start()` uses `withWaitForReady()`, gRPC never calls `onError` on the stream observer — it hangs indefinitely.

The ready timeout did fire after 2s and notify subscribers, but left the stream open under the assumption:
> _"no need to start a retry task — xds stream internally will keep retrying"_

With `withWaitForReady()` and a name resolution error, no `onError` is ever delivered, so the retry mechanism is never triggered.

## Fix

When the ready timeout fires on a non-ready stream, call `handleRpcStreamClosed(DEADLINE_EXCEEDED)` instead of just `notifyStreamError`. This closes the stream, notifies subscribers, and schedules a retry with exponential backoff — the same path as any other stream failure. The hanging `withWaitForReady()` gRPC call is then cancelled, which is a no-op for the response observer since `_closed` is already set.

Result: instead of hanging forever, the client retries with backoff (up to 30s) until DNS resolves.

## Race condition

The existing guard `if (_adsStream != stream || stream.isReady()) return` protects against the timeout task firing at the same instant the stream becomes ready (since `cancel(false)` in `readyHandler` won't stop a task already running):

- `_adsStream != stream` — stream was already closed/replaced before the timeout ran
- `stream.isReady()` — stream became ready between dequeue and the guard check

**Tradeoff introduced by this fix**: before, losing this race caused a spurious error+reconnect notification. After, it causes a spurious reconnect (timeout closes the stream just as it goes ready, `readyHandler` sees `_adsStream == null` and returns, retry reconnects cleanly). This is acceptable — a rare unnecessary reconnect vs. hanging forever. Fully eliminating the race would require `cancel(true)` in `readyHandler`, which is a separate change.

## Changes

- `startRpcStreamLocal()`: timeout lambda delegates to new `handleReadyTimeout(stream)`
- `handleReadyTimeout(AdsStream)`: `@VisibleForTesting` method with the fix logic
- `createTestAdsStream()`: `@VisibleForTesting` factory for an unstarted `AdsStream` (used in tests)
- `testReadyTimeoutClosesStreamAndSchedulesRetry`: verifies subscribers get `DEADLINE_EXCEEDED`, stream is closed, and retry is scheduled
- `testReadyTimeoutIsNoOpWhenStreamMismatch`: verifies the race-condition guard is a no-op when streams differ

## Testing

Tests were verified as genuine regression guards by reverting to the old behavior and confirming failure:
```
ADS stream should be closed after ready timeout expected [null] but found [XdsClientImpl$AdsStream@71e643b1]
```
Both tests pass on the fixed code (`BUILD SUCCESSFUL`).