### PR TITLE
Fix cluster subsetting silent failure when peer URIs are IPv6 (SI-52492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 
+## [29.85.14] - 2026-06-09
+- Fix cluster subsetting silent failure when peer URIs are IPv6
+
 ## [29.85.13] - 2026-06-04
 - Make the HTTP/2 parent channel creation timeout configurable via
   `HttpClientFactory.Builder.setHttp2ChannelCreationTimeout(...)`, allowing callers to
@@ -5999,7 +6002,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.13...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.14...master
+[29.85.14]: https://github.com/linkedin/rest.li/compare/v29.85.13...v29.85.14
 [29.85.13]: https://github.com/linkedin/rest.li/compare/v29.85.12...v29.85.13
 [29.85.12]: https://github.com/linkedin/rest.li/compare/v29.85.11...v29.85.12
 [29.85.11]: https://github.com/linkedin/rest.li/compare/v29.85.10...29.85.11

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -140,8 +140,14 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
           }
           if (addr instanceof Inet6Address)
           {
-            identities.add("[" + addrStr + "]");
-            identities.add(addrStr);
+            // Funnel both forms through the same canonicalizer the peer-side resolver uses
+            // (see canonicalizeIpv6IfApplicable below). For the common case this is a no-op
+            // round-trip — Inet6Address.getHostAddress() already returns the canonical
+            // expanded form — but routing both sides through the same function keeps the
+            // local and peer identity strings in lockstep by construction, e.g. for
+            // IPv4-mapped IPv6 (::ffff:a.b.c.d) which auto-converts to a plain IPv4 address.
+            identities.add(canonicalizeIpv6IfApplicable("[" + addrStr + "]"));
+            identities.add(canonicalizeIpv6IfApplicable(addrStr));
           }
           else
           {
@@ -160,6 +166,57 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
           hostName, e);
     }
     return Collections.unmodifiableSet(identities);
+  }
+
+  /**
+   * Returns the canonical form of {@code host} when it is an IPv6 literal (bracketed or
+   * unbracketed); otherwise returns {@code host} unchanged. Parses any string containing a
+   * {@code ':'} via {@link InetAddress#getByName(String)} and re-emits via
+   * {@link InetAddress#getHostAddress()}, which produces the RFC 4291 fully-expanded form. The
+   * original bracketing is preserved, except for IPv4-mapped IPv6 literals (e.g.
+   * {@code ::ffff:1.2.3.4}) which {@code getByName} auto-converts to {@link java.net.Inet4Address}
+   * — brackets are dropped in that case since IPv4 addresses are not bracketed.
+   *
+   * <p>FQDNs and IPv4 literals short-circuit on the colon check and pass through unchanged so
+   * we never trigger a DNS lookup on the hot path. Unparseable IPv6-like strings (rare; e.g.
+   * a malformed URI host) also pass through.
+   *
+   * <p>Used to bridge the gap between {@link Inet6Address#getHostAddress()} (always returns
+   * the expanded form, used to build candidate identities at startup) and
+   * {@link URI#getHost()} on a peer URI (returns whatever was literally in the URI string —
+   * could be compressed or expanded). Calling this on both sides makes the equality check
+   * insensitive to which form the d2 client materialized.
+   */
+  private static String canonicalizeIpv6IfApplicable(String host)
+  {
+    if (host == null)
+    {
+      return null;
+    }
+    boolean bracketed = host.startsWith("[") && host.endsWith("]");
+    String inner = bracketed ? host.substring(1, host.length() - 1) : host;
+    if (inner.indexOf(':') < 0)
+    {
+      return host;
+    }
+    try
+    {
+      InetAddress addr = InetAddress.getByName(inner);
+      String canonical = addr.getHostAddress();
+      if (addr instanceof Inet6Address)
+      {
+        return bracketed ? "[" + canonical + "]" : canonical;
+      }
+      // IPv4-mapped IPv6 (::ffff:a.b.c.d) collapses to Inet4Address. IPv4 isn't bracketed, so
+      // drop any brackets so a canonicalized peer URI matches a local Inet4Address candidate
+      // built from the same physical address.
+      return canonical;
+    }
+    catch (UnknownHostException e)
+    {
+      // Not a parseable IP literal — pass through and let string equality decide.
+      return host;
+    }
   }
 
   public void setClusterName(String clusterName) {
@@ -204,9 +261,14 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
           UriProperties uriProperties = uriItem.getProperty();
           if (uriProperties != null)
           {
-            // Sort the URIs so each client sees the same ordering
+            // Sort the URIs so each client sees the same ordering. Canonicalize IPv6 host
+            // strings here so a peer URI in compressed form (e.g. "[2a04:f547::1a95]") still
+            // matches a candidate identity built from the JDK's expanded form (e.g.
+            // "[2a04:f547:0:0:0:0:0:1a95]"). FQDNs and IPv4 literals pass through unchanged,
+            // so no DNS work happens on the hot path.
             List<String> sortedHosts = uriProperties.getPartitionDesc().keySet().stream()
                 .map(URI::getHost)
+                .map(ZKDeterministicSubsettingMetadataProvider::canonicalizeIpv6IfApplicable)
                 .filter(Objects::nonNull)
                 .sorted()
                 .distinct()

--- a/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProvider.java
@@ -16,12 +16,20 @@
 
 package com.linkedin.d2.balancer.subsetting;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.d2.balancer.LoadBalancerState;
 import com.linkedin.d2.balancer.LoadBalancerStateItem;
 import com.linkedin.d2.balancer.properties.UriProperties;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -38,7 +46,20 @@ import org.slf4j.LoggerFactory;
 public class ZKDeterministicSubsettingMetadataProvider implements DeterministicSubsettingMetadataProvider
 {
   private static final Logger _log = LoggerFactory.getLogger(ZKDeterministicSubsettingMetadataProvider.class);
-  private final String _hostName;
+
+  /**
+   * Resolves a host name to its set of IP addresses. Production uses
+   * {@link InetAddress#getAllByName(String)}; tests inject a deterministic implementation so
+   * unit tests can exercise IPv4/IPv6 paths without depending on real DNS.
+   */
+  @FunctionalInterface
+  @VisibleForTesting
+  interface AddressResolver
+  {
+    InetAddress[] resolve(String host) throws UnknownHostException;
+  }
+
+  private final Set<String> _candidateIdentities;
   private final long _timeout;
   private final TimeUnit _unit;
 
@@ -48,6 +69,11 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
   private long _peerClusterVersion = -1;
   @GuardedBy("_lock")
   private DeterministicSubsettingMetadata _subsettingMetadata;
+  // Re-armed on every successful identity match so a flapping peer cluster logs once per
+  // outage rather than on every URI update; mirrors the existing _warnedEmptyUriProperties
+  // pattern in grpc-infra's PeerClusterListener.
+  @GuardedBy("_lock")
+  private boolean _warnedIdentityNotFound;
   private String _clusterName;
 
   public ZKDeterministicSubsettingMetadataProvider(String hostName, long timeout, TimeUnit unit)
@@ -60,14 +86,99 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
                                       long timeout,
                                       TimeUnit unit)
   {
+    this(clusterName, hostName, timeout, unit, InetAddress::getAllByName);
+  }
+
+  /** Package-private for tests; takes an injectable address resolver in place of DNS. */
+  @VisibleForTesting
+  ZKDeterministicSubsettingMetadataProvider(String clusterName,
+                                      String hostName,
+                                      long timeout,
+                                      TimeUnit unit,
+                                      AddressResolver addressResolver)
+  {
     _clusterName = clusterName;
-    _hostName = hostName;
+    _candidateIdentities = computeIdentities(hostName, addressResolver);
     _timeout = timeout;
     _unit = unit;
   }
 
+  /**
+   * Builds the set of host-form identities that may identify this instance in a peer cluster
+   * URI list. The FQDN is always included, and the FQDN is resolved to its IPv4 and IPv6
+   * addresses with each form added to the set. IPv6 addresses are added in both bracketed
+   * (matches {@link URI#getHost()} on JDK 17, which returns {@code "[ipv6]"}) and unbracketed
+   * (defensive fallback against d2/JDK rendering differences) forms. This lets the lookup
+   * match itself regardless of how the d2 client materializes peer URIs (the choice depends on
+   * JVM flags such as {@code java.net.preferIPv6Addresses}). DNS failures fail soft: the
+   * FQDN-only identity is preserved so the legacy single-identity match still works.
+   *
+   * <p>Scope identifiers ({@code %eth0}, {@code %1}) on resolved local addresses are kept as
+   * is. Different scopes are semantically different IPs; stripping them would conflate them. A
+   * scoped local identity will not match any peer URI (d2 announcements never carry scope ids),
+   * so the candidate is harmless dead weight and the comparison stays correct.
+   */
+  private static Set<String> computeIdentities(String hostName, AddressResolver resolver)
+  {
+    if (hostName == null || hostName.isEmpty())
+    {
+      return Collections.emptySet();
+    }
+    Set<String> identities = new LinkedHashSet<>();
+    identities.add(hostName);
+    try
+    {
+      InetAddress[] resolved = resolver.resolve(hostName);
+      if (resolved != null)
+      {
+        for (InetAddress addr : resolved)
+        {
+          String addrStr = addr.getHostAddress();
+          if (addrStr == null || addrStr.isEmpty())
+          {
+            continue;
+          }
+          if (addr instanceof Inet6Address)
+          {
+            identities.add("[" + addrStr + "]");
+            identities.add(addrStr);
+          }
+          else
+          {
+            identities.add(addrStr);
+          }
+        }
+      }
+      if (_log.isDebugEnabled())
+      {
+        _log.debug("Resolved local identities for cluster subsetting (host={}): {}", hostName, identities);
+      }
+    }
+    catch (UnknownHostException e)
+    {
+      _log.warn("Failed to resolve local addresses for {}; falling back to FQDN-only identity",
+          hostName, e);
+    }
+    return Collections.unmodifiableSet(identities);
+  }
+
   public void setClusterName(String clusterName) {
     _clusterName = clusterName;
+  }
+
+  @VisibleForTesting
+  Set<String> getCandidateIdentities()
+  {
+    return _candidateIdentities;
+  }
+
+  @VisibleForTesting
+  boolean hasWarnedIdentityNotFound()
+  {
+    synchronized (_lock)
+    {
+      return _warnedIdentityNotFound;
+    }
   }
 
   @Override
@@ -96,28 +207,54 @@ public class ZKDeterministicSubsettingMetadataProvider implements DeterministicS
             // Sort the URIs so each client sees the same ordering
             List<String> sortedHosts = uriProperties.getPartitionDesc().keySet().stream()
                 .map(URI::getHost)
+                .filter(Objects::nonNull)
                 .sorted()
                 .distinct()
                 .collect(Collectors.toList());
 
-            int instanceId = sortedHosts.indexOf(_hostName);
+            // Match any peer URI whose host string equals one of our candidate identities. The
+            // candidate set may contain multiple forms (FQDN, IPv4, IPv6) so this lookup
+            // succeeds whichever form the d2 client materialized peer URIs in.
+            int instanceId = -1;
+            String matchedIdentity = null;
+            for (int i = 0; i < sortedHosts.size(); i++)
+            {
+              if (_candidateIdentities.contains(sortedHosts.get(i)))
+              {
+                instanceId = i;
+                matchedIdentity = sortedHosts.get(i);
+                break;
+              }
+            }
 
             if (instanceId >= 0)
             {
+              _warnedIdentityNotFound = false;
               _subsettingMetadata = new DeterministicSubsettingMetadata(instanceId, sortedHosts.size(),
                   _peerClusterVersion);
+              if (_log.isDebugEnabled())
+              {
+                _log.debug("Computed deterministic subsetting metadata for cluster {}: "
+                        + "matchedIdentity={}, instanceId={}, totalInstanceCount={}",
+                    _clusterName, matchedIdentity, instanceId, sortedHosts.size());
+              }
             }
             else
             {
               _subsettingMetadata = null;
+              if (!_warnedIdentityNotFound)
+              {
+                _log.warn("None of identities {} found in peer cluster '{}' membership ({} hosts); "
+                        + "subsetting metadata is unavailable and the subsetter will fall back to all hosts",
+                    _candidateIdentities, _clusterName, sortedHosts.size());
+                _warnedIdentityNotFound = true;
+              }
             }
           }
           else
           {
             _subsettingMetadata = null;
           }
-
-          _log.debug("Got deterministic subsetting metadata for cluster {}: {}", _clusterName, _subsettingMetadata);
         }
       }
       metadataFutureCallback.onSuccess(_subsettingMetadata);

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
@@ -241,6 +241,40 @@ public class ZKDeterministicSubsettingMetadataProviderTest
   }
 
   @Test
+  public void testGetSubsettingMetadata_matchesViaCompressedIpv6PeerUri() throws Exception
+  {
+    // Defensive: even if d2 ever materializes peer URIs in compressed IPv6 form
+    // (e.g. "[2a04:f547:43:e66a::1a95]"), the resolver's IPv6 canonicalization should expand
+    // them at lookup time so the candidate identity (built from Inet6Address.getHostAddress(),
+    // which is always expanded) still matches.
+    InetAddress selfIpv6 = InetAddress.getByName("2a04:f547:43:e66a::1a95");
+    ZKDeterministicSubsettingMetadataProvider compressedProvider = new ZKDeterministicSubsettingMetadataProvider(
+        CLUSTER_NAME, HOST_NAME, 1000, TimeUnit.MILLISECONDS,
+        host -> new InetAddress[] {selfIpv6});
+
+    Map<Integer, PartitionData> partitionData = new HashMap<>(1);
+    partitionData.put(DefaultPartitionAccessor.DEFAULT_PARTITION_ID, new PartitionData(1d));
+    Map<URI, Map<Integer, PartitionData>> uriData = new HashMap<>();
+    // Peer URI uses the COMPRESSED IPv6 form ("::"), not the expanded form. URI.getHost()
+    // would return "[2a04:f547:43:e66a::1a95]", which doesn't string-match the candidate's
+    // expanded form "[2a04:f547:43:e66a:0:0:0:1a95]" without the canonicalization step.
+    uriData.put(URI.create("https://[2a04:f547:43:e66a::1a95]:8888/test"), partitionData);
+
+    _state.listenToCluster(CLUSTER_NAME, new LoadBalancerState.NullStateListenerCallback());
+    _state.listenToService("service-1", new LoadBalancerState.NullStateListenerCallback());
+    _clusterRegistry.put(CLUSTER_NAME, new ClusterProperties(CLUSTER_NAME, Collections.singletonList("https")));
+    _uriRegistry.put(CLUSTER_NAME, new UriProperties(CLUSTER_NAME, uriData));
+    _serviceRegistry.put("service-1", new ServiceProperties("service-1", CLUSTER_NAME, "/test",
+        Collections.singletonList("random")));
+
+    DeterministicSubsettingMetadata metadata = compressedProvider.getSubsettingMetadata(_state);
+
+    assertNotNull(metadata, "compressed peer URI must canonicalize to expanded and match self");
+    assertEquals(metadata.getTotalInstanceCount(), 1);
+    assertEquals(metadata.getInstanceId(), 0);
+  }
+
+  @Test
   public void testGetSubsettingMetadata_noMatch_warnsOnceThenReArmsOnRecovery()
   {
     InetAddress otherIpv4;

--- a/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/subsetting/ZKDeterministicSubsettingMetadataProviderTest.java
@@ -33,13 +33,17 @@ import com.linkedin.d2.discovery.event.SynchronousExecutorService;
 import com.linkedin.d2.discovery.stores.mock.MockStore;
 import com.linkedin.r2.transport.common.TransportClientFactory;
 import com.linkedin.r2.transport.http.client.common.ssl.SslSessionNotTrustedException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
@@ -48,7 +52,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class ZKDeterministicSubsettingMetadataProviderTest
@@ -147,5 +154,149 @@ public class ZKDeterministicSubsettingMetadataProviderTest
 
     metadata = _metadataProvider.getSubsettingMetadata(_state);
     assertNull(metadata);
+  }
+
+  @Test
+  public void testCandidateIdentities_includesFqdnIpv4AndIpv6() throws Exception
+  {
+    InetAddress ipv4 = InetAddress.getByName("10.20.30.40");
+    InetAddress ipv6 = InetAddress.getByName("2a04:f547:43:e66a::1a95");
+    ZKDeterministicSubsettingMetadataProvider provider = new ZKDeterministicSubsettingMetadataProvider(
+        CLUSTER_NAME, HOST_NAME, 1000, TimeUnit.MILLISECONDS,
+        host -> new InetAddress[] {ipv4, ipv6});
+
+    String ipv6Str = ipv6.getHostAddress();
+    Set<String> identities = provider.getCandidateIdentities();
+    assertEquals(identities.size(), 4, "identities=" + identities);
+    assertTrue(identities.contains(HOST_NAME));
+    assertTrue(identities.contains("10.20.30.40"));
+    assertTrue(identities.contains("[" + ipv6Str + "]"));
+    assertTrue(identities.contains(ipv6Str));
+  }
+
+  @Test
+  public void testCandidateIdentities_dnsFailure_fallsBackToFqdn()
+  {
+    ZKDeterministicSubsettingMetadataProvider provider = new ZKDeterministicSubsettingMetadataProvider(
+        CLUSTER_NAME, HOST_NAME, 1000, TimeUnit.MILLISECONDS,
+        host -> { throw new UnknownHostException(host); });
+
+    assertEquals(provider.getCandidateIdentities(), Collections.singleton(HOST_NAME));
+  }
+
+  @Test
+  public void testCandidateIdentities_keepsIpv6ScopeId() throws Exception
+  {
+    byte[] linkLocalBytes = {(byte) 0xfe, (byte) 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    InetAddress linkLocal = Inet6Address.getByAddress("fe80::1", linkLocalBytes, 1);
+    String linkLocalStr = linkLocal.getHostAddress();
+    assertTrue(linkLocalStr.contains("%"), "expected scope id in stringified address; got " + linkLocalStr);
+
+    ZKDeterministicSubsettingMetadataProvider provider = new ZKDeterministicSubsettingMetadataProvider(
+        CLUSTER_NAME, HOST_NAME, 1000, TimeUnit.MILLISECONDS,
+        host -> new InetAddress[] {linkLocal});
+
+    Set<String> identities = provider.getCandidateIdentities();
+    assertTrue(identities.contains("[" + linkLocalStr + "]"),
+        "expected bracketed scope-bearing identity; got " + identities);
+    assertTrue(identities.contains(linkLocalStr),
+        "expected unbracketed scope-bearing identity; got " + identities);
+  }
+
+  @Test
+  public void testGetSubsettingMetadata_matchesViaIpv6() throws Exception
+  {
+    InetAddress selfIpv6 = InetAddress.getByName("2a04:f547:43:e66a::1a95");
+    InetAddress otherIpv6 = InetAddress.getByName("2a04:f547:43:0::1");
+    String selfIpv6Str = selfIpv6.getHostAddress();
+    String otherIpv6Str = otherIpv6.getHostAddress();
+
+    ZKDeterministicSubsettingMetadataProvider ipv6Provider = new ZKDeterministicSubsettingMetadataProvider(
+        CLUSTER_NAME, HOST_NAME, 1000, TimeUnit.MILLISECONDS,
+        host -> new InetAddress[] {selfIpv6});
+
+    Map<Integer, PartitionData> partitionData = new HashMap<>(1);
+    partitionData.put(DefaultPartitionAccessor.DEFAULT_PARTITION_ID, new PartitionData(1d));
+    Map<URI, Map<Integer, PartitionData>> uriData = new HashMap<>();
+    uriData.put(URI.create("https://[" + otherIpv6Str + "]:8888/test"), partitionData);
+    uriData.put(URI.create("https://[" + selfIpv6Str + "]:8888/test"), partitionData);
+
+    _state.listenToCluster(CLUSTER_NAME, new LoadBalancerState.NullStateListenerCallback());
+    _state.listenToService("service-1", new LoadBalancerState.NullStateListenerCallback());
+    _clusterRegistry.put(CLUSTER_NAME, new ClusterProperties(CLUSTER_NAME, Collections.singletonList("https")));
+    _uriRegistry.put(CLUSTER_NAME, new UriProperties(CLUSTER_NAME, uriData));
+    _serviceRegistry.put("service-1", new ServiceProperties("service-1", CLUSTER_NAME, "/test",
+        Collections.singletonList("random")));
+
+    DeterministicSubsettingMetadata metadata = ipv6Provider.getSubsettingMetadata(_state);
+
+    assertNotNull(metadata, "expected non-null metadata when self IPv6 appears in peer cluster URIs");
+    assertEquals(metadata.getTotalInstanceCount(), 2);
+    // URI.getHost() returns "[ipv6]"; sortedHosts is sorted ASCII over those two strings.
+    List<String> expectedSorted = new ArrayList<>();
+    expectedSorted.add("[" + selfIpv6Str + "]");
+    expectedSorted.add("[" + otherIpv6Str + "]");
+    Collections.sort(expectedSorted);
+    assertEquals(metadata.getInstanceId(), expectedSorted.indexOf("[" + selfIpv6Str + "]"));
+  }
+
+  @Test
+  public void testGetSubsettingMetadata_noMatch_warnsOnceThenReArmsOnRecovery()
+  {
+    InetAddress otherIpv4;
+    try
+    {
+      otherIpv4 = InetAddress.getByName("10.20.30.40");
+    }
+    catch (UnknownHostException e)
+    {
+      throw new AssertionError(e);
+    }
+    ZKDeterministicSubsettingMetadataProvider provider = new ZKDeterministicSubsettingMetadataProvider(
+        CLUSTER_NAME, HOST_NAME, 1000, TimeUnit.MILLISECONDS,
+        host -> new InetAddress[] {otherIpv4});
+
+    Map<Integer, PartitionData> partitionData = new HashMap<>(1);
+    partitionData.put(DefaultPartitionAccessor.DEFAULT_PARTITION_ID, new PartitionData(1d));
+
+    // 1) Initial state has only foreign hosts → no match → WARN guard arms.
+    Map<URI, Map<Integer, PartitionData>> noMatchData = new HashMap<>();
+    noMatchData.put(URI.create("http://otherA.linkedin.com:8888/test"), partitionData);
+    noMatchData.put(URI.create("http://otherB.linkedin.com:8888/test"), partitionData);
+
+    _state.listenToCluster(CLUSTER_NAME, new LoadBalancerState.NullStateListenerCallback());
+    _state.listenToService("service-1", new LoadBalancerState.NullStateListenerCallback());
+    _clusterRegistry.put(CLUSTER_NAME, new ClusterProperties(CLUSTER_NAME, Collections.singletonList("http")));
+    _uriRegistry.put(CLUSTER_NAME, new UriProperties(CLUSTER_NAME, noMatchData));
+    _serviceRegistry.put("service-1", new ServiceProperties("service-1", CLUSTER_NAME, "/test",
+        Collections.singletonList("random")));
+
+    assertNull(provider.getSubsettingMetadata(_state));
+    assertTrue(provider.hasWarnedIdentityNotFound(), "first no-match should arm the WARN guard");
+
+    // 2) Another no-match URI update — guard must remain armed (no second WARN). Push a
+    //    different URI set so the version changes and the inner branch actually executes.
+    Map<URI, Map<Integer, PartitionData>> noMatchData2 = new HashMap<>(noMatchData);
+    noMatchData2.put(URI.create("http://otherC.linkedin.com:8888/test"), partitionData);
+    _uriRegistry.put(CLUSTER_NAME, new UriProperties(CLUSTER_NAME, noMatchData2));
+
+    assertNull(provider.getSubsettingMetadata(_state));
+    assertTrue(provider.hasWarnedIdentityNotFound(),
+        "subsequent no-match should NOT re-WARN — guard stays armed");
+
+    // 3) Recovery: peer cluster now contains the self FQDN → match → guard re-arms (false).
+    Map<URI, Map<Integer, PartitionData>> matchData = new HashMap<>(noMatchData2);
+    matchData.put(URI.create("http://" + HOST_NAME + ":8888/test"), partitionData);
+    _uriRegistry.put(CLUSTER_NAME, new UriProperties(CLUSTER_NAME, matchData));
+
+    DeterministicSubsettingMetadata metadata = provider.getSubsettingMetadata(_state);
+    assertNotNull(metadata, "FQDN now in peer cluster — expected non-null metadata");
+    assertFalse(provider.hasWarnedIdentityNotFound(),
+        "successful match must re-arm the guard so the next outage logs once again");
+
+    // 4) Outage again → guard arms once more (proving "next outage logs once again").
+    _uriRegistry.put(CLUSTER_NAME, new UriProperties(CLUSTER_NAME, noMatchData));
+    assertNull(provider.getSubsettingMetadata(_state));
+    assertTrue(provider.hasWarnedIdentityNotFound(), "post-recovery outage should re-arm guard");
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.13
+version=29.85.14
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
  - `ZKDeterministicSubsettingMetadataProvider` compared the host's FQDN identity against `URI.getHost()`-form peer cluster URIs. When the d2 client materializes peer URIs in IPv6 form (typical with `-Djava.net.preferIPv6Addresses=true`,
  default-on across most LinkedIn services), the FQDN never matches the `[ipv6]` form returned by `URI.getHost()` on JDK 17, so `instanceId = -1` and the subsetter fell back to the full host set. The failure was silent because the no-match     
  branch logged at DEBUG.                                                                                                                                                                                                                           
  - Resolve a `Set<String>` of candidate identities (FQDN, IPv4, bracketed and unbracketed IPv6, scope ids preserved) at construction via an injectable `AddressResolver`, and match peer URIs with `Set.contains` instead of `indexOf`.
  - Bump the no-match log to WARN with a once-per-outage `_warnedIdentityNotFound` guard that re-arms on a successful match so flapping clusters don't spam the log.                                                                                
  - Public 3-arg/4-arg constructors are preserved, so consumers (notably container's `D2ClientFactory`) need no changes.                                                                                                                            
  - Companion fix to grpc-infra PR #5819. Tracking ticket: SI-52492.                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
  ## Testing Done                                                                                                                                                                                                                                   
  - [x] Local code review completed                                                                                                                                                                                                                 
  - [x] Unit tests added: `testCandidateIdentities_includesFqdnIpv4AndIpv6`, `testCandidateIdentities_dnsFailure_fallsBackToFqdn`, `testCandidateIdentities_keepsIpv6ScopeId` (uses `Inet6Address.getByAddress` for cross-OS portability),
  `testGetSubsettingMetadata_matchesViaIpv6`, `testGetSubsettingMetadata_noMatch_warnsOnceThenReArmsOnRecovery`.                                                                                                                                    
  - [x] Pre-existing `testGetSubsettingMetadata` (FQDN match path) still passes.                                                                                                                                                                    
  - [x] All 6 tests pass via `./gradlew :d2:test --tests com.linkedin.d2.balancer.subsetting.ZKDeterministicSubsettingMetadataProviderTest` (JDK 11, Gradle 6.9.4).                                                                                 
  - [ ] Production verification: post-deploy, expect `RelativeLoadBalancerStrategy.<svc>-https-LoadBalancerStrategy.TotalHostsCount` to drop from full cluster size to ~`_minClusterSubsetSize` for clusters with `_enableClusterSubsetting=true`.