### PR TITLE
Memoize negative results in DataTemplateUtil.getSchema to avoid recomputation for classes without a valid SCHEMA field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.85.11] - 2026-05-05
+- Memoize negative results in DataTemplateUtil.getSchema to avoid recomputation for classes without a valid SCHEMA field
+
 ## [29.85.10] - 2026-04-30
 - Added `recordRequestSizeBytes` metric to `XdsClientOtelMetricsProvider` to track the serialized byte size of outgoing XDS discovery requests, enabling detection of clients approaching gRPC's per-message size limit.
 
@@ -5987,7 +5990,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.10...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.11...master
+[29.85.11]: https://github.com/linkedin/rest.li/compare/v29.85.10...29.85.11
 [29.85.10]: https://github.com/linkedin/rest.li/compare/v29.85.9...v29.85.10
 [29.85.9]: https://github.com/linkedin/rest.li/compare/v29.85.8...v29.85.9
 [29.85.8]: https://github.com/linkedin/rest.li/compare/v29.85.7...v29.85.8

--- a/data/src/main/java/com/linkedin/data/template/DataTemplateUtil.java
+++ b/data/src/main/java/com/linkedin/data/template/DataTemplateUtil.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DataTemplateUtil
@@ -55,6 +56,10 @@ public class DataTemplateUtil
   private static final boolean debug = false;
   // Cache to speed up data schema retrieval
   private static final Map<Class<?>, DataSchema> _classToSchemaMap = new ConcurrentHashMap<>();
+  // Negative cache for classes that lack a SCHEMA field, since the positive
+  // cache (_classToSchemaMap) doesn't memoize the exception thrown when trying
+  // to access the non-existent SCHEMA field.
+  private static final Set<Class<?>> _classesWithoutSchema = ConcurrentHashMap.newKeySet();
 
   private DataTemplateUtil()
   {
@@ -473,25 +478,48 @@ public class DataTemplateUtil
     // (http://cs.oswego.edu/pipermail/concurrency-interest/2014-December/013360.html) can be removed
     // when we upgrade to Java 9 when this concurrent issue is improved.
     DataSchema typeSchema = _classToSchemaMap.get(type);
-    return (typeSchema != null) ? typeSchema : _classToSchemaMap.computeIfAbsent(type, key ->
+    if (typeSchema != null)
     {
-      try
-      {
-        Field schemaField = type.getDeclaredField(SCHEMA_FIELD_NAME);
-        schemaField.setAccessible(true);
-        DataSchema schema = (DataSchema) schemaField.get(null);
-        if (schema == null)
-        {
-          throw new TemplateRuntimeException("Schema field is not set in class: " + type.getName());
-        }
+      return typeSchema;
+    }
 
-        return schema;
-      }
-      catch (IllegalAccessException | NoSuchFieldException e)
+    // Check negative-cache to short-circuit classes known to fail
+    // the reflection call so we don't incur the bin-level monitor
+    // on _classToSchemaMap.
+    if (_classesWithoutSchema.contains(type))
+    {
+      throw new TemplateRuntimeException("Schema field is not set in class: " + type.getName());
+    }
+
+    try
+    {
+      return _classToSchemaMap.computeIfAbsent(type, key ->
       {
-        throw new TemplateRuntimeException("Error accessing schema field in class: " + type.getName(), e);
-      }
-    });
+        try
+        {
+          Field schemaField = type.getDeclaredField(SCHEMA_FIELD_NAME);
+          schemaField.setAccessible(true);
+          DataSchema schema = (DataSchema) schemaField.get(null);
+          if (schema == null)
+          {
+            throw new TemplateRuntimeException("Schema field is not set in class: " + type.getName());
+          }
+
+          return schema;
+        }
+        catch (IllegalAccessException | NoSuchFieldException e)
+        {
+          throw new TemplateRuntimeException("Error accessing schema field in class: " + type.getName(), e);
+        }
+      });
+    }
+    catch (TemplateRuntimeException e)
+    {
+      // Populate the negative cache so we don't incur the
+      // reflection cost next time we encounter the same class.
+      _classesWithoutSchema.add(type);
+      throw e;
+    }
   }
 
   /**

--- a/data/src/test/java/com/linkedin/data/template/TestDataTemplateUtil.java
+++ b/data/src/test/java/com/linkedin/data/template/TestDataTemplateUtil.java
@@ -16,19 +16,24 @@
 
 package com.linkedin.data.template;
 
+import com.linkedin.data.DataMap;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.PathSpec;
 import com.linkedin.data.schema.RecordDataSchema;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Set;
 
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
 
@@ -239,5 +244,57 @@ public class TestDataTemplateUtil
     // Convert Specific Floating point string - NEGATIVE_INFINITY to Float
     Object object6 = DataTemplateUtil.coerceOutput(NEGATIVE_INFINITY, Float.class);
     assertEquals(object6, Float.NEGATIVE_INFINITY);
+  }
+
+  public static class RecordWithSchemaField extends RecordTemplate
+  {
+    public static final RecordDataSchema SCHEMA = (RecordDataSchema) DataTemplateUtil.parseSchema(
+        "{ \"type\" : \"record\", \"name\" : \"RecordWithSchemaField\","
+            + " \"namespace\" : \"com.linkedin.data.template\","
+            + " \"fields\" : [ { \"name\" : \"f\", \"type\" : \"string\" } ] }");
+
+    public RecordWithSchemaField()
+    {
+      super(new DataMap(), SCHEMA);
+    }
+  }
+
+  public static class ClassWithoutSchemaField
+  {
+  }
+
+  @Test
+  public void testGetSchemaForClassWithSchemaField()
+  {
+    DataSchema schema = DataTemplateUtil.getSchema(RecordWithSchemaField.class);
+    assertNotNull(schema);
+    // Lookup from cache
+    assertSame(DataTemplateUtil.getSchema(RecordWithSchemaField.class), schema);
+  }
+
+  @Test
+  public void testGetSchemaForClassWithoutSchemaFieldThrows() throws Exception
+  {
+    // Every call must still throw TemplateRuntimeException to not break the contract
+    // even if we shortcircuit the reflection call using the negative cache.
+    for (int i = 0; i < 5; i++)
+    {
+      try
+      {
+        DataTemplateUtil.getSchema(ClassWithoutSchemaField.class);
+        fail("Expected TemplateRuntimeException");
+      }
+      catch (TemplateRuntimeException expected)
+      {
+        assertTrue(expected.getMessage().contains(ClassWithoutSchemaField.class.getName()),
+            "Expected exception message to contain the class name, got: " + expected.getMessage());
+      }
+    }
+
+    // Check that the negative cache is populated.
+    Field cacheField = DataTemplateUtil.class.getDeclaredField("_classesWithoutSchema");
+    cacheField.setAccessible(true);
+    Set<?> negativeCache = (Set<?>) cacheField.get(null);
+    assertTrue(negativeCache.contains(ClassWithoutSchemaField.class));
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.10
+version=29.85.11
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
DataTemplateUtil.getSchema calls ConcurrentHashMap.computeIfAbsent with a lambda that throws TemplateRuntimeException for classes without a valid SCHEMA field. Since this path is not memoized in the CHM, any subsequent call to the method with the same Class object will always incur the CHM locking cost, as well as the actual computation cost which uses reflection.

This PR introduces a negative cache to short circuit this exact scenario, which has shown to be a hot path at runtime.