### PR TITLE
Add @RestrictedApi to D2ClientBuilder constructor and build()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ project.ext.externalDependency = [
   'disruptor': 'com.lmax:disruptor:3.2.0',
   'easymock': 'org.easymock:easymock:4.0.2',
   'findbugs': 'com.google.code.findbugs:annotations:3.0.0',
+  'errorProneAnnotations': 'com.google.errorprone:error_prone_annotations:2.26.1',
   'mockito': 'org.mockito:mockito-all:1.9.5',
   'metricsCore': 'io.dropwizard.metrics:metrics-core:4.2.10',
   'guava': 'com.google.guava:guava:18.0',

--- a/d2/build.gradle
+++ b/d2/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   compile externalDependency.zero_allocation_hashing
   compile externalDependency.xchart
   compileOnly externalDependency.findbugs
+  compileOnly externalDependency.errorProneAnnotations
   testCompile externalDependency.metricsCore
   testCompile externalDependency.xerialSnappy
   testCompile externalDependency.testng

--- a/d2/src/main/java/com/linkedin/d2/balancer/AllowRawD2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/AllowRawD2ClientBuilder.java
@@ -1,0 +1,49 @@
+/*
+   Copyright (c) 2024 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Opt-in allowlist annotation for direct use of {@link D2ClientBuilder}.
+ *
+ * <p>Annotating a class or method with this annotation suppresses the Error Prone
+ * {@code RestrictedApiChecker} warning that is raised when constructing or calling
+ * {@link D2ClientBuilder#build()} directly.</p>
+ *
+ * <p><b>This annotation should only be used as a temporary migration aid.</b>
+ * All usages should eventually be migrated to {@code D2ClientFactory} (container).
+ * See <a href="go/onboardindis">go/onboardindis</a> for migration instructions.</p>
+ *
+ * <p>To track remaining usages, search for {@code cu:AllowRawD2ClientBuilder} in Jarvis.</p>
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface AllowRawD2ClientBuilder
+{
+  /**
+   * Required justification for why this class/method needs direct D2ClientBuilder access.
+   * Helps reviewers assess whether the exception is legitimate.
+   */
+  String reason();
+}

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -79,6 +79,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
+import com.google.errorprone.annotations.RestrictedApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,9 +100,29 @@ public class D2ClientBuilder
   private boolean _restOverStream = false;
   private final D2ClientConfig _config = new D2ClientConfig();
 
+  @RestrictedApi(
+      explanation = "Direct instantiation of D2ClientBuilder is restricted for LinkedIn-internal callers. "
+          + "Use D2ClientFactory (container) instead. See go/onboardindis.",
+      link = "go/onboardindis",
+      allowedOnPath = ".*/factory/D2ClientFactory\\.java"   // LinkedIn's blessed factory
+          + "|.*/test/.*"                                   // all test code
+          + "|^(?!.*com/linkedin).*$",                     // all non-LinkedIn (open-source) callers
+      allowlistAnnotations = {AllowRawD2ClientBuilder.class, SuppressWarnings.class}
+  )
+  public D2ClientBuilder() {}
+
   /**
    * @return {@link D2Client} that is not started yet. Call start(Callback) to start it.
    */
+  @RestrictedApi(
+      explanation = "Direct use of D2ClientBuilder.build() is restricted for LinkedIn-internal callers. "
+          + "Use D2ClientFactory (container) instead. See go/onboardindis.",
+      link = "go/onboardindis",
+      allowedOnPath = ".*/factory/D2ClientFactory\\.java"   // LinkedIn's blessed factory
+          + "|.*/test/.*"                                   // all test code
+          + "|^(?!.*com/linkedin).*$",                     // all non-LinkedIn (open-source) callers
+      allowlistAnnotations = {AllowRawD2ClientBuilder.class, SuppressWarnings.class}
+  )
   public D2Client build()
   {
     if (!_config.disableDetectLiRawD2Client && isLiRawD2Client())


### PR DESCRIPTION
## Summary

Annotate `D2ClientBuilder`'s constructor and `build()` method with Error Prone's `@RestrictedApi` to produce **compile-time errors** when LinkedIn-internal callers instantiate or invoke the builder directly outside of blessed paths. External open-source callers are unaffected.

---

## Motivation

`D2ClientBuilder` is a raw, low-level API. LinkedIn container apps must use `D2ClientFactory` instead, which automatically applies INDIS configuration, future platform migrations, and framework features.

A `LOG.warn` / `LOG.error` at runtime already exists but:
- It only fires when the process runs, not when code is written
- It is easy to miss in log noise
- It cannot block new regressions at code-review time

A compile-time Error Prone checker closes the feedback loop at **build time**.

---

## Changes

### `build.gradle` (root)
- Added `errorProneAnnotations: 'com.google.errorprone:error_prone_annotations:2.26.1'` to `externalDependency`

### `d2/build.gradle`
- Added `compileOnly externalDependency.errorProneAnnotations`

### `AllowRawD2ClientBuilder.java` _(new)_
- Opt-in marker annotation for LinkedIn-internal callers that legitimately need direct access during migration
- Has a required `reason()` field to force documentation at every exception
- `@Retention(CLASS)` — compile-time only, no runtime cost
- `@Target({TYPE, METHOD, CONSTRUCTOR})` — callers can be surgical about scope

### `D2ClientBuilder.java`
- Added `import com.google.errorprone.annotations.RestrictedApi`
- Added explicit no-arg constructor annotated with `@RestrictedApi`
- Annotated `build()` with `@RestrictedApi`

---

## Allowed callers

| Caller | Path contains `com/linkedin`? | Result |
|---|---|---|
| `D2ClientFactory.java` | yes | ✅ allowed (explicit path match) |
| Any `test/` file | either | ✅ allowed (explicit path match) |
| External user (`org.foo`, `com.example`, etc.) | no | ✅ allowed (`^(?!.*com/linkedin).*$`) |
| LinkedIn-internal app (`com.linkedin.container`) | yes | ❌ blocked → compile error |
| LinkedIn-internal app with `@AllowRawD2ClientBuilder` | yes | ✅ allowed (annotation escape hatch) |
| LinkedIn-internal app with `@SuppressWarnings("RestrictedApiChecker")` | yes | ✅ allowed (emergency escape hatch) |

### `allowedOnPath` breakdown

```java
allowedOnPath = ".*/factory/D2ClientFactory\\.java"  // LinkedIn's blessed factory
    + "|.*/test/.*"                                   // all test code
    + "|^(?!.*com/linkedin).*$",                      // all non-LinkedIn (open-source) callers
```

---

## Migration tracking

Search **`cu:AllowRawD2ClientBuilder`** in Jarvis codesearch to get a live inventory of remaining exceptions and drive them to zero over time.

---

## Testing & Verification

### ⚠️ Prerequisite: Error Prone compiler plugin

`@RestrictedApi` is enforced by Error Prone's `RestrictedApiChecker` — it requires the **`net.ltgt.errorprone` Gradle plugin** to be configured as the compiler plugin. Without it, the annotation compiles cleanly but is **not enforced**. This PR adds the annotation and allowlist infrastructure; wiring in the Gradle plugin is the necessary follow-up to activate enforcement.

### Local demo — all 6 cases verified

A standalone project with Error Prone configured was used to verify all enforcement scenarios end-to-end:

| # | File | Caller type | Expected | Actual |
|---|---|---|---|---|
| 1 | `com/linkedin/demo/BadCaller.java` | LinkedIn-internal, no annotation | ❌ BLOCKED | ❌ `[RestrictedApi]` error |
| 2 | `org/external/ExternalUser.java` | External open-source | ✅ ALLOWED | ✅ compiles clean |
| 3 | `com/linkedin/demo/AllowedInternalCaller.java` | LinkedIn-internal + `@AllowRawD2ClientBuilder` | ✅ ALLOWED | ✅ compiles clean |
| 4 | `com/linkedin/demo/SuppressedCaller.java` | LinkedIn-internal + `@SuppressWarnings` | ✅ ALLOWED | ✅ compiles clean |
| 5 | `com/linkedin/factory/D2ClientFactory.java` | Blessed factory path | ✅ ALLOWED | ✅ compiles clean |
| 6 | `com/linkedin/test/D2ClientBuilderTest.java` | `test/` path | ✅ ALLOWED | ✅ compiles clean |

**Case 1 — LinkedIn-internal caller blocked:**

```java
// com/linkedin/demo/BadCaller.java
public class BadCaller {
    public void go() { new D2ClientBuilder().build(); }
}
```
```
BadCaller.java:4: error: [RestrictedApi] Restricted for LinkedIn-internal callers.
    Use D2ClientFactory. See go/onboardindis.
        public void go() { new D2ClientBuilder().build(); }
                                                 ^
```

**Case 2 — External open-source caller allowed (no annotation needed):**

```java
// org/external/ExternalUser.java
public class ExternalUser {
    public void go() { new D2ClientBuilder().build(); } // compiles clean
}
```

**Case 3 — LinkedIn-internal with `@AllowRawD2ClientBuilder` allowed:**

```java
@AllowRawD2ClientBuilder(reason = "Legacy service, migrating via JIRA-1234")
public class AllowedInternalCaller {
    public void go() { new D2ClientBuilder().build(); } // compiles clean
}
```

### `D2ClientBuilderTest` — passes locally (Java 11, Gradle 6.9.4)

```
BUILD SUCCESSFUL
D2ClientBuilderTest: all tests pass (test/ matches allowedOnPath — no restriction triggered)
```

---

## Related
- go/onboardindis — INDIS migration guide
- `D2ClientFactory` in `pegasus-d2-client-factory`
- Follow-up: add `net.ltgt.errorprone` Gradle plugin to activate compile-time enforcement