### PR TITLE
[DO NOT MERGE] CI repro of release 29.85.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+
+## [29.85.12] - 2026-05-14
 - Avoid per-request HashSet allocation in RelativeLoadBalancerStrategy
 - Make `recordRequestSizeBytes` a `default` no-op method on `XdsClientOtelMetricsProvider` to restore binary compatibility with older implementations (e.g., container <= 38.31.0) that predate the method.
 
@@ -5992,7 +5994,8 @@ patch operations can re-use these classes for generating patch messages.
 
 ## [0.14.1]
 
-[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.11...master
+[Unreleased]: https://github.com/linkedin/rest.li/compare/v29.85.12...master
+[29.85.12]: https://github.com/linkedin/rest.li/compare/v29.85.11...v29.85.12
 [29.85.11]: https://github.com/linkedin/rest.li/compare/v29.85.10...29.85.11
 [29.85.10]: https://github.com/linkedin/rest.li/compare/v29.85.9...v29.85.10
 [29.85.9]: https://github.com/linkedin/rest.li/compare/v29.85.8...v29.85.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=29.85.11
+version=29.85.12
 group=com.linkedin.pegasus
 org.gradle.configureondemand=true
 org.gradle.parallel=true


### PR DESCRIPTION
## Summary
- **Do not merge.** Identical to #1172 (cherry-pick of the same commit). Opening this only to isolate whether the persistent Java 8 CI failure on #1172 is something tied to that specific PR / branch / runner pool, or whether the same change fails CI universally today.

If this PR's Java 8 CI passes, #1172's failure is environmental/sticky to that PR/branch and we can safely merge #1172. If this PR also fails the same way, the issue is broader.

## Testing Done
- [x] Local `:d2-int-test:test --tests TestDynamicClient` passes on JDK 8 (4/4)
- [ ] CI to be observed on this PR for comparison