### PR TITLE
Make recordRequestSizeBytes a default no-op for backward compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and what APIs have changed, if applicable.
 
 ## [Unreleased]
 - Avoid per-request HashSet allocation in RelativeLoadBalancerStrategy
+- Make `recordRequestSizeBytes` a `default` no-op method on `XdsClientOtelMetricsProvider` to restore binary compatibility with older implementations (e.g., container <= 38.31.0) that predate the method.
 
 ## [29.85.11] - 2026-05-05
 - Memoize negative results in DataTemplateUtil.getSchema to avoid recomputation for classes without a valid SCHEMA field

--- a/d2/src/main/java/com/linkedin/d2/jmx/XdsClientOtelMetricsProvider.java
+++ b/d2/src/main/java/com/linkedin/d2/jmx/XdsClientOtelMetricsProvider.java
@@ -93,5 +93,7 @@ public interface XdsClientOtelMetricsProvider {
    * @param clientName the name of the XDS client
    * @param sizeBytes  the serialized size in bytes of the {@code DeltaDiscoveryRequest}
    */
-  void recordRequestSizeBytes(String clientName, long sizeBytes);
+  default void recordRequestSizeBytes(String clientName, long sizeBytes) {
+    // Default no-op: implementors may override to record the metric.
+  }
 }


### PR DESCRIPTION
## Summary
- Changes `XdsClientOtelMetricsProvider#recordRequestSizeBytes` from an abstract method to a `default` no-op so older implementations (e.g., container <= 38.31.0) keep linking against pegasus >= 29.85.10.
- Adds a CHANGELOG entry under `[Unreleased]`.

## Background
PR #1166 made `recordRequestSizeBytes` abstract, breaking linkage for consumers that resolve container <= 38.31.0 with pegasus >= 29.85.10 in the same version set. Making it a `default` no-op is source- and binary-compatible; real implementors still override.


## Testing Done
- [x] Local code review completed
- [ ] CI build green on this PR

No behavioral test added: the change replaces an abstract declaration with an empty `default` body, so there is no logic to assert. The existing implementation in container that overrides this method (and the `recordRequestSizeBytes` call sites covered by the tests added in #1166) continue to exercise the real recording path.