### PR TITLE
Make HTTP/2 channel creation timeout configurable

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -46,7 +46,7 @@ if [ ! -z "$GITHUB_HEAD_REF" ] && [ ! -z "$GITHUB_BASE_REF" ]; then
     exit 1
   fi
   # Skip module-specific tests if its module dependencies haven't been touched
-  CONDITIONAL_TESTING_MODULES='d2 r2-int-test restli-int-test'
+  CONDITIONAL_TESTING_MODULES='d2 r2-int-test restli-int-test multipart-mime'
   echo "This is a PR build, so testing will be conditional for these subprojects: [${CONDITIONAL_TESTING_MODULES// /,}]"
   # If any Gradle file was touched, run all tests just to be safe
   if (git diff ${GITHUB_BASE_REF}...HEAD --name-only | grep '\.gradle' > /dev/null); then

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -46,7 +46,7 @@ if [ ! -z "$GITHUB_HEAD_REF" ] && [ ! -z "$GITHUB_BASE_REF" ]; then
     exit 1
   fi
   # Skip module-specific tests if its module dependencies haven't been touched
-  CONDITIONAL_TESTING_MODULES='d2 r2-int-test restli-int-test multipart-mime'
+  CONDITIONAL_TESTING_MODULES='d2 r2-int-test restli-int-test'
   echo "This is a PR build, so testing will be conditional for these subprojects: [${CONDITIONAL_TESTING_MODULES// /,}]"
   # If any Gradle file was touched, run all tests just to be safe
   if (git diff ${GITHUB_BASE_REF}...HEAD --name-only | grep '\.gradle' > /dev/null); then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Make the HTTP/2 parent channel creation timeout configurable via
+  `HttpClientFactory.Builder.setHttp2ChannelCreationTimeout(...)`, allowing callers to
+  fail faster on unreachable hosts (default unchanged at 10,000ms).
 
 ## [29.85.12] - 2026-05-14
 - Avoid per-request HashSet allocation in RelativeLoadBalancerStrategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.85.13] - 2026-06-04
 - Make the HTTP/2 parent channel creation timeout configurable via
   `HttpClientFactory.Builder.setHttp2ChannelCreationTimeout(...)`, allowing callers to
   fail faster on unreachable hosts (default unchanged at 10,000ms).
@@ -5997,7 +5999,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.12...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.13...master
+[29.85.13]: https://github.com/linkedin/rest.li/compare/v29.85.12...v29.85.13
 [29.85.12]: https://github.com/linkedin/rest.li/compare/v29.85.11...v29.85.12
 [29.85.11]: https://github.com/linkedin/rest.li/compare/v29.85.10...29.85.11
 [29.85.10]: https://github.com/linkedin/rest.li/compare/v29.85.9...v29.85.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.12
+version=29.85.13
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelLifecycle.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelLifecycle.java
@@ -76,7 +76,8 @@ class Http2ChannelLifecycle implements AsyncPool.Lifecycle<Channel>
   private long _lastActiveTime;
 
   Http2ChannelLifecycle(SocketAddress address, ScheduledExecutorService scheduler, Clock clock,
-      ChannelGroup channelGroup, boolean ssl, long maxContentLength, long idleTimeout, AsyncPool.Lifecycle<Channel> parentChannelLifecycle)
+      ChannelGroup channelGroup, boolean ssl, long maxContentLength, long idleTimeout,
+      AsyncPool.Lifecycle<Channel> parentChannelLifecycle, long channelCreationTimeoutMs)
   {
     _address = address;
     _scheduler = scheduler;
@@ -87,7 +88,7 @@ class Http2ChannelLifecycle implements AsyncPool.Lifecycle<Channel>
     _idleTimeout = idleTimeout;
     _parentChannelLifecycle = parentChannelLifecycle;
     _childChannelCount = 0;
-    _channelCreationTimeoutMs = DEFAULT_CHANNEL_CREATION_TIMEOUT_MS; // TODO: expose this through cfg2
+    _channelCreationTimeoutMs = channelCreationTimeoutMs > 0 ? channelCreationTimeoutMs : DEFAULT_CHANNEL_CREATION_TIMEOUT_MS;
 
     _lastActiveTime = _clock.currentTimeMillis();
     _scheduler.scheduleAtFixedRate(this::closeParentIfIdle, idleTimeout, idleTimeout, TimeUnit.MILLISECONDS);

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
@@ -79,8 +79,7 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
       int sslHandShakeTimeout) {
     this(scheduler, eventLoopGroup, channelGroup, strategy, sslContext, sslParameters, maxPoolSize, minPoolSize,
         maxPoolWaiterSize, maxInitialLineLength, maxHeaderSize, maxChunkSize, idleTimeout, maxContentLength, tcpNoDelay,
-        enableSSLSessionResumption, connectTimeout, sslHandShakeTimeout, null,
-        Http2ChannelLifecycle.DEFAULT_CHANNEL_CREATION_TIMEOUT_MS);
+        enableSSLSessionResumption, connectTimeout, sslHandShakeTimeout, null);
   }
 
   @Deprecated

--- a/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelPoolFactory.java
@@ -51,6 +51,7 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
   private final int _minPoolSize;
   private final boolean _tcpNoDelay;
   private final boolean _ssl;
+  private final long _channelCreationTimeoutMs;
   private final Bootstrap _bootstrap;
   private final ChannelGroup _allChannels;
   private final ScheduledExecutorService _scheduler;
@@ -78,7 +79,35 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
       int sslHandShakeTimeout) {
     this(scheduler, eventLoopGroup, channelGroup, strategy, sslContext, sslParameters, maxPoolSize, minPoolSize,
         maxPoolWaiterSize, maxInitialLineLength, maxHeaderSize, maxChunkSize, idleTimeout, maxContentLength, tcpNoDelay,
-        enableSSLSessionResumption, connectTimeout, sslHandShakeTimeout, null);
+        enableSSLSessionResumption, connectTimeout, sslHandShakeTimeout, null,
+        Http2ChannelLifecycle.DEFAULT_CHANNEL_CREATION_TIMEOUT_MS);
+  }
+
+  @Deprecated
+  public Http2ChannelPoolFactory(
+      ScheduledExecutorService scheduler,
+      EventLoopGroup eventLoopGroup,
+      ChannelGroup channelGroup,
+      AsyncPoolImpl.Strategy strategy,
+      SSLContext sslContext,
+      SSLParameters sslParameters,
+      int maxPoolSize,
+      int minPoolSize,
+      int maxPoolWaiterSize,
+      int maxInitialLineLength,
+      int maxHeaderSize,
+      int maxChunkSize,
+      long idleTimeout,
+      long maxContentLength,
+      boolean tcpNoDelay,
+      boolean enableSSLSessionResumption,
+      int connectTimeout,
+      int sslHandShakeTimeout,
+      String udsAddress) {
+    this(scheduler, eventLoopGroup, channelGroup, strategy, sslContext, sslParameters, maxPoolSize, minPoolSize,
+        maxPoolWaiterSize, maxInitialLineLength, maxHeaderSize, maxChunkSize, idleTimeout, maxContentLength, tcpNoDelay,
+        enableSSLSessionResumption, connectTimeout, sslHandShakeTimeout, udsAddress,
+        Http2ChannelLifecycle.DEFAULT_CHANNEL_CREATION_TIMEOUT_MS);
   }
 
   public Http2ChannelPoolFactory(
@@ -100,7 +129,8 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
       boolean enableSSLSessionResumption,
       int connectTimeout,
       int sslHandShakeTimeout,
-      String udsAddress)
+      String udsAddress,
+      long channelCreationTimeoutMs)
   {
     final ChannelInitializer<Channel> initializer = new Http2ChannelInitializer(
         sslContext, sslParameters, maxInitialLineLength, maxHeaderSize, maxChunkSize, maxContentLength,
@@ -115,6 +145,7 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
     _idleTimeout = idleTimeout;
     _maxContentLength = maxContentLength;
     _tcpNoDelay = tcpNoDelay;
+    _channelCreationTimeoutMs = channelCreationTimeoutMs;
 
     Bootstrap bootstrap = !StringUtils.isEmpty(udsAddress) ?
         new Bootstrap().channel(getDomainSocketClass()) : new Bootstrap().channel(NioSocketChannel.class);
@@ -144,7 +175,8 @@ public class Http2ChannelPoolFactory implements ChannelPoolFactory
                 _bootstrap,
                 _allChannels,
                 _tcpNoDelay
-            )),
+            ),
+            _channelCreationTimeoutMs),
         _maxPoolSize,
         _idleTimeout,
         _scheduler,

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
@@ -41,6 +41,7 @@ import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.message.stream.StreamRequest;
 import com.linkedin.r2.message.stream.StreamResponse;
 import com.linkedin.r2.netty.client.DnsMetricsCallback;
+import com.linkedin.r2.netty.client.http2.Http2ChannelLifecycle;
 import com.linkedin.r2.transport.common.TransportClientFactory;
 import com.linkedin.r2.transport.common.bridge.client.TransportClient;
 import com.linkedin.r2.transport.common.bridge.common.TransportCallback;
@@ -159,6 +160,7 @@ public class HttpClientFactory implements TransportClientFactory
   public static final int DEFAULT_CONNECT_TIMEOUT = 30000;
   public static final int DEFAULT_SSL_HANDSHAKE_TIMEOUT = 10000;
   public static final int DEFAULT_CHANNELPOOL_WAITER_TIMEOUT = Integer.MAX_VALUE;
+  public static final long DEFAULT_HTTP2_CHANNEL_CREATION_TIMEOUT_MS = Http2ChannelLifecycle.DEFAULT_CHANNEL_CREATION_TIMEOUT_MS;
   public static final double DEFAULT_MAX_CLIENT_REQUEST_RETRY_RATIO = 0.2;
   public static final double UNLIMITED_CLIENT_REQUEST_RETRY_RATIO = 1.0;
   /**
@@ -203,6 +205,7 @@ public class HttpClientFactory implements TransportClientFactory
   private final int _connectTimeout;
   private final int _sslHandShakeTimeout;
   private final int _channelPoolWaiterTimeout;
+  private final long _http2ChannelCreationTimeoutMs;
   private final String _udsAddress;
   /** Request compression config for each http service. */
   private final Map<String, CompressionConfig> _requestCompressionConfigs;
@@ -657,7 +660,8 @@ public class HttpClientFactory implements TransportClientFactory
         shutdownCallbackExecutor, jmxManager, requestCompressionThresholdDefault, requestCompressionConfigs,
         responseCompressionConfigs, compressionExecutor, defaultHttpVersion, shareConnection, eventProviderRegistry,
         enableSSLSessionResumption, usePipelineV2, executorsToShutDown, DEFAULT_CONNECT_TIMEOUT,
-        DEFAULT_SSL_HANDSHAKE_TIMEOUT, DEFAULT_CHANNELPOOL_WAITER_TIMEOUT, udsAddress, null);
+        DEFAULT_SSL_HANDSHAKE_TIMEOUT, DEFAULT_CHANNELPOOL_WAITER_TIMEOUT, udsAddress, null,
+        DEFAULT_HTTP2_CHANNEL_CREATION_TIMEOUT_MS);
   }
 
   private HttpClientFactory(FilterChain filters,
@@ -682,7 +686,8 @@ public class HttpClientFactory implements TransportClientFactory
                             int sslHandShakeTimeout,
                             int channelPoolWaiterTimeout,
                             String udsAddress,
-                            DnsMetricsCallback dnsMetricsCallback)
+                            DnsMetricsCallback dnsMetricsCallback,
+                            long http2ChannelCreationTimeoutMs)
   {
     _filters = filters;
     _eventLoopGroup = eventLoopGroup;
@@ -698,6 +703,7 @@ public class HttpClientFactory implements TransportClientFactory
     _connectTimeout = connectTimeout;
     _sslHandShakeTimeout = sslHandShakeTimeout;
     _channelPoolWaiterTimeout = channelPoolWaiterTimeout;
+    _http2ChannelCreationTimeoutMs = http2ChannelCreationTimeoutMs;
     _udsAddress = udsAddress;
     _dnsMetricsCallback = dnsMetricsCallback;
     if (requestCompressionConfigs == null)
@@ -715,7 +721,7 @@ public class HttpClientFactory implements TransportClientFactory
     _defaultHttpVersion = defaultHttpVersion;
     _channelPoolManagerFactory = new ChannelPoolManagerFactoryImpl(
         _eventLoopGroup, _executor, enableSSLSessionResumption,_usePipelineV2, _channelPoolWaiterTimeout,
-        _connectTimeout, _sslHandShakeTimeout);
+        _connectTimeout, _sslHandShakeTimeout, _http2ChannelCreationTimeoutMs);
 
     if (eventProviderRegistry != null)
     {
@@ -760,6 +766,7 @@ public class HttpClientFactory implements TransportClientFactory
     private int _connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private int _sslHandShakeTimeout = DEFAULT_SSL_HANDSHAKE_TIMEOUT;
     private int _channelPoolWaiterTimeout = DEFAULT_CHANNELPOOL_WAITER_TIMEOUT;
+    private long _http2ChannelCreationTimeoutMs = DEFAULT_HTTP2_CHANNEL_CREATION_TIMEOUT_MS;
     private DnsMetricsCallback _dnsMetricsCallback;
 
     /**
@@ -931,6 +938,20 @@ public class HttpClientFactory implements TransportClientFactory
       return this;
     }
 
+    /**
+     * Sets the timeout for HTTP/2 parent channel creation. When establishing a new HTTP/2
+     * connection, if the TCP + TLS handshake does not complete within this timeout, an
+     * {@link ObjectCreationTimeoutException} is thrown. Lower values cause faster fail-over
+     * to healthy hosts but may trigger false positives on slow networks.
+     *
+     * @param http2ChannelCreationTimeoutMs timeout in milliseconds (default: 10000)
+     */
+    public Builder setHttp2ChannelCreationTimeout(long http2ChannelCreationTimeoutMs)
+    {
+      _http2ChannelCreationTimeoutMs = http2ChannelCreationTimeoutMs;
+      return this;
+    }
+
     public Builder setChannelPoolWaiterTimeout(int channelPoolWaiterTimeout)
     {
       _channelPoolWaiterTimeout = channelPoolWaiterTimeout;
@@ -1007,7 +1028,7 @@ public class HttpClientFactory implements TransportClientFactory
         _requestCompressionThresholdDefault, _requestCompressionConfigs, _responseCompressionConfigs,
         compressionExecutor, _defaultHttpVersion, _shareConnection, eventProviderRegistry, _enableSSLSessionResumption,
           _usePipelineV2, executorsToShutDown, _connectTimeout, _sslHandShakeTimeout, _channelPoolWaiterTimeout,
-          _udsAddress, _dnsMetricsCallback);
+          _udsAddress, _dnsMetricsCallback, _http2ChannelCreationTimeoutMs);
     }
 
   }

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/HttpClientFactory.java
@@ -41,7 +41,6 @@ import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.message.stream.StreamRequest;
 import com.linkedin.r2.message.stream.StreamResponse;
 import com.linkedin.r2.netty.client.DnsMetricsCallback;
-import com.linkedin.r2.netty.client.http2.Http2ChannelLifecycle;
 import com.linkedin.r2.transport.common.TransportClientFactory;
 import com.linkedin.r2.transport.common.bridge.client.TransportClient;
 import com.linkedin.r2.transport.common.bridge.common.TransportCallback;
@@ -160,7 +159,7 @@ public class HttpClientFactory implements TransportClientFactory
   public static final int DEFAULT_CONNECT_TIMEOUT = 30000;
   public static final int DEFAULT_SSL_HANDSHAKE_TIMEOUT = 10000;
   public static final int DEFAULT_CHANNELPOOL_WAITER_TIMEOUT = Integer.MAX_VALUE;
-  public static final long DEFAULT_HTTP2_CHANNEL_CREATION_TIMEOUT_MS = Http2ChannelLifecycle.DEFAULT_CHANNEL_CREATION_TIMEOUT_MS;
+  public static final long DEFAULT_HTTP2_CHANNEL_CREATION_TIMEOUT_MS = 10000;
   public static final double DEFAULT_MAX_CLIENT_REQUEST_RETRY_RATIO = 0.2;
   public static final double UNLIMITED_CLIENT_REQUEST_RETRY_RATIO = 1.0;
   /**

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolManagerFactoryImpl.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolManagerFactoryImpl.java
@@ -19,6 +19,7 @@ package com.linkedin.r2.transport.http.client.common;
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.util.None;
 import com.linkedin.r2.netty.client.http.HttpChannelPoolFactory;
+import com.linkedin.r2.netty.client.http2.Http2ChannelLifecycle;
 import com.linkedin.r2.netty.client.http2.Http2ChannelPoolFactory;
 import com.linkedin.r2.transport.http.client.rest.HttpNettyChannelPoolFactory;
 import com.linkedin.r2.transport.http.client.stream.http.HttpNettyStreamChannelPoolFactory;
@@ -56,6 +57,7 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
   private final int _channelPoolWaiterTimeout;
   private final int _connectTimeout;
   private final int _sslHandShakeTimeout;
+  private final long _http2ChannelCreationTimeoutMs;
 
   /**
    * @param eventLoopGroup The EventLoopGroup; it is the caller's responsibility to shut
@@ -65,9 +67,19 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
    * @param enableSSLSessionResumption Enable reuse of Ssl Session.
    * @param usePipelineV2 Use unified new code.
    */
+  @Deprecated
   public ChannelPoolManagerFactoryImpl(EventLoopGroup eventLoopGroup, ScheduledExecutorService scheduler,
       boolean enableSSLSessionResumption, boolean usePipelineV2, int channelPoolWaiterTimeout,
       int connectTimeout, int sslHandShakeTimeout)
+  {
+    this(eventLoopGroup, scheduler, enableSSLSessionResumption, usePipelineV2, channelPoolWaiterTimeout,
+        connectTimeout, sslHandShakeTimeout,
+        Http2ChannelLifecycle.DEFAULT_CHANNEL_CREATION_TIMEOUT_MS);
+  }
+
+  public ChannelPoolManagerFactoryImpl(EventLoopGroup eventLoopGroup, ScheduledExecutorService scheduler,
+      boolean enableSSLSessionResumption, boolean usePipelineV2, int channelPoolWaiterTimeout,
+      int connectTimeout, int sslHandShakeTimeout, long http2ChannelCreationTimeoutMs)
   {
     _eventLoopGroup = eventLoopGroup;
     _scheduler = scheduler;
@@ -76,6 +88,7 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
     _channelPoolWaiterTimeout = channelPoolWaiterTimeout;
     _connectTimeout = connectTimeout;
     _sslHandShakeTimeout = sslHandShakeTimeout;
+    _http2ChannelCreationTimeoutMs = http2ChannelCreationTimeoutMs;
   }
 
   @Override
@@ -204,7 +217,8 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
           _enableSSLSessionResumption,
           _connectTimeout,
           _sslHandShakeTimeout,
-          channelPoolManagerKey.getUdsAddress());
+          channelPoolManagerKey.getUdsAddress(),
+          _http2ChannelCreationTimeoutMs);
     }
     else
     {

--- a/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolManagerFactoryImpl.java
+++ b/r2-netty/src/main/java/com/linkedin/r2/transport/http/client/common/ChannelPoolManagerFactoryImpl.java
@@ -19,8 +19,8 @@ package com.linkedin.r2.transport.http.client.common;
 import com.linkedin.common.callback.Callback;
 import com.linkedin.common.util.None;
 import com.linkedin.r2.netty.client.http.HttpChannelPoolFactory;
-import com.linkedin.r2.netty.client.http2.Http2ChannelLifecycle;
 import com.linkedin.r2.netty.client.http2.Http2ChannelPoolFactory;
+import com.linkedin.r2.transport.http.client.HttpClientFactory;
 import com.linkedin.r2.transport.http.client.rest.HttpNettyChannelPoolFactory;
 import com.linkedin.r2.transport.http.client.stream.http.HttpNettyStreamChannelPoolFactory;
 import com.linkedin.r2.transport.http.client.stream.http2.Http2NettyStreamChannelPoolFactory;
@@ -74,7 +74,7 @@ public class ChannelPoolManagerFactoryImpl implements ChannelPoolManagerFactory
   {
     this(eventLoopGroup, scheduler, enableSSLSessionResumption, usePipelineV2, channelPoolWaiterTimeout,
         connectTimeout, sslHandShakeTimeout,
-        Http2ChannelLifecycle.DEFAULT_CHANNEL_CREATION_TIMEOUT_MS);
+        HttpClientFactory.DEFAULT_HTTP2_CHANNEL_CREATION_TIMEOUT_MS);
   }
 
   public ChannelPoolManagerFactoryImpl(EventLoopGroup eventLoopGroup, ScheduledExecutorService scheduler,


### PR DESCRIPTION
## Summary

- The HTTP/2 parent channel creation timeout was hardcoded at 10,000ms with a [TODO comment](https://github.com/linkedin/rest.li/blob/master/r2-netty/src/main/java/com/linkedin/r2/netty/client/http2/Http2ChannelLifecycle.java#L90) to expose it via cfg2
- When a downstream host becomes unreachable, **all** concurrent requests to that host queue behind the parent channel bootstrap and block for the full 10s timeout before failing — destroying p95 latency for callers
- This change threads a configurable channelCreationTimeoutMs through: HttpClientFactory.Builder → ChannelPoolManagerFactoryImpl → Http2ChannelPoolFactory → Http2ChannelLifecycle

## Usage

```java
new HttpClientFactory.Builder()
    .setHttp2ChannelCreationTimeout(3000)
    .build();
```

## Backwards Compatibility

- Default remains **10,000ms** — no behavioral change for existing users
- All existing constructors preserved as @Deprecated overloads
- Zero breaking changes

## Motivation

In production, a single flaky host that fails SSL handshakes intermittently causes the 10s hardcoded timeout to block all concurrent HTTP/2 requests to that host (due to the parent channel bootstrapping pattern in Http2ChannelLifecycle). A lower configurable timeout (e.g. 3s) allows D2 degrader to mark unhealthy hosts faster, significantly reducing p95 latency impact.

## Files Changed

| File | Change |
|------|--------|
| Http2ChannelLifecycle.java | Accept channelCreationTimeoutMs as constructor param |
| Http2ChannelPoolFactory.java | Thread timeout through; deprecate old constructors |
| ChannelPoolManagerFactoryImpl.java | Thread timeout through; deprecate old constructor |
| HttpClientFactory.java | Add setHttp2ChannelCreationTimeout() builder method |