### PR TITLE
Prepare release for 29.85.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.85.12] - 2026-05-14
 - Avoid per-request HashSet allocation in RelativeLoadBalancerStrategy
 - Make `recordRequestSizeBytes` a `default` no-op method on `XdsClientOtelMetricsProvider` to restore binary compatibility with older implementations (e.g., container <= 38.31.0) that predate the method.
 
@@ -5992,7 +5994,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.12...master
+[29.85.12]: https://github.com/linkedin/rest.li/compare/v29.85.11...v29.85.12
 [29.85.11]: https://github.com/linkedin/rest.li/compare/v29.85.10...29.85.11
 [29.85.10]: https://github.com/linkedin/rest.li/compare/v29.85.9...v29.85.10
 [29.85.9]: https://github.com/linkedin/rest.li/compare/v29.85.8...v29.85.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.11
+version=29.85.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
- Bumps version to `29.85.12` in `gradle.properties`
- Moves changelog entries (HashSet allocation fix; `recordRequestSizeBytes` default no-op fix from #1171) from `[Unreleased]` to `[29.85.12]`

## Test plan
- [ ] No code changes, version bump and changelog only.