### PR TITLE
Emit request size bytes metric for XDS discovery requests

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/jmx/NoOpXdsClientOtelMetricsProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/NoOpXdsClientOtelMetricsProvider.java
@@ -93,4 +93,12 @@ public class NoOpXdsClientOtelMetricsProvider implements XdsClientOtelMetricsPro
   public void updateActiveInitialWaitTime(String clientName, long waitTimeMs) {
     // No-op
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void recordRequestSizeBytes(String clientName, long sizeBytes) {
+    // No-op
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/XdsClientJmx.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/XdsClientJmx.java
@@ -238,4 +238,9 @@ public class XdsClientJmx implements XdsClientJmxMBean
     _resourceInvalidCount.incrementAndGet();
     _xdsClientOtelMetricsProvider.recordResourceInvalid(getClientName());
   }
+
+  public void recordRequestSizeBytes(long sizeBytes)
+  {
+    _xdsClientOtelMetricsProvider.recordRequestSizeBytes(getClientName(), sizeBytes);
+  }
 }

--- a/d2/src/main/java/com/linkedin/d2/jmx/XdsClientOtelMetricsProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/XdsClientOtelMetricsProvider.java
@@ -85,4 +85,13 @@ public interface XdsClientOtelMetricsProvider {
    * @param waitTimeMs the wait time in milliseconds
    */
   void updateActiveInitialWaitTime(String clientName, long waitTimeMs);
+
+  /**
+   * Records the serialized byte size of an outgoing discovery request.
+   * Used to detect clients approaching or exceeding gRPC's per-message size limit.
+   *
+   * @param clientName the name of the XDS client
+   * @param sizeBytes  the serialized size in bytes of the {@code DeltaDiscoveryRequest}
+   */
+  void recordRequestSizeBytes(String clientName, long sizeBytes);
 }

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsClientImpl.java
@@ -1752,6 +1752,7 @@ public class XdsClientImpl extends XdsClient
       _xdsClientJmx.incrementRequestSentCount();
       _xdsClientJmx.addToIrvSentCount(resourceVersions.size());
       DeltaDiscoveryRequest request = new DiscoveryRequestData(_node, type, resources, resourceVersions).toEnvoyProto();
+      _xdsClientJmx.recordRequestSizeBytes(request.getSerializedSize());
       _requestWriter.onNext(request);
       _log.debug("Sent DiscoveryRequest\n{}", request);
     }

--- a/d2/src/test/java/com/linkedin/d2/jmx/TestXdsClientOtelMetricsProvider.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/TestXdsClientOtelMetricsProvider.java
@@ -66,6 +66,11 @@ public class TestXdsClientOtelMetricsProvider implements XdsClientOtelMetricsPro
     _calls.add(new MetricsInvocation("updateActiveInitialWaitTime", clientName, waitTimeMs));
   }
 
+  @Override
+  public void recordRequestSizeBytes(String clientName, long sizeBytes) {
+    _calls.add(new MetricsInvocation("recordRequestSizeBytes", clientName, sizeBytes));
+  }
+
   // Helper methods for verification
 
   public int getCallCount(String methodName) {
@@ -124,6 +129,16 @@ public class TestXdsClientOtelMetricsProvider implements XdsClientOtelMetricsPro
     return null;
   }
 
+  public Long getLastSizeBytes(String methodName) {
+    for (int i = _calls.size() - 1; i >= 0; i--) {
+      MetricsInvocation call = _calls.get(i);
+      if (call.methodName.equals(methodName)) {
+        return call.sizeBytes;
+      }
+    }
+    return null;
+  }
+
   /**
    * Clears all recorded calls. Useful for resetting state between tests.
    */
@@ -141,6 +156,7 @@ public class TestXdsClientOtelMetricsProvider implements XdsClientOtelMetricsPro
     Long latencyMs;
     Boolean isConnected;
     Long waitTimeMs;
+    Long sizeBytes;
 
     MetricsInvocation(String methodName, String clientName) {
       this.methodName = methodName;
@@ -154,11 +170,18 @@ public class TestXdsClientOtelMetricsProvider implements XdsClientOtelMetricsPro
 
     MetricsInvocation(String methodName, String clientName, long value) {
       this(methodName, clientName);
-      // Determine if it's latency or wait time based on method name
-      if (methodName.equals("recordServerLatency")) {
-        this.latencyMs = value;
-      } else if (methodName.equals("updateActiveInitialWaitTime")) {
-        this.waitTimeMs = value;
+      switch (methodName) {
+        case "recordServerLatency":
+          this.latencyMs = value;
+          break;
+        case "updateActiveInitialWaitTime":
+          this.waitTimeMs = value;
+          break;
+        case "recordRequestSizeBytes":
+          this.sizeBytes = value;
+          break;
+        default:
+          break;
       }
     }
 

--- a/d2/src/test/java/com/linkedin/d2/jmx/XdsClientOtelMetricsProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/jmx/XdsClientOtelMetricsProviderTest.java
@@ -113,6 +113,17 @@ public class XdsClientOtelMetricsProviderTest {
   }
 
   @Test
+  public void testRecordRequestSizeBytes() {
+    String clientName = "test-client-12";
+    long sizeBytes = 1024L;
+    _testProvider.recordRequestSizeBytes(clientName, sizeBytes);
+
+    assertEquals(_testProvider.getCallCount("recordRequestSizeBytes"), 1);
+    assertEquals(_testProvider.getLastClientName("recordRequestSizeBytes"), clientName);
+    assertEquals(_testProvider.getLastSizeBytes("recordRequestSizeBytes").longValue(), sizeBytes);
+  }
+
+  @Test
   public void testMultipleCalls() {
     String clientName = "test-client-multi";
     
@@ -149,6 +160,7 @@ public class XdsClientOtelMetricsProviderTest {
     _testProvider.recordServerLatency(clientName, 200L);
     _testProvider.updateConnectionState(clientName, true);
     _testProvider.updateActiveInitialWaitTime(clientName, 3000L);
+    _testProvider.recordRequestSizeBytes(clientName, 512L);
 
     // Verify all methods were called exactly once
     assertEquals(_testProvider.getCallCount("recordConnectionLost"), 1);
@@ -162,5 +174,6 @@ public class XdsClientOtelMetricsProviderTest {
     assertEquals(_testProvider.getCallCount("recordServerLatency"), 1);
     assertEquals(_testProvider.getCallCount("updateConnectionState"), 1);
     assertEquals(_testProvider.getCallCount("updateActiveInitialWaitTime"), 1);
+    assertEquals(_testProvider.getCallCount("recordRequestSizeBytes"), 1);
   }
 }


### PR DESCRIPTION
## Summary
- Adds `recordRequestSizeBytes(clientName, sizeBytes)` to `XdsClientOtelMetricsProvider` interface
- Wires it through `XdsClientJmx.recordRequestSizeBytes(sizeBytes)`
- Emits the serialized proto size on every `sendDiscoveryRequest` call via `request.getSerializedSize()`
- `NoOpXdsClientOtelMetricsProvider` updated with a no-op impl

## Motivation
Lets operators detect XDS clients whose `initial_resource_versions` maps are approaching gRPC's per-message size limit on reconnect. No performance impact — protobuf caches the serialized size, which gRPC reuses during serialization.

## Test plan
- [ ] Verify `recordRequestSizeBytes` is called in `XdsClientImplTest` on `sendDiscoveryRequest`
- [ ] Implement `recordRequestSizeBytes` in `XdsClientOtelTracker` in the `container` repo with a corresponding entry in `XdsClientSemantics`