### PR TITLE
Fix 'occured' -> 'occurred' typos in d2 exceptions and Callbacks Javadoc

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/discovery/PropertySerializationException.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/PropertySerializationException.java
@@ -21,7 +21,7 @@
 package com.linkedin.d2.discovery;
 
 /**
- * Denotes a data format or other error occured during serialization or deserialization.
+ * Denotes a data format or other error occurred during serialization or deserialization.
  * @author Steven Ihde
  * @version $Revision: $
  */

--- a/d2/src/main/java/com/linkedin/d2/discovery/stores/PropertyStoreException.java
+++ b/d2/src/main/java/com/linkedin/d2/discovery/stores/PropertyStoreException.java
@@ -21,7 +21,7 @@
 package com.linkedin.d2.discovery.stores;
 
 /**
- * Denotes a communication error occured during an operation on a PropertyStore.
+ * Denotes a communication error occurred during an operation on a PropertyStore.
  * @author Steven Ihde
  * @version $Revision: $
  */

--- a/pegasus-common/src/main/java/com/linkedin/common/callback/Callbacks.java
+++ b/pegasus-common/src/main/java/com/linkedin/common/callback/Callbacks.java
@@ -91,7 +91,7 @@ public class Callbacks
 
   /**
    * Returns a new callback which defers invocation of another callback until a specified
-   * number of onSuccess() or onError() calls to the new callback have occured.
+   * number of onSuccess() or onError() calls to the new callback have occurred.
    *
    * @param callback
    *          the underlying callback


### PR DESCRIPTION
Fix 3 instances of `occured` → `occurred` across 3 Java files (Javadoc-only):

- `d2/discovery/stores/PropertyStoreException.java`
- `d2/discovery/PropertySerializationException.java`
- `pegasus-common/common/callback/Callbacks.java`