### PR TITLE
Avoid per-request HashSet allocation in RelativeLoadBalancerStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Avoid per-request HashSet allocation in RelativeLoadBalancerStrategy
 
 ## [29.85.11] - 2026-05-05
 - Memoize negative results in DataTemplateUtil.getSchema to avoid recomputation for classes without a valid SCHEMA field

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -883,6 +883,11 @@ public class D2ClientBuilder
     return this;
   }
 
+  public D2ClientBuilder setEnableRelativeStrategyDeferredAllocation(boolean enableRelativeStrategyDeferredAllocation) {
+    _config.enableRelativeStrategyDeferredAllocation = enableRelativeStrategyDeferredAllocation;
+    return this;
+  }
+
   public D2ClientBuilder setXdsInitialResourceVersionsEnabled(boolean xdsIRVEnabled)
   {
     _config.xdsInitialResourceVersionsEnabled = xdsIRVEnabled;
@@ -971,7 +976,7 @@ public class D2ClientBuilder
       // TODO: create StateUpdater.LoadBalanceConfig and pass it to the RelativeLoadBalancerStrategyFactory
       final RelativeLoadBalancerStrategyFactory relativeLoadBalancerStrategyFactory = new RelativeLoadBalancerStrategyFactory(
           _config._executorService, _config.healthCheckOperations, Collections.emptyList(), _config.eventEmitter,
-          SystemClock.instance(), _config.loadBalanceStreamException);
+          SystemClock.instance(), _config.loadBalanceStreamException, _config.enableRelativeStrategyDeferredAllocation);
       loadBalancerStrategyFactories.putIfAbsent(RelativeLoadBalancerStrategy.RELATIVE_LOAD_BALANCER_STRATEGY_NAME,
           relativeLoadBalancerStrategyFactory);
     }

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -191,6 +191,7 @@ public class D2ClientConfig
   public XdsClientOtelMetricsProvider xdsClientOtelMetricsProvider = new NoOpXdsClientOtelMetricsProvider();
   public boolean loadBalanceStreamException = false;
   public boolean enablePotentialClientsCache = false;
+  public boolean enableRelativeStrategyDeferredAllocation = false;
   public boolean xdsInitialResourceVersionsEnabled = false;
   public Integer xdsStreamMaxRetryBackoffSeconds = null;
   public String xdsMinimumJavaVersion = DEFAULT_MINIMUM_JAVA_VERSION;

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/LoadBalancerStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/LoadBalancerStrategy.java
@@ -51,7 +51,9 @@ public interface LoadBalancerStrategy
    * @param requestContext
    * @param clusterGenerationId
    * @param partitionId
-   * @param trackerClients
+   * @param trackerClients candidate clients for this partition. Implementations may retain a
+   *     reference and read from it asynchronously (e.g. on an executor thread), so the caller
+   *     MUST NOT mutate this map after the call returns.
    * @return TrackerClient
    */
   @Nullable
@@ -82,7 +84,9 @@ public interface LoadBalancerStrategy
    *
    * @param clusterGenerationId
    * @param partitionId
-   * @param trackerClients
+   * @param trackerClients candidate clients for this partition. Implementations may retain a
+   *     reference and read from it asynchronously (e.g. on an executor thread), so the caller
+   *     MUST NOT mutate this map after the call returns.
    * @return Ring
    */
   @Nonnull

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategy.java
@@ -50,12 +50,21 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
 
   private final StateUpdater _stateUpdater;
   private final ClientSelector _clientSelector;
+  private final boolean _enableRelativeStrategyDeferredAllocation;
 
   public RelativeLoadBalancerStrategy(StateUpdater stateUpdater,
                                       ClientSelector clientSelector)
   {
+    this(stateUpdater, clientSelector, false);
+  }
+
+  public RelativeLoadBalancerStrategy(StateUpdater stateUpdater,
+                                      ClientSelector clientSelector,
+                                      boolean enableRelativeStrategyDeferredAllocation)
+  {
     _stateUpdater = stateUpdater;
     _clientSelector = clientSelector;
+    _enableRelativeStrategyDeferredAllocation = enableRelativeStrategyDeferredAllocation;
   }
 
   @Override
@@ -90,7 +99,9 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
       return null;
     }
 
-    _stateUpdater.updateState(new HashSet<>(trackerClients.values()), partitionId, clusterGenerationId, shouldForceUpdate);
+    _stateUpdater.updateState(
+        _enableRelativeStrategyDeferredAllocation ? trackerClients.values() : new HashSet<>(trackerClients.values()),
+        partitionId, clusterGenerationId, shouldForceUpdate);
     Ring<URI> ring = _stateUpdater.getRing(partitionId);
     return _clientSelector.getTrackerClient(request, requestContext, ring, trackerClients);
   }
@@ -115,7 +126,9 @@ public class RelativeLoadBalancerStrategy implements LoadBalancerStrategy
   @Override
   public Ring<URI> getRing(long clusterGenerationId, int partitionId, Map<URI, TrackerClient> trackerClients, boolean shouldForceUpdate)
   {
-    _stateUpdater.updateState(new HashSet<>(trackerClients.values()), partitionId, clusterGenerationId, shouldForceUpdate);
+    _stateUpdater.updateState(
+        _enableRelativeStrategyDeferredAllocation ? trackerClients.values() : new HashSet<>(trackerClients.values()),
+        partitionId, clusterGenerationId, shouldForceUpdate);
     return _stateUpdater.getRing(partitionId);
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategyFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategyFactory.java
@@ -77,16 +77,25 @@ public class RelativeLoadBalancerStrategyFactory implements LoadBalancerStrategy
   private final EventEmitter _eventEmitter;
   private final Clock _clock;
   private final boolean _loadBalanceStreamException;
+  private final boolean _enableRelativeStrategyDeferredAllocation;
 
   public RelativeLoadBalancerStrategyFactory(ScheduledExecutorService executorService, HealthCheckOperations healthCheckOperations,
       List<PartitionStateUpdateListener.Factory<PartitionState>> stateListenerFactories, EventEmitter eventEmitter, Clock clock)
   {
-    this(executorService, healthCheckOperations, stateListenerFactories, eventEmitter, clock, false);
+    this(executorService, healthCheckOperations, stateListenerFactories, eventEmitter, clock, false, false);
   }
 
   public RelativeLoadBalancerStrategyFactory(ScheduledExecutorService executorService, HealthCheckOperations healthCheckOperations,
       List<PartitionStateUpdateListener.Factory<PartitionState>> stateListenerFactories, EventEmitter eventEmitter, Clock clock,
       boolean loadBalanceStreamException)
+  {
+    this(executorService, healthCheckOperations, stateListenerFactories, eventEmitter, clock,
+        loadBalanceStreamException, false);
+  }
+
+  public RelativeLoadBalancerStrategyFactory(ScheduledExecutorService executorService, HealthCheckOperations healthCheckOperations,
+      List<PartitionStateUpdateListener.Factory<PartitionState>> stateListenerFactories, EventEmitter eventEmitter, Clock clock,
+      boolean loadBalanceStreamException, boolean enableRelativeStrategyDeferredAllocation)
   {
     _executorService = executorService;
     _healthCheckOperations = healthCheckOperations;
@@ -94,6 +103,7 @@ public class RelativeLoadBalancerStrategyFactory implements LoadBalancerStrategy
     _eventEmitter = (eventEmitter == null) ? new NoopEventEmitter() : eventEmitter;
     _clock = clock;
     _loadBalanceStreamException = loadBalanceStreamException;
+    _enableRelativeStrategyDeferredAllocation = enableRelativeStrategyDeferredAllocation;
   }
 
 
@@ -106,7 +116,8 @@ public class RelativeLoadBalancerStrategyFactory implements LoadBalancerStrategy
 
     return new RelativeLoadBalancerStrategy(getRelativeStateUpdater(relativeStrategyProperties,
                                             serviceProperties.getServiceName(), serviceProperties.getClusterName(),
-                                            serviceProperties.getPath()), getClientSelector(relativeStrategyProperties));
+                                            serviceProperties.getPath()), getClientSelector(relativeStrategyProperties),
+                                            _enableRelativeStrategyDeferredAllocation);
   }
 
   private StateUpdater getRelativeStateUpdater(D2RelativeStrategyProperties relativeStrategyProperties,

--- a/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/strategies/relative/StateUpdater.java
@@ -25,7 +25,9 @@ import com.linkedin.d2.balancer.util.hashing.Ring;
 import com.linkedin.util.degrader.CallTracker;
 import com.linkedin.util.degrader.ErrorType;
 import java.net.URI;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -124,12 +126,12 @@ public class StateUpdater
   /**
    * Update the state of the partition if necessary
    * This update is triggered by the request. If the cluster is not initialized or the uris changed, we will update the state.
-   *  @param trackerClients The set of hosts for this partition
+   *  @param trackerClients The hosts for this partition
    * @param partitionId The id of the partition
    * @param clusterGenerationId The id that uniquely identifies a set of hosts in the cluster
    * @param shouldForceUpdate Whether or not to force update
    */
-  public void updateState(Set<TrackerClient> trackerClients, int partitionId, long clusterGenerationId,
+  public void updateState(Collection<TrackerClient> trackerClients, int partitionId, long clusterGenerationId,
       boolean shouldForceUpdate)
   {
     if (!_partitionLoadBalancerStateMap.containsKey(partitionId))
@@ -144,7 +146,6 @@ public class StateUpdater
       {
         _lock.unlock();
       }
-
     }
     else if (shouldForceUpdate || clusterGenerationId != _partitionLoadBalancerStateMap.get(partitionId).getClusterGenerationId()
         || trackerClients.size() != _partitionLoadBalancerStateMap.get(partitionId).getPointsMap().size())
@@ -231,7 +232,7 @@ public class StateUpdater
    * @param clusterGenerationId The id that identifies the cluster version
    * @param shouldForceUpdate Whether or not to force update
    */
-  void updateStateForPartition(Set<TrackerClient> trackerClients, int partitionId, PartitionState oldPartitionState,
+  void updateStateForPartition(Collection<TrackerClient> trackerClients, int partitionId, PartitionState oldPartitionState,
       Long clusterGenerationId, boolean shouldForceUpdate)
   {
     LOG.debug("Updating for partition: " + partitionId + ", state: " + oldPartitionState);
@@ -265,7 +266,7 @@ public class StateUpdater
    * We will check the cluster generation id again before performing the actual update to make sure only one updates got executed
    * This can be guaranteed because the executor service has has 1 thread
    */
-  void updateStateDueToClusterChange(Set<TrackerClient> trackerClients, int partitionId, Long newClusterGenerationId,
+  void updateStateDueToClusterChange(Collection<TrackerClient> trackerClients, int partitionId, Long newClusterGenerationId,
       boolean shouldForceUpdate)
   {
     if (shouldForceUpdate || newClusterGenerationId != _partitionLoadBalancerStateMap.get(partitionId).getClusterGenerationId()
@@ -279,7 +280,7 @@ public class StateUpdater
   /**
    * Update the health score of all tracker clients for the service
    */
-  private void updateBaseHealthScoreAndState(Set<TrackerClient> trackerClients,
+  private void updateBaseHealthScoreAndState(Collection<TrackerClient> trackerClients,
       PartitionState partitionState, long clusterAvgLatency,
       boolean clusterUpdated, Map<TrackerClient, CallTracker.CallStats> lastCallStatsMap)
   {
@@ -288,10 +289,13 @@ public class StateUpdater
 
     // Remove the trackerClients from original map if there is any change in uri list
     Map<TrackerClient, TrackerClientState> trackerClientStateMap = partitionState.getTrackerClientStateMap();
-    if (clusterUpdated)
+    if (clusterUpdated && !trackerClientStateMap.isEmpty())
     {
+      Set<TrackerClient> trackerClientSet = trackerClients instanceof Set
+          ? (Set<TrackerClient>) trackerClients
+          : new HashSet<>(trackerClients);
       List<TrackerClient> trackerClientsToRemove = trackerClientStateMap.keySet().stream()
-          .filter(oldTrackerClient -> !trackerClients.contains(oldTrackerClient))
+          .filter(oldTrackerClient -> !trackerClientSet.contains(oldTrackerClient))
           .collect(Collectors.toList());
       for (TrackerClient trackerClient : trackerClientsToRemove)
       {
@@ -300,7 +304,7 @@ public class StateUpdater
     }
   }
 
-  private void calculateBaseHealthScore(Set<TrackerClient> trackerClients, PartitionState partitionState,
+  private void calculateBaseHealthScore(Collection<TrackerClient> trackerClients, PartitionState partitionState,
       long avgClusterLatency, Map<TrackerClient, CallTracker.CallStats> lastCallStatsMap)
   {
     Map<TrackerClient, TrackerClientState> trackerClientStateMap = partitionState.getTrackerClientStateMap();
@@ -391,7 +395,7 @@ public class StateUpdater
   /**
    * Get the weighted average cluster latency
    */
-  private long getAvgClusterLatency(Set<TrackerClient> trackerClients, Map<TrackerClient, CallTracker.CallStats> latestCallStatsMap)
+  private long getAvgClusterLatency(Collection<TrackerClient> trackerClients, Map<TrackerClient, CallTracker.CallStats> latestCallStatsMap)
   {
     long latencySum = 0;
     long outstandingLatencySum = 0;
@@ -478,7 +482,7 @@ public class StateUpdater
     return callCount == 0 ? 0 : validExceptionCount / callCount;
   }
 
-  private void initializePartition(Set<TrackerClient> trackerClients, int partitionId, long clusterGenerationId)
+  private void initializePartition(Collection<TrackerClient> trackerClients, int partitionId, long clusterGenerationId)
   {
     if (!_partitionLoadBalancerStateMap.containsKey(partitionId))
     {

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/PartitionStateTestDataBuilder.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/PartitionStateTestDataBuilder.java
@@ -19,6 +19,7 @@ package com.linkedin.d2.balancer.strategies.relative;
 import com.linkedin.d2.balancer.clients.TrackerClient;
 import com.linkedin.d2.balancer.strategies.DistributionNonDiscreteRingFactory;
 import com.linkedin.d2.balancer.strategies.LoadBalancerQuarantine;
+import com.linkedin.d2.balancer.strategies.PartitionStateUpdateListener;
 import com.linkedin.d2.balancer.strategies.RingFactory;
 import java.net.URI;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ public class PartitionStateTestDataBuilder
   private Set<TrackerClient> _recoveryTrackerClients = new HashSet<>();
   private Map<TrackerClient, LoadBalancerQuarantine> _quarantineMap = new HashMap<>();
   private Map<TrackerClient, TrackerClientState> _trackerClientStateMap = new HashMap<>();
+  private List<PartitionStateUpdateListener<PartitionState>> _listeners = new ArrayList<>();
 
   PartitionStateTestDataBuilder()
   {
@@ -96,10 +98,16 @@ public class PartitionStateTestDataBuilder
     return this;
   }
 
+  PartitionStateTestDataBuilder setListeners(List<PartitionStateUpdateListener<PartitionState>> listeners)
+  {
+    _listeners = listeners;
+    return this;
+  }
+
   PartitionState build()
   {
     return new PartitionState(DEFAULT_PARTITION_ID, _ringFactory, DEFAULT_POINTS_PER_WEIGHT,
         _recoveryTrackerClients, _clusterGenerationId, _quarantineMap, new HashMap<>(), new HashMap<>(),
-        _trackerClientStateMap, new ArrayList<>());
+        _trackerClientStateMap, _listeners);
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategyTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/RelativeLoadBalancerStrategyTest.java
@@ -1,0 +1,158 @@
+/*
+   Copyright (c) 2026 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.linkedin.d2.balancer.strategies.relative;
+
+import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.util.hashing.RandomHash;
+import com.linkedin.d2.balancer.util.hashing.Ring;
+import com.linkedin.r2.message.Request;
+import com.linkedin.r2.message.RequestContext;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests that {@link RelativeLoadBalancerStrategy} passes the right concrete {@code Collection} type
+ * to {@link StateUpdater#updateState} based on the {@code enableRelativeStrategyDeferredAllocation}
+ * flag.
+ */
+public class RelativeLoadBalancerStrategyTest
+{
+  private static final long CLUSTER_GENERATION_ID = 0L;
+  private static final int PARTITION_ID = 0;
+
+  private static class Fixture
+  {
+    final Map<URI, TrackerClient> trackerClients;
+    final StateUpdater stateUpdater;
+    final ClientSelector clientSelector;
+
+    Fixture(int clientCount)
+    {
+      this.trackerClients = buildTrackerClients(clientCount);
+      URI anyUri = trackerClients.keySet().iterator().next();
+      Ring<URI> ring = Mockito.mock(Ring.class);
+      Mockito.when(ring.get(anyInt())).thenReturn(anyUri);
+      this.stateUpdater = Mockito.mock(StateUpdater.class);
+      Mockito.when(stateUpdater.getRing(anyInt())).thenReturn(ring);
+      this.clientSelector = new ClientSelector(new RandomHash());
+    }
+  }
+
+  @Test
+  public void testFlagOffPassesHashSet()
+  {
+    Fixture f = new Fixture(2);
+    RelativeLoadBalancerStrategy strategy =
+        new RelativeLoadBalancerStrategy(f.stateUpdater, f.clientSelector, false /* deferred off */);
+
+    strategy.getTrackerClient(Mockito.mock(Request.class), new RequestContext(),
+        CLUSTER_GENERATION_ID, PARTITION_ID, f.trackerClients, false);
+
+    Collection<TrackerClient> captured = captureUpdateStateArg(f.stateUpdater);
+    assertTrue(captured instanceof Set, "flag off should wrap into a Set (HashSet) at the call site");
+  }
+
+  @Test
+  public void testFlagOnPassesValuesView()
+  {
+    Fixture f = new Fixture(2);
+    RelativeLoadBalancerStrategy strategy =
+        new RelativeLoadBalancerStrategy(f.stateUpdater, f.clientSelector, true /* deferred on */);
+
+    strategy.getTrackerClient(Mockito.mock(Request.class), new RequestContext(),
+        CLUSTER_GENERATION_ID, PARTITION_ID, f.trackerClients, false);
+
+    Collection<TrackerClient> captured = captureUpdateStateArg(f.stateUpdater);
+    assertFalse(captured instanceof Set,
+        "flag on should pass Map.values() (a non-Set Collection) without wrapping");
+  }
+
+  @Test
+  public void testGetRingFlagOffPassesHashSet()
+  {
+    Fixture f = new Fixture(2);
+    RelativeLoadBalancerStrategy strategy =
+        new RelativeLoadBalancerStrategy(f.stateUpdater, f.clientSelector, false);
+
+    strategy.getRing(CLUSTER_GENERATION_ID, PARTITION_ID, f.trackerClients, false);
+
+    Collection<TrackerClient> captured = captureUpdateStateArg(f.stateUpdater);
+    assertTrue(captured instanceof Set);
+  }
+
+  @Test
+  public void testGetRingFlagOnPassesValuesView()
+  {
+    Fixture f = new Fixture(2);
+    RelativeLoadBalancerStrategy strategy =
+        new RelativeLoadBalancerStrategy(f.stateUpdater, f.clientSelector, true);
+
+    strategy.getRing(CLUSTER_GENERATION_ID, PARTITION_ID, f.trackerClients, false);
+
+    Collection<TrackerClient> captured = captureUpdateStateArg(f.stateUpdater);
+    assertFalse(captured instanceof Set);
+  }
+
+  @Test
+  public void testDefaultConstructorDefaultsFlagOff()
+  {
+    Fixture f = new Fixture(2);
+    // Two-arg constructor must preserve legacy behavior (flag defaults to false).
+    RelativeLoadBalancerStrategy strategy = new RelativeLoadBalancerStrategy(f.stateUpdater, f.clientSelector);
+
+    strategy.getTrackerClient(Mockito.mock(Request.class), new RequestContext(),
+        CLUSTER_GENERATION_ID, PARTITION_ID, f.trackerClients, false);
+
+    Collection<TrackerClient> captured = captureUpdateStateArg(f.stateUpdater);
+    assertTrue(captured instanceof Set,
+        "two-arg ctor must default to flag=false (legacy HashSet-wrapping behavior)");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Collection<TrackerClient> captureUpdateStateArg(StateUpdater stateUpdater)
+  {
+    ArgumentCaptor<Collection> captor = ArgumentCaptor.forClass(Collection.class);
+    Mockito.verify(stateUpdater).updateState(captor.capture(), anyInt(), anyLong(), anyBoolean());
+    return (Collection<TrackerClient>) captor.getValue();
+  }
+
+  private static Map<URI, TrackerClient> buildTrackerClients(int count)
+  {
+    Map<URI, TrackerClient> map = new HashMap<>();
+    for (int i = 0; i < count; i++)
+    {
+      URI uri = URI.create("http://host" + i + ":8080");
+      TrackerClient client = Mockito.mock(TrackerClient.class);
+      Mockito.when(client.getUri()).thenReturn(uri);
+      map.put(uri, client);
+    }
+    return map;
+  }
+}

--- a/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/strategies/relative/StateUpdaterTest.java
@@ -19,6 +19,7 @@ package com.linkedin.d2.balancer.strategies.relative;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.d2.D2RelativeStrategyProperties;
 import com.linkedin.d2.balancer.clients.TrackerClient;
+import com.linkedin.d2.balancer.strategies.PartitionStateUpdateListener;
 import com.linkedin.r2.util.NamedThreadFactory;
 import com.linkedin.test.util.retry.ThreeRetries;
 import com.linkedin.util.degrader.ErrorType;
@@ -250,10 +251,21 @@ public class StateUpdaterTest
     executorService.shutdown();
   }
 
-  @Test(retryAnalyzer = ThreeRetries.class) // Known to be flaky in CI
+  @Test
   public void testClusterGenerationIdChange() throws InterruptedException {
+    // Reset _quarantineManager: an earlier test (testExecutorScheduleWithError) installs a
+    // doThrow stub on this shared mock, which would otherwise leak in and abort the executor task.
+    Mockito.doNothing().when(_quarantineManager).updateQuarantineState(any(), any(), anyLong());
+
+    // Listener-based latch: onUpdate is invoked by the executor only AFTER the new partition state
+    // has been swapped into _partitionLoadBalancerStateMap and updateRing() has refreshed _pointsMap,
+    // so the post-await assertions observe a fully consistent state with no timing race.
+    CountDownLatch updateCompleted = new CountDownLatch(1);
+    PartitionStateUpdateListener<PartitionState> listener = ps -> updateCompleted.countDown();
+
     PartitionState state = new PartitionStateTestDataBuilder()
         .setClusterGenerationId(DEFAULT_CLUSTER_GENERATION_ID)
+        .setListeners(Collections.singletonList(listener))
         .build();
 
     List<TrackerClient> trackerClients = TrackerClientMockHelper.mockTrackerClients(2,
@@ -266,13 +278,9 @@ public class StateUpdaterTest
     _stateUpdater = new StateUpdater(relativeStrategyProperties, _quarantineManager, executorService,
         partitionLoadBalancerStateMap, Collections.emptyList(), SERVICE_NAME);
 
-    // update will be scheduled twice, once from interval update, once from cluster change
-    CountDownLatch countDownLatch = new CountDownLatch(2);
-    Mockito.doAnswer(new ExecutionCountDown<>(countDownLatch)).when(_quarantineManager).updateQuarantineState(any(), any(), anyLong());
-
     // Cluster generation id changed from 0 to 1
     _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, 1, false);
-    if (!countDownLatch.await(5, TimeUnit.SECONDS))
+    if (!updateCompleted.await(5, TimeUnit.SECONDS))
     {
       fail("cluster update failed to finish within 5 seconds");
     }
@@ -281,11 +289,102 @@ public class StateUpdaterTest
     executorService.shutdown();
   }
 
-  @Test(retryAnalyzer = ThreeRetries.class) // Known to be flaky in CI
+  /**
+   * Exercises the non-Set Collection slow path in {@link StateUpdater#updateBaseHealthScoreAndState}.
+   * When the caller passes {@code Map.values()} (a non-Set Collection) and the state map has pre-existing
+   * entries, the {@code instanceof Set} guard takes the else-branch and materializes a HashSet locally
+   * for the identity-based {@code contains()}.
+   */
+  @Test
+  public void testClusterGenerationIdChangeWithNonSetCollection() throws InterruptedException
+  {
+    // Reset _quarantineManager (see testClusterGenerationIdChange comment).
+    Mockito.doNothing().when(_quarantineManager).updateQuarantineState(any(), any(), anyLong());
+
+    List<TrackerClient> initialClients = TrackerClientMockHelper.mockTrackerClients(3,
+        Arrays.asList(20, 20, 20), Arrays.asList(10, 10, 10),
+        Arrays.asList(200L, 500L, 300L), Arrays.asList(100L, 200L, 150L), Arrays.asList(0, 0, 0));
+
+    // Count=2: one onUpdate fires after the initial partition setup, another after the cluster-change
+    // executor task completes the partition swap into _partitionLoadBalancerStateMap. Awaiting both
+    // guarantees a fully consistent post-update state when we assert below.
+    CountDownLatch updateCompleted = new CountDownLatch(2);
+    PartitionStateUpdateListener.Factory<PartitionState> listenerFactory =
+        partitionId -> ps -> updateCompleted.countDown();
+
+    ConcurrentMap<Integer, PartitionState> partitionLoadBalancerStateMap = new ConcurrentHashMap<>();
+    ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    D2RelativeStrategyProperties props = RelativeLoadBalancerStrategyFactory.putDefaultValues(new D2RelativeStrategyProperties());
+    _stateUpdater = new StateUpdater(props, _quarantineManager, executorService,
+        partitionLoadBalancerStateMap, Collections.singletonList(listenerFactory), SERVICE_NAME);
+
+    // Step 1: initialize the partition so the state map has entries; this is the precondition
+    // for exercising the `instanceof Set` else-branch on the subsequent cluster change.
+    _stateUpdater.updateState(new HashSet<>(initialClients), DEFAULT_PARTITION_ID, DEFAULT_CLUSTER_GENERATION_ID, false);
+
+    // Step 2: cluster change with a smaller set of clients passed as a non-Set Collection (Map.values()).
+    // One of the original clients is dropped, exercising the contains()-based removal logic with
+    // a Collection that is not a Set.
+    Map<URI, TrackerClient> newClientsMap = new HashMap<>();
+    newClientsMap.put(initialClients.get(0).getUri(), initialClients.get(0));
+    newClientsMap.put(initialClients.get(1).getUri(), initialClients.get(1));
+    assertFalse(newClientsMap.values() instanceof Set, "precondition: Map.values() must not be a Set");
+
+    _stateUpdater.updateState(newClientsMap.values(), DEFAULT_PARTITION_ID, 1L, false);
+    if (!updateCompleted.await(5, TimeUnit.SECONDS))
+    {
+      fail("cluster update failed to finish within 5 seconds");
+    }
+
+    // After the update the dropped client should be removed and the two retained clients present.
+    Map<URI, Integer> pointsMap = _stateUpdater.getPointsMap(DEFAULT_PARTITION_ID);
+    assertEquals(pointsMap.size(), 2);
+    assertTrue(pointsMap.containsKey(initialClients.get(0).getUri()));
+    assertTrue(pointsMap.containsKey(initialClients.get(1).getUri()));
+    assertFalse(pointsMap.containsKey(initialClients.get(2).getUri()),
+        "dropped client should be removed via the non-Set Collection slow path");
+    executorService.shutdown();
+  }
+
+  /**
+   * Equivalence: an initial {@code updateState} call with a non-Set Collection (e.g. {@code Map.values()})
+   * produces the same partition state as one with a HashSet of the same elements.
+   */
+  @Test
+  public void testInitializePartitionWithNonSetCollection()
+  {
+    setup(new D2RelativeStrategyProperties(), new ConcurrentHashMap<>());
+
+    List<TrackerClient> trackerClients = TrackerClientMockHelper.mockTrackerClients(2,
+        Arrays.asList(20, 20), Arrays.asList(10, 10), Arrays.asList(200L, 500L), Arrays.asList(100L, 200L), Arrays.asList(0, 0));
+
+    Map<URI, TrackerClient> clientsMap = new HashMap<>();
+    for (TrackerClient client : trackerClients)
+    {
+      clientsMap.put(client.getUri(), client);
+    }
+    assertFalse(clientsMap.values() instanceof Set, "precondition: Map.values() must not be a Set");
+
+    _stateUpdater.updateState(clientsMap.values(), DEFAULT_PARTITION_ID, DEFAULT_CLUSTER_GENERATION_ID, false);
+
+    assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(0).getUri()).intValue(), HEALTHY_POINTS);
+    assertEquals(_stateUpdater.getPointsMap(DEFAULT_PARTITION_ID).get(trackerClients.get(1).getUri()).intValue(), HEALTHY_POINTS);
+  }
+
+  @Test
   public void testForceUpdate() throws InterruptedException
   {
+    // Reset _quarantineManager (see testClusterGenerationIdChange comment).
+    Mockito.doNothing().when(_quarantineManager).updateQuarantineState(any(), any(), anyLong());
+
+    // Count=2: two updateState calls each produce one onUpdate after their respective partition
+    // swap. Awaiting both guarantees the post-force-update state is fully observable.
+    CountDownLatch updateCompleted = new CountDownLatch(2);
+    PartitionStateUpdateListener<PartitionState> listener = ps -> updateCompleted.countDown();
+
     PartitionState state = new PartitionStateTestDataBuilder()
         .setClusterGenerationId(DEFAULT_CLUSTER_GENERATION_ID)
+        .setListeners(Collections.singletonList(listener))
         .build();
 
     List<TrackerClient> trackerClients = TrackerClientMockHelper.mockTrackerClients(2,
@@ -298,14 +397,10 @@ public class StateUpdaterTest
     _stateUpdater = new StateUpdater(relativeStrategyProperties, _quarantineManager, executorService,
         partitionLoadBalancerStateMap, Collections.emptyList(), SERVICE_NAME);
 
-    // update will be scheduled three times, once from interval update, once from cluster change, once from force update
-    CountDownLatch countDownLatch = new CountDownLatch(3);
-    Mockito.doAnswer(new ExecutionCountDown<>(countDownLatch)).when(_quarantineManager).updateQuarantineState(any(), any(), anyLong());
-
     // Cluster generation id changed from 0 to 1
     _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, 1, false);
     _stateUpdater.updateState(new HashSet<>(trackerClients), DEFAULT_PARTITION_ID, 1, true);
-    if (!countDownLatch.await(5, TimeUnit.SECONDS))
+    if (!updateCompleted.await(5, TimeUnit.SECONDS))
     {
       fail("cluster update failed to finish within 5 seconds");
     }


### PR DESCRIPTION
JFR identified the HashSet copy constructor call in `RelativeLoadBalancerStrategy.getTrackerClient` to be a hotspot since this is executed once per request. The copied set is only consumed by the executor task on cluster changes, not by the steady-state path, such that the construction is wasted most of the time.

Since the map that backs the TrackerClient values are not mutated and have no duplicates, defer the construction of the set to when it's actually necessary.

Bonus: fix flaky test in StateUpdaterTest