### PR TITLE
Add opt-in D2 client subscription to the IndisRegistryObserver Cluster

### DIFF
--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -253,6 +253,8 @@ public class D2ClientBuilder
                   _config.indisDownstreamServicesFetchTimeout,
                   _config.xdsClientOtelMetricsProvider
     );
+    // Copied after construction to avoid threading another parameter through the large D2ClientConfig constructor.
+    cfg.subscribeToIndisObserverCluster = _config.subscribeToIndisObserverCluster;
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() : _config.lbWithFacilitiesFactory;
@@ -860,6 +862,11 @@ public class D2ClientBuilder
 
   public D2ClientBuilder setSubscribeToUriGlobCollection(boolean subscribeToUriGlobCollection) {
     _config.subscribeToUriGlobCollection = subscribeToUriGlobCollection;
+    return this;
+  }
+
+  public D2ClientBuilder setSubscribeToIndisObserverCluster(boolean subscribeToIndisObserverCluster) {
+    _config.subscribeToIndisObserverCluster = subscribeToIndisObserverCluster;
     return this;
   }
 

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientBuilder.java
@@ -238,6 +238,7 @@ public class D2ClientBuilder
                   _config.xdsChannelLoadBalancingPolicy,
                   _config.xdsChannelLoadBalancingPolicyConfig,
                   _config.subscribeToUriGlobCollection,
+                  _config.subscribeToIndisObserverCluster,
                   _config._xdsServerMetricsProvider,
                   _config.loadBalanceStreamException,
                   _config.enablePotentialClientsCache,
@@ -253,8 +254,6 @@ public class D2ClientBuilder
                   _config.indisDownstreamServicesFetchTimeout,
                   _config.xdsClientOtelMetricsProvider
     );
-    // Copied after construction to avoid threading another parameter through the large D2ClientConfig constructor.
-    cfg.subscribeToIndisObserverCluster = _config.subscribeToIndisObserverCluster;
 
     final LoadBalancerWithFacilitiesFactory loadBalancerFactory = (_config.lbWithFacilitiesFactory == null) ?
       new ZKFSLoadBalancerWithFacilitiesFactory() : _config.lbWithFacilitiesFactory;

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -182,6 +182,13 @@ public class D2ClientConfig
   public Long xdsChannelKeepAliveTimeMins = null;
 
   public boolean subscribeToUriGlobCollection = false;
+  /**
+   * When enabled, the xDS-based D2 client subscribes to the INDIS observer's own D2 cluster
+   * ("IndisRegistryObserver") so it receives and caches the live observer endpoint set over xDS.
+   * This is the first step toward removing the hard DNS-DISCO dependency for discovering the observer.
+   * Defaults to false; intended to be ramped on via config.
+   */
+  public boolean subscribeToIndisObserverCluster = false;
   public XdsServerMetricsProvider _xdsServerMetricsProvider = new NoOpXdsServerMetricsProvider();
 
   /**

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -185,7 +185,6 @@ public class D2ClientConfig
   /**
    * When enabled, the xDS-based D2 client subscribes to the INDIS observer's own D2 cluster
    * ("IndisRegistryObserver") so it receives and caches the live observer endpoint set over xDS.
-   * This is the first step toward removing the hard DNS-DISCO dependency for discovering the observer.
    * Defaults to false; intended to be ramped on via config.
    */
   public boolean subscribeToIndisObserverCluster = false;

--- a/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
+++ b/d2/src/main/java/com/linkedin/d2/balancer/D2ClientConfig.java
@@ -298,6 +298,7 @@ public class D2ClientConfig
                  String xdsChannelLoadBalancingPolicy,
                  Map<String, ?> xdsChannelLoadBalancingPolicyConfig,
                  boolean subscribeToUriGlobCollection,
+                 boolean subscribeToIndisObserverCluster,
                  XdsServerMetricsProvider xdsServerMetricsProvider,
                  boolean loadBalanceStreamException,
                  boolean enablePotentialClientsCache,
@@ -351,6 +352,7 @@ public class D2ClientConfig
         xdsChannelLoadBalancingPolicy,
         xdsChannelLoadBalancingPolicyConfig,
         subscribeToUriGlobCollection,
+        subscribeToIndisObserverCluster,
         xdsServerMetricsProvider,
         loadBalanceStreamException,
         enablePotentialClientsCache,
@@ -438,6 +440,7 @@ public class D2ClientConfig
                  String xdsChannelLoadBalancingPolicy,
                  Map<String, ?> xdsChannelLoadBalancingPolicyConfig,
                  boolean subscribeToUriGlobCollection,
+                 boolean subscribeToIndisObserverCluster,
                  XdsServerMetricsProvider xdsServerMetricsProvider,
                  boolean loadBalanceStreamException,
                  boolean enablePotentialClientsCache,
@@ -525,6 +528,7 @@ public class D2ClientConfig
     this.xdsChannelLoadBalancingPolicyConfig = xdsChannelLoadBalancingPolicyConfig;
     this.xdsChannelKeepAliveTimeMins = xdsChannelKeepAliveTimeMins;
     this.subscribeToUriGlobCollection = subscribeToUriGlobCollection;
+    this.subscribeToIndisObserverCluster = subscribeToIndisObserverCluster;
     this._xdsServerMetricsProvider = xdsServerMetricsProvider;
     this.loadBalanceStreamException = loadBalanceStreamException;
     this.enablePotentialClientsCache = enablePotentialClientsCache;

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -56,6 +56,9 @@ public class XdsToD2PropertiesAdaptor
   private static final String D2_URI_NODE_PREFIX = "/d2/uris/";
   private static final char PATH_SEPARATOR = '/';
   private static final String NON_EXISTENT_CLUSTER = "NonExistentCluster";
+  // The INDIS observer's own D2 cluster. Subscribing to it lets every client cache the live observer
+  // endpoint set over xDS, so discovering the observer no longer hard-depends on DNS-DISCO.
+  private static final String INDIS_REGISTRY_OBSERVER_CLUSTER = "IndisRegistryObserver";
 
   private final XdsClient _xdsClient;
   private final List<XdsConnectionListener> _xdsConnectionListeners = Collections.synchronizedList(new ArrayList<>());
@@ -90,6 +93,8 @@ public class XdsToD2PropertiesAdaptor
   private PropertyEventBus<UriProperties> _uriEventBus;
   private PropertyEventBus<ServiceProperties> _serviceEventBus;
   private PropertyEventBus<ClusterProperties> _clusterEventBus;
+  // When true, start() also subscribes to the INDIS observer's own cluster (see INDIS_REGISTRY_OBSERVER_CLUSTER).
+  private boolean _subscribeToObserverCluster = false;
 
   public XdsToD2PropertiesAdaptor(XdsClient xdsClient, DualReadStateManager dualReadStateManager,
       ServiceDiscoveryEventEmitter eventEmitter)
@@ -111,6 +116,11 @@ public class XdsToD2PropertiesAdaptor
     _servicePropertiesJsonSerializer = servicePropertiesJsonSerializer;
   }
 
+  public void setSubscribeToObserverCluster(boolean subscribeToObserverCluster)
+  {
+    _subscribeToObserverCluster = subscribeToObserverCluster;
+  }
+
   public void start()
   {
     _xdsClient.start();
@@ -118,6 +128,13 @@ public class XdsToD2PropertiesAdaptor
     // TODO: Note, this is a workaround since the xDS client implementation currently integrates connection
     //   error/success notifications along with the resource updates. This can be improved in a future refactor.
     listenToCluster(NON_EXISTENT_CLUSTER);
+    if (_subscribeToObserverCluster)
+    {
+      // Subscribe to the observer's own cluster and uris so the live observer endpoint set is received and
+      // cached over xDS. Re-subscription on reconnect is handled automatically by XdsClientImpl.
+      listenToCluster(INDIS_REGISTRY_OBSERVER_CLUSTER);
+      listenToUris(INDIS_REGISTRY_OBSERVER_CLUSTER);
+    }
   }
 
   public void shutdown()

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -56,8 +56,8 @@ public class XdsToD2PropertiesAdaptor
   private static final String D2_URI_NODE_PREFIX = "/d2/uris/";
   private static final char PATH_SEPARATOR = '/';
   private static final String NON_EXISTENT_CLUSTER = "NonExistentCluster";
-  // The INDIS observer's own D2 cluster. Subscribing to it lets every client cache the live observer
-  // endpoint set over xDS, so discovering the observer no longer hard-depends on DNS-DISCO.
+  // The INDIS observer's own D2 cluster. Subscribing to it lets a client cache the live observer
+  // endpoint set over xDS.
   private static final String INDIS_REGISTRY_OBSERVER_CLUSTER = "IndisRegistryObserver";
 
   private final XdsClient _xdsClient;

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -94,7 +94,7 @@ public class XdsToD2PropertiesAdaptor
   private PropertyEventBus<ServiceProperties> _serviceEventBus;
   private PropertyEventBus<ClusterProperties> _clusterEventBus;
   // When true, start() also subscribes to the INDIS observer's own cluster (see INDIS_REGISTRY_OBSERVER_CLUSTER).
-  private boolean _subscribeToObserverCluster = false;
+  private boolean _subscribeToIndisObserverCluster = false;
 
   public XdsToD2PropertiesAdaptor(XdsClient xdsClient, DualReadStateManager dualReadStateManager,
       ServiceDiscoveryEventEmitter eventEmitter)
@@ -116,9 +116,9 @@ public class XdsToD2PropertiesAdaptor
     _servicePropertiesJsonSerializer = servicePropertiesJsonSerializer;
   }
 
-  public void setSubscribeToObserverCluster(boolean subscribeToObserverCluster)
+  public void setSubscribeToIndisObserverCluster(boolean subscribeToIndisObserverCluster)
   {
-    _subscribeToObserverCluster = subscribeToObserverCluster;
+    _subscribeToIndisObserverCluster = subscribeToIndisObserverCluster;
   }
 
   public void start()
@@ -128,7 +128,7 @@ public class XdsToD2PropertiesAdaptor
     // TODO: Note, this is a workaround since the xDS client implementation currently integrates connection
     //   error/success notifications along with the resource updates. This can be improved in a future refactor.
     listenToCluster(NON_EXISTENT_CLUSTER);
-    if (_subscribeToObserverCluster)
+    if (_subscribeToIndisObserverCluster)
     {
       // Subscribe to the observer's own cluster and uris so the live observer endpoint set is received and
       // cached over xDS. Re-subscription on reconnect is handled automatically by XdsClientImpl.

--- a/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/XdsToD2PropertiesAdaptor.java
@@ -56,9 +56,10 @@ public class XdsToD2PropertiesAdaptor
   private static final String D2_URI_NODE_PREFIX = "/d2/uris/";
   private static final char PATH_SEPARATOR = '/';
   private static final String NON_EXISTENT_CLUSTER = "NonExistentCluster";
-  // The INDIS observer's own D2 cluster. Subscribing to it lets a client cache the live observer
+  // The INDIS observer's own D2 cluster and service. Subscribing to it lets a client cache the live observer
   // endpoint set over xDS.
   private static final String INDIS_REGISTRY_OBSERVER_CLUSTER = "IndisRegistryObserver";
+  private static final String INDIS_REGISTRY_OBSERVER_SERVICE = "indisRegistryObserver";
 
   private final XdsClient _xdsClient;
   private final List<XdsConnectionListener> _xdsConnectionListeners = Collections.synchronizedList(new ArrayList<>());
@@ -93,7 +94,7 @@ public class XdsToD2PropertiesAdaptor
   private PropertyEventBus<UriProperties> _uriEventBus;
   private PropertyEventBus<ServiceProperties> _serviceEventBus;
   private PropertyEventBus<ClusterProperties> _clusterEventBus;
-  // When true, start() also subscribes to the INDIS observer's own cluster (see INDIS_REGISTRY_OBSERVER_CLUSTER).
+  // When true, start() also subscribes to the INDIS observer's own service, cluster, and uris.
   private boolean _subscribeToIndisObserverCluster = false;
 
   public XdsToD2PropertiesAdaptor(XdsClient xdsClient, DualReadStateManager dualReadStateManager,
@@ -130,8 +131,8 @@ public class XdsToD2PropertiesAdaptor
     listenToCluster(NON_EXISTENT_CLUSTER);
     if (_subscribeToIndisObserverCluster)
     {
-      // Subscribe to the observer's own cluster and uris so the live observer endpoint set is received and
-      // cached over xDS. Re-subscription on reconnect is handled automatically by XdsClientImpl.
+      // Subscribe to the observer's own service, cluster, and uris
+      listenToService(INDIS_REGISTRY_OBSERVER_SERVICE);
       listenToCluster(INDIS_REGISTRY_OBSERVER_CLUSTER);
       listenToUris(INDIS_REGISTRY_OBSERVER_CLUSTER);
     }

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -79,7 +79,7 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
 
     XdsToD2PropertiesAdaptor adaptor = new XdsToD2PropertiesAdaptor(xdsClient, config.dualReadStateManager,
         config.serviceDiscoveryEventEmitter, config.clientServicesConfig);
-    adaptor.setSubscribeToObserverCluster(config.subscribeToIndisObserverCluster);
+    adaptor.setSubscribeToIndisObserverCluster(config.subscribeToIndisObserverCluster);
 
     XdsDirectory directory = new XdsDirectory(xdsClient);
 

--- a/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
+++ b/d2/src/main/java/com/linkedin/d2/xds/balancer/XdsLoadBalancerWithFacilitiesFactory.java
@@ -79,6 +79,7 @@ public class XdsLoadBalancerWithFacilitiesFactory implements LoadBalancerWithFac
 
     XdsToD2PropertiesAdaptor adaptor = new XdsToD2PropertiesAdaptor(xdsClient, config.dualReadStateManager,
         config.serviceDiscoveryEventEmitter, config.clientServicesConfig);
+    adaptor.setSubscribeToObserverCluster(config.subscribeToIndisObserverCluster);
 
     XdsDirectory directory = new XdsDirectory(xdsClient);
 

--- a/d2/src/test/java/com/linkedin/d2/balancer/D2ClientBuilderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/D2ClientBuilderTest.java
@@ -57,7 +57,7 @@ public class D2ClientBuilderTest
     // The flag set on the builder must reach the D2ClientConfig handed to the load balancer factory, i.e. it
     // must be carried through the (large) D2ClientConfig constructor rather than dropped. Capture that config
     // during build() and assert the flag is set. (XdsLoadBalancerWithFacilitiesFactory then forwards it to
-    // XdsToD2PropertiesAdaptor.setSubscribeToObserverCluster, which TestXdsToD2PropertiesAdaptor covers.)
+    // XdsToD2PropertiesAdaptor.setSubscribeToIndisObserverCluster, which TestXdsToD2PropertiesAdaptor covers.)
     boolean[] factoryInvoked = {false};
 
     new D2ClientBuilder()

--- a/d2/src/test/java/com/linkedin/d2/balancer/D2ClientBuilderTest.java
+++ b/d2/src/test/java/com/linkedin/d2/balancer/D2ClientBuilderTest.java
@@ -17,6 +17,9 @@
 package com.linkedin.d2.balancer;
 
 import com.linkedin.d2.balancer.zkfs.ZKFSUtil;
+import com.linkedin.r2.transport.common.TransportClientFactory;
+import java.util.Collections;
+import java.util.Map;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -46,5 +49,51 @@ public class D2ClientBuilderTest
       Assert.assertEquals(config.d2ServicePath, expectedD2ServicePath);
       return Mockito.mock(LoadBalancerWithFacilities.class);
     });
+  }
+
+  @Test
+  void testSubscribeToIndisObserverClusterPropagatesToConfig()
+  {
+    // The flag set on the builder must reach the D2ClientConfig handed to the load balancer factory, i.e. it
+    // must be carried through the (large) D2ClientConfig constructor rather than dropped. Capture that config
+    // during build() and assert the flag is set. (XdsLoadBalancerWithFacilitiesFactory then forwards it to
+    // XdsToD2PropertiesAdaptor.setSubscribeToObserverCluster, which TestXdsToD2PropertiesAdaptor covers.)
+    boolean[] factoryInvoked = {false};
+
+    new D2ClientBuilder()
+        .setClientFactories(emptyClientFactories()) // keep the test hermetic: no real transport factories
+        .setSubscribeToIndisObserverCluster(true)
+        .setLoadBalancerWithFacilitiesFactory(config -> {
+          factoryInvoked[0] = true;
+          Assert.assertTrue(config.subscribeToIndisObserverCluster,
+              "subscribeToIndisObserverCluster set on the builder should propagate to the config given to the factory");
+          return Mockito.mock(LoadBalancerWithFacilities.class);
+        })
+        .build();
+
+    Assert.assertTrue(factoryInvoked[0], "build() should have invoked the load balancer factory");
+  }
+
+  @Test
+  void testSubscribeToIndisObserverClusterDefaultsFalse()
+  {
+    boolean[] factoryInvoked = {false};
+
+    new D2ClientBuilder()
+        .setClientFactories(emptyClientFactories())
+        .setLoadBalancerWithFacilitiesFactory(config -> {
+          factoryInvoked[0] = true;
+          Assert.assertFalse(config.subscribeToIndisObserverCluster,
+              "subscribeToIndisObserverCluster should default to false when not set on the builder");
+          return Mockito.mock(LoadBalancerWithFacilities.class);
+        })
+        .build();
+
+    Assert.assertTrue(factoryInvoked[0], "build() should have invoked the load balancer factory");
+  }
+
+  private static Map<String, TransportClientFactory> emptyClientFactories()
+  {
+    return Collections.emptyMap();
   }
 }

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -66,6 +66,8 @@ public class TestXdsToD2PropertiesAdaptor {
   private static final String OBSERVER_CLUSTER_NAME = "IndisRegistryObserver";
   private static final String OBSERVER_CLUSTER_RESOURCE_NAME = CLUSTER_NODE_PREFIX + OBSERVER_CLUSTER_NAME;
   private static final String OBSERVER_URI_RESOURCE_NAME = URI_NODE_PREFIX + OBSERVER_CLUSTER_NAME;
+  private static final String OBSERVER_SERVICE_NAME = "indisRegistryObserver";
+  private static final String OBSERVER_SERVICE_RESOURCE_NAME = "/d2/services/" + OBSERVER_SERVICE_NAME;
   private static final long VERSION = 123;
   private static final long VERSION_2 = 124;
   private static final String LOCAL_HOST = "localhost";
@@ -390,8 +392,8 @@ public class TestXdsToD2PropertiesAdaptor {
 
     adaptor.start();
 
-    // both the observer's cluster node and its uri map are subscribed to, so the live observer endpoint set
-    // is received and cached over xDS.
+    // the observer's service, cluster, and uri map are all subscribed to.
+    verify(fixture._xdsClient).watchXdsResource(eq(OBSERVER_SERVICE_RESOURCE_NAME), anyNodeWatcher());
     verify(fixture._xdsClient).watchXdsResource(eq(OBSERVER_CLUSTER_RESOURCE_NAME), anyNodeWatcher());
     verify(fixture._xdsClient).watchXdsResource(eq(OBSERVER_URI_RESOURCE_NAME), anyMapWatcher());
   }
@@ -404,7 +406,8 @@ public class TestXdsToD2PropertiesAdaptor {
 
     adaptor.start();
 
-    // with the flag off (default), the observer cluster/uris are never subscribed to.
+    // with the flag off (default), the observer service/cluster/uris are never subscribed to.
+    verify(fixture._xdsClient, never()).watchXdsResource(eq(OBSERVER_SERVICE_RESOURCE_NAME), anyNodeWatcher());
     verify(fixture._xdsClient, never()).watchXdsResource(eq(OBSERVER_CLUSTER_RESOURCE_NAME), anyNodeWatcher());
     verify(fixture._xdsClient, never()).watchXdsResource(eq(OBSERVER_URI_RESOURCE_NAME), anyMapWatcher());
   }

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -383,11 +383,11 @@ public class TestXdsToD2PropertiesAdaptor {
   }
 
   @Test
-  public void testStartSubscribesToObserverClusterWhenEnabled()
+  public void testStartSubscribesToIndisObserverClusterWhenEnabled()
   {
     XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
     XdsToD2PropertiesAdaptor adaptor = fixture.getSpiedAdaptor();
-    adaptor.setSubscribeToObserverCluster(true);
+    adaptor.setSubscribeToIndisObserverCluster(true);
 
     adaptor.start();
 
@@ -398,7 +398,7 @@ public class TestXdsToD2PropertiesAdaptor {
   }
 
   @Test
-  public void testStartDoesNotSubscribeToObserverClusterByDefault()
+  public void testStartDoesNotSubscribeToIndisObserverClusterByDefault()
   {
     XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
     XdsToD2PropertiesAdaptor adaptor = fixture.getSpiedAdaptor();

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -66,7 +66,6 @@ public class TestXdsToD2PropertiesAdaptor {
   private static final String OBSERVER_CLUSTER_NAME = "IndisRegistryObserver";
   private static final String OBSERVER_CLUSTER_RESOURCE_NAME = CLUSTER_NODE_PREFIX + OBSERVER_CLUSTER_NAME;
   private static final String OBSERVER_URI_RESOURCE_NAME = URI_NODE_PREFIX + OBSERVER_CLUSTER_NAME;
-  private static final String NON_EXISTENT_CLUSTER_RESOURCE_NAME = CLUSTER_NODE_PREFIX + "NonExistentCluster";
   private static final long VERSION = 123;
   private static final long VERSION_2 = 124;
   private static final String LOCAL_HOST = "localhost";
@@ -405,9 +404,7 @@ public class TestXdsToD2PropertiesAdaptor {
 
     adaptor.start();
 
-    // start() still runs its existing connection-probe subscription...
-    verify(fixture._xdsClient).watchXdsResource(eq(NON_EXISTENT_CLUSTER_RESOURCE_NAME), anyNodeWatcher());
-    // ...but with the flag off (default), the observer cluster/uris are never subscribed to.
+    // with the flag off (default), the observer cluster/uris are never subscribed to.
     verify(fixture._xdsClient, never()).watchXdsResource(eq(OBSERVER_CLUSTER_RESOURCE_NAME), anyNodeWatcher());
     verify(fixture._xdsClient, never()).watchXdsResource(eq(OBSERVER_URI_RESOURCE_NAME), anyMapWatcher());
   }

--- a/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
+++ b/d2/src/test/java/com/linkedin/d2/xds/TestXdsToD2PropertiesAdaptor.java
@@ -63,6 +63,10 @@ public class TestXdsToD2PropertiesAdaptor {
   private static final ClusterStoreProperties PRIMARY_CLUSTER_PROPERTIES = new ClusterStoreProperties(PRIMARY_CLUSTER_NAME);
   private static final String URI_SYMLINK_RESOURCE_NAME = URI_NODE_PREFIX + SYMLINK_NAME;
   private static final String PRIMARY_URI_RESOURCE_NAME = URI_NODE_PREFIX + PRIMARY_CLUSTER_NAME;
+  private static final String OBSERVER_CLUSTER_NAME = "IndisRegistryObserver";
+  private static final String OBSERVER_CLUSTER_RESOURCE_NAME = CLUSTER_NODE_PREFIX + OBSERVER_CLUSTER_NAME;
+  private static final String OBSERVER_URI_RESOURCE_NAME = URI_NODE_PREFIX + OBSERVER_CLUSTER_NAME;
+  private static final String NON_EXISTENT_CLUSTER_RESOURCE_NAME = CLUSTER_NODE_PREFIX + "NonExistentCluster";
   private static final long VERSION = 123;
   private static final long VERSION_2 = 124;
   private static final String LOCAL_HOST = "localhost";
@@ -376,6 +380,36 @@ public class TestXdsToD2PropertiesAdaptor {
     D2URIMapResourceWatcher uriWatcher = fixture._uriMapWatcher;
     uriWatcher.onChanged(EMPTY_DATA_URI_MAP);
     verify(fixture._uriEventBus).publishInitialize(PRIMARY_CLUSTER_NAME, null);
+  }
+
+  @Test
+  public void testStartSubscribesToObserverClusterWhenEnabled()
+  {
+    XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
+    XdsToD2PropertiesAdaptor adaptor = fixture.getSpiedAdaptor();
+    adaptor.setSubscribeToObserverCluster(true);
+
+    adaptor.start();
+
+    // both the observer's cluster node and its uri map are subscribed to, so the live observer endpoint set
+    // is received and cached over xDS.
+    verify(fixture._xdsClient).watchXdsResource(eq(OBSERVER_CLUSTER_RESOURCE_NAME), anyNodeWatcher());
+    verify(fixture._xdsClient).watchXdsResource(eq(OBSERVER_URI_RESOURCE_NAME), anyMapWatcher());
+  }
+
+  @Test
+  public void testStartDoesNotSubscribeToObserverClusterByDefault()
+  {
+    XdsToD2PropertiesAdaptorFixture fixture = new XdsToD2PropertiesAdaptorFixture();
+    XdsToD2PropertiesAdaptor adaptor = fixture.getSpiedAdaptor();
+
+    adaptor.start();
+
+    // start() still runs its existing connection-probe subscription...
+    verify(fixture._xdsClient).watchXdsResource(eq(NON_EXISTENT_CLUSTER_RESOURCE_NAME), anyNodeWatcher());
+    // ...but with the flag off (default), the observer cluster/uris are never subscribed to.
+    verify(fixture._xdsClient, never()).watchXdsResource(eq(OBSERVER_CLUSTER_RESOURCE_NAME), anyNodeWatcher());
+    verify(fixture._xdsClient, never()).watchXdsResource(eq(OBSERVER_URI_RESOURCE_NAME), anyMapWatcher());
   }
 
   private static XdsD2.D2URI getD2URI(String clusterName, String uri, long version)


### PR DESCRIPTION
## Summary

This change lets a D2 xDS client subscribe to `IndisRegistryObserver` cluster, so it receives and caches the live observer endpoint set the same way it learns about any other cluster.

## What changed

- New `D2ClientConfig.subscribeToIndisObserverCluster` (default `false`), plumbed through `D2ClientBuilder` and `XdsLoadBalancerWithFacilitiesFactory` into `XdsToD2PropertiesAdaptor`.
- When enabled, `XdsToD2PropertiesAdaptor.start()` additionally subscribes to the observer's cluster, service, and URI.

When the flag is off (the default), behavior is unchanged.

## Testing

**Unit Tests**
- `TestXdsToD2PropertiesAdaptor` — asserts `start()` subscribes to the observer cluster, service, and URI when the flag is enabled, and does **not** when it is off (the default).
- `D2ClientBuilderTest` — asserts the flag set on the builder propagates through the `D2ClientConfig` constructor to the config handed to the load balancer factory, and defaults to `false`.

**Integration (manual, against a live observer)**
Ran a real D2 xDS client (via `XdsToD2SampleClient`, driven through the full `D2ClientBuilder` path with the flag enabled) against a running local observer. The client subscribed to both observer resources and received the observer's own endpoint over xDS:

```
143:21:20:20.974 INFO  com.linkedin.d2.xds.XdsClientImpl - Subscribing to NODE resource: /d2/services/indisRegistryObserver
154:21:20:20.975 INFO  com.linkedin.d2.xds.XdsClientImpl - Subscribing to NODE resource: /d2/clusters/IndisRegistryObserver
165:21:20:20.976 INFO  com.linkedin.d2.xds.XdsClientImpl - Subscribing to D2_URI_MAP resource: /d2/uris/IndisRegistryObserver
215:21:20:20.997 INFO  com.linkedin.d2.xds.XdsClientImpl - Received initial data for NODE /d2/services/indisRegistryObserver. Set state to FETCHED.
233:21:20:21.078 INFO  com.linkedin.d2.xds.XdsClientImpl - Received initial data for NODE /d2/clusters/IndisRegistryObserver. Set state to FETCHED.
251:21:20:21.092 INFO  com.linkedin.d2.xds.XdsClientImpl - Received initial data for D2_URI_MAP /d2/uris/IndisRegistryObserver. Set state to FETCHED.
```
