### PR TITLE
Fix SmoothRateLimiter precision loss from millisecond rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.85.7] - 2026-04-08
+- Fix SmoothRateLimiter precision loss by switching from millisecond to nanosecond time tracking, eliminating ~33% QPS error for rates with fractional-ms periods.
+
 ## [29.85.6] - 2026-03-06
 - Add cluster subsetting configuration (enableClusterSubsetting, minClusterSubsetSize) to D2Cluster and ClusterProperties.
 
@@ -5973,7 +5976,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.6...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.7...master
+[29.85.7]: https://github.com/linkedin/rest.li/compare/v29.85.6...v29.85.7
 [29.85.6]: https://github.com/linkedin/rest.li/compare/v29.85.5...v29.85.6
 [29.85.5]: https://github.com/linkedin/rest.li/compare/v29.85.4...v29.85.5
 [29.85.4]: https://github.com/linkedin/rest.li/compare/v29.85.3...v29.85.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.7-rc.8
+version=29.85.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.7
+version=29.85.7-rc.8
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.6
+version=29.85.7
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/pegasus-common/src/main/java/com/linkedin/util/clock/Clock.java
+++ b/pegasus-common/src/main/java/com/linkedin/util/clock/Clock.java
@@ -37,6 +37,6 @@ public interface Clock
    */
   default long currentTimeNanos()
   {
-    return System.nanoTime();
+    return currentTimeMillis() * 1_000_000L;
   }
 }

--- a/pegasus-common/src/main/java/com/linkedin/util/clock/Clock.java
+++ b/pegasus-common/src/main/java/com/linkedin/util/clock/Clock.java
@@ -31,4 +31,12 @@ public interface Clock
    * @return the current time of this clock in milliseconds.
    */
   long currentTimeMillis();
+
+  /**
+   * @return the current time of this clock in nanoseconds.
+   */
+  default long currentTimeNanos()
+  {
+    return System.nanoTime();
+  }
 }

--- a/pegasus-common/src/main/java/com/linkedin/util/clock/SettableClock.java
+++ b/pegasus-common/src/main/java/com/linkedin/util/clock/SettableClock.java
@@ -64,4 +64,10 @@ public class SettableClock implements Clock
   {
     _currentTimeMillis -= millis;
   }
+
+  @Override
+  public long currentTimeNanos()
+  {
+    return _currentTimeMillis * 1_000_000L;
+  }
 }

--- a/pegasus-common/src/main/java/com/linkedin/util/clock/SettableClock.java
+++ b/pegasus-common/src/main/java/com/linkedin/util/clock/SettableClock.java
@@ -64,10 +64,4 @@ public class SettableClock implements Clock
   {
     _currentTimeMillis -= millis;
   }
-
-  @Override
-  public long currentTimeNanos()
-  {
-    return _currentTimeMillis * 1_000_000L;
-  }
 }

--- a/pegasus-common/src/main/java/com/linkedin/util/clock/SystemClock.java
+++ b/pegasus-common/src/main/java/com/linkedin/util/clock/SystemClock.java
@@ -46,4 +46,10 @@ public class SystemClock implements Clock
   {
     return System.currentTimeMillis();
   }
+
+  @Override
+  public long currentTimeNanos()
+  {
+    return System.nanoTime();
+  }
 }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ConstantQpsRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ConstantQpsRateLimiter.java
@@ -22,6 +22,7 @@ import com.linkedin.util.clock.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.Random;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -130,7 +131,13 @@ public class ConstantQpsRateLimiter extends SmoothRateLimiter
 
     public int getNextExecutionDelay(Rate rate)
     {
-      return _random.nextInt(Math.max(1, (int) (rate.getPeriodRaw() / rate.getEventsRaw())));
+      return _random.nextInt(Math.max(1, rate.getEventIntervalMillis()));
+    }
+
+    @Override
+    public long getNextExecutionDelayNanos(Rate rate)
+    {
+      return ThreadLocalRandom.current().nextLong(Math.max(1L, rate.getEventIntervalNanos()));
     }
   }
 }

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/SmoothRateLimiter.java
@@ -233,7 +233,7 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     EventLoop(Clock clock)
     {
       _clock = clock;
-      _permitTime = _clock.currentTimeMillis();
+      _permitTime = _clock.currentTimeNanos();
       Rate rate = _rate;
       _permitAvailableCount = rate.getEvents();
       _permitsInTimeFrame = rate.getEvents();
@@ -247,10 +247,10 @@ public class SmoothRateLimiter implements AsyncRateLimiter
       // before entering the next period
       _permitAvailableCount = Math.max(rate.getEvents() - (_permitsInTimeFrame - _permitAvailableCount), 0);
       _permitsInTimeFrame = rate.getEvents();
-      long now = _clock.currentTimeMillis();
+      long now = _clock.currentTimeNanos();
       // ensure to recalculate the delay, discounting any time already delayed
       long timeSinceLastPermit = now - _permitTime;
-      _delayUntil = now + Math.max(0, (_executionTracker.getNextExecutionDelay(_rate) - timeSinceLastPermit));
+      _delayUntil = now + Math.max(0, (_executionTracker.getNextExecutionDelayNanos(_rate) - timeSinceLastPermit));
 
       loop();
     }
@@ -258,14 +258,14 @@ public class SmoothRateLimiter implements AsyncRateLimiter
     public void loop()
     {
       // Checks if permits should be refreshed
-      long now = _clock.currentTimeMillis();
+      long now = _clock.currentTimeNanos();
       Rate rate = _rate;
-      if (now - _permitTime >= rate.getPeriod())
+      if (now - _permitTime >= rate.getPeriodNanos())
       {
         _permitTime = now;
         _permitAvailableCount = rate.getEvents();
         _permitsInTimeFrame = rate.getEvents();
-        _delayUntil = now + _executionTracker.getNextExecutionDelay(_rate);
+        _delayUntil = now + _executionTracker.getNextExecutionDelayNanos(_rate);
       }
 
       if (_executionTracker.isPaused())
@@ -281,7 +281,7 @@ public class SmoothRateLimiter implements AsyncRateLimiter
 
       if (_permitAvailableCount > 0 && _delayUntil <= now)
       {
-        _delayUntil = now + _executionTracker.getNextExecutionDelay(_rate);
+        _delayUntil = now + _executionTracker.getNextExecutionDelayNanos(_rate);
         _permitAvailableCount--;
         Callback<None> callback = null;
         try
@@ -321,12 +321,12 @@ public class SmoothRateLimiter implements AsyncRateLimiter
         {
           // avoids executing too many duplicate tasks
           // reschedule next iteration of the event loop to the next delay, or the beginning of the next period
-          long nextRunRelativeTime = _permitAvailableCount > 0 ? _delayUntil - now : Math.max(0, _permitTime + rate.getPeriod() - now);
+          long nextRunRelativeTime = _permitAvailableCount > 0 ? _delayUntil - now : Math.max(0, _permitTime + rate.getPeriodNanos() - now);
           long nextRunAbsolute = now + nextRunRelativeTime;
           if (_nextScheduled > nextRunAbsolute || _nextScheduled <= now)
           {
             _nextScheduled = nextRunAbsolute;
-            _scheduler.schedule(this::loop, nextRunRelativeTime, TimeUnit.MILLISECONDS);
+            _scheduler.schedule(this::loop, nextRunRelativeTime, TimeUnit.NANOSECONDS);
           }
         }
         catch (Throwable throwable)

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/Rate.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/Rate.java
@@ -118,6 +118,36 @@ public class Rate
     return _period;
   }
 
+  /**
+   * Gets period in Nanoseconds.
+   *
+   * @return Period in nanoseconds.
+   */
+  public long getPeriodNanos()
+  {
+    return (long) (_period * 1_000_000L);
+  }
+
+  /**
+   * Gets the duration of a single event interval in milliseconds.
+   *
+   * @return Milliseconds per event.
+   */
+  public int getEventIntervalMillis()
+  {
+    return (int) (_period / _events);
+  }
+
+  /**
+   * Gets the duration of a single event interval in nanoseconds.
+   *
+   * @return Nanoseconds per event.
+   */
+  public long getEventIntervalNanos()
+  {
+    return (long) (_period / _events * 1_000_000L);
+  }
+
   public boolean equals(Object o)
   {
     if (this == o)

--- a/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/RateLimiterExecutionTracker.java
+++ b/r2-core/src/main/java/com/linkedin/r2/transport/http/client/ratelimiter/RateLimiterExecutionTracker.java
@@ -56,9 +56,16 @@ public interface RateLimiterExecutionTracker
     int getMaxBuffered();
 
     /**
-     * @return amount of delay to be incurred before executing the next callback, based on provided rate
+     * @return amount of delay in milliseconds to be incurred before executing the next callback, based on provided rate
      */
     default int getNextExecutionDelay(Rate rate) {
         return 0;
+    }
+
+    /**
+     * @return amount of delay in nanoseconds to be incurred before executing the next callback, based on provided rate
+     */
+    default long getNextExecutionDelayNanos(Rate rate) {
+        return getNextExecutionDelay(rate) * 1_000_000L;
     }
 }

--- a/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestSmoothRateLimiter.java
+++ b/r2-core/src/test/java/com/linkedin/r2/transport/http/client/ratelimiter/TestSmoothRateLimiter.java
@@ -22,11 +22,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.common.util.None;
 import com.linkedin.r2.transport.http.client.AsyncRateLimiter;
 import com.linkedin.r2.transport.http.client.SmoothRateLimiter;
+import com.linkedin.test.util.ClockedExecutor;
 import com.linkedin.util.clock.Clock;
 
 import java.util.concurrent.TimeUnit;
@@ -35,6 +37,7 @@ import org.junit.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class TestSmoothRateLimiter extends BaseTestSmoothRateLimiter
@@ -116,6 +119,59 @@ public class TestSmoothRateLimiter extends BaseTestSmoothRateLimiter
     }
     callback.get(5, TimeUnit.SECONDS);
     Assert.assertTrue("The tasks should run", callback.isDone());
+  }
+
+  /**
+   * Verifies that nanosecond period tracking produces accurate dispatch rates for fractional
+   * millisecond periods.
+   *
+   * <p>At 750 QPS with burst=1, the Rate constructor computes an internal period of
+   * 1000/750 = 1.333ms. Previously, {@link Rate#getPeriod()} rounded this to 1ms, causing the
+   * event loop to dispatch at ~1000 QPS (+33% error). With nanosecond tracking via
+   * {@link Rate#getPeriodNanos()}, the period is represented as 1,333,333ns and the dispatch
+   * rate matches the target.</p>
+   */
+  @Test(timeOut = 10000)
+  public void testFractionalPeriodAccuracy()
+  {
+    ClockedExecutor executor = new ClockedExecutor();
+    SmoothRateLimiter rateLimiter = new SmoothRateLimiter(
+        executor, executor, executor, _queue, Integer.MAX_VALUE,
+        SmoothRateLimiter.BufferOverflowMode.DROP, RATE_LIMITER_NAME_TEST);
+
+    int targetQps = 750;
+    int burst = 1;
+    rateLimiter.setRate(targetQps, ONE_SECOND_PERIOD, burst);
+
+    AtomicInteger dispatchCount = new AtomicInteger(0);
+
+    for (int i = 0; i < targetQps * 4; i++)
+    {
+      rateLimiter.submit(new Callback<None>()
+      {
+        @Override
+        public void onError(Throwable e) { }
+
+        @Override
+        public void onSuccess(None result)
+        {
+          dispatchCount.incrementAndGet();
+        }
+      });
+    }
+
+    int durationSeconds = 3;
+    executor.runFor(ONE_SECOND_PERIOD * durationSeconds);
+
+    int totalDispatches = dispatchCount.get();
+    int expectedTotal = targetQps * durationSeconds;
+    double errorPercent = 100.0 * Math.abs(totalDispatches - expectedTotal) / expectedTotal;
+
+    // Without nanosecond tracking, getPeriod() rounds 1.333ms to 1ms, yielding ~1000 QPS (+33% error).
+    // With nanosecond tracking, getPeriodNanos() = 1,333,333ns and the rate is accurate within 5%.
+    assertTrue(errorPercent < 5.0,
+        "Dispatched " + totalDispatches + " in " + durationSeconds + "s, expected ~" + expectedTotal
+            + " (error " + String.format("%.1f", errorPercent) + "%)");
   }
 
   protected AsyncRateLimiter getRateLimiter(ScheduledExecutorService executorService, ExecutorService executor, Clock clock)

--- a/test-util/src/main/java/com/linkedin/test/util/ClockedExecutor.java
+++ b/test-util/src/main/java/com/linkedin/test/util/ClockedExecutor.java
@@ -29,8 +29,9 @@ import org.slf4j.LoggerFactory;
 public class ClockedExecutor implements Clock, ScheduledExecutorService
 {
   private static final Logger LOG = LoggerFactory.getLogger(ClockedExecutor.class);
+  private static final long NANOS_PER_MILLI = 1_000_000L;
 
-  private volatile long _currentTimeMillis = 0L;
+  private volatile long _currentTimeNanos = 0L;
   private volatile Boolean _stopped = true;
   private volatile long _taskCount = 0L;
   private PriorityBlockingQueue<ClockedTask> _taskList = new PriorityBlockingQueue<>();
@@ -42,6 +43,11 @@ public class ClockedExecutor implements Clock, ScheduledExecutorService
 
   public Future<Void> runUntil(long untilTime)
   {
+    return runUntilNanos(untilTime * NANOS_PER_MILLI);
+  }
+
+  private Future<Void> runUntilNanos(long untilTimeNanos)
+  {
     if (!_stopped)
     {
       throw new IllegalArgumentException("Already Started!");
@@ -52,32 +58,32 @@ public class ClockedExecutor implements Clock, ScheduledExecutorService
     }
     _stopped = false;
 
-    while (!_stopped && !_taskList.isEmpty() && (untilTime <= 0L || untilTime >= _currentTimeMillis))
+    while (!_stopped && !_taskList.isEmpty() && (untilTimeNanos <= 0L || untilTimeNanos >= _currentTimeNanos))
     {
       ClockedTask task = _taskList.peek();
       long expectTime = task.getScheduledTime();
 
-      if (expectTime > untilTime)
+      if (expectTime > untilTimeNanos)
       {
-        _currentTimeMillis = untilTime;
+        _currentTimeNanos = untilTimeNanos;
         break;
       }
 
       _taskList.remove();
 
-      if (expectTime > _currentTimeMillis)
+      if (expectTime > _currentTimeNanos)
       {
-        _currentTimeMillis = expectTime;
+        _currentTimeNanos = expectTime;
       }
       if (LOG.isDebugEnabled())
       {
-        LOG.debug("Processing task " + task.toString() + " total {}, time {}", _taskList.size(), _currentTimeMillis);
+        LOG.debug("Processing task " + task.toString() + " total {}, time {}", _taskList.size(), _currentTimeNanos);
       }
       task.run();
       _taskCount++;
       if (task.repeatCount() > 0 && !task.isCancelled() && !_stopped)
       {
-        task.reschedule(_currentTimeMillis);
+        task.reschedule(_currentTimeNanos);
         _taskList.add(task);
       }
     }
@@ -93,7 +99,7 @@ public class ClockedExecutor implements Clock, ScheduledExecutorService
   @Override
   public ScheduledFuture<Void> schedule(Runnable cmd, long delay, TimeUnit unit)
   {
-    ClockedTask task = new ClockedTask("ScheduledTask", cmd, _currentTimeMillis + unit.toMillis(delay));
+    ClockedTask task = new ClockedTask("ScheduledTask", cmd, _currentTimeNanos + unit.toNanos(delay));
     _taskList.add(task);
     return task;
   }
@@ -108,7 +114,7 @@ public class ClockedExecutor implements Clock, ScheduledExecutorService
   public ScheduledFuture<Void> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit)
   {
     ClockedTask task =
-      new ClockedTask("scheduleAtFixedRate", command, _currentTimeMillis + unit.toMillis(initialDelay), unit.toMillis(period), Long.MAX_VALUE);
+      new ClockedTask("scheduleAtFixedRate", command, _currentTimeNanos + unit.toNanos(initialDelay), unit.toNanos(period), Long.MAX_VALUE);
     _taskList.add(task);
     return task;
   }
@@ -117,21 +123,21 @@ public class ClockedExecutor implements Clock, ScheduledExecutorService
   public ScheduledFuture<Void> scheduleWithFixedDelay(Runnable cmd, long initDelay, long interval, TimeUnit unit)
   {
     ClockedTask task =
-      new ClockedTask("scheduledWithDelayTask", cmd, _currentTimeMillis + unit.toMillis(initDelay), unit.toMillis(interval), Long.MAX_VALUE);
+      new ClockedTask("scheduledWithDelayTask", cmd, _currentTimeNanos + unit.toNanos(initDelay), unit.toNanos(interval), Long.MAX_VALUE);
     _taskList.add(task);
     return task;
   }
 
   public void scheduleWithRepeat(Runnable cmd, long initDelay, long interval, long repeatTimes)
   {
-    ClockedTask task = new ClockedTask("scheduledWithRepeatTask", cmd, _currentTimeMillis + initDelay, interval, repeatTimes);
+    ClockedTask task = new ClockedTask("scheduledWithRepeatTask", cmd, _currentTimeNanos + initDelay * NANOS_PER_MILLI, interval * NANOS_PER_MILLI, repeatTimes);
     _taskList.add(task);
   }
 
   @Override
   public void execute(Runnable cmd)
   {
-    ClockedTask task = new ClockedTask("executeTask", cmd, _currentTimeMillis);
+    ClockedTask task = new ClockedTask("executeTask", cmd, _currentTimeNanos);
     _taskList.add(task);
   }
 
@@ -220,42 +226,48 @@ public class ClockedExecutor implements Clock, ScheduledExecutorService
   @Override
   public long currentTimeMillis()
   {
-    return _currentTimeMillis;
+    return _currentTimeNanos / NANOS_PER_MILLI;
+  }
+
+  @Override
+  public long currentTimeNanos()
+  {
+    return _currentTimeNanos;
   }
 
   @Override
   public String toString()
   {
-    return "ClockedExecutor [_currentTimeMillis: " + _currentTimeMillis + "_taskList:" + _taskList.stream().map(e -> e.toString())
+    return "ClockedExecutor [_currentTimeMillis: " + currentTimeMillis() + "_taskList:" + _taskList.stream().map(e -> e.toString())
       .collect(Collectors.joining(","));
   }
 
   public long getCurrentTimeMillis()
   {
-    return _currentTimeMillis;
+    return _currentTimeNanos / NANOS_PER_MILLI;
   }
 
   private class ClockedTask implements Runnable, ScheduledFuture<Void>
   {
     final private String _name;
-    private long _expectTimeMillis;
-    private long _interval;
+    private long _expectTimeNanos;
+    private long _intervalNanos;
     private Runnable _task;
     private long _repeatTimes;
     private CountDownLatch _done;
     private boolean _cancelled;
 
-    ClockedTask(String name, Runnable task, long scheduledTime)
+    ClockedTask(String name, Runnable task, long scheduledTimeNanos)
     {
-      this(name, task, scheduledTime, 0l, 0l);
+      this(name, task, scheduledTimeNanos, 0L, 0L);
     }
 
-    ClockedTask(String name, Runnable task, long scheduledTime, long interval, long repeat)
+    ClockedTask(String name, Runnable task, long scheduledTimeNanos, long intervalNanos, long repeat)
     {
       _name = name;
       _task = task;
-      _expectTimeMillis = scheduledTime;
-      _interval = interval;
+      _expectTimeNanos = scheduledTimeNanos;
+      _intervalNanos = intervalNanos;
       _repeatTimes = repeat;
       _done = new CountDownLatch(1);
       _cancelled = false;
@@ -278,14 +290,14 @@ public class ClockedExecutor implements Clock, ScheduledExecutorService
 
     long getScheduledTime()
     {
-      return _expectTimeMillis;
+      return _expectTimeNanos;
     }
 
-    void reschedule(long currentTime)
+    void reschedule(long currentTimeNanos)
     {
-      if (!_cancelled && currentTime >= _expectTimeMillis && _repeatTimes-- > 0)
+      if (!_cancelled && currentTimeNanos >= _expectTimeNanos && _repeatTimes-- > 0)
       {
-        _expectTimeMillis += (_interval - (currentTime - _expectTimeMillis));
+        _expectTimeNanos += (_intervalNanos - (currentTimeNanos - _expectTimeNanos));
         _done = new CountDownLatch(1);
       }
     }
@@ -333,19 +345,19 @@ public class ClockedExecutor implements Clock, ScheduledExecutorService
     @Override
     public long getDelay(TimeUnit unit)
     {
-      return unit.convert(_expectTimeMillis - _currentTimeMillis, TimeUnit.MILLISECONDS);
+      return unit.convert(_expectTimeNanos - _currentTimeNanos, TimeUnit.NANOSECONDS);
     }
 
     @Override
     public int compareTo(Delayed other)
     {
-      return (int) (getDelay(TimeUnit.MILLISECONDS) - other.getDelay(TimeUnit.MILLISECONDS));
+      return Long.compare(getDelay(TimeUnit.NANOSECONDS), other.getDelay(TimeUnit.NANOSECONDS));
     }
 
     @Override
     public String toString()
     {
-      return "ClockedTask [_name=" + _name + "_expectedTime=" + _expectTimeMillis + "_repeatTimes=" + _repeatTimes + "_interval=" + _interval + "]";
+      return "ClockedTask [_name=" + _name + "_expectedTime=" + _expectTimeNanos + "_repeatTimes=" + _repeatTimes + "_interval=" + _intervalNanos + "]";
     }
   }
 }


### PR DESCRIPTION
## Summary

- `Rate.getPeriod()` rounds to the nearest millisecond via `Math.round()`, causing significant QPS error for rates with fractional-ms periods (e.g. 750 QPS with burst=1 has a 1.333ms period that rounds to 1ms → +33% error)
- Switches `SmoothRateLimiter` to nanosecond time tracking via new additive APIs: `Clock.currentTimeNanos()`, `Rate.getPeriodNanos()`, `Rate.getEventIntervalMillis()/getEventIntervalNanos()`, and `RateLimiterExecutionTracker.getNextExecutionDelayNanos()`
- No existing APIs were changed — all additions are backward-compatible with defaults that delegate to existing methods

## Testing Done

- Added `testFractionalPeriodAccuracy` in `TestSmoothRateLimiter`: sets 750 QPS with burst=1 (1.333ms period), runs for 3s, asserts <5% error
- Verified the test **fails on old code**: dispatches 3000 in 3s instead of 2250 (33.3% error from rounding 1.333ms → 1ms)
- Verified the test **passes on new code**: dispatches ~2250 in 3s (<5% error using 1,333,333ns period)
- All existing rate limiter tests pass (`TestSmoothRateLimiter`, `TestConstantQpsRateLimiter`, `TestRampUpRateLimiter`, `BaseTestSmoothRateLimiter`)