### PR TITLE
Fix MIMEParse null-guard to eliminate huge number of NPE traps/sec

### DIFF
--- a/restli-server/src/main/java/com/linkedin/restli/internal/server/util/MIMEParse.java
+++ b/restli-server/src/main/java/com/linkedin/restli/internal/server/util/MIMEParse.java
@@ -148,7 +148,7 @@ public final class MIMEParse
   {
     ParseResults results = parseMimeType(range);
     String q = results.params.get(QUALITY_PARAM);
-    float f = NumberUtils.toFloat(q, 1);
+    float f = (q == null) ? 1.0f : NumberUtils.toFloat(q, 1);
     if (StringUtils.isBlank(q) || f < 0 || f > 1)
       results.params.put(QUALITY_PARAM, "1");
     return results;
@@ -223,7 +223,8 @@ public final class MIMEParse
           if (fitness > bestFitness)
           {
             bestFitness = fitness;
-            bestFitQ = NumberUtils.toFloat(range.params.get(QUALITY_PARAM), 0);
+            String qParam = range.params.get(QUALITY_PARAM);
+            bestFitQ = (qParam == null) ? 0f : NumberUtils.toFloat(qParam, 0);
             bestFitParams = range.params;
           }
         }


### PR DESCRIPTION
NumberUtils.toFloat(null, default) internally calls Float.parseFloat(null) which throws NullPointerException before returning the default value. This fires fillInStackTrace on every request for each media type without a "q" parameter (the common case). Add null checks to short-circuit the call and return the default directly, preserving identical behavior without the exception overhead.